### PR TITLE
Prioritize Swiftly vehicle trip and route assignments

### DIFF
--- a/lib/concentrate/data_discrepancy.ex
+++ b/lib/concentrate/data_discrepancy.ex
@@ -1,0 +1,18 @@
+defmodule Concentrate.DataDiscrepancy do
+  @type t :: %__MODULE__{
+          attribute: String.t(),
+          sources: [source()]
+        }
+
+  @enforce_keys [:attribute]
+
+  @type source :: %{
+          id: String.t(),
+          value: String.t()
+        }
+
+  defstruct [
+    :attribute,
+    sources: []
+  ]
+end

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -77,7 +77,9 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
             block_id: Map.get(vp, "block_id"),
             run_id: Map.get(vp, "run_id"),
             operator_id: Map.get(operator, "id"),
-            operator_name: Map.get(operator, "name")
+            operator_name: Map.get(operator, "name"),
+            source: "busloc",
+            data_discrepancies: nil
           )
         ]
 

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -78,7 +78,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
             run_id: Map.get(vp, "run_id"),
             operator_id: Map.get(operator, "id"),
             operator_name: Map.get(operator, "name"),
-            source: "busloc",
+            sources: MapSet.new(["busloc"]),
             data_discrepancies: nil
           )
         ]

--- a/lib/concentrate/parser/swiftly_realtime_vehicles.ex
+++ b/lib/concentrate/parser/swiftly_realtime_vehicles.ex
@@ -54,7 +54,7 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehicles do
       schedule_adherence_secs: Map.get(vehicle_data, "schAdhSecs"),
       schedule_adherence_string: Map.get(vehicle_data, "schAdhStr"),
       scheduled_headway_secs: Map.get(vehicle_data, "scheduledHeadwaySecs"),
-      source: "swiftly",
+      sources: MapSet.new(["swiftly"]),
       data_discrepancies: nil
     )
   end

--- a/lib/concentrate/parser/swiftly_realtime_vehicles.ex
+++ b/lib/concentrate/parser/swiftly_realtime_vehicles.ex
@@ -53,7 +53,9 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehicles do
       route_id: Map.get(vehicle_data, "routeId"),
       schedule_adherence_secs: Map.get(vehicle_data, "schAdhSecs"),
       schedule_adherence_string: Map.get(vehicle_data, "schAdhStr"),
-      scheduled_headway_secs: Map.get(vehicle_data, "scheduledHeadwaySecs")
+      scheduled_headway_secs: Map.get(vehicle_data, "scheduledHeadwaySecs"),
+      source: "swiftly",
+      data_discrepancies: nil
     )
   end
 

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -74,9 +74,9 @@ defmodule Concentrate.VehiclePosition do
         second
         | trip_id:
             swiftly_priority(
-              VehiclePosition.source(second),
+              second.source,
               second.trip_id,
-              VehiclePosition.source(first),
+              first.source,
               first.trip_id
             ),
           stop_id: first_value(second.stop_id, first.stop_id),
@@ -97,9 +97,9 @@ defmodule Concentrate.VehiclePosition do
           direction_id: first_value(second.direction_id, first.direction_id),
           headsign:
             swiftly_priority(
-              VehiclePosition.source(second),
+              second.source,
               second.headsign,
-              VehiclePosition.source(first),
+              first.source,
               first.headsign
             ),
           headway_secs: first_value(second.headway_secs, first.headway_secs),
@@ -116,9 +116,9 @@ defmodule Concentrate.VehiclePosition do
             ),
           route_id:
             swiftly_priority(
-              VehiclePosition.source(second),
+              second.source,
               second.route_id,
-              VehiclePosition.source(first),
+              first.source,
               first.route_id
             ),
           schedule_adherence_secs:
@@ -146,7 +146,7 @@ defmodule Concentrate.VehiclePosition do
       do: first_value(first_value, second_value)
 
     defp merge_sources(first, second) do
-      [VehiclePosition.source(first), VehiclePosition.source(second)]
+      [first.source, second.source]
       |> Enum.sort()
       |> Enum.join("|")
     end
