### PR TITLE
Fix prettier trailing comma configuration

### DIFF
--- a/assets/.prettierrc
+++ b/assets/.prettierrc
@@ -1,5 +1,4 @@
 {
   "semi": false,
-  "singleQuote": false,
-  "trailingComma": "es5"
+  "singleQuote": false
 }

--- a/assets/.prettierrc
+++ b/assets/.prettierrc
@@ -1,5 +1,5 @@
 {
   "semi": false,
   "singleQuote": false,
-  "trailingComma": "all",
+  "trailingComma": "es5"
 }


### PR DESCRIPTION
Prettier was occasionally inserting commas that tslint said shouldn't be there.