### PR TITLE
Triangles: variant, bugfix, vehicle properties panel

### DIFF
--- a/assets/css/_incoming_box.scss
+++ b/assets/css/_incoming_box.scss
@@ -23,11 +23,6 @@
   }
 }
 
-.m-incoming-box__vehicle-icon {
-  margin-right: 0.5rem;
-}
-
-.m-incoming-box__vehicle-icon-svg {
-  height: 14px;
-  width: 18px;
+.m-incoming-box__vehicle-label {
+  margin-left: 0.5rem;
 }

--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -26,7 +26,7 @@
       stroke: $color-secondary-light;
     }
 
-    .m-ladder__vehicle-label-background {
+    .m-vehicle-icon__label-background {
       fill: $color-secondary-light;
     }
   }
@@ -36,7 +36,7 @@
       stroke: $color-secondary-medium;
     }
 
-    .m-ladder__vehicle-label-background {
+    .m-vehicle-icon__label-background {
       fill: $color-secondary-medium;
     }
   }

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -52,6 +52,10 @@ $color-line-gapped-light: #75e8ff;
   font-weight: 700;
 }
 
+@mixin font-big {
+  font-size: 1.25rem;
+}
+
 @mixin font-body {
   font-size: 0.875rem;
 }

--- a/assets/css/_vehicle_icon.scss
+++ b/assets/css/_vehicle_icon.scss
@@ -3,3 +3,45 @@
   stroke: $color-bg-base;
   stroke-width: 2;
 }
+
+.m-vehicle-icon__label-background {
+  fill: $color-bg-base;
+}
+
+.m-vehicle-icon__label {
+  fill: currentColor;
+}
+
+.m-vehicle-icon__variant {
+  fill: $color-font-light;
+}
+
+.m-vehicle-icon--small {
+  .m-vehicle-icon__label {
+    @include font-tiny;
+  }
+
+  .m-vehicle-icon__variant {
+    @include font-tiny;
+  }
+}
+
+.m-vehicle-icon--medium {
+  .m-vehicle-icon__label {
+    @include font-tiny;
+  }
+
+  .m-vehicle-icon__variant {
+    @include font-small;
+  }
+}
+
+.m-vehicle-icon--large {
+  .m-vehicle-icon__label {
+    @include font-header-big;
+  }
+
+  .m-vehicle-icon__variant {
+    @include font-big;
+  }
+}