@@ -164,11 +164,11 @@ defmodule Concentrate.VehiclePosition do
           attribute: key,
           sources: [
             %{
-              id: VehiclePosition.source(first),
+              id: first.source,
               value: first_val
             },
             %{
-              id: VehiclePosition.source(second),
+              id: second.source,
               value: second_val
             }
           ]

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -162,30 +162,29 @@ defmodule Concentrate.VehiclePosition do
         {:headsign, &VehiclePosition.headsign/1}
       ]
 
-      for {key, accessor_fn} <- attributes,
-          {first_val, second_val} <- do_discrepancies(accessor_fn, first, second) do
-        %DataDiscrepancy{
-          attribute: key,
-          sources: [
-            %{
-              id: first.source,
-              value: first_val
-            },
-            %{
-              id: second.source,
-              value: second_val
-            }
-          ]
-        }
-      end
+      Enum.flat_map(attributes, &discrepancy(&1, first, second))
     end
 
-    defp do_discrepancies(accessor_fn, first, second) do
+    defp discrepancy({key, accessor_fn}, first, second) do
       first_val = accessor_fn.(first)
       second_val = accessor_fn.(second)
 
       if first_val != second_val do
-        [{first_val, second_val}]
+        [
+          %DataDiscrepancy{
+            attribute: key,
+            sources: [
+              %{
+                id: first.source,
+                value: first_val
+              },
+              %{
+                id: second.source,
+                value: second_val
+              }
+            ]
+          }
+        ]
       else
         []
       end

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -146,10 +146,14 @@ defmodule Concentrate.VehiclePosition do
       do: first_value(first_value, second_value)
 
     defp merge_sources(first, second) do
-      [first.source, second.source]
+      [first, second]
+      |> Enum.flat_map(&sources/1)
+      |> Enum.uniq()
       |> Enum.sort()
       |> Enum.join("|")
     end
+
+    defp sources(vp), do: String.split(vp.source, "|")
 
     defp discrepancies(first, second) do
       attributes = [

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -95,7 +95,13 @@ defmodule Concentrate.VehiclePosition do
           stop_name: first_value(second.stop_name, first.stop_name),
           operator: first_value(second.operator, first.operator),
           direction_id: first_value(second.direction_id, first.direction_id),
-          headsign: first_value(second.headsign, first.headsign),
+          headsign:
+            swiftly_priority(
+              VehiclePosition.source(second),
+              second.headsign,
+              VehiclePosition.source(first),
+              first.headsign
+            ),
           headway_secs: first_value(second.headway_secs, first.headway_secs),
           previous_vehicle_id: first_value(second.previous_vehicle_id, first.previous_vehicle_id),
           previous_vehicle_schedule_adherence_secs:
@@ -148,7 +154,8 @@ defmodule Concentrate.VehiclePosition do
     defp discrepancies(first, second) do
       attributes = [
         {:trip_id, &VehiclePosition.trip_id/1},
-        {:route_id, &VehiclePosition.route_id/1}
+        {:route_id, &VehiclePosition.route_id/1},
+        {:headsign, &VehiclePosition.headsign/1}
       ]
 
       for {key, accessor_fn} <- attributes,

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -142,26 +142,23 @@ defmodule Concentrate.VehiclePosition do
     defp first_value(value, _) when not is_nil(value), do: value
     defp first_value(_, value), do: value
 
+    defp swiftly_priority(source1, value1, source2, value2)
+
+    defp swiftly_priority(_source1, value1, _source2, nil), do: value1
+
+    defp swiftly_priority(_source1, nil, _source2, value2), do: value2
+
     defp swiftly_priority(source1, value1, source2, value2) do
       cond do
         VehiclePosition.comes_from_swiftly(%{source: source1}) ->
-          cond do
-            value1 == nil ->
-              value2
-
-            VehiclePosition.comes_from_swiftly(%{source: source2}) ->
-              first_value(value1, value2)
-
-            true ->
-              value1
+          if VehiclePosition.comes_from_swiftly(%{source: source2}) do
+            first_value(value1, value2)
+          else
+            value1
           end
 
         VehiclePosition.comes_from_swiftly(%{source: source2}) ->
-          if value2 == nil do
-            value1
-          else
-            value2
-          end
+          value2
 
         true ->
           first_value(value1, value2)

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -47,8 +47,8 @@ defmodule Concentrate.VehiclePosition do
     super(opts)
   end
 
-  def comes_from_swiftly(%{sources: %MapSet{} = sources}), do: Enum.member?(sources, "swiftly")
-  def comes_from_swiftly(_), do: false
+  def comes_from_swiftly?(%{sources: %MapSet{} = sources}), do: Enum.member?(sources, "swiftly")
+  def comes_from_swiftly?(_), do: false
 
   defimpl Concentrate.Mergeable do
     alias Concentrate.VehiclePosition
@@ -148,14 +148,14 @@ defmodule Concentrate.VehiclePosition do
 
     defp swiftly_priority(sources1, value1, sources2, value2) do
       cond do
-        VehiclePosition.comes_from_swiftly(%{sources: sources1}) ->
-          if VehiclePosition.comes_from_swiftly(%{sources: sources2}) do
+        VehiclePosition.comes_from_swiftly?(%{sources: sources1}) ->
+          if VehiclePosition.comes_from_swiftly?(%{sources: sources2}) do
             first_value(value1, value2)
           else
             value1
           end
 
-        VehiclePosition.comes_from_swiftly(%{sources: sources2}) ->
+        VehiclePosition.comes_from_swiftly?(%{sources: sources2}) ->
           value2
 
         true ->

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -129,7 +129,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  run_id: "128-1007",
                  status: :STOPPED_AT,
                  last_updated: 1_534_340_406,
-                 source: "busloc",
+                 sources: MapSet.new(["busloc"]),
                  data_discrepancies: nil
                )
     end

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -128,7 +128,9 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  operator_name: "EVANS",
                  run_id: "128-1007",
                  status: :STOPPED_AT,
