### PR TITLE
bugfix: group timepoints with same id but different stop_id

### DIFF
--- a/lib/gtfs/data.ex
+++ b/lib/gtfs/data.ex
@@ -84,11 +84,15 @@ defmodule Gtfs.Data do
   @spec timepoint_ids_for_route_patterns([RoutePattern.t()], t()) :: [StopTime.timepoint_id()]
   defp timepoint_ids_for_route_patterns(route_patterns, data) do
     route_patterns
-    |> Enum.map(fn route_pattern -> route_pattern.representative_trip_id end)
-    |> Enum.map(fn trip_id -> trip(data, trip_id).stop_times end)
+    |> Enum.map(fn route_pattern ->
+      trip_id = route_pattern.representative_trip_id
+      trip = trip(data, trip_id)
+
+      trip.stop_times
+      |> Enum.map(fn stop_time -> stop_time.timepoint_id end)
+      |> Enum.filter(& &1)
+    end)
     |> Helpers.merge_lists()
-    |> Enum.reject(&(&1.timepoint_id == nil))
-    |> Enum.map(& &1.timepoint_id)
   end
 
   @spec bus_route_patterns(binary(), MapSet.t(Route.id())) :: [RoutePattern.t()]

--- a/test/gtfs/data_test.exs
+++ b/test/gtfs/data_test.exs
@@ -14,65 +14,114 @@ defmodule Gtfs.DataTest do
     assert Data.all_routes(data) == [%Route{id: "1"}, %Route{id: "2"}]
   end
 
-  test "timepoint_ids_on_route/2 returns all timepoint IDs for this route (either direction), sorted" do
-    data = %Data{
-      routes: [%Route{id: "r1"}, %Route{id: "r2"}],
-      route_patterns: [
-        %RoutePattern{
-          id: "rp1",
-          route_id: "r1",
-          direction_id: 0,
-          representative_trip_id: "t1"
-        },
-        %RoutePattern{
-          id: "rp2",
-          route_id: "r2",
-          direction_id: 0,
-          representative_trip_id: "t2"
-        },
-        %RoutePattern{
-          id: "rp3",
-          route_id: "r1",
-          direction_id: 1,
-          representative_trip_id: "t3"
-        }
-      ],
-      stops: %{},
-      trips: %{
-        "t1" => %Trip{
-          id: "t1",
-          route_id: "r1",
-          headsign: "h1",
-          route_pattern_id: "rp1",
-          stop_times: [
-            %StopTime{stop_id: "s1", timepoint_id: "tp1"},
-            %StopTime{stop_id: "s7", timepoint_id: nil}
-          ]
-        },
-        "t2" => %Trip{
-          id: "t2",
-          route_id: "r2",
-          headsign: "h2",
-          route_pattern_id: "rp2",
-          stop_times: [
-            %StopTime{stop_id: "s2", timepoint_id: "tp2"},
-            %StopTime{stop_id: "s3", timepoint_id: "tp3"}
-          ]
-        },
-        "t3" => %Trip{
-          id: "t3",
-          route_id: "r1",
-          headsign: "h3",
-          route_pattern_id: "rp3",
-          stop_times: [
-            %StopTime{stop_id: "s4", timepoint_id: "tp4"},
-            %StopTime{stop_id: "s5", timepoint_id: "tp1"}
-          ]
+  describe "timepoint_ids_on_route/2" do
+    test "returns all timepoint IDs for this route (either direction), sorted" do
+      data = %Data{
+        routes: [%Route{id: "r1"}, %Route{id: "r2"}],
+        route_patterns: [
+          %RoutePattern{
+            id: "rp1",
+            route_id: "r1",
+            direction_id: 0,
+            representative_trip_id: "t1"
+          },
+          %RoutePattern{
+            id: "rp2",
+            route_id: "r2",
+            direction_id: 0,
+            representative_trip_id: "t2"
+          },
+          %RoutePattern{
+            id: "rp3",
+            route_id: "r1",
+            direction_id: 1,
+            representative_trip_id: "t3"
+          }
+        ],
+        stops: [],
+        trips: %{
+          "t1" => %Trip{
+            id: "t1",
+            route_id: "r1",
+            headsign: "h1",
+            route_pattern_id: "rp1",
+            stop_times: [
+              %StopTime{stop_id: "s1", timepoint_id: "tp1"},
+              %StopTime{stop_id: "s7", timepoint_id: nil}
+            ]
+          },
+          "t2" => %Trip{
+            id: "t2",
+            route_id: "r2",
+            headsign: "h2",
+            route_pattern_id: "rp2",
+            stop_times: [
+              %StopTime{stop_id: "s2", timepoint_id: "tp2"},
+              %StopTime{stop_id: "s3", timepoint_id: "tp3"}
+            ]
+          },
+          "t3" => %Trip{
+            id: "t3",
+            route_id: "r1",
+            headsign: "h3",
+            route_pattern_id: "rp3",
+            stop_times: [
+              %StopTime{stop_id: "s4", timepoint_id: "tp4"},
+              %StopTime{stop_id: "s5", timepoint_id: "tp1"}
+            ]
+          }
         }
       }
-    }
 
-    assert Data.timepoint_ids_on_route(data, "r1") == ["tp4", "tp1"]
+      assert Data.timepoint_ids_on_route(data, "r1") == ["tp4", "tp1"]
+    end
+
+    test "groups timepoints together even when they're on different stops" do
+      data = %Data{
+        routes: [%Route{id: "r1"}],
+        route_patterns: [
+          %RoutePattern{
+            id: "rp1",
+            route_id: "r1",
+            direction_id: 1,
+            representative_trip_id: "t1"
+          },
+          %RoutePattern{
+            id: "rp2",
+            route_id: "r1",
+            direction_id: 1,
+            representative_trip_id: "t2"
+          }
+        ],
+        stops: [],
+        trips: %{
+          "t1" => %Trip{
+            id: "t1",
+            route_id: "r1",
+            headsign: "h1",
+            route_pattern_id: "rp1",
+            stop_times: [
+              %StopTime{stop_id: "s1", timepoint_id: "t1"},
+              %StopTime{stop_id: "s3b", timepoint_id: "t3"}
+            ]
+          },
+          "t2" => %Trip{
+            id: "t2",
+            route_id: "r1",
+            headsign: "h2",
+            route_pattern_id: "rp2",
+            stop_times: [
+              %StopTime{stop_id: "s1", timepoint_id: "t1"},
+              %StopTime{stop_id: "s2", timepoint_id: "t2"},
+              %StopTime{stop_id: "s3a", timepoint_id: "t3"},
+              %StopTime{stop_id: "s4", timepoint_id: "t4"}
+            ]
+          }
+        }
+      }
+
+      assert Data.timepoint_ids_on_route(data, "r1") == ["t1", "t2", "t3", "t4"]
+    end
   end
 
   describe "stop/2" do


### PR DESCRIPTION
Asana Task: [🐞 Route 70 timepoints differ from TransitMaster](https://app.asana.com/0/1112935048846093/1124514350579975)
<img width="223" alt="Screen Shot 2019-05-29 at 16 21 25" src="https://user-images.githubusercontent.com/23065557/58588507-d2020e00-822d-11e9-9171-634029ec39a5.png">

I indented an existing test. Try viewing the diff with whitespace ignored for a better view.