--- a/assets/css/_vehicle_properties_panel.scss
+++ b/assets/css/_vehicle_properties_panel.scss
@@ -15,7 +15,6 @@
 }
 
 .m-vehicle-properties-panel__label {
-  @include font-header-big;
   flex: 0 0 auto;
   padding: 1rem;
   text-align: center;

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -7,7 +7,7 @@ import {
   VehicleDirection,
   vehicleDirectionOnLadder,
 } from "./ladder"
-import VehicleIcon from "./vehicleIcon"
+import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
 
 const IncomingBoxVehicle = ({
   vehicle,
@@ -20,23 +20,21 @@ const IncomingBoxVehicle = ({
 }) => {
   const dispatch = useContext(DispatchContext)
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
-  const rotation =
+  const orientation =
     vehicleDirectionOnLadder(vehicle, ladderDirection) === VehicleDirection.Down
-      ? 180
-      : 0
+      ? Orientation.Down
+      : Orientation.Up
 
   return (
     <button
       className={"m-incoming-box__vehicle " + selectedClass}
       onClick={() => dispatch(selectVehicle(vehicle.id))}
     >
-      <div className="m-incoming-box__vehicle-icon">
-        <svg className="m-incoming-box__vehicle-icon-svg">
-          <g transform={`rotate(${rotation},9,7)`}>
-            <VehicleIcon scale={0.38} />
-          </g>
-        </svg>
-      </div>
+      <VehicleIcon
+        size={Size.Small}
+        orientation={orientation}
+        variant={vehicle.viaVariant}
+      />
       <div className="m-incoming-box__vehicle-label">{vehicle.label}</div>
     </button>
   )

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react"
 import DispatchContext from "../contexts/dispatchContext"
 import { Timepoint, Vehicle, VehicleId, VehicleTimepointStatus } from "../skate"
 import { selectVehicle } from "../state"
-import VehicleIcon from "./vehicleIcon"
+import { Orientation, Size, VehicleIconSvgNode } from "./vehicleIcon"
 
 // Timepoints come from the API in the ZeroToOne direction
 export enum LadderDirection {
@@ -153,11 +153,7 @@ const LadderVehicle = ({
     vehicle,
     ladderDirection
   )
-  const centerOfVehicleGroupX = 16
-  const centerOfVehicleGroupY = 13
-  const widthOfVehicleGroup = centerOfVehicleGroupX * 2
-  const x =
-    vehicleDirection === VehicleDirection.Up ? 47 : -(48 + widthOfVehicleGroup)
+  const x = vehicleDirection === VehicleDirection.Up ? 63 : -63
   const vehicleY =
     timepointStatusY(
       vehicle.timepointStatus,
@@ -175,13 +171,16 @@ const LadderVehicle = ({
   )
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
 
-  const rotation = vehicleDirection === VehicleDirection.Down ? 180 : 0
+  const orientation =
+    vehicleDirection === VehicleDirection.Down
+      ? Orientation.Down
+      : Orientation.Up
 
   return (
     <g>
       {scheduledY && (
         <ScheduledLine
-          vehicleX={x + centerOfVehicleGroupX}
+          vehicleX={x}
           vehicleY={vehicleY}
           roadLineX={roadLineX}
           scheduledY={scheduledY}
@@ -189,12 +188,15 @@ const LadderVehicle = ({
       )}
       <g
         className={`m-ladder__vehicle ${selectedClass}`}
-        transform={`translate(${x},${vehicleY -
-          centerOfVehicleGroupY}) rotate(${rotation},${centerOfVehicleGroupX},${centerOfVehicleGroupY})`}
+        transform={`translate(${x},${vehicleY})`}
         onClick={() => dispatch(selectVehicle(vehicle.id))}
       >
-        <VehicleIcon scale={0.625} />
-        <VehicleLabel vehicle={vehicle} rotation={rotation} x={0} y={26} />
+        <VehicleIconSvgNode
+          size={Size.Medium}
+          orientation={orientation}
+          label={vehicle.label}
+          variant={vehicle.viaVariant}
+        />
       </g>
     </g>
   )
@@ -221,37 +223,6 @@ const timepointStatusY = (
   }
   return null
 }
-
-const VehicleLabel = ({
-  vehicle,
-  rotation,
-  x,
-  y,
-}: {
-  vehicle: Vehicle
-  rotation: number
-  x: number
-  y: number
-}) => (
-  <svg className="m-ladder__vehicle-label" x={x} y={y}>
-    <rect
-      className="m-ladder__vehicle-label-background"
-      rx="5.5"
-      ry="5.5"
-      width="30"
-      height="11"
-    />
-    <text
-      className="m-ladder__vehicle-label-text"
-      textAnchor="inherit"
-      x="5"
-      y="9"
-      transform={`rotate(${rotation},15,6)`}
-    >
-      {vehicle.label}
-    </text>
-  </svg>
-)
 
 const ScheduledLine = ({
   vehicleX,

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,16 +1,302 @@
 import React from "react"
 
-const VehicleIcon = ({ scale }: { scale?: number }) => {
-  const scaleAmount = scale || 1.0
+export enum Orientation {
+  Up,
+  Down,
+  Left,
+  Right,
+}
 
+export enum Size {
+  Small,
+  Medium,
+  Large,
+}
+
+export interface Props {
+  size: Size
+  orientation: Orientation
+  label?: string
+  variant?: string | null
+}
+
+/*
+Size of the triangle for calculation of the viewbox and positioning the label
+Sizes are before scaling, relative to the center of the triangle
+*/
+const X_CENTER_TO_SIDE = 22
+const Y_CENTER_TO_POINT = 16
+const Y_CENTER_TO_BASE = 20
+
+export const VehicleIcon = (props: Props) => {
+  const { left, top, width, height } = viewBox(props)
   return (
-    <g className="m-vehicle-icon" transform={`scale(${scaleAmount})`}>
-      <path
-        className={"m-vehicle-icon__triangle"}
-        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-      />
+    <svg
+      style={{ width, height }}
+      viewBox={`${left} ${top} ${width} ${height}`}
+    >
+      <VehicleIconSvgNode {...props} />
+    </svg>
+  )
+}
+
+const viewBox = ({
+  size,
+  orientation,
+  label,
+}: Props): { left: number; top: number; width: number; height: number } => {
+  // shrink the viewbox to fit around the triangle and label
+  const scale = scaleForSize(size)
+  const labelBgWidth = label ? labelBackgroundWidth(size) : 0
+  const labelBgHeight = label ? labelBackgroundHeight(size) : 0
+  let left = 0
+  let right = 0
+  let top = 0
+  let bottom = 0
+  switch (orientation) {
+    case Orientation.Up:
+      left = -scale * X_CENTER_TO_SIDE
+      top = -scale * Y_CENTER_TO_POINT
+      right = scale * X_CENTER_TO_SIDE
+      bottom = scale * Y_CENTER_TO_BASE + labelBgHeight
+      break
+    case Orientation.Down:
+      left = -scale * X_CENTER_TO_SIDE
+      top = -scale * Y_CENTER_TO_BASE - labelBgHeight
+      right = scale * X_CENTER_TO_SIDE
+      bottom = scale * Y_CENTER_TO_POINT
+      break
+    case Orientation.Left:
+      left = -scale * Y_CENTER_TO_POINT
+      top = -scale * X_CENTER_TO_SIDE
+      right = scale * Y_CENTER_TO_BASE
+      bottom = scale * X_CENTER_TO_SIDE + labelBgHeight
+      break
+    case Orientation.Right:
+      left = -scale * Y_CENTER_TO_BASE
+      top = -scale * X_CENTER_TO_SIDE
+      right = scale * Y_CENTER_TO_POINT
+      bottom = scale * X_CENTER_TO_SIDE + labelBgHeight
+      break
+  }
+  left = Math.min(left, -labelBgWidth / 2)
+  right = Math.max(right, labelBgWidth / 2)
+  const width = right - left
+  const height = bottom - top
+  return { left, top, width, height }
+}
+
+export const VehicleIconSvgNode = ({
+  size,
+  orientation,
+  label,
+  variant,
+}: Props) => {
+  return (
+    <g className={`m-vehicle-icon m-vehicle-icon${sizeClassSuffix(size)}`}>
+      {label ? (
+        <Label size={size} orientation={orientation} label={label} />
+      ) : null}
+      <Triangle size={size} orientation={orientation} />
+      {variant && variant !== "_" ? (
+        <Variant size={size} orientation={orientation} variant={variant} />
+      ) : null}
     </g>
   )
+}
+
+const Triangle = ({
+  size,
+  orientation,
+}: {
+  size: Size
+  orientation: Orientation
+}) => {
+  const scale = scaleForSize(size)
+  const rotation = rotationForOrientation(orientation)
+  return (
+    <path
+      className="m-vehicle-icon__triangle"
+      d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+      // Move the center to 0,0
+      transform={`scale(${scale}) rotate(${rotation}) translate(-24,-22)`}
+    />
+  )
+}
+
+const Label = ({
+  size,
+  orientation,
+  label,
+}: {
+  size: Size
+  orientation: Orientation
+  label: string
+}) => {
+  const scale = scaleForSize(size)
+  const labelBgWidth = labelBackgroundWidth(size)
+  const labelBgHeight = labelBackgroundHeight(size)
+  let labelBgTop = 0
+  switch (orientation) {
+    // adjust by 1 to cover any small gap between the triangle and the label
+    case Orientation.Up:
+      labelBgTop = scale * Y_CENTER_TO_BASE - 1
+      break
+    case Orientation.Down:
+      labelBgTop = -scale * Y_CENTER_TO_BASE - labelBgHeight + 1
+      break
+    case Orientation.Left:
+    case Orientation.Right:
+      labelBgTop = scale * X_CENTER_TO_SIDE - 1
+      break
+  }
+  const labelY = labelBgTop + labelBgHeight / 2
+
+  return (
+    <>
+      <rect
+        className="m-vehicle-icon__label-background"
+        x={-labelBgWidth / 2}
+        y={labelBgTop}
+        width={labelBgWidth}
+        height={labelBgHeight}
+        rx={labelBgHeight / 2}
+        ry={labelBgHeight / 2}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        x="0"
+        y={labelY}
+        textAnchor="middle"
+        dominantBaseline="central"
+      >
+        {label}
+      </text>
+    </>
+  )
+}
+
+const Variant = ({
+  size,
+  orientation,
+  variant,
+}: {
+  size: Size
+  orientation: Orientation
+  variant: string
+}) => {
+  const scale = scaleForSize(size)
+
+  // space between the triangle base and the variant letter
+  let margin = 0
+  switch (size) {
+    case Size.Small:
+      margin = 2
+      break
+    case Size.Medium:
+      margin = 4
+      break
+    case Size.Large:
+      margin = 6
+      break
+  }
+
+  let variantPositionOpts = {}
+  switch (orientation) {
+    // anchor the variant to the center of the base (with a small margin)
+    case Orientation.Up:
+      variantPositionOpts = {
+        dominantBaseline: "alphabetic",
+        textAnchor: "middle",
+        x: 0,
+        y: scale * Y_CENTER_TO_BASE - margin,
+      }
+      break
+    case Orientation.Down:
+      variantPositionOpts = {
+        dominantBaseline: "hanging",
+        textAnchor: "middle",
+        x: 0,
+        y: -scale * Y_CENTER_TO_BASE + margin,
+      }
+      break
+    case Orientation.Left:
+      variantPositionOpts = {
+        dominantBaseline: "central",
+        textAnchor: "end",
+        x: scale * Y_CENTER_TO_BASE - margin,
+        y: 0,
+      }
+      break
+    case Orientation.Right:
+      variantPositionOpts = {
+        dominantBaseline: "central",
+        textAnchor: "start",
+        x: -scale * Y_CENTER_TO_BASE + margin,
+        y: 0,
+      }
+      break
+  }
+  return (
+    <text className="m-vehicle-icon__variant" {...variantPositionOpts}>
+      {variant}
+    </text>
+  )
+}
+
+const sizeClassSuffix = (size: Size): string => {
+  switch (size) {
+    case Size.Small:
+      return "--small"
+    case Size.Medium:
+      return "--medium"
+    case Size.Large:
+      return "--large"
+  }
+}
+
+const scaleForSize = (size: Size): number => {
+  switch (size) {
+    case Size.Small:
+      return 0.38
+    case Size.Medium:
+      return 0.625
+    case Size.Large:
+      return 1
+  }
+}
+
+const rotationForOrientation = (orientation: Orientation): number => {
+  switch (orientation) {
+    case Orientation.Up:
+      return 0
+    case Orientation.Down:
+      return 180
+    case Orientation.Left:
+      return 270
+    case Orientation.Right:
+      return 90
+  }
+}
+
+const labelBackgroundWidth = (size: Size): number => {
+  switch (size) {
+    case Size.Small:
+    case Size.Medium:
+      return 26
+    case Size.Large:
+      return 64
+  }
+}
+
+const labelBackgroundHeight = (size: Size): number => {
+  switch (size) {
+    case Size.Small:
+    case Size.Medium:
+      return 11
+    case Size.Large:
+      return 24
+  }
 }
 
 export default VehicleIcon

--- a/assets/src/components/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/vehiclePropertiesPanel.tsx
@@ -4,6 +4,7 @@ import detectSwipe, { SwipeDirection } from "../helpers/detectSwipe"
 import { Route, Vehicle } from "../skate.d"
 import { deselectVehicle } from "../state"
 import CloseButton from "./closeButton"
+import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
 
 interface Props {
   selectedVehicle: Vehicle
@@ -68,7 +69,14 @@ const Header = ({
   hideMe: () => void
 }) => (
   <div className="m-vehicle-properties-panel__header">
-    <div className="m-vehicle-properties-panel__label">{vehicle.label}</div>
+    <div className="m-vehicle-properties-panel__label">
+      <VehicleIcon
+        size={Size.Large}
+        orientation={Orientation.Up}
+        label={vehicle.label}
+        variant={vehicle.viaVariant}
+      />
+    </div>
     <div className="m-vehicle-properties-panel__variant">
       <div className="m-vehicle-properties-panel__inbound-outbound">
         {directionName(vehicle, selectedVehicleRoute)}

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -11,45 +11,41 @@ exports[`highlights a selected vehicle 1`] = `
     <g
       className="m-ladder__vehicle selected"
       onClick={[Function]}
-      transform="translate(47,302) rotate(0,16,13)"
+      transform="translate(63,315)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={11.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(0,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={17}
         >
           upward
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(0) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <g>
     <line
       className="m-ladder__scheduled-line"
-      x1={-64}
+      x1={-63}
       x2={-40}
       y1={-157.5}
       y2={-157.5}
@@ -57,39 +53,35 @@ exports[`highlights a selected vehicle 1`] = `
     <g
       className="m-ladder__vehicle "
       onClick={[Function]}
-      transform="translate(-80,-170.5) rotate(180,16,13)"
+      transform="translate(-63,-157.5)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={-22.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(180,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={-17}
         >
           downward
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(180) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <line
@@ -183,45 +175,41 @@ exports[`renders a ladder 1`] = `
     <g
       className="m-ladder__vehicle "
       onClick={[Function]}
-      transform="translate(47,302) rotate(0,16,13)"
+      transform="translate(63,315)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={11.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(0,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={17}
         >
           upward
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(0) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <g>
     <line
       className="m-ladder__scheduled-line"
-      x1={-64}
+      x1={-63}
       x2={-40}
       y1={-157.5}
       y2={-157.5}
@@ -229,78 +217,70 @@ exports[`renders a ladder 1`] = `
     <g
       className="m-ladder__vehicle "
       onClick={[Function]}
-      transform="translate(-80,-170.5) rotate(180,16,13)"
+      transform="translate(-63,-157.5)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={-22.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(180,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={-17}
         >
           downward
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(180) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <g>
     <g
       className="m-ladder__vehicle "
       onClick={[Function]}
-      transform="translate(-80,-23) rotate(180,16,13)"
+      transform="translate(-63,-10)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={-22.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(180,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={-17}
         >
           notimepoint
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(180) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <line
@@ -394,39 +374,35 @@ exports[`renders a ladder with no timepoints 1`] = `
     <g
       className="m-ladder__vehicle "
       onClick={[Function]}
-      transform="translate(47,-23) rotate(0,16,13)"
+      transform="translate(63,-10)"
     >
       <g
-        className="m-vehicle-icon"
-        transform="scale(0.625)"
-      >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-        />
-      </g>
-      <svg
-        className="m-ladder__vehicle-label"
-        x={0}
-        y={26}
+        className="m-vehicle-icon m-vehicle-icon--medium"
       >
         <rect
-          className="m-ladder__vehicle-label-background"
-          height="11"
-          rx="5.5"
-          ry="5.5"
-          width="30"
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={11.5}
         />
         <text
-          className="m-ladder__vehicle-label-text"
-          textAnchor="inherit"
-          transform="rotate(0,15,6)"
-          x="5"
-          y="9"
+          className="m-vehicle-icon__label"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={17}
         >
           upward
         </text>
-      </svg>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(0) translate(-24,-22)"
+        />
+      </g>
     </g>
   </g>
   <line

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -224,45 +224,50 @@ exports[`renders a route ladder with vehicles 1`] = `
       <g
         className="m-ladder__vehicle "
         onClick={[Function]}
-        transform="translate(47,92) rotate(0,16,13)"
+        transform="translate(63,105)"
       >
         <g
-          className="m-vehicle-icon"
-          transform="scale(0.625)"
-        >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          />
-        </g>
-        <svg
-          className="m-ladder__vehicle-label"
-          x={0}
-          y={26}
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
-            className="m-ladder__vehicle-label-background"
-            height="11"
-            rx="5.5"
-            ry="5.5"
-            width="30"
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={11.5}
           />
           <text
-            className="m-ladder__vehicle-label-text"
-            textAnchor="inherit"
-            transform="rotate(0,15,6)"
-            x="5"
-            y="9"
+            className="m-vehicle-icon__label"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={17}
           >
             1818
           </text>
-        </svg>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={8.5}
+          >
+            4
+          </text>
+        </g>
       </g>
     </g>
     <g>
       <line
         className="m-ladder__scheduled-line"
-        x1={-64}
+        x1={-63}
         x2={-40}
         y1={420}
         y2={420}
@@ -270,39 +275,35 @@ exports[`renders a route ladder with vehicles 1`] = `
       <g
         className="m-ladder__vehicle "
         onClick={[Function]}
-        transform="translate(-80,407) rotate(180,16,13)"
+        transform="translate(-63,420)"
       >
         <g
-          className="m-vehicle-icon"
-          transform="scale(0.625)"
-        >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          />
-        </g>
-        <svg
-          className="m-ladder__vehicle-label"
-          x={0}
-          y={26}
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
-            className="m-ladder__vehicle-label-background"
-            height="11"
-            rx="5.5"
-            ry="5.5"
-            width="30"
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={-22.5}
           />
           <text
-            className="m-ladder__vehicle-label-text"
-            textAnchor="inherit"
-            transform="rotate(180,15,6)"
-            x="5"
-            y="9"
+            className="m-vehicle-icon__label"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={-17}
           >
             0479
           </text>
-        </svg>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(180) translate(-24,-22)"
+          />
+        </g>
       </g>
     </g>
     <line
@@ -439,45 +440,50 @@ exports[`renders a route ladder with vehicles in the incoming box 1`] = `
       <g
         className="m-ladder__vehicle "
         onClick={[Function]}
-        transform="translate(47,92) rotate(0,16,13)"
+        transform="translate(63,105)"
       >
         <g
-          className="m-vehicle-icon"
-          transform="scale(0.625)"
-        >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          />
-        </g>
-        <svg
-          className="m-ladder__vehicle-label"
-          x={0}
-          y={26}
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
-            className="m-ladder__vehicle-label-background"
-            height="11"
-            rx="5.5"
-            ry="5.5"
-            width="30"
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={11.5}
           />
           <text
-            className="m-ladder__vehicle-label-text"
-            textAnchor="inherit"
-            transform="rotate(0,15,6)"
-            x="5"
-            y="9"
+            className="m-vehicle-icon__label"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={17}
           >
             1818
           </text>
-        </svg>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={8.5}
+          >
+            4
+          </text>
+        </g>
       </g>
     </g>
     <g>
       <line
         className="m-ladder__scheduled-line"
-        x1={-64}
+        x1={-63}
         x2={-40}
         y1={420}
         y2={420}
@@ -485,39 +491,35 @@ exports[`renders a route ladder with vehicles in the incoming box 1`] = `
       <g
         className="m-ladder__vehicle "
         onClick={[Function]}
-        transform="translate(-80,407) rotate(180,16,13)"
+        transform="translate(-63,420)"
       >
         <g
-          className="m-vehicle-icon"
-          transform="scale(0.625)"
-        >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          />
-        </g>
-        <svg
-          className="m-ladder__vehicle-label"
-          x={0}
-          y={26}
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
-            className="m-ladder__vehicle-label-background"
-            height="11"
-            rx="5.5"
-            ry="5.5"
-            width="30"
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={-22.5}
           />
           <text
-            className="m-ladder__vehicle-label-text"
-            textAnchor="inherit"
-            transform="rotate(180,15,6)"
-            x="5"
-            y="9"
+            className="m-vehicle-icon__label"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={-17}
           >
             0479
           </text>
-        </svg>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(180) translate(-24,-22)"
+          />
+        </g>
       </g>
     </g>
     <line

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -1,25 +1,823 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`allows you to scale the icon 1`] = `
-<g
-  className="m-vehicle-icon"
-  transform="scale(0.5)"
->
-  <path
-    className="m-vehicle-icon__triangle"
-    d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-  />
-</g>
+exports[`renders an unwrapped svg node 1`] = `
+<svg>
+  <g
+    className="m-vehicle-icon m-vehicle-icon--medium"
+  >
+    <rect
+      className="m-vehicle-icon__label-background"
+      height={11}
+      rx={5.5}
+      ry={5.5}
+      width={26}
+      x={-13}
+      y={-22.5}
+    />
+    <text
+      className="m-vehicle-icon__label"
+      dominantBaseline="central"
+      textAnchor="middle"
+      x="0"
+      y={-17}
+    >
+      0617
+    </text>
+    <path
+      className="m-vehicle-icon__triangle"
+      d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+      transform="scale(0.625) rotate(180) translate(-24,-22)"
+    />
+  </g>
+</svg>
 `;
 
-exports[`renders a triange vehicle icon 1`] = `
-<g
-  className="m-vehicle-icon"
-  transform="scale(1)"
->
-  <path
-    className="m-vehicle-icon__triangle"
-    d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-  />
-</g>
+exports[`renders in all directions and sizes 1`] = `
+Array [
+  <svg
+    style={
+      Object {
+        "height": 13.68,
+        "width": 16.72,
+      }
+    }
+    viewBox="-8.36 -6.08 16.72 13.68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(0) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 16.72,
+        "width": 13.68,
+      }
+    }
+    viewBox="-7.6 -8.36 13.68 16.72"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(90) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 13.68,
+        "width": 16.72,
+      }
+    }
+    viewBox="-8.36 -7.6 16.72 13.68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(180) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 16.72,
+        "width": 13.68,
+      }
+    }
+    viewBox="-6.08 -8.36 13.68 16.72"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(270) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 22.5,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -10 27.5 22.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(0) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 27.5,
+        "width": 22.5,
+      }
+    }
+    viewBox="-12.5 -13.75 22.5 27.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(90) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 22.5,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -12.5 27.5 22.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(180) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 27.5,
+        "width": 22.5,
+      }
+    }
+    viewBox="-10 -13.75 22.5 27.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(270) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 36,
+        "width": 44,
+      }
+    }
+    viewBox="-22 -16 44 36"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(0) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 44,
+        "width": 36,
+      }
+    }
+    viewBox="-20 -22 36 44"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(90) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 36,
+        "width": 44,
+      }
+    }
+    viewBox="-22 -20 44 36"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(180) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 44,
+        "width": 36,
+      }
+    }
+    viewBox="-16 -22 36 44"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(270) translate(-24,-22)"
+      />
+    </g>
+  </svg>,
+]
+`;
+
+exports[`renders with variants and labels 1`] = `
+Array [
+  <svg
+    style={
+      Object {
+        "height": 24.68,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -6.08 26 24.68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={6.6}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.1}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(0) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="alphabetic"
+        textAnchor="middle"
+        x={0}
+        y={5.6}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 27.72,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -8.36 26 27.72"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={7.359999999999999}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.86}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(90) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="start"
+        x={-5.6}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 24.68,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -18.6 26 24.68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={-17.6}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={-12.100000000000001}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(180) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="hanging"
+        textAnchor="middle"
+        x={0}
+        y={-5.6}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 27.72,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -8.36 26 27.72"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={7.359999999999999}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.86}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(270) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="end"
+        x={5.6}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 33.5,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -10 27.5 33.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={11.5}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={17}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(0) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="alphabetic"
+        textAnchor="middle"
+        x={0}
+        y={8.5}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 38.5,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -13.75 26 38.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={12.75}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={18.25}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(90) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="start"
+        x={-8.5}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 33.5,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -23.5 27.5 33.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={-22.5}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={-17}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(180) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="hanging"
+        textAnchor="middle"
+        x={0}
+        y={-8.5}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 38.5,
+        "width": 26,
+      }
+    }
+    viewBox="-13 -13.75 26 38.5"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={26}
+        x={-13}
+        y={12.75}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={18.25}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.625) rotate(270) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="end"
+        x={8.5}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 60,
+        "width": 64,
+      }
+    }
+    viewBox="-32 -16 64 60"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={24}
+        rx={12}
+        ry={12}
+        width={64}
+        x={-32}
+        y={19}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={31}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(0) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="alphabetic"
+        textAnchor="middle"
+        x={0}
+        y={14}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 68,
+        "width": 64,
+      }
+    }
+    viewBox="-32 -22 64 68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={24}
+        rx={12}
+        ry={12}
+        width={64}
+        x={-32}
+        y={21}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={33}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(90) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="start"
+        x={-14}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 60,
+        "width": 64,
+      }
+    }
+    viewBox="-32 -44 64 60"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={24}
+        rx={12}
+        ry={12}
+        width={64}
+        x={-32}
+        y={-43}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={-31}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(180) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="hanging"
+        textAnchor="middle"
+        x={0}
+        y={-14}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 68,
+        "width": 64,
+      }
+    }
+    viewBox="-32 -22 64 68"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--large"
+    >
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={24}
+        rx={12}
+        ry={12}
+        width={64}
+        x={-32}
+        y={21}
+      />
+      <text
+        className="m-vehicle-icon__label"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={33}
+      >
+        0617
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(1) rotate(270) translate(-24,-22)"
+      />
+      <text
+        className="m-vehicle-icon__variant"
+        dominantBaseline="central"
+        textAnchor="end"
+        x={14}
+        y={0}
+      >
+        X
+      </text>
+    </g>
+  </svg>,
+]
 `;

--- a/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -12,7 +12,52 @@ Array [
       <div
         className="m-vehicle-properties-panel__label"
       >
-        v1-label
+        <svg
+          style={
+            Object {
+              "height": 60,
+              "width": 64,
+            }
+          }
+          viewBox="-32 -16 64 60"
+        >
+          <g
+            className="m-vehicle-icon m-vehicle-icon--large"
+          >
+            <rect
+              className="m-vehicle-icon__label-background"
+              height={24}
+              rx={12}
+              ry={12}
+              width={64}
+              x={-32}
+              y={19}
+            />
+            <text
+              className="m-vehicle-icon__label"
+              dominantBaseline="central"
+              textAnchor="middle"
+              x="0"
+              y={31}
+            >
+              v1-label
+            </text>
+            <path
+              className="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              transform="scale(1) rotate(0) translate(-24,-22)"
+            />
+            <text
+              className="m-vehicle-icon__variant"
+              dominantBaseline="alphabetic"
+              textAnchor="middle"
+              x={0}
+              y={14}
+            >
+              X
+            </text>
+          </g>
+        </svg>
       </div>
       <div
         className="m-vehicle-properties-panel__variant"
@@ -160,7 +205,52 @@ Array [
       <div
         className="m-vehicle-properties-panel__label"
       >
-        v1-label
+        <svg
+          style={
+            Object {
+              "height": 60,
+              "width": 64,
+            }
+          }
+          viewBox="-32 -16 64 60"
+        >
+          <g
+            className="m-vehicle-icon m-vehicle-icon--large"
+          >
+            <rect
+              className="m-vehicle-icon__label-background"
+              height={24}
+              rx={12}
+              ry={12}
+              width={64}
+              x={-32}
+              y={19}
+            />
+            <text
+              className="m-vehicle-icon__label"
+              dominantBaseline="central"
+              textAnchor="middle"
+              x="0"
+              y={31}
+            >
+              v1-label
+            </text>
+            <path
+              className="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              transform="scale(1) rotate(0) translate(-24,-22)"
+            />
+            <text
+              className="m-vehicle-icon__variant"
+              dominantBaseline="alphabetic"
+              textAnchor="middle"
+              x={0}
+              y={14}
+            >
+              X
+            </text>
+          </g>
+        </svg>
       </div>
       <div
         className="m-vehicle-properties-panel__variant"
@@ -308,7 +398,52 @@ Array [
       <div
         className="m-vehicle-properties-panel__label"
       >
-        v1-label
+        <svg
+          style={
+            Object {
+              "height": 60,
+              "width": 64,
+            }
+          }
+          viewBox="-32 -16 64 60"
+        >
+          <g
+            className="m-vehicle-icon m-vehicle-icon--large"
+          >
+            <rect
+              className="m-vehicle-icon__label-background"
+              height={24}
+              rx={12}
+              ry={12}
+              width={64}
+              x={-32}
+              y={19}
+            />
+            <text
+              className="m-vehicle-icon__label"
+              dominantBaseline="central"
+              textAnchor="middle"
+              x="0"
+              y={31}
+            >
+              v1-label
+            </text>
+            <path
+              className="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              transform="scale(1) rotate(0) translate(-24,-22)"
+            />
+            <text
+              className="m-vehicle-icon__variant"
+              dominantBaseline="alphabetic"
+              textAnchor="middle"
+              x={0}
+              y={14}
+            >
+              X
+            </text>
+          </g>
+        </svg>
       </div>
       <div
         className="m-vehicle-properties-panel__variant"

--- a/assets/tests/components/vehicleIcon.test.tsx
+++ b/assets/tests/components/vehicleIcon.test.tsx
@@ -1,15 +1,129 @@
 import React from "react"
 import renderer from "react-test-renderer"
-import VehicleIcon from "../../src/components/vehicleIcon"
+import VehicleIcon, {
+  Orientation,
+  Size,
+  VehicleIconSvgNode,
+} from "../../src/components/vehicleIcon"
 
-test("renders a triange vehicle icon", () => {
-  const tree = renderer.create(<VehicleIcon />).toJSON()
+test("renders in all directions and sizes", () => {
+  const tree = renderer
+    .create(
+      <>
+        <VehicleIcon size={Size.Small} orientation={Orientation.Up} />
+        <VehicleIcon size={Size.Small} orientation={Orientation.Right} />
+        <VehicleIcon size={Size.Small} orientation={Orientation.Down} />
+        <VehicleIcon size={Size.Small} orientation={Orientation.Left} />
+        <VehicleIcon size={Size.Medium} orientation={Orientation.Up} />
+        <VehicleIcon size={Size.Medium} orientation={Orientation.Right} />
+        <VehicleIcon size={Size.Medium} orientation={Orientation.Down} />
+        <VehicleIcon size={Size.Medium} orientation={Orientation.Left} />
+        <VehicleIcon size={Size.Large} orientation={Orientation.Up} />
+        <VehicleIcon size={Size.Large} orientation={Orientation.Right} />
+        <VehicleIcon size={Size.Large} orientation={Orientation.Down} />
+        <VehicleIcon size={Size.Large} orientation={Orientation.Left} />
+      </>
+    )
+    .toJSON()
 
   expect(tree).toMatchSnapshot()
 })
 
-test("allows you to scale the icon", () => {
-  const tree = renderer.create(<VehicleIcon scale={0.5} />).toJSON()
+test("renders with variants and labels", () => {
+  const tree = renderer
+    .create(
+      <>
+        <VehicleIcon
+          size={Size.Small}
+          orientation={Orientation.Up}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Small}
+          orientation={Orientation.Right}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Small}
+          orientation={Orientation.Down}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Small}
+          orientation={Orientation.Left}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Up}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Right}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Down}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Left}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Large}
+          orientation={Orientation.Up}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Large}
+          orientation={Orientation.Right}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Large}
+          orientation={Orientation.Down}
+          label="0617"
+          variant="X"
+        />
+        <VehicleIcon
+          size={Size.Large}
+          orientation={Orientation.Left}
+          label="0617"
+          variant="X"
+        />
+      </>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+test("renders an unwrapped svg node", () => {
+  const tree = renderer
+    .create(
+      <svg>
+        <VehicleIconSvgNode
+          size={Size.Medium}
+          orientation={Orientation.Down}
+          label="0617"
+        />
+      </svg>
+    )
+    .toJSON()
 
   expect(tree).toMatchSnapshot()
 })


### PR DESCRIPTION
Asana Tasks:
[Put variant number in the triangle](https://app.asana.com/0/1112935048846093/1123217669646641)
[🐛vehicle triangle in incoming box is cut off](https://app.asana.com/0/1112935048846093/1125794829210438)
[Add triangle to the Vehicle Properties Panel header](https://app.asana.com/0/1112935048846093/1124847099574986)

<img width="621" alt="Screen Shot 2019-06-10 at 14 51 57" src="https://user-images.githubusercontent.com/23065557/59221584-a1a76180-8b95-11e9-9f9c-6cc67cd4422b.png">
<img width="610" alt="Screen Shot 2019-06-10 at 14 52 31" src="https://user-images.githubusercontent.com/23065557/59221585-a1a76180-8b95-11e9-9544-4c1f8498fe3f.png">

This PR changes a lot about how we make vehicle icons.
* Pulls the label and (new) variant into the VehicleIcon component.
* Handles up, down, left, and right-facing vehicles. We don't have any horizontal vehicles yet, but the label/variant placement rules are pretty different for them so I wanted to make sure I didn't make that future work more difficult.
* Has separate interfaces for returning an svg node (for the ladder) vs an html node (for the incoming box and VPP).
* The html node calculates the viewbox and width/height needed to tightly fit the icon. (Missing the viewbox and hardcoding the width+height was the source of the clipping bug)

Here's all the possible orientations and directions. Top two rows are as html nodes and bottom rows are as svg nodes. The line in the svg goes through the centers of the triangles, which is where the schedule line is drawn from, and the point that's used to position the triangle on the ladder. E.g. if a vehicle is at a timepoint, the timepoint will be level with that center of the triangle.
<img width="608" alt="Screen Shot 2019-06-10 at 14 48 58" src="https://user-images.githubusercontent.com/23065557/59222886-8e49c580-8b98-11e9-9898-f13571f798f8.png">
And with the backgrounds highlighted:
<img width="607" alt="Screen Shot 2019-06-10 at 14 49 25" src="https://user-images.githubusercontent.com/23065557/59222899-99045a80-8b98-11e9-9cea-5f4d5af18ac3.png">
