### PR TITLE
Use integer stop sequence for sorting

### DIFF
--- a/lib/gtfs/data.ex
+++ b/lib/gtfs/data.ex
@@ -97,7 +97,8 @@ defmodule Gtfs.Data do
   defp timepoint_ids_for_route_patterns(route_patterns, data) do
     route_patterns
     |> Enum.map(fn route_pattern -> route_pattern.representative_trip_id end)
-    |> Enum.flat_map(fn trip_id -> stop_times_on_trip(data, trip_id) end)
+    |> Enum.map(fn trip_id -> stop_times_on_trip(data, trip_id) end)
+    |> Helpers.merge_lists()
     |> Enum.reject(&(&1.timepoint_id == nil))
     |> Enum.map(& &1.timepoint_id)
   end

--- a/lib/gtfs/stop_time.ex
+++ b/lib/gtfs/stop_time.ex
@@ -36,7 +36,7 @@ defmodule Gtfs.StopTime do
     |> Enum.group_by(fn stop_time_row -> stop_time_row["trip_id"] end)
     |> Helpers.map_values(fn stop_times_on_trip ->
       stop_times_on_trip
-      |> Enum.sort_by(fn stop_time_row -> stop_time_row["stop_sequence"] end)
+      |> Enum.sort_by(&stop_sequence_integer/1)
       |> Enum.map(fn stop_time_row ->
         # Use nil instead of an empty string for timepoint_id if there is no checkpoint_id
         timepoint_id =
@@ -52,4 +52,7 @@ defmodule Gtfs.StopTime do
 
   @spec row_in_trip_id_set?(Csv.row(), MapSet.t(Trip.id())) :: boolean
   def row_in_trip_id_set?(row, trip_id_set), do: MapSet.member?(trip_id_set, row["trip_id"])
+
+  @spec stop_sequence_integer(Csv.row()) :: integer()
+  def stop_sequence_integer(stop_time_row), do: String.to_integer(stop_time_row["stop_sequence"])
 end

--- a/test/gtfs/stop_time_test.exs
+++ b/test/gtfs/stop_time_test.exs
@@ -29,6 +29,18 @@ defmodule Gtfs.StopTimeTest do
       "checkpoint_id" => "melwa"
     },
     %{
+      "trip_id" => "39770780",
+      "arrival_time" => "05:20:00",
+      "departure_time" => "05:20:00",
+      "stop_id" => "4",
+      "stop_sequence" => "10",
+      "stop_headsign" => "",
+      "pickup_type" => "0",
+      "drop_off_type" => "0",
+      "timepoint" => "0",
+      "checkpoint_id" => "tenner"
+    },
+    %{
       "trip_id" => "39770783",
       "arrival_time" => "10:15:00",
       "departure_time" => "10:15:00",
@@ -71,7 +83,8 @@ defmodule Gtfs.StopTimeTest do
       assert StopTime.trip_stop_times_from_csv(@csv_rows) == %{
                "39770780" => [
                  %StopTime{stop_id: "64", timepoint_id: "dudly"},
-                 %StopTime{stop_id: "3", timepoint_id: "melwa"}
+                 %StopTime{stop_id: "3", timepoint_id: "melwa"},
+                 %StopTime{stop_id: "4", timepoint_id: "tenner"}
                ],
                "39770783" => [
                  %StopTime{stop_id: "23391", timepoint_id: "bbsta"},
@@ -91,6 +104,12 @@ defmodule Gtfs.StopTimeTest do
              )
 
       refute StopTime.row_in_trip_id_set?(List.first(@csv_rows), MapSet.new(["1", "2"]))
+    end
+  end
+
+  describe "stop_sequence_integer/1" do
+    test "returns the stop_sequency value as an integer" do
+      assert StopTime.stop_sequence_integer(List.first(@csv_rows)) == 1
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [[Investigate] Improve timepoint ordering](https://app.asana.com/0/1112935048846093/1120792726911308)

Fixes a sorting bug once you hit double digits.

Merge lists instead of using flat_map.