### PR TITLE
/_health endpoint

### DIFF
--- a/lib/gtfs.ex
+++ b/lib/gtfs.ex
@@ -109,9 +109,11 @@ defmodule Gtfs do
     GenServer.start_link(__MODULE__, {:url, url}, name: __MODULE__)
   end
 
-  @spec start_mocked(mocked_files) :: GenServer.on_start()
+  @spec start_mocked(mocked_files) :: pid()
   def start_mocked(mocked_files) do
-    GenServer.start_link(__MODULE__, {:mocked_files, mocked_files})
+    {:ok, pid} =
+      GenServer.start_link(__MODULE__, {:mocked_files, mocked_files})
+    pid
   end
 
   # Initialization (Server)

--- a/lib/gtfs/health_server.ex
+++ b/lib/gtfs/health_server.ex
@@ -1,0 +1,52 @@
+defmodule Gtfs.HealthServer do
+  @moduledoc """
+  GenServer to keep track of whether the GTFS GenServer is up and running
+  """
+
+  use GenServer
+
+  @type state :: :not_loaded | :loaded
+
+  # Client functions
+
+  @spec default_server() :: GenServer.server()
+  def default_server(), do: __MODULE__
+
+  @spec start_link() :: GenServer.on_start()
+  def start_link() do
+    GenServer.start_link(__MODULE__, nil, name: default_server())
+  end
+
+  @spec start_mocked() :: pid()
+  def start_mocked() do
+    {:ok, pid} = GenServer.start_link(__MODULE__, nil)
+    pid
+  end
+
+  @spec loaded(GenServer.server()) :: :ok
+  def loaded(server) do
+    GenServer.cast(server, :loaded)
+  end
+
+  @spec ready?(GenServer.server()) :: boolean()
+  def ready?(server) do
+    GenServer.call(server, :ready?)
+  end
+
+  # Server functions
+
+  @impl true
+  def init(nil) do
+    {:ok, :not_loaded}
+  end
+
+  @impl true
+  def handle_cast(:loaded, _state) do
+    {:noreply, :loaded}
+  end
+
+  @impl true
+  def handle_call(:ready?, _from, state) do
+    {:reply, state == :loaded, state}
+  end
+end

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -16,12 +16,13 @@ defmodule Skate.Application do
       SkateWeb.Endpoint,
       # Starts a worker by calling: Skate.Worker.start_link(arg)
       # {Skate.Worker, arg},
+      worker(Gtfs.HealthServer, []),
       worker(Gtfs, [Application.get_env(:skate, :gtfs_url)])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: Skate.Supervisor]
+    opts = [strategy: :one_for_all, name: Skate.Supervisor]
     Supervisor.start_link(children, opts)
   end
 

--- a/lib/skate_web/controllers/health_controller.ex
+++ b/lib/skate_web/controllers/health_controller.ex
@@ -1,0 +1,17 @@
+defmodule SkateWeb.HealthController do
+  @moduledoc """
+  Simple controller to return 200 OK when the website is healthy.
+  """
+  use SkateWeb, :controller
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _params) do
+    health_server_pid = conn.assigns[:health_server_pid] || Gtfs.HealthServer.default_server()
+
+    if Gtfs.HealthServer.ready?(health_server_pid) do
+      send_resp(conn, :ok, "")
+    else
+      send_resp(conn, :service_unavailable, "")
+    end
+  end
+end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -14,6 +14,11 @@ defmodule SkateWeb.Router do
   end
 
   scope "/", SkateWeb do
+    # no pipe
+    get "/_health", HealthController, :index
+  end
+
+  scope "/", SkateWeb do
     pipe_through :browser
 
     get "/", PageController, :index

