### PR TITLE
Improve dev scripts

### DIFF
--- a/assets/.prettierignore
+++ b/assets/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 package.json
+tsconfig.json

--- a/assets/.prettierrc
+++ b/assets/.prettierrc
@@ -1,4 +1,4 @@
 {
   "semi": false,
-  "singleQuote": false
+  "trailingComma": "es5"
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -2,17 +2,17 @@
   "repository": {},
   "license": "MIT",
   "scripts": {
-    "check": "tsc --noEmit && tslint -p .",
     "deploy": "webpack --mode production",
     "build": "webpack --mode development",
     "watch": "webpack --mode development --watch",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:update": "jest -u",
-    "format": "npm run format:ts && npm run format:ts && npm run format:css",
-    "format:js": "prettier --write {.,**}/*.{js,json}",
-    "format:ts": "prettier --write {.,**}/*.{ts,tsx} && tslint --fix -p .",
-    "format:css": "prettier --write {.,**}/*.{css,scss}"
+    "check": "tsc --noEmit && npm run lint:check && npm run format:check",
+    "lint": "tslint --fix -p .",
+    "lint:check": "tslint -p .",
+    "format": "prettier --write {.,**}/*.{js,json,ts,tsx,css,scss}",
+    "format:check": "prettier --check {.,**}/*.{js,json,ts,tsx,css,scss}"
   },
   "dependencies": {
     "phoenix": "file:../deps/phoenix",

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -1,5 +1,7 @@
 import { fetchRoutes, fetchTimepointsForRoute } from "../src/api"
 
+// tslint:disable no-empty
+
 declare global {
   interface Window {
     /* eslint-disable typescript/no-explicit-any */
@@ -32,10 +34,18 @@ describe("fetchRoutes", () => {
         status: 500,
       })
 
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(() => {})
+
     fetchRoutes()
-      .then(() => done("fetchRoutes did not throw an error"))
+      .then(() => {
+        spyConsoleError.mockRestore()
+        done("fetchRoutes did not throw an error")
+      })
       .catch(error => {
         expect(error).not.toBeUndefined()
+        expect(spyConsoleError).toHaveBeenCalled()
+        spyConsoleError.mockRestore()
         done()
       })
   })
@@ -70,10 +80,18 @@ describe("fetchTimepointsForRoute", () => {
         status: 500,
       })
 
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(() => {})
+
     fetchTimepointsForRoute("28")
-      .then(() => done("fetchTimepointsForRoute did not throw an error"))
+      .then(() => {
+        spyConsoleError.mockRestore()
+        done("fetchTimepointsForRoute did not throw an error")
+      })
       .catch(error => {
         expect(error).not.toBeUndefined()
+        expect(spyConsoleError).toHaveBeenCalled()
+        spyConsoleError.mockRestore()
         done()
       })
   })

--- a/assets/tests/testHelpers/svgStubber.js
+++ b/assets/tests/testHelpers/svgStubber.js
@@ -1,1 +1,1 @@
-module.exports = "SVG";
+module.exports = "SVG"

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -3,12 +3,12 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "target": "es5",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "es2015",                    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
@@ -23,30 +23,30 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strict": true,                        /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true               /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -8,7 +8,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
@@ -39,7 +39,7 @@
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/assets/tslint.json
+++ b/assets/tslint.json
@@ -2,33 +2,14 @@
   "defaultSeverity": "error",
   "extends": [
     "tslint:recommended",
-    "tslint-config-prettier",
     "tslint-react",
-    "tslint-react-hooks"
+    "tslint-react-hooks",
+    "tslint-config-prettier"
   ],
   "jsRules": {},
   "rules": {
-    "quotemark": [true, "double", "jsx-double", "avoid-escape"],
-    "semicolon": [true, "never"],
-    "trailing-comma": [
-      true,
-      {
-        "multiline": {
-          "properties": "always",
-          "arrays": "always",
-          "exports": "always",
-          "functions": "never",
-          "imports": "always",
-          "objects": "always",
-          "typeLiterals": "never"
-        },
-        "singleline": "never",
-        "esSpecCompliant": "true"
-      }
-    ],
     "interface-name": [true, "never-prefix"],
     "jsx-no-lambda": false,
-    "jsx-no-multiline-js": false,
     "object-literal-sort-keys": { "options": "match-declaration-order" },
     "react-hooks-nesting": "error",
     "variable-name": [

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -9,15 +9,15 @@ module.exports = (env, options) => ({
   optimization: {
     minimizer: [
       new UglifyJsPlugin({ cache: true, parallel: true, sourceMap: false }),
-      new OptimizeCSSAssetsPlugin({})
-    ]
+      new OptimizeCSSAssetsPlugin({}),
+    ],
   },
   entry: {
-    "./js/app.tsx": ["./src/app.tsx"].concat(glob.sync("./vendor/**/*.js"))
+    "./js/app.tsx": ["./src/app.tsx"].concat(glob.sync("./vendor/**/*.js")),
   },
   output: {
     filename: "app.js",
-    path: path.resolve(__dirname, "../priv/static/js")
+    path: path.resolve(__dirname, "../priv/static/js"),
   },
   module: {
     rules: [
@@ -25,20 +25,20 @@ module.exports = (env, options) => ({
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader"
-        }
+          loader: "babel-loader",
+        },
       },
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
         use: [
           {
-            loader: "babel-loader"
+            loader: "babel-loader",
           },
           {
-            loader: "ts-loader"
-          }
-        ]
+            loader: "ts-loader",
+          },
+        ],
       },
       {
         test: /\.s?css$/,
@@ -48,15 +48,15 @@ module.exports = (env, options) => ({
             loader: "css-loader",
             options: {
               autoprefixer: {
-                browsers: ["last 2 versions"]
+                browsers: ["last 2 versions"],
               },
-              plugins: () => [autoprefixer]
-            }
+              plugins: () => [autoprefixer],
+            },
           },
           {
-            loader: "sass-loader"
-          }
-        ]
+            loader: "sass-loader",
+          },
+        ],
       },
       {
         test: /\.svg$/,
@@ -65,19 +65,19 @@ module.exports = (env, options) => ({
           {
             loader: "svgo-loader",
             options: {
-              externalConfig: "svgo.yml"
-            }
-          }
-        ]
-      }
-    ]
+              externalConfig: "svgo.yml",
+            },
+          },
+        ],
+      },
+    ],
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".jsx"],
-    modules: ["deps", "node_modules"]
+    modules: ["deps", "node_modules"],
   },
   plugins: [
     new MiniCssExtractPlugin({ filename: "../css/app.css" }),
-    new CopyWebpackPlugin([{ from: "static/", to: "../" }])
-  ]
+    new CopyWebpackPlugin([{ from: "static/", to: "../" }]),
+  ],
 })


### PR DESCRIPTION
* move formatting rules out of tslint and into prettier.
  - The list of rules that should be handled by prettier are defined in `tslint-prettier-config` (and [listed here](https://unpkg.com/tslint-config-prettier@1.18.0/lib/index.json))
* fix npm run check and tweak npm scripts
* tsconfig.json nicer manual formatting
* quiet the noisy api tests that call console.error