### PR TITLE
Show route, variant, and headsign in vehicle properties

### DIFF
--- a/assets/css/_vehicle_properties_panel.scss
+++ b/assets/css/_vehicle_properties_panel.scss
@@ -15,6 +15,11 @@
   justify-content: flex-end;
 }
 
+.m-vehicle-properties-panel__title {
+  flex: 1 1 auto;
+  text-align: center;
+}
+
 dl.m-vehicle-properties-panel__vehicle-properties {
   margin-bottom: 2rem;
 }

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -60,6 +60,12 @@ const Vehicle = ({ vehicle }: { vehicle: Vehicle }) => {
         <em>trip_id:</em> {vehicle.trip_id}
       </li>
       <li>
+        <em>headsign:</em> {vehicle.headsign}
+      </li>
+      <li>
+        <em>variant:</em> {vehicle.via_variant}
+      </li>
+      <li>
         <em>stop status:</em> {vehicle.stop_status.status},<br />
         <em>stop:</em> {vehicle.stop_status.stop_id}
       </li>

--- a/assets/src/components/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/vehiclePropertiesPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react"
 import DispatchContext from "../contexts/dispatchContext"
 import detectSwipe, { SwipeDirection } from "../helpers/detectSwipe"
-import { Vehicle } from "../skate.d"
+import { RouteId, Vehicle, ViaVariant } from "../skate.d"
 import { deselectVehicle } from "../state"
 import CloseButton from "./closeButton"
 
@@ -28,6 +28,12 @@ const VehiclePropertiesPanel = ({ selectedVehicle }: Props) => {
 &destination=${selectedVehicle.latitude.toString()},${selectedVehicle.longitude.toString()}\
 &travelmode=driving`
 
+  const titleText: string = routeVariantText(
+    selectedVehicle.route_id,
+    selectedVehicle.via_variant,
+    selectedVehicle.headsign
+  )
+
   return (
     <>
       <div
@@ -35,6 +41,7 @@ const VehiclePropertiesPanel = ({ selectedVehicle }: Props) => {
         className="m-vehicle-properties-panel"
       >
         <div className="m-vehicle-properties-panel__header">
+          <div className="m-vehicle-properties-panel__title">{titleText}</div>
           <CloseButton onClick={hideMe} />
         </div>
 
@@ -69,6 +76,16 @@ const VehiclePropertiesPanel = ({ selectedVehicle }: Props) => {
       />
     </>
   )
+}
+
+export const routeVariantText = (
+  routeId: RouteId,
+  viaVariant: ViaVariant | null,
+  headsign: string | null
+): string => {
+  const viaVariantFormatted = viaVariant && viaVariant !== "_" ? viaVariant : ""
+  const headsignFormatted = headsign ? ` ${headsign}` : ""
+  return `${routeId}_${viaVariantFormatted}${headsignFormatted}`
 }
 
 export default VehiclePropertiesPanel

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -35,6 +35,8 @@ export interface Vehicle {
   direction_id: Direction
   route_id: RouteId
   trip_id: TripId
+  headsign: string | null
+  via_variant: ViaVariant | null
   stop_status: VehicleStopStatus
   timepoint_status: VehicleTimepointStatus | null
 }
@@ -54,3 +56,5 @@ export interface VehicleTimepointStatus {
 export type VehiclesByRouteId = ByRouteId<Vehicle[]>
 
 export type VehicleStatus = "in_transit_to" | "stopped_at"
+
+export type ViaVariant = string

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -398,6 +398,20 @@ exports[`renders a route ladder with vehicles 1`] = `
     </li>
     <li>
       <em>
+        headsign:
+      </em>
+       
+      h0
+    </li>
+    <li>
+      <em>
+        variant:
+      </em>
+       
+      4
+    </li>
+    <li>
+      <em>
         stop status:
       </em>
        
@@ -489,6 +503,18 @@ exports[`renders a route ladder with vehicles 1`] = `
       </em>
        
       39914128
+    </li>
+    <li>
+      <em>
+        headsign:
+      </em>
+       
+    </li>
+    <li>
+      <em>
+        variant:
+      </em>
+       
     </li>
     <li>
       <em>

--- a/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -9,6 +9,11 @@ Array [
     <div
       className="m-vehicle-properties-panel__header"
     >
+      <div
+        className="m-vehicle-properties-panel__title"
+      >
+        r1_4 headsign
+      </div>
       <button
         className="m-close-button"
         onClick={[Function]}

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -18,6 +18,8 @@ test("renders a ladder", () => {
       direction_id: 1,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",
@@ -36,6 +38,8 @@ test("renders a ladder", () => {
       direction_id: 0,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",
@@ -54,6 +58,8 @@ test("renders a ladder", () => {
       direction_id: 0,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",
@@ -89,6 +95,8 @@ test("highlights a selected vehicle", () => {
       direction_id: 1,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",
@@ -107,6 +115,8 @@ test("highlights a selected vehicle", () => {
       direction_id: 0,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",
@@ -146,6 +156,8 @@ test("clicking a vehicle selects that vehicle", () => {
     direction_id: 1,
     route_id: "route",
     trip_id: "trip",
+    headsign: null,
+    via_variant: null,
     stop_status: {
       status: "in_transit_to",
       stop_id: "stop",
@@ -185,6 +197,8 @@ test("renders a ladder with no timepoints", () => {
       direction_id: 1,
       route_id: "route",
       trip_id: "trip",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "stop",

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -37,6 +37,8 @@ test("renders a route ladder with vehicles", () => {
       direction_id: 0,
       route_id: "1",
       trip_id: "39914237",
+      headsign: "h0",
+      via_variant: "4",
       stop_status: {
         status: "in_transit_to",
         stop_id: "57",
@@ -55,6 +57,8 @@ test("renders a route ladder with vehicles", () => {
       direction_id: 1,
       route_id: "1",
       trip_id: "39914128",
+      headsign: null,
+      via_variant: null,
       stop_status: {
         status: "in_transit_to",
         stop_id: "59",

--- a/assets/tests/components/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/vehiclePropertiesPanel.test.tsx
@@ -1,7 +1,9 @@
 import { mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
-import VehiclePropertiesPanel from "../../src/components/vehiclePropertiesPanel"
+import VehiclePropertiesPanel, {
+  routeVariantText,
+} from "../../src/components/vehiclePropertiesPanel"
 import DispatchProvider from "../../src/providers/dispatchProvider"
 import { Vehicle } from "../../src/skate"
 import { deselectVehicle } from "../../src/state"
@@ -62,5 +64,21 @@ describe("VehiclePropertiesPanel", () => {
     wrapper.find(".m-vehicle-properties-panel__close").simulate("click")
 
     expect(mockDispatch).toHaveBeenCalledWith(deselectVehicle())
+  })
+})
+
+describe("routeVariantText", () => {
+  test("has variant and headsign", () => {
+    expect(routeVariantText("39", "X", "Forest Hills")).toEqual(
+      "39_X Forest Hills"
+    )
+  })
+
+  test("missing variant and headsign", () => {
+    expect(routeVariantText("39", null, null)).toEqual("39_")
+  })
+
+  test("doesn't show underscore variant character", () => {
+    expect(routeVariantText("39", "_", null)).toEqual("39_")
   })
 })

--- a/assets/tests/components/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/vehiclePropertiesPanel.test.tsx
@@ -15,6 +15,8 @@ const vehicle: Vehicle = {
   direction_id: 0,
   route_id: "r1",
   trip_id: "t1",
+  headsign: "headsign",
+  via_variant: "4",
   stop_status: {
     status: "in_transit_to",
     stop_id: "s1",

--- a/lib/gtfs/data.ex
+++ b/lib/gtfs/data.ex
@@ -10,17 +10,13 @@ defmodule Gtfs.Data do
           routes: [Route.t()],
           route_patterns: [RoutePattern.t()],
           stops: [Stop.t()],
-          trip_stop_times: trip_stop_times(),
-          trips: [Trip.t()]
+          trips: %{Trip.id() => Trip.t()}
         }
-
-  @type trip_stop_times :: %{Trip.id() => [StopTime.t()]}
 
   @enforce_keys [
     :routes,
     :route_patterns,
     :stops,
-    :trip_stop_times,
     :trips
   ]
 
@@ -28,7 +24,6 @@ defmodule Gtfs.Data do
     :routes,
     :route_patterns,
     :stops,
-    :trip_stop_times,
     :trips
   ]
 
@@ -36,17 +31,6 @@ defmodule Gtfs.Data do
 
   @spec all_routes(t()) :: [Route.t()]
   def all_routes(%__MODULE__{routes: routes}), do: routes
-
-  @spec all_trips(t()) :: [Trip.t()]
-  def all_trips(%__MODULE__{trips: trips}), do: trips
-
-  @spec stop_times_on_trip(t(), Trip.id()) :: [StopTime.t()]
-  def stop_times_on_trip(
-        %__MODULE__{trip_stop_times: trip_stop_times},
-        trip_id
-      ) do
-    Map.get(trip_stop_times, trip_id, [])
-  end
 
   @spec timepoint_ids_on_route(t(), Route.id()) :: [StopTime.timepoint_id()]
   def timepoint_ids_on_route(
@@ -66,20 +50,19 @@ defmodule Gtfs.Data do
     ])
   end
 
+  @spec trip(t(), Trip.id()) :: Trip.t() | nil
+  def trip(%__MODULE__{trips: trips}, trip_id), do: trips[trip_id]
+
   @spec parse_files(files()) :: t()
   def parse_files(files) do
     bus_routes = Csv.parse(files["routes.txt"], &Route.bus_route_row?/1, &Route.from_csv_row/1)
     bus_route_ids = MapSet.new(bus_routes, & &1.id)
 
-    bus_trips = bus_trips(files["trips.txt"], bus_route_ids)
-    bus_trip_ids = MapSet.new(bus_trips, & &1.id)
-
     %__MODULE__{
       routes: bus_routes,
       route_patterns: bus_route_patterns(files["route_patterns.txt"], bus_route_ids),
       stops: all_stops(files["stops.txt"]),
-      trip_stop_times: bus_trip_stop_times(files["stop_times.txt"], bus_trip_ids),
-      trips: bus_trips
+      trips: bus_trips(files["trips.txt"], files["stop_times.txt"], bus_route_ids)
     }
   end
 
@@ -97,19 +80,10 @@ defmodule Gtfs.Data do
   defp timepoint_ids_for_route_patterns(route_patterns, data) do
     route_patterns
     |> Enum.map(fn route_pattern -> route_pattern.representative_trip_id end)
-    |> Enum.map(fn trip_id -> stop_times_on_trip(data, trip_id) end)
+    |> Enum.map(fn trip_id -> trip(data, trip_id).stop_times end)
     |> Helpers.merge_lists()
     |> Enum.reject(&(&1.timepoint_id == nil))
     |> Enum.map(& &1.timepoint_id)
-  end
-
-  @spec bus_trips(binary(), MapSet.t(Route.id())) :: [Trip.t()]
-  defp bus_trips(trips_data, bus_route_ids) do
-    Csv.parse(
-      trips_data,
-      &Trip.row_in_route_id_set?(&1, bus_route_ids),
-      &Trip.from_csv_row/1
-    )
   end
 
   @spec bus_route_patterns(binary(), MapSet.t(Route.id())) :: [RoutePattern.t()]
@@ -124,10 +98,25 @@ defmodule Gtfs.Data do
   @spec all_stops(binary()) :: [Stop.t()]
   defp all_stops(stops_data), do: Csv.parse(stops_data, fn _row -> true end, &Stop.from_csv_row/1)
 
-  @spec bus_trip_stop_times(binary(), MapSet.t(Trip.id())) :: trip_stop_times()
-  defp bus_trip_stop_times(stop_times_data, bus_trip_ids) do
-    stop_times_data
-    |> Csv.parse(&StopTime.row_in_trip_id_set?(&1, bus_trip_ids))
-    |> StopTime.trip_stop_times_from_csv()
+  @spec bus_trips(binary(), binary(), MapSet.t(Route.id())) :: %{Trip.id() => Trip.t()}
+  defp bus_trips(trips_data, stop_times_data, bus_route_ids) do
+    bus_trips =
+      Csv.parse(
+        trips_data,
+        &Trip.row_in_route_id_set?(&1, bus_route_ids),
+        &Trip.from_csv_row/1
+      )
+
+    bus_trip_ids = MapSet.new(bus_trips, & &1.id)
+
+    bus_trip_stop_times =
+      stop_times_data
+      |> Csv.parse(&StopTime.row_in_trip_id_set?(&1, bus_trip_ids))
+      |> StopTime.trip_stop_times_from_csv()
+
+    Map.new(
+      bus_trips,
+      fn trip -> {trip.id, %{trip | stop_times: Map.get(bus_trip_stop_times, trip.id, [])}} end
+    )
   end
 end

--- a/lib/gtfs/route_pattern.ex
+++ b/lib/gtfs/route_pattern.ex
@@ -6,6 +6,12 @@ defmodule Gtfs.RoutePattern do
 
   @type id :: String.t()
 
+  @doc """
+  A one-character id for disambiguating variants within a given route_id and direction_id
+  a member of [0-9A-Z_]
+  """
+  @type via_variant :: String.t()
+
   @type t :: %__MODULE__{
           id: id(),
           route_id: Route.id(),
@@ -50,4 +56,20 @@ defmodule Gtfs.RoutePattern do
   @spec by_direction([t()]) :: %{Direction.id() => [t()]}
   def by_direction(route_patterns),
     do: Enum.group_by(route_patterns, fn route_pattern -> route_pattern.direction_id end)
+
+  @doc """
+  via_variants are given by hastus, but not propogated through GTFS.
+  But we can reconstruct them from the route_pattern_id
+  in the route_pattern_id "116-4-1"
+  "116" is the route_id,
+  "4" is the via_variant,
+  and "1" is the direction_id
+  """
+  @spec via_variant(id()) :: via_variant()
+  def via_variant(route_pattern_id) do
+    "-" <> <<via_variant::bytes-size(1)>> <> "-" <> <<_direction_id::bytes-size(1)>> =
+      String.slice(route_pattern_id, -4..-1)
+
+    via_variant
+  end
 end

--- a/lib/gtfs/stop_time.ex
+++ b/lib/gtfs/stop_time.ex
@@ -7,7 +7,6 @@ defmodule Gtfs.StopTime do
   @derive Jason.Encoder
 
   alias Gtfs.Csv
-  alias Gtfs.Data
   alias Gtfs.Helpers
   alias Gtfs.Stop
   alias Gtfs.Trip
@@ -29,7 +28,7 @@ defmodule Gtfs.StopTime do
 
   @type timepoint_id :: String.t()
 
-  @spec trip_stop_times_from_csv([Csv.row()]) :: Data.trip_stop_times()
+  @spec trip_stop_times_from_csv([Csv.row()]) :: %{Trip.id() => [t()]}
   def trip_stop_times_from_csv(stop_times_csv) do
     stop_times_csv
     |> Enum.group_by(fn stop_time_row -> stop_time_row["trip_id"] end)

--- a/lib/gtfs/trip.ex
+++ b/lib/gtfs/trip.ex
@@ -1,31 +1,49 @@
 defmodule Gtfs.Trip do
   alias Gtfs.Csv
   alias Gtfs.Route
+  alias Gtfs.RoutePattern
+  alias Gtfs.StopTime
 
   @type id :: String.t()
 
   @type t :: %__MODULE__{
           id: id(),
-          route_id: Route.id()
+          route_id: Route.id(),
+          headsign: String.t(),
+          # Shuttles do not have route_pattern_ids
+          route_pattern_id: RoutePattern.id() | nil,
+          stop_times: [StopTime.t()]
         }
 
   @enforce_keys [
     :id,
-    :route_id
+    :route_id,
+    :headsign
   ]
 
   @derive Jason.Encoder
 
   defstruct [
     :id,
-    :route_id
+    :route_id,
+    :headsign,
+    :route_pattern_id,
+    stop_times: []
   ]
 
   @spec from_csv_row(Csv.row()) :: t()
   def from_csv_row(row) do
+    route_pattern_id =
+      case row["route_pattern_id"] do
+        "" -> nil
+        route_pattern_id -> route_pattern_id
+      end
+
     %__MODULE__{
       id: row["trip_id"],
-      route_id: row["route_id"]
+      route_id: row["route_id"],
+      headsign: row["trip_headsign"],
+      route_pattern_id: route_pattern_id
     }
   end
 

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -1,26 +1,19 @@
 defmodule SkateWeb.VehiclesChannelTest do
   use SkateWeb.ChannelCase
 
-  alias Gtfs.StopTime
   alias Phoenix.Socket
   alias Realtime.Vehicle
   alias SkateWeb.{UserSocket, VehiclesChannel}
 
   describe "join/3" do
     setup do
-      real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
+      real_trip_fn = Application.get_env(:realtime, :trip_fn)
 
       on_exit(fn ->
-        Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
+        Application.put_env(:realtime, :trip_fn, real_trip_fn)
       end)
 
-      Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
-        [
-          %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-          %StopTime{stop_id: "6554", timepoint_id: nil},
-          %StopTime{stop_id: "6555", timepoint_id: "tp2"}
-        ]
-      end)
+      Application.put_env(:realtime, :trip_fn, fn _trip_id -> nil end)
 
       socket = socket(UserSocket, "", %{})
 
@@ -45,19 +38,13 @@ defmodule SkateWeb.VehiclesChannelTest do
 
   describe "handle_info/2" do
     setup do
-      real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
+      real_trip_fn = Application.get_env(:realtime, :trip_fn)
 
       on_exit(fn ->
-        Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
+        Application.put_env(:realtime, :trip_fn, real_trip_fn)
       end)
 
-      Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
-        [
-          %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-          %StopTime{stop_id: "6554", timepoint_id: nil},
-          %StopTime{stop_id: "6555", timepoint_id: "tp2"}
-        ]
-      end)
+      Application.put_env(:realtime, :trip_fn, fn _trip_id -> nil end)
 
       {:ok, _, socket} =
         UserSocket

--- a/test/gtfs/cache_file_test.exs
+++ b/test/gtfs/cache_file_test.exs
@@ -17,8 +17,7 @@ defmodule Gtfs.CacheFileTest do
         routes: [%Route{id: "1"}],
         route_patterns: [],
         stops: [],
-        trip_stop_times: %{},
-        trips: []
+        trips: %{}
       }
 
       filepath = CacheFile.cache_filename() |> CacheFile.generate_filepath()
@@ -35,8 +34,7 @@ defmodule Gtfs.CacheFileTest do
         routes: [%Route{id: "2"}],
         route_patterns: [],
         stops: [],
-        trip_stop_times: %{},
-        trips: []
+        trips: %{}
       }
 
       filepath = CacheFile.generate_filepath("load_gtfs_1_test_map.terms")

--- a/test/gtfs/data_test.exs
+++ b/test/gtfs/data_test.exs
@@ -12,58 +12,42 @@ defmodule Gtfs.DataTest do
       routes: [%Route{id: "1"}, %Route{id: "2"}],
       route_patterns: [],
       stops: [],
-      trip_stop_times: %{},
-      trips: []
+      trips: %{}
     }
 
     assert Data.all_routes(data) == [%Route{id: "1"}, %Route{id: "2"}]
   end
 
-  test "all_trips/1 returns all the trips" do
+  test "trip/1 returns the trip" do
     data = %Data{
       routes: [],
       route_patterns: [],
       stops: [],
-      trip_stop_times: %{},
-      trips: [%Trip{id: "t1", route_id: "r1"}, %Trip{id: "t2", route_id: "r2"}]
+      trips: %{
+        "t1" => %Trip{
+          id: "t1",
+          route_id: "r1",
+          headsign: "h",
+          route_pattern_id: "r1-_-0",
+          stop_times: [
+            %StopTime{stop_id: "s1", timepoint_id: nil}
+          ]
+        }
+      }
     }
 
-    assert Data.all_trips(data) == [
-             %Trip{id: "t1", route_id: "r1"},
-             %Trip{id: "t2", route_id: "r2"}
-           ]
+    assert %Trip{id: "t1"} = Data.trip(data, "t1")
   end
 
-  test "stop_times_on_trip/2 returns all stop times for this route (either direction), sorted" do
+  test "trip/1 returns nil if the trip doesn't exist" do
     data = %Data{
-      routes: [%Route{id: "r1"}, %Route{id: "r2"}],
+      routes: [],
       route_patterns: [],
       stops: [],
-      trip_stop_times: %{
-        "t1" => [
-          %StopTime{stop_id: "s1", timepoint_id: nil},
-          %StopTime{stop_id: "s2", timepoint_id: nil}
-        ],
-        "t2" => [
-          %StopTime{stop_id: "s3", timepoint_id: nil}
-        ]
-      },
-      trips: [
-        %Trip{
-          id: "t1",
-          route_id: "r1"
-        },
-        %Trip{
-          id: "t2",
-          route_id: "r2"
-        }
-      ]
+      trips: %{}
     }
 
-    assert Data.stop_times_on_trip(data, "t1") == [
-             %StopTime{stop_id: "s1", timepoint_id: nil},
-             %StopTime{stop_id: "s2", timepoint_id: nil}
-           ]
+    assert Data.trip(data, "t1") == nil
   end
 
   test "timepoint_ids_on_route/2 returns all timepoint IDs for this route (either direction), sorted" do
@@ -90,30 +74,38 @@ defmodule Gtfs.DataTest do
         }
       ],
       stops: [],
-      trip_stop_times: %{
-        "t1" => [
-          %StopTime{stop_id: "s1", timepoint_id: "tp1"},
-          %StopTime{stop_id: "s7", timepoint_id: nil}
-        ],
-        "t2" => [
-          %StopTime{stop_id: "s2", timepoint_id: "tp2"},
-          %StopTime{stop_id: "s3", timepoint_id: "tp3"}
-        ],
-        "t3" => [
-          %StopTime{stop_id: "s4", timepoint_id: "tp4"},
-          %StopTime{stop_id: "s5", timepoint_id: "tp1"}
-        ]
-      },
-      trips: [
-        %Trip{
+      trips: %{
+        "t1" => %Trip{
           id: "t1",
-          route_id: "r1"
+          route_id: "r1",
+          headsign: "h1",
+          route_pattern_id: "rp1",
+          stop_times: [
+            %StopTime{stop_id: "s1", timepoint_id: "tp1"},
+            %StopTime{stop_id: "s7", timepoint_id: nil}
+          ]
         },
-        %Trip{
+        "t2" => %Trip{
           id: "t2",
-          route_id: "r2"
+          route_id: "r2",
+          headsign: "h2",
+          route_pattern_id: "rp2",
+          stop_times: [
+            %StopTime{stop_id: "s2", timepoint_id: "tp2"},
+            %StopTime{stop_id: "s3", timepoint_id: "tp3"}
+          ]
+        },
+        "t3" => %Trip{
+          id: "t3",
+          route_id: "r1",
+          headsign: "h3",
+          route_pattern_id: "rp3",
+          stop_times: [
+            %StopTime{stop_id: "s4", timepoint_id: "tp4"},
+            %StopTime{stop_id: "s5", timepoint_id: "tp1"}
+          ]
         }
-      ]
+      }
     }
 
     assert Data.timepoint_ids_on_route(data, "r1") == ["tp4", "tp1"]

--- a/test/gtfs/route_pattern_test.exs
+++ b/test/gtfs/route_pattern_test.exs
@@ -121,4 +121,18 @@ defmodule Gtfs.RoutePatternTest do
              }
     end
   end
+
+  describe "via_variant/1" do
+    test "gets via_variant out of route_pattern_id" do
+      assert RoutePattern.via_variant("116-4-1") == "4"
+    end
+
+    test "works with underscores" do
+      assert RoutePattern.via_variant("116-_-0") == "_"
+    end
+
+    test "works with route_ids that have hyphens" do
+      assert RoutePattern.via_variant("Green-B-3-1") == "3"
+    end
+  end
 end

--- a/test/gtfs/trip_test.exs
+++ b/test/gtfs/trip_test.exs
@@ -1,0 +1,45 @@
+defmodule Gtfs.TripTest do
+  use ExUnit.Case, async: true
+
+  alias Gtfs.Trip
+
+  describe "from_csv_row" do
+    test "builds a Trip struct from a csv row" do
+      csv_row = %{
+        "route_id" => "1",
+        "service_id" => "BUS22019-hbc29011-Weekday-02",
+        "trip_id" => "39914057",
+        "trip_headsign" => "Harvard",
+        "trip_short_name" => "",
+        "direction_id" => "0",
+        "block_id" => "C01-20",
+        "shape_id" => "010070",
+        "wheelchair_accessible" => "1",
+        "trip_route_type" => "",
+        "route_pattern_id" => "1-_-0",
+        "bikes_allowed" => "1"
+      }
+
+      assert %Trip{id: "39914057"} = Trip.from_csv_row(csv_row)
+    end
+
+    test "missing route_pattern_id is read as nil" do
+      csv_row = %{
+        "route_id" => "1",
+        "service_id" => "BUS22019-hbc29011-Weekday-02",
+        "trip_id" => "39914057",
+        "trip_headsign" => "Harvard",
+        "trip_short_name" => "",
+        "direction_id" => "0",
+        "block_id" => "C01-20",
+        "shape_id" => "010070",
+        "wheelchair_accessible" => "1",
+        "trip_route_type" => "",
+        "route_pattern_id" => "",
+        "bikes_allowed" => "1"
+      }
+
+      assert %Trip{route_pattern_id: nil} = Trip.from_csv_row(csv_row)
+    end
+  end
+end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -1,24 +1,17 @@
 defmodule Realtime.ServerTest do
   use ExUnit.Case, async: true
 
-  alias Gtfs.StopTime
   alias Realtime.Server
 
   describe "public interface" do
     setup do
-      real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
+      real_trip_fn = Application.get_env(:realtime, :trip_fn)
 
       on_exit(fn ->
-        Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
+        Application.put_env(:realtime, :trip_fn, real_trip_fn)
       end)
 
-      Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
-        [
-          %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-          %StopTime{stop_id: "6554", timepoint_id: nil},
-          %StopTime{stop_id: "6555", timepoint_id: "tp2"}
-        ]
-      end)
+      Application.put_env(:realtime, :trip_fn, fn _trip_id -> nil end)
 
       bypass = Bypass.open()
       url = "http://localhost:#{bypass.port}/VehiclePositions.json"

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -1,6 +1,7 @@
 defmodule Realtime.VehicleTest do
   use ExUnit.Case, async: true
 
+  alias Gtfs.Trip
   alias Gtfs.StopTime
   alias Realtime.Vehicle
 
@@ -31,18 +32,24 @@ defmodule Realtime.VehicleTest do
 
   describe "decode/1" do
     test "translates JSON data into a Vehicle struct" do
-      real_stop_times_on_trip_fn = Application.get_env(:realtime, :stop_times_on_trip_fn)
+      real_trip_fn = Application.get_env(:realtime, :trip_fn)
 
       on_exit(fn ->
-        Application.put_env(:realtime, :stop_times_on_trip_fn, real_stop_times_on_trip_fn)
+        Application.put_env(:realtime, :trip_fn, real_trip_fn)
       end)
 
-      Application.put_env(:realtime, :stop_times_on_trip_fn, fn _trip_id ->
-        [
-          %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-          %StopTime{stop_id: "6554", timepoint_id: nil},
-          %StopTime{stop_id: "6555", timepoint_id: "tp2"}
-        ]
+      Application.put_env(:realtime, :trip_fn, fn "39984755" ->
+        %Trip{
+          id: "39984755",
+          route_id: "505",
+          headsign: "headsign",
+          route_pattern_id: "505-_-0",
+          stop_times: [
+            %StopTime{stop_id: "6553", timepoint_id: "tp1"},
+            %StopTime{stop_id: "6554", timepoint_id: nil},
+            %StopTime{stop_id: "6555", timepoint_id: "tp2"}
+          ]
+        }
       end)
 
       input = Jason.decode!(@vehicle_json_string)
@@ -56,6 +63,8 @@ defmodule Realtime.VehicleTest do
                direction_id: 0,
                route_id: "505",
                trip_id: "39984755",
+               headsign: "headsign",
+               via_variant: "_",
                stop_status: %{
                  status: :in_transit_to,
                  stop_id: "6555"


### PR DESCRIPTION
Asana Task: [Add the (adjusted) Route Pattern ID and Headsign to the Vehicle Properties Panel](https://app.asana.com/0/1112935048846093/1120980093841755)

<img width="857" alt="Screen Shot 2019-05-16 at 13 51 15" src="https://user-images.githubusercontent.com/23065557/57878300-b89da280-77e7-11e9-9c04-ff67c61daa21.png">

This takes the via variant from the middle of the route pattern id, which is approximately the value ops uses. There are some differences and adjustments that we don't take into account. Getting it to match better seems complicated, so I pulled it out into a separate ticket: [Bring via_variant more in line with the numbers ops uses](https://app.asana.com/0/1112935048846093/1123452464647596)

Stop times have been moved into the `Trip` object and the `trips` field of `Gtfs.Data` so that both it and the headsign/route_pattern_id can be looked up at once.