--- a/test/gtfs/health_server_test.exs
+++ b/test/gtfs/health_server_test.exs
@@ -1,0 +1,26 @@
+defmodule Gtfs.HealthServerTest do
+  use ExUnit.Case
+
+  alias Gtfs.HealthServer
+
+  test "becomes ready after calling loaded" do
+    pid = HealthServer.start_mocked()
+    refute HealthServer.ready?(pid)
+    HealthServer.loaded(pid)
+    assert HealthServer.ready?(pid)
+  end
+
+  test "gtfs server tells the health server it's loaded" do
+    health_server_pid = HealthServer.start_mocked()
+    refute HealthServer.ready?(health_server_pid)
+    gtfs_pid = Gtfs.start_mocked(%{}, health_server_pid)
+    # Make a synchronous call to make sure the data is loaded
+    Gtfs.all_routes(gtfs_pid)
+    assert HealthServer.ready?(health_server_pid)
+  end
+
+  test "real gtfs server uses the default health server" do
+    # The real data takes longer to load than the tests take to run
+    refute HealthServer.ready?(HealthServer.default_server())
+  end
+end

--- a/test/gtfs_test.exs
+++ b/test/gtfs_test.exs
@@ -7,7 +7,7 @@ defmodule GtfsTest do
 
   describe "all_routes" do
     test "all_routes" do
-      {:ok, pid} =
+      pid =
         Gtfs.start_mocked(%{
           "routes.txt" => [
             "route_id,route_long_name",
@@ -23,7 +23,7 @@ defmodule GtfsTest do
 
   describe "timepoints_on_route" do
     test "timepoints_on_route" do
-      {:ok, pid} =
+      pid =
         Gtfs.start_mocked(%{
           "route_patterns.txt" => [
             "route_pattern_id,route_id,direction_id,representative_trip_id",
@@ -42,7 +42,7 @@ defmodule GtfsTest do
     end
 
     test "merges multiple trips into a coherent order" do
-      {:ok, pid} =
+      pid =
         Gtfs.start_mocked(%{
           "route_patterns.txt" => [
             "route_pattern_id,route_id,direction_id,representative_trip_id",
@@ -66,7 +66,7 @@ defmodule GtfsTest do
     end
 
     test "merges stops from both directions, flipping direction 0" do
-      {:ok, pid} =
+      pid =
         Gtfs.start_mocked(%{
           "route_patterns.txt" => [
             "route_pattern_id,route_id,direction_id,representative_trip_id",

--- a/test/skate_web/controllers/health_controller_test.exs
+++ b/test/skate_web/controllers/health_controller_test.exs
@@ -1,0 +1,27 @@
+defmodule SkateWeb.HealthControllerTest do
+  use SkateWeb.ConnCase
+
+  describe "index" do
+    test "returns 200 when health server is ready", %{conn: conn} do
+      health_server_pid = Gtfs.HealthServer.start_mocked()
+      Gtfs.HealthServer.loaded(health_server_pid)
+      conn = Plug.Conn.assign(conn, :health_server_pid, health_server_pid)
+      response = get(conn, Routes.health_path(conn, :index))
+      assert response.status == 200
+    end
+
+    test "returns 503 when health server is not ready", %{conn: conn} do
+      health_server_pid = Gtfs.HealthServer.start_mocked()
+      conn = Plug.Conn.assign(conn, :health_server_pid, health_server_pid)
+      response = get(conn, Routes.health_path(conn, :index))
+      assert response.status == 503
+    end
+
+    test "uses the default health server", %{conn: conn} do
+      # The real gtfs data takes longer to load than the tests take to run.
+      # So it won't be ready
+      response = get(conn, Routes.health_path(conn, :index))
+      assert response.status == 503
+    end
+  end
+end


### PR DESCRIPTION
Asana Task: [/_health endpoint](https://app.asana.com/0/1112935048846093/1117444455227122)

Makes a `/_health` endpoint
Returns 200 if healthy
Returns 503 if the gtfs genserver hasn't loaded yet.

It's a little weird since the genserver will timeout if it's not loaded, rather than returning false, and I don't know the best way to express that.

Another issue: if you catch a genserver timeout, the reply will still happen later, and can clog up the clients mailbox, as mentioned here https://cultivatehq.com/posts/genserver-call-timeouts/ . Unfortunately, I couldn't find much information on this, how to fix it, or whether it's actually a problem, so I haven't tried to do anything about it.

Perhaps a way to avoid the timeout issues would be to have a separate genserver whose only job is to keep track of whether the gtfs genserver is awake, but that seems like a lot of infrastructure for this one simple thing.

I'm not really happy with this code. Is there a different approach I should consider?
