### PR TITLE
draw line to scheduled point on ladder. add time to stop_time

### DIFF
--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -34,3 +34,8 @@
   color: $dark;
   font-size: 0.5625rem;
 }
+
+.m-ladder__scheduled-line {
+  stroke: $light-periwinkle;
+  stroke-width: 2;
+}

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -47,6 +47,7 @@ export interface Vehicle {
   operator_name: string
   stop_status: VehicleStopStatus
   timepoint_status: VehicleTimepointStatus | null
+  scheduled_timepoint_status: VehicleTimepointStatus | null
   route_status: VehicleRouteStatus
 }
 

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -7,6 +7,84 @@ exports[`highlights a selected vehicle 1`] = `
   viewBox="-90 -40 180 500"
   width={180}
 >
+  <g>
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(47,302) rotate(0,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle selected"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(0,15,6)"
+          x="5"
+          y="9"
+        >
+          upward
+        </text>
+      </svg>
+    </g>
+  </g>
+  <g>
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(-80,-170.5) rotate(180,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle "
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(180,15,6)"
+          x="5"
+          y="9"
+        >
+          downward
+        </text>
+      </svg>
+    </g>
+  </g>
   <line
     className="m-ladder__line"
     x1={-40}
@@ -84,80 +162,6 @@ exports[`highlights a selected vehicle 1`] = `
   >
     t0
   </text>
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(47,315) rotate(0,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle selected"
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(0,15,6)"
-        x="5"
-        y="9"
-      >
-        upward
-      </text>
-    </svg>
-  </g>
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(-80,-157.5) rotate(180,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle "
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(180,15,6)"
-        x="5"
-        y="9"
-      >
-        downward
-      </text>
-    </svg>
-  </g>
 </svg>
 `;
 
@@ -168,6 +172,130 @@ exports[`renders a ladder 1`] = `
   viewBox="-90 -40 180 500"
   width={180}
 >
+  <g>
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(47,302) rotate(0,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle "
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(0,15,6)"
+          x="5"
+          y="9"
+        >
+          upward
+        </text>
+      </svg>
+    </g>
+  </g>
+  <g>
+    <line
+      className="m-ladder__scheduled-line"
+      x1={-64}
+      x2={-40}
+      y1={-157.5}
+      y2={-157.5}
+    />
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(-80,-170.5) rotate(180,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle "
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(180,15,6)"
+          x="5"
+          y="9"
+        >
+          downward
+        </text>
+      </svg>
+    </g>
+  </g>
+  <g>
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(-80,-23) rotate(180,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle "
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(180,15,6)"
+          x="5"
+          y="9"
+        >
+          notimepoint
+        </text>
+      </svg>
+    </g>
+  </g>
   <line
     className="m-ladder__line"
     x1={-40}
@@ -245,117 +373,6 @@ exports[`renders a ladder 1`] = `
   >
     t0
   </text>
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(47,315) rotate(0,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle "
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(0,15,6)"
-        x="5"
-        y="9"
-      >
-        upward
-      </text>
-    </svg>
-  </g>
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(-80,-157.5) rotate(180,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle "
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(180,15,6)"
-        x="5"
-        y="9"
-      >
-        downward
-      </text>
-    </svg>
-  </g>
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(-80,-10) rotate(180,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle "
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(180,15,6)"
-        x="5"
-        y="9"
-      >
-        notimepoint
-      </text>
-    </svg>
-  </g>
 </svg>
 `;
 
@@ -366,6 +383,45 @@ exports[`renders a ladder with no timepoints 1`] = `
   viewBox="-90 -40 180 500"
   width={180}
 >
+  <g>
+    <g
+      className="m-ladder__vehicle"
+      onClick={[Function]}
+      transform="translate(47,-23) rotate(0,16,13)"
+    >
+      <g
+        className="m-vehicle-icon"
+        transform="scale(0.625)"
+      >
+        <path
+          className="m-vehicle-icon__triangle "
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        />
+      </g>
+      <svg
+        className="m-ladder__vehicle-label"
+        x={0}
+        y={26}
+      >
+        <rect
+          className="m-ladder__vehicle-label-background"
+          height="11"
+          rx="5.5"
+          ry="5.5"
+          width="30"
+        />
+        <text
+          className="m-ladder__vehicle-label-text"
+          textAnchor="inherit"
+          transform="rotate(0,15,6)"
+          x="5"
+          y="9"
+        >
+          upward
+        </text>
+      </svg>
+    </g>
+  </g>
   <line
     className="m-ladder__line"
     x1={-40}
@@ -380,42 +436,5 @@ exports[`renders a ladder with no timepoints 1`] = `
     y1="0"
     y2={420}
   />
-  <g
-    className="m-ladder__vehicle"
-    onClick={[Function]}
-    transform="translate(47,-10) rotate(0,16,13)"
-  >
-    <g
-      className="m-vehicle-icon"
-      transform="scale(0.625)"
-    >
-      <path
-        className="m-vehicle-icon__triangle "
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
-    </g>
-    <svg
-      className="m-ladder__vehicle-label"
-      x={0}
-      y={26}
-    >
-      <rect
-        className="m-ladder__vehicle-label-background"
-        height="11"
-        rx="5.5"
-        ry="5.5"
-        width="30"
-      />
-      <text
-        className="m-ladder__vehicle-label-text"
-        textAnchor="inherit"
-        transform="rotate(0,15,6)"
-        x="5"
-        y="9"
-      >
-        upward
-      </text>
-    </svg>
-  </g>
 </svg>
 `;

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -220,6 +220,91 @@ exports[`renders a route ladder with vehicles 1`] = `
     viewBox="-90 -40 180 500"
     width={180}
   >
+    <g>
+      <g
+        className="m-ladder__vehicle"
+        onClick={[Function]}
+        transform="translate(47,92) rotate(0,16,13)"
+      >
+        <g
+          className="m-vehicle-icon"
+          transform="scale(0.625)"
+        >
+          <path
+            className="m-vehicle-icon__triangle "
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          />
+        </g>
+        <svg
+          className="m-ladder__vehicle-label"
+          x={0}
+          y={26}
+        >
+          <rect
+            className="m-ladder__vehicle-label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="30"
+          />
+          <text
+            className="m-ladder__vehicle-label-text"
+            textAnchor="inherit"
+            transform="rotate(0,15,6)"
+            x="5"
+            y="9"
+          >
+            1818
+          </text>
+        </svg>
+      </g>
+    </g>
+    <g>
+      <line
+        className="m-ladder__scheduled-line"
+        x1={-64}
+        x2={-40}
+        y1={420}
+        y2={420}
+      />
+      <g
+        className="m-ladder__vehicle"
+        onClick={[Function]}
+        transform="translate(-80,407) rotate(180,16,13)"
+      >
+        <g
+          className="m-vehicle-icon"
+          transform="scale(0.625)"
+        >
+          <path
+            className="m-vehicle-icon__triangle "
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          />
+        </g>
+        <svg
+          className="m-ladder__vehicle-label"
+          x={0}
+          y={26}
+        >
+          <rect
+            className="m-ladder__vehicle-label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="30"
+          />
+          <text
+            className="m-ladder__vehicle-label-text"
+            textAnchor="inherit"
+            transform="rotate(180,15,6)"
+            x="5"
+            y="9"
+          >
+            0479
+          </text>
+        </svg>
+      </g>
+    </g>
     <line
       className="m-ladder__line"
       x1={-40}
@@ -297,80 +382,6 @@ exports[`renders a route ladder with vehicles 1`] = `
     >
       MORTN
     </text>
-    <g
-      className="m-ladder__vehicle"
-      onClick={[Function]}
-      transform="translate(47,105) rotate(0,16,13)"
-    >
-      <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle "
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
-      >
-        <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
-        />
-        <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(0,15,6)"
-          x="5"
-          y="9"
-        >
-          1818
-        </text>
-      </svg>
-    </g>
-    <g
-      className="m-ladder__vehicle"
-      onClick={[Function]}
-      transform="translate(-80,420) rotate(180,16,13)"
-    >
-      <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle "
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
-      >
-        <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
-        />
-        <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(180,15,6)"
-          x="5"
-          y="9"
-        >
-          0479
-        </text>
-      </svg>
-    </g>
   </svg>
   <div
     className="m-incoming-box"

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -123,8 +123,12 @@ const vehicle: Vehicle = {
     stop_name: "stop",
   },
   timepoint_status: {
-    timepoint_id: "MATPN",
+    timepoint_id: "WELLH",
     fraction_until_timepoint: 0.5,
+  },
+  scheduled_timepoint_status: {
+    timepoint_id: "MORTN",
+    fraction_until_timepoint: 0.8,
   },
   route_status: "incoming",
 }

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -32,6 +32,7 @@ test("renders a ladder", () => {
         timepoint_id: "t1",
         fraction_until_timepoint: 0.5,
       },
+      scheduled_timepoint_status: null,
       route_status: "on_route",
     },
     {
@@ -57,6 +58,10 @@ test("renders a ladder", () => {
         timepoint_id: "t2",
         fraction_until_timepoint: 0.75,
       },
+      scheduled_timepoint_status: {
+        timepoint_id: "t2",
+        fraction_until_timepoint: 0.75,
+      },
       route_status: "on_route",
     },
     {
@@ -79,6 +84,7 @@ test("renders a ladder", () => {
         stop_name: "stop",
       },
       timepoint_status: null,
+      scheduled_timepoint_status: null,
       route_status: "on_route",
     },
   ]
@@ -124,6 +130,7 @@ test("highlights a selected vehicle", () => {
         timepoint_id: "t1",
         fraction_until_timepoint: 0.5,
       },
+      scheduled_timepoint_status: null,
       route_status: "on_route",
     },
     {
@@ -149,6 +156,7 @@ test("highlights a selected vehicle", () => {
         timepoint_id: "t2",
         fraction_until_timepoint: 0.75,
       },
+      scheduled_timepoint_status: null,
       route_status: "incoming",
     },
   ]
@@ -195,6 +203,7 @@ test("clicking a vehicle selects that vehicle", () => {
       timepoint_id: "t1",
       fraction_until_timepoint: 0.5,
     },
+    scheduled_timepoint_status: null,
     route_status: "on_route",
   }
 
@@ -238,6 +247,7 @@ test("renders a ladder with no timepoints", () => {
         stop_name: "stop",
       },
       timepoint_status: null,
+      scheduled_timepoint_status: null,
       route_status: "on_route",
     },
   ]

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -57,6 +57,7 @@ test("renders a route ladder with vehicles", () => {
         timepoint_id: "MATPN",
         fraction_until_timepoint: 0.5,
       },
+      scheduled_timepoint_status: null,
       route_status: "on_route",
     },
     {
@@ -79,6 +80,10 @@ test("renders a route ladder with vehicles", () => {
         stop_name: "59",
       },
       timepoint_status: {
+        timepoint_id: "MORTN",
+        fraction_until_timepoint: 0.0,
+      },
+      scheduled_timepoint_status: {
         timepoint_id: "MORTN",
         fraction_until_timepoint: 0.0,
       },
@@ -130,6 +135,7 @@ test("renders a route ladder with vehicles in the incoming box", () => {
         timepoint_id: "MATPN",
         fraction_until_timepoint: 0.5,
       },
+      scheduled_timepoint_status: null,
       route_status: "incoming",
     },
     {
@@ -155,6 +161,7 @@ test("renders a route ladder with vehicles in the incoming box", () => {
         timepoint_id: "MORTN",
         fraction_until_timepoint: 0.0,
       },
+      scheduled_timepoint_status: null,
       route_status: "incoming",
     },
   ]
@@ -272,6 +279,7 @@ test("clicking an incoming vehicle selects that vehicle", () => {
       timepoint_id: "MATPN",
       fraction_until_timepoint: 0.5,
     },
+    scheduled_timepoint_status: null,
     route_status: "incoming",
   }
 

--- a/assets/tests/components/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/vehiclePropertiesPanel.test.tsx
@@ -31,6 +31,7 @@ const vehicle: Vehicle = {
     timepoint_id: "tp1",
     fraction_until_timepoint: 0.5,
   },
+  scheduled_timepoint_status: null,
   route_status: "on_route",
 }
 

--- a/lib/gtfs/csv.ex
+++ b/lib/gtfs/csv.ex
@@ -33,8 +33,8 @@ defmodule Gtfs.Csv do
     file_binary
     |> String.split("\n")
     |> Enum.reject(&(&1 == ""))
-    |> CSV.decode(headers: true)
-    |> Stream.flat_map(fn {:ok, csv_row} ->
+    |> CSV.decode!(headers: true)
+    |> Stream.flat_map(fn csv_row ->
       if Enum.all?(row_filters, fn row_filter -> row_filter.(csv_row) end) do
         [row_decoder.(csv_row)]
       else

--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -1,0 +1,28 @@
+defmodule Realtime.Helpers do
+  @doc """
+  Returns the first element that matches the condition, and also the element that appears before it in the list.
+
+  Returns nil if no element matches or if there is no previous element (because the first element matched)
+
+      iex> Realtime.Helpers.find_and_previous([1,2,3,4], fn x -> x > 2 end)
+      {2,3}
+
+      iex> Realtime.Helpers.find_and_previous([], fn x -> x > 2 end)
+      nil
+
+      iex> Realtime.Helpers.find_and_previous([3,4], fn x -> x > 2 end)
+      nil
+
+      iex> Realtime.Helpers.find_and_previous([1,2], fn x -> x > 2 end)
+      nil
+  """
+  @spec find_and_previous([element], (element -> boolean())) :: {element, element} | nil
+        when element: any()
+  def find_and_previous(elements, condition) do
+    case Enum.find_index(elements, condition) do
+      nil -> nil
+      0 -> nil
+      i -> {Enum.at(elements, i - 1), Enum.at(elements, i)}
+    end
+  end
+end

--- a/lib/util/time.ex
+++ b/lib/util/time.ex
@@ -1,0 +1,131 @@
+defmodule Util.Time do
+  @typedoc """
+  Seconds after midnight.
+  This is used as a date-agnostic way to talk about time of day.
+  It's really seconds after 12 hours before noon, in order to avoid complications with DST.
+  Times are measured relative to the date of service,
+  so times > 24*60*60 are after midnight relative to the previous date.
+  """
+  @type time_of_day :: integer()
+
+  @typedoc """
+  Unix timestamp, seconds past the epoch
+  """
+  @type timestamp :: integer()
+
+  @spec now :: timestamp()
+  def now do
+    System.system_time(:second)
+  end
+
+  @doc """
+  Times greater than 24:00:00 are allowed.
+
+      iex> Util.Time.parse_hhmmss("05:00:00")
+      18000
+
+      iex> Util.Time.parse_hhmmss("22:00:00")
+      79200
+
+      # Times past 24:00 are measured from the previous day
+      iex> Util.Time.parse_hhmmss("25:00:00")
+      90000
+  """
+  @spec parse_hhmmss(String.t()) :: time_of_day()
+  def parse_hhmmss(time_string) do
+    [hh_string, mm_string, ss_string] = String.split(time_string, ":")
+    h = String.to_integer(hh_string)
+    m = String.to_integer(mm_string)
+    s = String.to_integer(ss_string)
+    h * 60 * 60 + m * 60 + s
+  end
+
+  @doc """
+  Converts a timestamp to a time_of_day in Eastern Time
+
+  Since time_of_day is not restricted to a 24 hour range,
+  it may be ambiguous which time_of_day is best.
+  Do you want 03:00 or 27:00?
+  Takes a "target" time_of_day and returns a time_of_day closest to it,
+  so the result time_of_day is the correct one in context.
+
+    # When the target is slightly earlier than the timestamp
+    iex> Util.Time.nearest_time_of_day_for_timestamp(
+    ...>   1546362000, # 2019-01-01 12:00:00 EST
+    ...>   Util.Time.parse_hhmmss("11:00:00")
+    ...> )
+    43200 # 12:00:00
+
+    # When the target is slightly later than the timestamp
+    iex> Util.Time.nearest_time_of_day_for_timestamp(
+    ...>   1546362000, # 2019-01-01 12:00:00 EST
+    ...>   Util.Time.parse_hhmmss("13:00:00")
+    ...> )
+    43200 # 12:00:00
+
+    # When the closest target is on the previous date.
+    iex> Util.Time.nearest_time_of_day_for_timestamp(
+    ...>   1546408800, # 2019-01-02 01:00:00 EST
+    ...>   Util.Time.parse_hhmmss("18:00:00")
+    ...> )
+    90000 # 25:00:00
+
+    # When the closest target is on the next date.
+    iex> Util.Time.nearest_time_of_day_for_timestamp(
+    ...>   1546383600, # 2019-01-01 18:00:00 EST
+    ...>   Util.Time.parse_hhmmss("01:00:00")
+    ...> )
+    -21600 # -06:00:00 (6 hours before the date starts)
+
+    # When the closest target is on the next date but same date of service.
+    iex> Util.Time.nearest_time_of_day_for_timestamp(
+    ...>   1546383600, # 2019-01-01 18:00:00 EST
+    ...>   Util.Time.parse_hhmmss("25:00:00")
+    ...> )
+    64800 # 18:00:00
+  """
+  @spec nearest_time_of_day_for_timestamp(timestamp(), time_of_day()) :: time_of_day()
+  def nearest_time_of_day_for_timestamp(timestamp, target) do
+    date_of_timestamp =
+      timestamp
+      |> DateTime.from_unix!(:second)
+      |> Timex.Timezone.convert("America/New_York")
+      |> DateTime.to_date()
+
+    on_same_date = time_of_day_for_timestamp(timestamp, date_of_timestamp)
+    days_to_move_forward = round((on_same_date - target) / (24 * 60 * 60))
+    date_to_use = Timex.shift(date_of_timestamp, days: days_to_move_forward)
+
+    time_of_day_for_timestamp(timestamp, date_to_use)
+  end
+
+  @doc """
+    iex> Util.Time.time_of_day_for_timestamp(
+    ...>   1546408800, # 2019-01-02 01:00:00 EST
+    ...>   ~D[2019-01-02]
+    ...> )
+    3600 # 01:00:00
+
+    iex> Util.Time.time_of_day_for_timestamp(
+    ...>   1546408800, # 2019-01-02 01:00:00 EST
+    ...>   ~D[2019-01-01]
+    ...> )
+    90000 # 25:00:00
+  """
+  @spec time_of_day_for_timestamp(timestamp(), Date.t()) :: time_of_day()
+  def time_of_day_for_timestamp(timestamp, date) do
+    noon = noon_on_date(date)
+    seconds_after_noon = timestamp - noon
+    seconds_after_noon + 12 * 60 * 60
+  end
+
+  @spec noon_on_date(Date.t()) :: timestamp()
+  defp noon_on_date(date) do
+    # Convert to datetime on the next date and shift back to ignore daylight saving time jumps.
+    date
+    |> Timex.shift(days: 1)
+    |> Timex.to_datetime("America/New_York")
+    |> Timex.shift(hours: -12)
+    |> Timex.to_unix()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Skate.MixProject do
       {:httpoison, "~> 1.5.0"},
       {:bypass, "~> 1.0.0", only: :test},
       {:csv, "~> 2.3.0"},
+      {:timex, "~> 3.5.0"},
       {:stream_data, "~> 0.4.3", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "artificery": {:hex, :artificery, "0.4.1", "90b1fcedb9034853b36dbea2174f9fc1172bd50b0686a723178103def5c9c1c8", [:mix], [], "hexpm"},
   "bypass": {:hex, :bypass, "1.0.0", "b78b3dcb832a71aca5259c1a704b2e14b55fd4e1327ff942598b4e7d1a7ad83d", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
   "csv": {:hex, :csv, "2.3.0", "e30e4bbe633653a5c2da43cab42a61623e0acc80ef40c321bc29f0d698697bd3", [:mix], [{:parallel_stream, "~> 1.0.4", [hex: :parallel_stream, repo: "hexpm", optional: false]}], "hexpm"},
@@ -30,5 +31,7 @@
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
+  "timex": {:hex, :timex, "3.5.0", "b0a23167da02d0fe4f1a4e104d1f929a00d348502b52432c05de875d0b9cffa5", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.20", "304b9e98a02840fb32a43ec111ffbe517863c8566eb04a061f1c4dbb90b4d84c", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/gtfs/data_test.exs
+++ b/test/gtfs/data_test.exs
@@ -79,8 +79,8 @@ defmodule Gtfs.DataTest do
             headsign: "h1",
             route_pattern_id: "rp1",
             stop_times: [
-              %StopTime{stop_id: "s1", timepoint_id: "tp1"},
-              %StopTime{stop_id: "s7", timepoint_id: nil}
+              %StopTime{stop_id: "s1", time: 1, timepoint_id: "tp1"},
+              %StopTime{stop_id: "s7", time: 2, timepoint_id: nil}
             ]
           },
           "t2" => %Trip{
@@ -89,8 +89,8 @@ defmodule Gtfs.DataTest do
             headsign: "h2",
             route_pattern_id: "rp2",
             stop_times: [
-              %StopTime{stop_id: "s2", timepoint_id: "tp2"},
-              %StopTime{stop_id: "s3", timepoint_id: "tp3"}
+              %StopTime{stop_id: "s2", time: 1, timepoint_id: "tp2"},
+              %StopTime{stop_id: "s3", time: 2, timepoint_id: "tp3"}
             ]
           },
           "t3" => %Trip{
@@ -99,8 +99,8 @@ defmodule Gtfs.DataTest do
             headsign: "h3",
             route_pattern_id: "rp3",
             stop_times: [
-              %StopTime{stop_id: "s4", timepoint_id: "tp4"},
-              %StopTime{stop_id: "s5", timepoint_id: "tp1"}
+              %StopTime{stop_id: "s4", time: 1, timepoint_id: "tp4"},
+              %StopTime{stop_id: "s5", time: 2, timepoint_id: "tp1"}
             ]
           }
         }
@@ -134,8 +134,8 @@ defmodule Gtfs.DataTest do
             headsign: "h1",
             route_pattern_id: "rp1",
             stop_times: [
-              %StopTime{stop_id: "s1", timepoint_id: "t1"},
-              %StopTime{stop_id: "s3b", timepoint_id: "t3"}
+              %StopTime{stop_id: "s1", time: 1, timepoint_id: "t1"},
+              %StopTime{stop_id: "s3b", time: 2, timepoint_id: "t3"}
             ]
           },
           "t2" => %Trip{
@@ -144,10 +144,10 @@ defmodule Gtfs.DataTest do
             headsign: "h2",
             route_pattern_id: "rp2",
             stop_times: [
-              %StopTime{stop_id: "s1", timepoint_id: "t1"},
-              %StopTime{stop_id: "s2", timepoint_id: "t2"},
-              %StopTime{stop_id: "s3a", timepoint_id: "t3"},
-              %StopTime{stop_id: "s4", timepoint_id: "t4"}
+              %StopTime{stop_id: "s1", time: 1, timepoint_id: "t1"},
+              %StopTime{stop_id: "s2", time: 2, timepoint_id: "t2"},
+              %StopTime{stop_id: "s3a", time: 3, timepoint_id: "t3"},
+              %StopTime{stop_id: "s4", time: 4, timepoint_id: "t4"}
             ]
           }
         }
@@ -220,7 +220,7 @@ defmodule Gtfs.DataTest do
             headsign: "h",
             route_pattern_id: "r1-_-0",
             stop_times: [
-              %StopTime{stop_id: "s1", timepoint_id: nil}
+              %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
             ]
           }
         }

--- a/test/gtfs/stop_time_test.exs
+++ b/test/gtfs/stop_time_test.exs
@@ -82,17 +82,66 @@ defmodule Gtfs.StopTimeTest do
     test "builds a trip stops map from a list of stop time csv rows" do
       assert StopTime.trip_stop_times_from_csv(@csv_rows) == %{
                "39770780" => [
-                 %StopTime{stop_id: "64", timepoint_id: "dudly"},
-                 %StopTime{stop_id: "3", timepoint_id: "melwa"},
-                 %StopTime{stop_id: "4", timepoint_id: "tenner"}
+                 %StopTime{stop_id: "64", time: 19140, timepoint_id: "dudly"},
+                 %StopTime{stop_id: "3", time: 19200, timepoint_id: "melwa"},
+                 %StopTime{stop_id: "4", time: 19200, timepoint_id: "tenner"}
                ],
                "39770783" => [
-                 %StopTime{stop_id: "23391", timepoint_id: "bbsta"},
+                 %StopTime{stop_id: "23391", time: 36900, timepoint_id: "bbsta"},
                  # Does not allow empty strings for timepoint_id
-                 %StopTime{stop_id: "173", timepoint_id: nil},
-                 %StopTime{stop_id: "11388", timepoint_id: "hunbv"}
+                 %StopTime{stop_id: "173", time: 37020, timepoint_id: nil},
+                 %StopTime{stop_id: "11388", time: 37200, timepoint_id: "hunbv"}
                ]
              }
+    end
+
+    test "if arrival_time or departure_time is missing, uses the other" do
+      csv_rows = [
+        %{
+          "trip_id" => "trip",
+          "arrival_time" => "05:00:01",
+          "departure_time" => "",
+          "stop_id" => "64",
+          "stop_sequence" => "1",
+          "stop_headsign" => "",
+          "pickup_type" => "0",
+          "drop_off_type" => "1",
+          "timepoint" => "1",
+          "checkpoint_id" => "dudly"
+        },
+        %{
+          "trip_id" => "trip",
+          "arrival_time" => "",
+          "departure_time" => "05:00:02",
+          "stop_id" => "3",
+          "stop_sequence" => "2",
+          "stop_headsign" => "",
+          "pickup_type" => "0",
+          "drop_off_type" => "0",
+          "timepoint" => "0",
+          "checkpoint_id" => "melwa"
+        },
+        %{
+          "trip_id" => "trip",
+          "arrival_time" => "05:00:03",
+          "departure_time" => "05:00:03",
+          "stop_id" => "4",
+          "stop_sequence" => "10",
+          "stop_headsign" => "",
+          "pickup_type" => "0",
+          "drop_off_type" => "0",
+          "timepoint" => "0",
+          "checkpoint_id" => "tenner"
+        }
+      ]
+
+      assert %{
+               "trip" => [
+                 %StopTime{time: 18001},
+                 %StopTime{time: 18002},
+                 %StopTime{time: 18003}
+               ]
+             } = StopTime.trip_stop_times_from_csv(csv_rows)
     end
   end
 
@@ -108,7 +157,7 @@ defmodule Gtfs.StopTimeTest do
   end
 
   describe "stop_sequence_integer/1" do
-    test "returns the stop_sequency value as an integer" do
+    test "returns the stop_sequence value as an integer" do
       assert StopTime.stop_sequence_integer(List.first(@csv_rows)) == 1
     end
   end

--- a/test/gtfs_test.exs
+++ b/test/gtfs_test.exs
@@ -88,10 +88,10 @@ defmodule GtfsTest do
             "39,39-trip,39-_-0"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_sequence,checkpoint_id",
-            "39-trip,1,check",
-            "39-trip,2,",
-            "blue-trip,1,other"
+            "trip_id,arrival_time,departure_time,stop_sequence,checkpoint_id",
+            "39-trip,,00:00:00,1,check",
+            "39-trip,,00:00:00,2,",
+            "blue-trip,,00:00:00,1,other"
           ]
         })
 
@@ -116,10 +116,10 @@ defmodule GtfsTest do
             "39,39-trip,39-_-0"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_sequence,checkpoint_id",
-            "39-trip,1,check",
-            "39-trip,2,",
-            "blue-trip,1,check"
+            "trip_id,arrival_time,departure_time,stop_sequence,checkpoint_id",
+            "39-trip,,00:00:00,1,check",
+            "39-trip,,00:00:00,2,",
+            "blue-trip,,00:00:00,1,check"
           ]
         })
 
@@ -147,14 +147,14 @@ defmodule GtfsTest do
             "route,t3,route-_-0"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_sequence,checkpoint_id",
-            "t1,11,c1",
-            "t1,12,c2",
-            "t3,31,c4",
-            "t3,32,c5",
-            "t2,21,c2",
-            "t2,22,c3",
-            "t2,23,c4"
+            "trip_id,arrival_time,departure_time,stop_sequence,checkpoint_id",
+            "t1,,00:00:00,11,c1",
+            "t1,,00:00:00,12,c2",
+            "t3,,00:00:00,31,c4",
+            "t3,,00:00:00,32,c5",
+            "t2,,00:00:00,21,c2",
+            "t2,,00:00:00,22,c3",
+            "t2,,00:00:00,23,c4"
           ]
         })
 
@@ -179,11 +179,11 @@ defmodule GtfsTest do
             "route,t1,route-_-0"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_sequence,checkpoint_id",
-            "t0,1,downtown",
-            "t0,2,suburb",
-            "t1,1,exurb",
-            "t1,2,suburb"
+            "trip_id,arrival_time,departure_time,stop_sequence,checkpoint_id",
+            "t0,,00:00:00,1,downtown",
+            "t0,,00:00:00,2,suburb",
+            "t1,,00:00:00,1,exurb",
+            "t1,,00:00:00,2,suburb"
           ]
         })
 
@@ -198,8 +198,8 @@ defmodule GtfsTest do
             "pattern,route,0,trip"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_sequence,checkpoint_id",
-            "trip,0,"
+            "trip_id,arrival_time,departure_time,stop_sequence,checkpoint_id",
+            "trip,,00:00:01,0,"
           ]
         })
 
@@ -243,10 +243,10 @@ defmodule GtfsTest do
             "route,t1,h1,route-_-0"
           ],
           "stop_times.txt" => [
-            "trip_id,stop_id,stop_sequence,checkpoint_id",
-            "t1,s4,1,exurb",
-            "t1,s5,2,",
-            "t1,s3,3,suburb"
+            "trip_id,arrival_time,departure_time,stop_id,stop_sequence,checkpoint_id",
+            "t1,,00:00:01,s4,1,exurb",
+            "t1,,00:00:02,s5,2,",
+            "t1,,00:00:03,s3,3,suburb"
           ]
         })
 
@@ -257,9 +257,9 @@ defmodule GtfsTest do
                headsign: "h1",
                route_pattern_id: "route-_-0",
                stop_times: [
-                 %StopTime{stop_id: "s4", timepoint_id: "exurb"},
-                 %StopTime{stop_id: "s5", timepoint_id: nil},
-                 %StopTime{stop_id: "s3", timepoint_id: "suburb"}
+                 %StopTime{stop_id: "s4", time: 1, timepoint_id: "exurb"},
+                 %StopTime{stop_id: "s5", time: 2, timepoint_id: nil},
+                 %StopTime{stop_id: "s3", time: 3, timepoint_id: "suburb"}
                ]
              }
     end

--- a/test/realtime/helpers_test.exs
+++ b/test/realtime/helpers_test.exs
@@ -1,0 +1,5 @@
+defmodule Realtime.HelpersTest do
+  use ExUnit.Case, async: true
+
+  doctest Realtime.Helpers
+end

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -21,9 +21,9 @@ defmodule Realtime.VehicleTest do
             headsign: "headsign",
             route_pattern_id: "505-_-0",
             stop_times: [
-              %StopTime{stop_id: "6553", timepoint_id: "tp1"},
-              %StopTime{stop_id: "6554", timepoint_id: nil},
-              %StopTime{stop_id: "6555", timepoint_id: "tp2"}
+              %StopTime{stop_id: "6553", time: 0, timepoint_id: "tp1"},
+              %StopTime{stop_id: "6554", time: 0, timepoint_id: nil},
+              %StopTime{stop_id: "6555", time: 0, timepoint_id: "tp2"}
             ]
           }
         else
@@ -140,31 +140,37 @@ defmodule Realtime.VehicleTest do
     end
   end
 
-  describe "timepoint_status/3" do
+  describe "timepoint_status/2" do
     test "returns 0.0 if the stop is a timepoint, plus the timepoint" do
       stop_times = [
         %StopTime{
           stop_id: "s1",
+          time: 0,
           timepoint_id: "tp1"
         },
         %StopTime{
           stop_id: "s2",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s3",
+          time: 0,
           timepoint_id: "tp3"
         },
         %StopTime{
           stop_id: "s4",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s5",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s6",
+          time: 0,
           timepoint_id: "tp2"
         }
       ]
@@ -181,26 +187,32 @@ defmodule Realtime.VehicleTest do
       stop_times = [
         %StopTime{
           stop_id: "s1",
+          time: 0,
           timepoint_id: "tp1"
         },
         %StopTime{
           stop_id: "s2",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s3",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s4",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s5",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s6",
+          time: 0,
           timepoint_id: "tp2"
         }
       ]
@@ -217,14 +229,17 @@ defmodule Realtime.VehicleTest do
       stop_times = [
         %StopTime{
           stop_id: "s1",
+          time: 0,
           timepoint_id: "tp1"
         },
         %StopTime{
           stop_id: "s2",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s3",
+          time: 0,
           timepoint_id: "tp3"
         }
       ]
@@ -241,10 +256,12 @@ defmodule Realtime.VehicleTest do
       stop_times = [
         %StopTime{
           stop_id: "s1",
+          time: 0,
           timepoint_id: nil
         },
         %StopTime{
           stop_id: "s2",
+          time: 0,
           timepoint_id: nil
         }
       ]
@@ -252,6 +269,80 @@ defmodule Realtime.VehicleTest do
       stop_id = "s2"
 
       assert Vehicle.timepoint_status(stop_times, stop_id) == nil
+    end
+  end
+
+  describe "scheduled_timepoint_status/2" do
+    test "returns the next timepoint it's scheduled to be at" do
+      stop_times = [
+        %StopTime{
+          stop_id: "1",
+          time: Util.Time.parse_hhmmss("12:05:00"),
+          timepoint_id: "1"
+        },
+        %StopTime{
+          stop_id: "2",
+          time: Util.Time.parse_hhmmss("12:10:00"),
+          timepoint_id: "2"
+        },
+        %StopTime{
+          stop_id: "3",
+          time: Util.Time.parse_hhmmss("12:20:00"),
+          timepoint_id: "3"
+        }
+      ]
+
+      # 2019-01-01 12:17:30 EST
+      now = 1_546_363_050
+
+      assert Vehicle.scheduled_timepoint_status(stop_times, now) == %{
+               timepoint_id: "3",
+               fraction_until_timepoint: 0.25
+             }
+    end
+
+    test "returns nil if the trip is in the future" do
+      stop_times = [
+        %StopTime{
+          stop_id: "1",
+          time: Util.Time.parse_hhmmss("13:05:00"),
+          timepoint_id: "1"
+        },
+        %StopTime{
+          stop_id: "2",
+          time: Util.Time.parse_hhmmss("13:10:00"),
+          timepoint_id: "2"
+        }
+      ]
+
+      # 2019-01-01 12:17:30 EST
+      now = 1_546_363_050
+      assert Vehicle.scheduled_timepoint_status(stop_times, now) == nil
+    end
+
+    test "returns nil if the trip is in the past" do
+      stop_times = [
+        %StopTime{
+          stop_id: "1",
+          time: Util.Time.parse_hhmmss("11:05:00"),
+          timepoint_id: "1"
+        },
+        %StopTime{
+          stop_id: "2",
+          time: Util.Time.parse_hhmmss("11:10:00"),
+          timepoint_id: "2"
+        }
+      ]
+
+      # 2019-01-01 12:17:30 EST
+      now = 1_546_363_050
+      assert Vehicle.scheduled_timepoint_status(stop_times, now) == nil
+    end
+
+    test "returns nil if we can't find the trip's stop_times" do
+      # 2019-01-01 12:17:30 EST
+      now = 1_546_363_050
+      assert Vehicle.scheduled_timepoint_status([], now) == nil
     end
   end
 
@@ -264,10 +355,12 @@ defmodule Realtime.VehicleTest do
         stop_times: [
           %StopTime{
             stop_id: "s1",
+            time: 0,
             timepoint_id: "s1"
           },
           %StopTime{
             stop_id: "s2",
+            time: 0,
             timepoint_id: nil
           }
         ]

--- a/test/util/time_test.exs
+++ b/test/util/time_test.exs
@@ -1,0 +1,4 @@
+defmodule Util.TimeTest do
+  use ExUnit.Case, async: true
+  doctest Util.Time
+end


### PR DESCRIPTION
<img width="212" alt="Screen Shot 2019-06-03 at 16 49 39" src="https://user-images.githubusercontent.com/23065557/58834420-59ca8c80-8621-11e9-8824-7b27a9c63c6a.png">


Asana Task: [Draw a line to where the bus should be at the moment](https://app.asana.com/0/1112935048846093/1122642346801329)

Times are stored in GTFS as e.g. "17:02:00". In the `stop_time` they're stored as a `Util.Time.time_of_day()`, which is seconds after midnight.

Calculates the scheduled location by:
* Getting the stop_times on the current trip. (This limits the scheduled location to being in the same direction as the bus. [Followup task to improve this](https://app.asana.com/0/1112935048846093/1125606672346265)
* Convert the current system time to a `time_of_day`, using the time of the first stop_time as a reference to make sure we correctly handle the transition from late-night to early-morning.
* Find the timepoint just before the scheduled time and the timepoint just after, and interpolate between their times.

If it's before the trip's scheduled start, or after its scheduled end, we can't interpolate, so no line is drawn. We could probably just draw the line to the first or last timepoint the trip, but I figured I'd just wait for [that followup task](https://app.asana.com/0/1112935048846093/1125606672346265) to improve the ends.