### PR TITLE
Make semaphore test script fail when any step fails

### DIFF
--- a/semaphore/test.sh
+++ b/semaphore/test.sh
@@ -1,5 +1,7 @@
+#!/usr/bin/env bash
+
 set -e
 
-mix coveralls.json
-pushd assets && npm test && popd
+mix coveralls.json &&
+pushd assets && npm test && popd &&
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Add a bash shebang.

Asana ticket: [🐞 Semaphore builds aren't failing when tests fail](https://app.asana.com/0/1112935048846093/1124224601646246)

A successful failure can be seen here: https://semaphoreci.com/mbta/skate/branches/mss-semaphore-test-failures/builds/2