### PR TITLE
Ignore replies that come after a timeout

### DIFF
--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -90,6 +90,10 @@ defmodule Realtime.Server do
     {:noreply, new_state}
   end
 
+  # If we get a reply after we've already timed out, ignore it
+  @impl true
+  def handle_info({reference, _}, state) when is_reference(reference), do: {:noreply, state}
+
   @impl true
   def handle_call({:subscribe, route_id}, _from, state) do
     registry_key = self()

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -4,70 +4,87 @@ defmodule Realtime.ServerTest do
   alias Gtfs.StopTime
   alias Realtime.Server
 
-  setup do
-    real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
+  describe "public interface" do
+    setup do
+      real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
 
-    on_exit(fn ->
-      Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
-    end)
+      on_exit(fn ->
+        Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
+      end)
 
-    Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
-      [
-        %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-        %StopTime{stop_id: "6554", timepoint_id: nil},
-        %StopTime{stop_id: "6555", timepoint_id: "tp2"}
-      ]
-    end)
+      Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
+        [
+          %StopTime{stop_id: "6553", timepoint_id: "tp1"},
+          %StopTime{stop_id: "6554", timepoint_id: nil},
+          %StopTime{stop_id: "6555", timepoint_id: "tp2"}
+        ]
+      end)
 
-    bypass = Bypass.open()
-    url = "http://localhost:#{bypass.port}/VehiclePositions.json"
+      bypass = Bypass.open()
+      url = "http://localhost:#{bypass.port}/VehiclePositions.json"
 
-    Bypass.expect(bypass, fn conn ->
-      sample_data = File.read!(__DIR__ <> "/concentrate_VehiclePositions.json")
-      Plug.Conn.resp(conn, 200, sample_data)
-    end)
+      Bypass.expect(bypass, fn conn ->
+        sample_data = File.read!(__DIR__ <> "/concentrate_VehiclePositions.json")
+        Plug.Conn.resp(conn, 200, sample_data)
+      end)
 
-    {:ok, server_pid} =
-      Server.start_link(
-        url: url,
-        poll_delay: 100
+      {:ok, server_pid} =
+        Server.start_link(
+          url: url,
+          poll_delay: 100
+        )
+
+      %{server_pid: server_pid}
+    end
+
+    test "clients get vehicles when subscribing", %{server_pid: server_pid} do
+      data = Server.subscribe("1", server_pid)
+
+      assert [at_least_one_vehicle | _rest] = data
+      assert at_least_one_vehicle.route_id == "1"
+    end
+
+    test "subscribed clients get data pushed to them", %{server_pid: server_pid} do
+      Server.subscribe("1", server_pid)
+
+      assert_receive(
+        {:new_realtime_data, data},
+        200,
+        "Client didn't receive vehicle positions"
       )
 
-    %{server_pid: server_pid}
+      assert [_at_least_one_vehicle | _rest] = data
+    end
+
+    test "subscribed clients get repeated messages", %{server_pid: server_pid} do
+      Server.subscribe("1", server_pid)
+
+      assert_receive(
+        {:new_realtime_data, _new_data},
+        200,
+        "Client didn't receive vehicle positions the first time"
+      )
+
+      assert_receive(
+        {:new_realtime_data, _new_data},
+        200,
+        "Client didn't receive vehicle positions the second time"
+      )
+    end
   end
 
-  test "clients get vehicles when subscribing", %{server_pid: server_pid} do
-    data = Server.subscribe("1", server_pid)
+  describe "backend implementation" do
+    test "handles reference info calls that come in after a timeout" do
+      state = %{
+        url: "http://example.com",
+        poll_delay: 1,
+        vehicles_timestamp: nil,
+        vehicles: []
+      }
 
-    assert [at_least_one_vehicle | _rest] = data
-    assert at_least_one_vehicle.route_id == "1"
-  end
+      response = Server.handle_info({make_ref(), []}, state)
 
-  test "subscribed clients get data pushed to them", %{server_pid: server_pid} do
-    Server.subscribe("1", server_pid)
-
-    assert_receive(
-      {:new_realtime_data, data},
-      200,
-      "Client didn't receive vehicle positions"
-    )
-
-    assert [_at_least_one_vehicle | _rest] = data
-  end
-
-  test "subscribed clients get repeated messages", %{server_pid: server_pid} do
-    Server.subscribe("1", server_pid)
-
-    assert_receive(
-      {:new_realtime_data, _new_data},
-      200,
-      "Client didn't receive vehicle positions the first time"
-    )
-
-    assert_receive(
-      {:new_realtime_data, _new_data},
-      200,
-      "Client didn't receive vehicle positions the second time"
-    )
+      assert response == {:noreply, state}
+    end
   end
 end


### PR DESCRIPTION
Asana ticket: [🐞 Fix dev server](https://app.asana.com/0/1112935048846093/709916117691679)

Fixes errors we were getting after requests timed out while the gtfs data was still loading.