-                 last_updated: 1_534_340_406
+                 last_updated: 1_534_340_406,
+                 source: "busloc",
+                 data_discrepancies: nil
                )
     end
   end

--- a/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
+++ b/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
@@ -83,7 +83,9 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehiclesTest do
           route_id: "39",
           schedule_adherence_secs: 0,
           schedule_adherence_string: "0.0 sec (ontime)",
-          scheduled_headway_secs: 120
+          scheduled_headway_secs: 120,
+          source: "swiftly",
+          data_discrepancies: nil
         )
 
       assert SwiftlyRealtimeVehicles.decode_vehicle(input) == expected

--- a/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
+++ b/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
@@ -84,7 +84,7 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehiclesTest do
           schedule_adherence_secs: 0,
           schedule_adherence_string: "0.0 sec (ontime)",
           scheduled_headway_secs: 120,
-          source: "swiftly",
+          sources: MapSet.new(["swiftly"]),
           data_discrepancies: nil
         )
 

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -199,57 +199,6 @@ defmodule Concentrate.VehiclePositionTest do
       assert Mergeable.merge(non_swiftly, swiftly) == expected
     end
 
-    test "merge/2 defaults to the latest value if both come from swiftly" do
-      swiftly =
-        new(
-          last_updated: 1,
-          latitude: 1,
-          longitude: 1,
-          trip_id: "swiftly_trip",
-          route_id: "swiftly_route",
-          sources: MapSet.new(["swiftly"])
-        )
-
-      swiftly_merged =
-        new(
-          last_updated: 2,
-          latitude: 2,
-          longitude: 2,
-          trip_id: "swiftly_merged_trip",
-          route_id: "swiftly_merged_route",
-          sources: MapSet.new(["busloc", "swiftly"])
-        )
-
-      expected =
-        new(
-          last_updated: 2,
-          latitude: 2,
-          longitude: 2,
-          trip_id: "swiftly_merged_trip",
-          route_id: "swiftly_merged_route",
-          sources: MapSet.new(["busloc", "swiftly"]),
-          data_discrepancies: [
-            %DataDiscrepancy{
-              attribute: :trip_id,
-              sources: [
-                %{id: "swiftly", value: "swiftly_trip"},
-                %{id: "busloc|swiftly", value: "swiftly_merged_trip"}
-              ]
-            },
-            %DataDiscrepancy{
-              attribute: :route_id,
-              sources: [
-                %{id: "swiftly", value: "swiftly_route"},
-                %{id: "busloc|swiftly", value: "swiftly_merged_route"}
-              ]
-            }
-          ]
-        )
-
-      assert Mergeable.merge(swiftly_merged, swiftly) == expected
-      assert Mergeable.merge(swiftly, swiftly_merged) == expected
-    end
-
     test "merge/2 doesn't include any data discrepancies if they values are the same" do
       first =
         new(

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -12,10 +12,10 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1,
           trip_id: "trip",
           route_id: "route",
-          source: "first"
+          sources: MapSet.new(["first"])
         )
 
