### PR TITLE
simplify timepoint_status format

### DIFF
--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react"
 import DispatchContext from "../contexts/dispatchContext"
-import { Timepoint, TimepointId, Vehicle, VehicleId } from "../skate"
+import { Timepoint, Vehicle, VehicleId } from "../skate"
 import { selectVehicle } from "../state"
 
 // Timepoints come from the API in the ZeroToOne direction
@@ -186,19 +186,16 @@ const yForVehicle = (
 ): number | null => {
   const timepoint_status = vehicle.timepoint_status
   if (timepoint_status) {
-    const timepoint_id: TimepointId | null = timepoint_status.timepoint_id
-    if (timepoint_id) {
-      const timepointIndex = timepoints.findIndex(
-        timepoint => timepoint.id === timepoint_id
+    const timepointIndex = timepoints.findIndex(
+      timepoint => timepoint.id === timepoint_status.timepoint_id
+    )
+    if (timepointIndex !== -1) {
+      const fractionDirection = direction === VehicleDirection.Up ? +1 : -1
+      return (
+        timepointSpacingY *
+        (timepointIndex +
+          timepoint_status.fraction_until_timepoint * fractionDirection)
       )
-      if (timepointIndex !== -1) {
-        const fractionDirection = direction === VehicleDirection.Up ? +1 : -1
-        return (
-          timepointSpacingY *
-          (timepointIndex +
-            timepoint_status.fraction_until_timepoint * fractionDirection)
-        )
-      }
     }
   }
   return null

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -64,8 +64,6 @@ const Vehicle = ({ vehicle }: { vehicle: Vehicle }) => {
         <em>stop:</em> {vehicle.stop_status.stop_id}
       </li>
       <li>
-        <em>timepoint status:</em>{" "}
-        {vehicle.timepoint_status && vehicle.timepoint_status.status},<br />
         <em>timepoint:</em>{" "}
         {vehicle.timepoint_status && vehicle.timepoint_status.timepoint_id},
         <br />

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -47,8 +47,7 @@ export interface VehicleStopStatus {
 }
 
 export interface VehicleTimepointStatus {
-  status: VehicleStatus
-  timepoint_id: TimepointId | null
+  timepoint_id: TimepointId
   fraction_until_timepoint: number
 }
 

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -263,3 +263,45 @@ exports[`renders a ladder 1`] = `
   </g>
 </svg>
 `;
+
+exports[`renders a ladder with no timepoints 1`] = `
+<svg
+  className="m-ladder"
+  height={500}
+  viewBox="-90 -40 180 500"
+  width={180}
+>
+  <line
+    className="m-ladder__line"
+    x1={-40}
+    x2={-40}
+    y1="0"
+    y2={420}
+  />
+  <line
+    className="m-ladder__line"
+    x1={40}
+    x2={40}
+    y1="0"
+    y2={420}
+  />
+  <g
+    className="m-ladder__vehicle"
+    onClick={[Function]}
+  >
+    <polygon
+      className="m-ladder__vehicle-triangle "
+      points="60,-20 45,0 75,0"
+    />
+    <text
+      className="m-ladder__vehicle-label"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x={60}
+      y={8}
+    >
+      upward
+    </text>
+  </g>
+</svg>
+`;

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -412,13 +412,6 @@ exports[`renders a route ladder with vehicles 1`] = `
     </li>
     <li>
       <em>
-        timepoint status:
-      </em>
-       
-      in_transit_to
-      ,
-      <br />
-      <em>
         timepoint:
       </em>
        
@@ -512,13 +505,6 @@ exports[`renders a route ladder with vehicles 1`] = `
       59
     </li>
     <li>
-      <em>
-        timepoint status:
-      </em>
-       
-      in_transit_to
-      ,
-      <br />
       <em>
         timepoint:
       </em>

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import renderer from "react-test-renderer"
 import Ladder, { LadderDirection } from "../../src/components/ladder"
 import DispatchProvider from "../../src/providers/dispatchProvider"
-import { Vehicle } from "../../src/skate"
+import { Timepoint, Vehicle } from "../../src/skate"
 import { selectVehicle } from "../../src/state"
 
 test("renders a ladder", () => {
@@ -23,7 +23,6 @@ test("renders a ladder", () => {
         stop_id: "stop",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "t1",
         fraction_until_timepoint: 0.5,
       },
@@ -42,7 +41,6 @@ test("renders a ladder", () => {
         stop_id: "stop",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "t2",
         fraction_until_timepoint: 0.75,
       },
@@ -96,7 +94,6 @@ test("highlights a selected vehicle", () => {
         stop_id: "stop",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "t1",
         fraction_until_timepoint: 0.5,
       },
@@ -115,7 +112,6 @@ test("highlights a selected vehicle", () => {
         stop_id: "stop",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "t2",
         fraction_until_timepoint: 0.75,
       },
@@ -155,7 +151,6 @@ test("clicking a vehicle selects that vehicle", () => {
       stop_id: "stop",
     },
     timepoint_status: {
-      status: "in_transit_to",
       timepoint_id: "t1",
       fraction_until_timepoint: 0.5,
     },
@@ -176,4 +171,39 @@ test("clicking a vehicle selects that vehicle", () => {
   wrapper.find(".m-ladder__vehicle").simulate("click")
 
   expect(mockDispatch).toHaveBeenCalledWith(selectVehicle(vehicle.id))
+})
+
+test("renders a ladder with no timepoints", () => {
+  const timepoints: Timepoint[] = []
+  const vehicles: Vehicle[] = [
+    {
+      id: "upward",
+      label: "upward",
+      timestamp: 0,
+      latitude: 0,
+      longitude: 0,
+      direction_id: 1,
+      route_id: "route",
+      trip_id: "trip",
+      stop_status: {
+        status: "in_transit_to",
+        stop_id: "stop",
+      },
+      timepoint_status: null,
+    },
+  ]
+  const ladderDirection = LadderDirection.OneToZero
+
+  const tree = renderer
+    .create(
+      <Ladder
+        timepoints={timepoints}
+        vehicles={vehicles}
+        ladderDirection={ladderDirection}
+        selectedVehicleId={undefined}
+      />
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
 })

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -42,7 +42,6 @@ test("renders a route ladder with vehicles", () => {
         stop_id: "57",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "MATPN",
         fraction_until_timepoint: 0.5,
       },
@@ -61,7 +60,6 @@ test("renders a route ladder with vehicles", () => {
         stop_id: "59",
       },
       timepoint_status: {
-        status: "in_transit_to",
         timepoint_id: "MORTN",
         fraction_until_timepoint: 0.0,
       },

--- a/assets/tests/components/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/vehiclePropertiesPanel.test.tsx
@@ -20,7 +20,6 @@ const vehicle: Vehicle = {
     stop_id: "s1",
   },
   timepoint_status: {
-    status: "in_transit_to",
     timepoint_id: "tp1",
     fraction_until_timepoint: 0.5,
   },

--- a/lib/gtfs/stop_time.ex
+++ b/lib/gtfs/stop_time.ex
@@ -13,7 +13,7 @@ defmodule Gtfs.StopTime do
   alias Gtfs.Trip
 
   @type t :: %__MODULE__{
-          timepoint_id: possible_timepoint_id(),
+          timepoint_id: timepoint_id() | nil,
           stop_id: Stop.id()
         }
 
@@ -28,7 +28,6 @@ defmodule Gtfs.StopTime do
   ]
 
   @type timepoint_id :: String.t()
-  @type possible_timepoint_id :: timepoint_id | nil
 
   @spec trip_stop_times_from_csv([Csv.row()]) :: Data.trip_stop_times()
   def trip_stop_times_from_csv(stop_times_csv) do

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -83,7 +83,6 @@ defmodule SkateWeb.VehiclesChannelTest do
             stop_id: "567"
           },
           timepoint_status: %{
-            status: :in_transit_to,
             timepoint_id: "tp2",
             fraction_until_timepoint: 0.4
           }

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -61,7 +61,6 @@ defmodule Realtime.VehicleTest do
                  stop_id: "6555"
                },
                timepoint_status: %{
-                 status: :in_transit_to,
                  timepoint_id: "tp2",
                  fraction_until_timepoint: 0.0
                }
@@ -69,7 +68,7 @@ defmodule Realtime.VehicleTest do
     end
   end
 
-  describe "fraction_until_timepoint/3" do
+  describe "timepoint_status/3" do
     test "returns 0.0 if the stop is a timepoint, plus the timepoint" do
       stop_times = [
         %StopTime{
@@ -100,12 +99,9 @@ defmodule Realtime.VehicleTest do
 
       stop_id = "s3"
 
-      assert Vehicle.fraction_until_timepoint(stop_times, stop_id) == {
-               0.0,
-               %StopTime{
-                 stop_id: "s3",
-                 timepoint_id: "tp3"
-               }
+      assert Vehicle.timepoint_status(stop_times, stop_id) == %{
+               timepoint_id: "tp3",
+               fraction_until_timepoint: 0.0
              }
     end
 
@@ -139,14 +135,51 @@ defmodule Realtime.VehicleTest do
 
       stop_id = "s3"
 
-      assert Vehicle.fraction_until_timepoint(stop_times, stop_id) ==
-               {
-                 0.6,
-                 %StopTime{
-                   stop_id: "s6",
-                   timepoint_id: "tp2"
-                 }
-               }
+      assert Vehicle.timepoint_status(stop_times, stop_id) == %{
+               timepoint_id: "tp2",
+               fraction_until_timepoint: 0.6
+             }
+    end
+
+    test "returns 0.0 if the stop is the first timepoint" do
+      stop_times = [
+        %StopTime{
+          stop_id: "s1",
+          timepoint_id: "tp1"
+        },
+        %StopTime{
+          stop_id: "s2",
+          timepoint_id: nil
+        },
+        %StopTime{
+          stop_id: "s3",
+          timepoint_id: "tp3"
+        }
+      ]
+
+      stop_id = "s1"
+
+      assert Vehicle.timepoint_status(stop_times, stop_id) == %{
+               timepoint_id: "tp1",
+               fraction_until_timepoint: 0.0
+             }
+    end
+
+    test "returns nil if on a route without timepoints" do
+      stop_times = [
+        %StopTime{
+          stop_id: "s1",
+          timepoint_id: nil
+        },
+        %StopTime{
+          stop_id: "s2",
+          timepoint_id: nil
+        }
+      ]
+
+      stop_id = "s2"
+
+      assert Vehicle.timepoint_status(stop_times, stop_id) == nil
     end
   end
 end


### PR DESCRIPTION
Asana Task: none

#43 didn't end up using the `timepoint_status.status` field (the `fraction_until_timepoint` field was enough), and a couple inspectors have recently said that a "Next Timepoint" feature wouldn't be useful, so I don't think we're likely to end up needing it for anything else, and we can take it out.

#43 also didn't end up using the `fraction_until_timepoint` field if the `timepoint_id` was `null`, so we can make `timepoint_id` always present, which makes a couple of things simpler.