### PR TITLE
don't disable hackney in tests

### DIFF
--- a/test/concentrate/producer/http_test.exs
+++ b/test/concentrate/producer/http_test.exs
@@ -14,10 +14,6 @@ defmodule Concentrate.Producer.HTTPTest do
   setup_all do
     {:ok, _} = Application.ensure_all_started(:hackney)
 
-    on_exit(fn ->
-      Application.stop(:hackney)
-    end)
-
     {:ok, _} =
       start_supervised(%{
         id: :hackney_pool,


### PR DESCRIPTION
I was getting errors when running `mix test` locally:

```
13:36:51.163 [error] GenServer Gtfs terminating
** (ArgumentError) argument error
    (stdlib) :ets.lookup_element(:hackney_config, :mod_metrics, 2)
    (hackney) /Users/sky/code/skate/deps/hackney/src/hackney_metrics.erl:27: :hackney_metrics.get_engine/0
    (hackney) /Users/sky/code/skate/deps/hackney/src/hackney_connect.erl:78: :hackney_connect.create_connection/5
    (hackney) /Users/sky/code/skate/deps/hackney/src/hackney_connect.erl:47: :hackney_connect.connect/5
    (hackney) /Users/sky/code/skate/deps/hackney/src/hackney.erl:330: :hackney.request/5
    (httpoison) lib/httpoison/base.ex:787: HTTPoison.Base.request/6
    (skate) lib/gtfs.ex:175: Gtfs.fetch_remote_files/1
    (skate) lib/gtfs.ex:164: Gtfs.gtfs_from_url/1
    (skate) lib/gtfs.ex:147: Gtfs.fetch_gtfs/1
    (skate) lib/gtfs.ex:105: Gtfs.handle_continue/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:388: :gen_server.loop/7
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:continue, {:load_gtfs, {:url, "https://cdn.mbta.com/MBTA_GTFS.zip"}, Gtfs.HealthServer}}


  2) test handle_info/2 pushes new vehicle data onto the socket (SkateWeb.VehiclesChannelTest)
     test/channels/vehicles_channel_test.exs:57
     ** (ArgumentError) argument error
     stacktrace:
       (stdlib) :ets.lookup(SkateWeb.Endpoint, :__phoenix_pubsub_server__)
       (phoenix) lib/phoenix/config.ex:42: Phoenix.Config.cache/3
       test/channels/vehicles_channel_test.exs:51: SkateWeb.VehiclesChannelTest.__ex_unit_setup_2/1
       test/channels/vehicles_channel_test.exs:1: SkateWeb.VehiclesChannelTest.__ex_unit__/2
```

This is because services making HTTP requests in the background during the test need hackney, but `http_test.exs` disabled hackney.

We likely need to put more thought into which services should be running in the background during tests (maybe none), but this is just a quick fix to unblock my local development.