-      second = new(last_updated: 2, latitude: 2, longitude: 2, source: "second")
+      second = new(last_updated: 2, latitude: 2, longitude: 2, sources: MapSet.new(["second"]))
 
       expected =
         new(
@@ -24,7 +24,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "trip",
           route_id: "route",
-          source: "first|second",
+          sources: MapSet.new(["first", "second"]),
           data_discrepancies: [
             %DataDiscrepancy{
               attribute: :trip_id,
@@ -67,7 +67,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1,
           trip_id: "swiftly_trip",
           route_id: "swiftly_route",
-          source: "swiftly"
+          sources: MapSet.new(["swiftly"])
         )
 
       non_swiftly =
@@ -77,7 +77,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "busloc_trip",
           route_id: "busloc_route",
-          source: "busloc"
+          sources: MapSet.new(["busloc"])
         )
 
       swiftly_later =
@@ -87,7 +87,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 3,
           trip_id: "swiftly_trip",
           route_id: "swiftly_route",
-          source: "swiftly"
+          sources: MapSet.new(["swiftly"])
         )
 
       expected =
@@ -97,7 +97,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "swiftly_trip",
           route_id: "swiftly_route",
-          source: "busloc|swiftly",
+          sources: MapSet.new(["busloc", "swiftly"]),
           data_discrepancies: [
             %DataDiscrepancy{
               attribute: :trip_id,
@@ -123,7 +123,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 3,
           trip_id: "swiftly_trip",
           route_id: "swiftly_route",
-          source: "busloc|swiftly",
+          sources: MapSet.new(["busloc", "swiftly"]),
           data_discrepancies: [
             %DataDiscrepancy{
               attribute: :trip_id,
@@ -156,7 +156,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1,
           trip_id: nil,
           route_id: nil,
-          source: "swiftly"
+          sources: MapSet.new(["swiftly"])
         )
 
       non_swiftly =
@@ -166,7 +166,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "busloc_trip",
           route_id: "busloc_route",
-          source: "busloc"
+          sources: MapSet.new(["busloc"])
         )
 
       expected =
@@ -176,7 +176,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "busloc_trip",
           route_id: "busloc_route",
-          source: "busloc|swiftly",
+          sources: MapSet.new(["busloc", "swiftly"]),
           data_discrepancies: [
             %DataDiscrepancy{
               attribute: :trip_id,
@@ -207,7 +207,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1,
           trip_id: "swiftly_trip",
           route_id: "swiftly_route",
-          source: "swiftly"
+          sources: MapSet.new(["swiftly"])
         )
 
       swiftly_merged =
@@ -217,7 +217,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "swiftly_merged_trip",
           route_id: "swiftly_merged_route",
-          source: "busloc|swiftly"
+          sources: MapSet.new(["busloc", "swiftly"])
         )
 
       expected =
@@ -227,7 +227,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "swiftly_merged_trip",
           route_id: "swiftly_merged_route",
-          source: "busloc|swiftly",
+          sources: MapSet.new(["busloc", "swiftly"]),
           data_discrepancies: [
             %DataDiscrepancy{
               attribute: :trip_id,
@@ -258,7 +258,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1,
           trip_id: "trip",
           route_id: "route",
-          source: "first"
+          sources: MapSet.new(["first"])
         )
 
       second =
@@ -268,7 +268,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "trip",
           route_id: "route",
-          source: "second"
+          sources: MapSet.new(["second"])
         )
 
       expected =
@@ -278,7 +278,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 2,
           trip_id: "trip",
           route_id: "route",
-          source: "first|second",
+          sources: MapSet.new(["first", "second"]),
           data_discrepancies: []
         )
 
@@ -286,76 +286,37 @@ defmodule Concentrate.VehiclePositionTest do
     end
   end
 
-  describe "sources/1" do
-    test "returns a single source in a list" do
-      vp =
-        new(
-          last_updated: 1,
-          latitude: 1,
-          longitude: 1,
-          source: "swiftly"
-        )
-
-      assert sources(vp) == ["swiftly"]
-    end
-
-    test "returns merged sources separated out" do
-      vp =
-        new(
-          last_updated: 1,
-          latitude: 1,
-          longitude: 1,
-          source: "busloc|swiftly"
-        )
-
-      assert sources(vp) == ["busloc", "swiftly"]
-    end
-
-    test "returns an empty array for a nil source" do
-      vp =
-        new(
-          last_updated: 1,
-          latitude: 1,
-          longitude: 1,
-          source: nil
-        )
-
-      assert sources(vp) == []
-    end
-  end
-
   describe "comes_from_swiftly/1" do
-    test "true if the source string is swiftly" do
+    test "true if sources include swiftly" do
       vp =
         new(
           last_updated: 1,
           latitude: 1,
           longitude: 1,
-          source: "swiftly"
+          sources: MapSet.new(["busloc", "swiftly"])
         )
 
       assert comes_from_swiftly(vp)
     end
 
-    test "true if source string is a merged value that includes swiftly" do
+    test "false if sources don't include swiftly" do
       vp =
         new(
           last_updated: 1,
           latitude: 1,
           longitude: 1,
-          source: "busloc|swiftly"
+          sources: MapSet.new(["busloc"])
         )
 
-      assert comes_from_swiftly(vp)
+      refute comes_from_swiftly(vp)
     end
 
-    test "false if source string doesn't include swiftly" do
+    test "false if there are no sources" do
       vp =
         new(
           last_updated: 1,
           latitude: 1,
-          longitude: 1,
-          source: "busloc"
+          longitude: 1
         )
 
       refute comes_from_swiftly(vp)

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -235,7 +235,7 @@ defmodule Concentrate.VehiclePositionTest do
     end
   end
 
-  describe "comes_from_swiftly/1" do
+  describe "comes_from_swiftly?/1" do
     test "true if sources include swiftly" do
       vp =
         new(
@@ -245,7 +245,7 @@ defmodule Concentrate.VehiclePositionTest do
           sources: MapSet.new(["busloc", "swiftly"])
         )
 
-      assert comes_from_swiftly(vp)
+      assert comes_from_swiftly?(vp)
     end
 
     test "false if sources don't include swiftly" do
@@ -257,7 +257,7 @@ defmodule Concentrate.VehiclePositionTest do
           sources: MapSet.new(["busloc"])
         )
 
