### PR TITLE
move fetchTimepoints to App. test effects.

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -58,6 +58,7 @@
     "webpack-cli": "^3.3.0"
   },
   "jest": {
+    "clearMocks": true,
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useReducer } from "react"
-import * as Api from "../api"
+import React, { useReducer } from "react"
+import { useFetchRoutes } from "../hooks/useFetchRoutes"
+import { useFetchTimepoints } from "../hooks/useFetchTimepoints"
 import DispatchProvider from "../providers/dispatchProvider"
-import { Route } from "../skate.d"
-import { initialState, reducer, setRoutes } from "../state"
+import { initialState, reducer } from "../state"
 import RouteLadders from "./routeLadders"
 import RoutePicker from "./routePicker"
 
@@ -10,11 +10,8 @@ const App = (): JSX.Element => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const { routes, selectedRouteIds, timepointsByRouteId } = state
 
-  useEffect(() => {
-    Api.fetchRoutes().then((newRoutes: Route[]) =>
-      dispatch(setRoutes(newRoutes))
-    )
-  }, [])
+  useFetchRoutes(dispatch)
+  useFetchTimepoints(selectedRouteIds, timepointsByRouteId, dispatch)
 
   const selectedRoutes = (routes || []).filter(route =>
     selectedRouteIds.includes(route.id)

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -1,13 +1,8 @@
-import React, { useContext, useEffect } from "react"
-import { fetchTimepointsForRoute } from "../api"
+import React, { useContext } from "react"
 import DispatchContext from "../contexts/dispatchContext"
 import { closeIcon } from "../helpers/icon"
 import { LoadableTimepoints, Route, Timepoint } from "../skate"
-import {
-  deselectRoute,
-  setLoadingTimepointsForRoute,
-  setTimepointsForRoute,
-} from "../state"
+import { deselectRoute } from "../state"
 import Loading from "./loading"
 
 interface Props {
@@ -49,34 +44,20 @@ const Timepoint = ({ timepoint }: { timepoint: Timepoint }) => (
   </li>
 )
 
-const RouteLadder = ({ route, timepoints }: Props) => {
-  const dispatch = useContext(DispatchContext)
+const RouteLadder = ({ route, timepoints }: Props) => (
+  <div className="m-route-ladder">
+    <Header route={route} />
 
-  useEffect(() => {
-    if (timepoints === undefined) {
-      dispatch(setLoadingTimepointsForRoute(route.id))
-
-      fetchTimepointsForRoute(route.id).then((newTimepoints: Timepoint[]) =>
-        dispatch(setTimepointsForRoute(route.id, newTimepoints))
-      )
-    }
-  }, [])
-
-  return (
-    <div className="m-route-ladder">
-      <Header route={route} />
-
-      {timepoints ? (
-        <ol className="m-route-ladder__timepoints">
-          {timepoints.map(timepoint => (
-            <Timepoint key={timepoint.id} timepoint={timepoint} />
-          ))}
-        </ol>
-      ) : (
-        <Loading />
-      )}
-    </div>
-  )
-}
+    {timepoints ? (
+      <ol className="m-route-ladder__timepoints">
+        {timepoints.map(timepoint => (
+          <Timepoint key={timepoint.id} timepoint={timepoint} />
+        ))}
+      </ol>
+    ) : (
+      <Loading />
+    )}
+  </div>
+)
 
 export default RouteLadder

--- a/assets/src/hooks/useFetchRoutes.ts
+++ b/assets/src/hooks/useFetchRoutes.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react"
+import { fetchRoutes } from "../api"
+import { Route } from "../skate"
+import { Dispatch, setRoutes } from "../state"
+
+export const useFetchRoutes = (dispatch: Dispatch): void => {
+  useEffect(() => {
+    fetchRoutes().then((newRoutes: Route[]) => dispatch(setRoutes(newRoutes)))
+  }, [])
+}

--- a/assets/src/hooks/useFetchTimepoints.ts
+++ b/assets/src/hooks/useFetchTimepoints.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react"
+import { fetchTimepointsForRoute } from "../api"
+import { RouteId, Timepoint, TimepointsByRouteId } from "../skate"
+import {
+  Dispatch,
+  setLoadingTimepointsForRoute,
+  setTimepointsForRoute,
+} from "../state"
+
+export const useFetchTimepoints = (
+  selectedRouteIds: RouteId[],
+  timepointsByRouteId: TimepointsByRouteId,
+  dispatch: Dispatch
+): void => {
+  useEffect(() => {
+    selectedRouteIds.forEach((routeId: RouteId) => {
+      if (!(routeId in timepointsByRouteId)) {
+        dispatch(setLoadingTimepointsForRoute(routeId))
+
+        fetchTimepointsForRoute(routeId).then((newTimepoints: Timepoint[]) =>
+          dispatch(setTimepointsForRoute(routeId, newTimepoints))
+        )
+      }
+    })
+  }, [selectedRouteIds])
+}

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -4,7 +4,5 @@ import App from "../../src/components/app"
 
 test("renders", () => {
   const tree = renderer.create(<App />).toJSON()
-
   expect(tree).toMatchSnapshot()
 })
-

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -1,17 +1,10 @@
 import { mount } from "enzyme"
 import React from "react"
-import renderer, { act } from "react-test-renderer"
+import renderer from "react-test-renderer"
 import RouteLadder from "../../src/components/routeLadder"
 import DispatchProvider from "../../src/providers/dispatchProvider"
 import { Route } from "../../src/skate"
 import { deselectRoute } from "../../src/state"
-
-declare global {
-  interface Window {
-    /* eslint-disable typescript/no-explicit-any */
-    fetch: (uri: string) => Promise<any>
-  }
-}
 
 test("renders a route ladder", () => {
   const route: Route = { id: "28" }
@@ -33,55 +26,6 @@ test("displays loading if we are fetching the timepoints", () => {
     .toJSON()
 
   expect(tree).toMatchSnapshot()
-})
-
-test("fetches timepoints for this route if we don't yet have them", () => {
-  const mockDispatch = jest.fn()
-  const route: Route = { id: "28" }
-  const timepoints = undefined
-
-  window.fetch = () =>
-    Promise.resolve({
-      json: () => ({
-        data: ["MATPN", "WELLH", "MORTN"],
-      }),
-      ok: true,
-      status: 200,
-    })
-
-  act(() => {
-    renderer
-      .create(
-        <DispatchProvider dispatch={mockDispatch}>
-          <RouteLadder route={route} timepoints={timepoints} />
-        </DispatchProvider>
-      )
-      .toJSON()
-  })
-
-  expect(mockDispatch.mock.calls.length).toBe(1)
-  expect(mockDispatch.mock.calls[0][0]).toEqual({
-    payload: { routeId: "28" },
-    type: "SET_LOADING_TIMEPOINTS_FOR_ROUTE",
-  })
-})
-
-test("does not fetch timepoints for this route if we are currently loading them", () => {
-  const mockDispatch = jest.fn()
-  const route: Route = { id: "28" }
-  const timepoints = null
-
-  act(() => {
-    renderer
-      .create(
-        <DispatchProvider dispatch={mockDispatch}>
-          <RouteLadder route={route} timepoints={timepoints} />
-        </DispatchProvider>
-      )
-      .toJSON()
-  })
-
-  expect(mockDispatch.mock.calls.length).toBe(0)
 })
 
 test("clicking the close button deselects that route", () => {

--- a/assets/tests/hooks/useFetchRoutes.test.ts
+++ b/assets/tests/hooks/useFetchRoutes.test.ts
@@ -1,0 +1,35 @@
+import { act } from "react-test-renderer"
+import * as Api from "../../src/api"
+import { useFetchRoutes } from "../../src/hooks/useFetchRoutes"
+import { testHook } from "../testHelpers/testHook"
+
+// tslint:disable: react-hooks-nesting no-empty
+
+jest.mock("../../src/api", () => ({
+  __esModule: true,
+  fetchRoutes: jest.fn(() => new Promise(() => {})),
+}))
+
+describe("useFetchRoutes", () => {
+  test("fetches routes", () => {
+    const mockFetchRoutes: jest.Mock = Api.fetchRoutes as jest.Mock
+    act(() => {
+      testHook(() => {
+        useFetchRoutes(jest.fn())
+      })
+    })
+    expect(mockFetchRoutes).toHaveBeenCalledTimes(1)
+  })
+
+  test("doesn't refetch routes on every render", () => {
+    const mockFetchRoutes: jest.Mock = Api.fetchRoutes as jest.Mock
+    act(() => {
+      const component = testHook(() => {
+        useFetchRoutes(jest.fn())
+      })
+      // Force a rerender
+      component.setProps({})
+    })
+    expect(mockFetchRoutes).toHaveBeenCalledTimes(1)
+  })
+})

--- a/assets/tests/hooks/useFetchTimepoints.test.ts
+++ b/assets/tests/hooks/useFetchTimepoints.test.ts
@@ -1,0 +1,51 @@
+import { act } from "react-test-renderer"
+import * as Api from "../../src/api"
+import { useFetchTimepoints } from "../../src/hooks/useFetchTimepoints"
+import { setLoadingTimepointsForRoute } from "../../src/state"
+import { testHook } from "../testHelpers/testHook"
+
+// tslint:disable: react-hooks-nesting no-empty
+
+jest.mock("../../src/api", () => ({
+  __esModule: true,
+  fetchTimepointsForRoute: jest.fn(() => new Promise(() => {})),
+}))
+
+describe("useFetchTimepoints", () => {
+  test("fetches timepoints for a route if we don't yet have them", () => {
+    const selectedRouteIds = ["1"]
+    const timepointsByRouteId = {}
+    const mockDispatch = jest.fn()
+
+    const mockFetchTimepoints: jest.Mock = Api.fetchTimepointsForRoute as jest.Mock
+
+    act(() => {
+      testHook(() => {
+        useFetchTimepoints(selectedRouteIds, timepointsByRouteId, mockDispatch)
+      })
+    })
+
+    expect(mockFetchTimepoints).toHaveBeenCalledTimes(1)
+    expect(mockFetchTimepoints).toHaveBeenCalledWith("1")
+    expect(mockDispatch).toHaveBeenCalledWith(setLoadingTimepointsForRoute("1"))
+  })
+
+  test("does not refetch timepoints that are loading or loaded", () => {
+    const selectedRouteIds = ["2", "3"]
+    const timepointsByRouteId = {
+      2: null,
+      3: [{ id: "t3" }],
+    }
+    const mockDispatch = jest.fn()
+    const mockFetchTimepoints: jest.Mock = Api.fetchTimepointsForRoute as jest.Mock
+
+    act(() => {
+      testHook(() => {
+        useFetchTimepoints(selectedRouteIds, timepointsByRouteId, mockDispatch)
+      })
+    })
+
+    expect(mockFetchTimepoints).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+})

--- a/assets/tests/testHelpers/testHook.tsx
+++ b/assets/tests/testHelpers/testHook.tsx
@@ -1,0 +1,13 @@
+import { mount, ReactWrapper } from "enzyme"
+import React from "react"
+
+type Callback = () => void
+
+const TestHook = ({ callback }: { callback: Callback }) => {
+  callback()
+  return null
+}
+
+export const testHook = (callback: Callback): ReactWrapper => {
+  return mount(<TestHook callback={callback} />)
+}


### PR DESCRIPTION
We finally have a way of testing effects that I feel
* tests everything we have adequately
* keeps tests isolated enough that future new tests won't trip over existing tests
* provides a structure that we can copy when testing future effects

This PR
* Moves the fetchTimepoints effect into App, so we can consolidate all effects at the top level.
* Tests for all the effects in App so far.

It doesn't add [the sockets task](https://app.asana.com/0/1112935048846093/1114820119722045) yet, but by providing a good testing framework, the socket tests will be easy enough to build on top of this PR.

---

Each effect is given its own custom hook, so we can test it independently from the App component.  That testing uses the `testHook` component from #26, which will need to be rebased on top of this.

Mocking is done by
```ts
// app.test.tsx
import { fetchRoutes } from "../../src/api"
jest.mock("../../src/api", () => ({
  __esModule: true,
  fetchRoutes: jest.fn(() => new Promise(() => {})),
}))
// In the test
    const mockFetchRoutes: jest.Mock = fetchRoutes as jest.Mock
    expect(mockFetchRoutes).toHaveBeenCalled()
```

The mock is shared within the file, but `"clearMocks": true` in the jest config (in `package.json`) prevents interference, as long as all tests are good about using `act` to make sure they're done with any effects by the end of the test.

So far, no tests need custom implementations of mocked functions. If we do, we'll have to make sure that the implementation is appropriately reset to the default mocked implementation.

This doesn't test that dispatch is called after the promises resolve. Should it?