-      refute comes_from_swiftly(vp)
+      refute comes_from_swiftly?(vp)
     end
 
     test "false if there are no sources" do
@@ -268,7 +268,7 @@ defmodule Concentrate.VehiclePositionTest do
           longitude: 1
         )
 
-      refute comes_from_swiftly(vp)
+      refute comes_from_swiftly?(vp)
     end
   end
 end

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -1,13 +1,48 @@
 defmodule Concentrate.VehiclePositionTest do
   use ExUnit.Case, async: true
   import Concentrate.VehiclePosition
-  alias Concentrate.Mergeable
+  alias Concentrate.{DataDiscrepancy, Mergeable}
 
   describe "Concentrate.Mergeable" do
-    test "merge/2 takes the latest of the two positions" do
-      first = new(last_updated: 1, latitude: 1, longitude: 1, trip_id: "trip")
-      second = new(last_updated: 2, latitude: 2, longitude: 2)
-      expected = new(last_updated: 2, latitude: 2, longitude: 2, trip_id: "trip")
+    test "merge/2 takes the latest of the two positions and notes discrepancies" do
+      first =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          trip_id: "trip",
+          route_id: "route",
+          source: "first"
+        )
+
+      second = new(last_updated: 2, latitude: 2, longitude: 2, source: "second")
+
+      expected =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "trip",
+          route_id: "route",
+          source: "first|second",
+          data_discrepancies: [
+            %DataDiscrepancy{
+              attribute: :trip_id,
+              sources: [
+                %{id: "first", value: "trip"},
+                %{id: "second", value: nil}
+              ]
+            },
+            %DataDiscrepancy{
+              attribute: :route_id,
+              sources: [
+                %{id: "first", value: "route"},
+                %{id: "second", value: nil}
+              ]
+            }
+          ]
+        )
+
       assert Mergeable.merge(first, second) == expected
       assert Mergeable.merge(second, first) == expected
     end
@@ -22,6 +57,143 @@ defmodule Concentrate.VehiclePositionTest do
       first = new(last_updated: nil, latitude: 1, longitude: 1, trip_id: "trip")
       second = new(last_updated: 2, latitude: 2, longitude: 2)
       assert Mergeable.merge(first, second) == second
+    end
+
+    test "merge/2 prioritizes the swiftly trip and route values if there is one" do
+      swiftly =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          trip_id: "swiftly_trip",
+          route_id: "swiftly_route",
+          source: "swiftly"
+        )
+
+      non_swiftly =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "busloc_trip",
+          route_id: "busloc_route",
+          source: "busloc"
+        )
+
+      expected =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "swiftly_trip",
+          route_id: "swiftly_route",
+          source: "busloc|swiftly",
+          data_discrepancies: [
+            %DataDiscrepancy{
+              attribute: :trip_id,
+              sources: [
+                %{id: "swiftly", value: "swiftly_trip"},
+                %{id: "busloc", value: "busloc_trip"}
+              ]
+            },
+            %DataDiscrepancy{
+              attribute: :route_id,
+              sources: [
+                %{id: "swiftly", value: "swiftly_route"},
+                %{id: "busloc", value: "busloc_route"}
+              ]
+            }
+          ]
+        )
+
+      assert Mergeable.merge(swiftly, non_swiftly) == expected
+      assert Mergeable.merge(non_swiftly, swiftly) == expected
+    end
+
+    test "merge/2 takes the other trip and route values if the swiftly values are nil" do
+      swiftly =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          trip_id: nil,
+          route_id: nil,
+          source: "swiftly"
+        )
+
+      non_swiftly =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "busloc_trip",
+          route_id: "busloc_route",
+          source: "busloc"
+        )
+
+      expected =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "busloc_trip",
+          route_id: "busloc_route",
+          source: "busloc|swiftly",
+          data_discrepancies: [
+            %DataDiscrepancy{
+              attribute: :trip_id,
+              sources: [
+                %{id: "swiftly", value: nil},
+                %{id: "busloc", value: "busloc_trip"}
+              ]
+            },
+            %DataDiscrepancy{
+              attribute: :route_id,
+              sources: [
+                %{id: "swiftly", value: nil},
+                %{id: "busloc", value: "busloc_route"}
+              ]
+            }
+          ]
+        )
+
+      assert Mergeable.merge(swiftly, non_swiftly) == expected
+      assert Mergeable.merge(non_swiftly, swiftly) == expected
+    end
+
+    test "merge/2 doesn't include any data discrepancies if they values are the same" do
+      first =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          trip_id: "trip",
+          route_id: "route",
+          source: "first"
+        )
+
+      second =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "trip",
+          route_id: "route",
+          source: "second"
+        )
+
+      expected =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          trip_id: "trip",
+          route_id: "route",
+          source: "first|second",
+          data_discrepancies: []
+        )
+
+      assert Mergeable.merge(first, second) == expected
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [Prioritize Swiftly vehicle trip assignment in concentrate merge](https://app.asana.com/0/1112935048846093/1126289135392019)

Save data discrepancies any time swiftly and busloc provide differing
trip_id or route_id.