### PR TITLE
Don't include route id and headway in discrepancies

### DIFF
--- a/assets/src/components/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/vehiclePropertiesPanel.tsx
@@ -259,7 +259,7 @@ const directionsUrl = (
 &destination=${latitude.toString()},${longitude.toString()}\
 &travelmode=driving`
 
-const shouldShowDataDiscrepancies = ({ dataDiscrepancies }: Vehicle) =>
+const shouldShowDataDiscrepancies = ({ dataDiscrepancies }: Vehicle): boolean =>
   inDebugMode() && dataDiscrepancies.length > 0
 
 const inDebugMode = (): boolean =>

--- a/assets/src/components/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/vehiclePropertiesPanel.tsx
@@ -260,7 +260,7 @@ const directionsUrl = (
 &travelmode=driving`
 
 const shouldShowDataDiscrepancies = ({ dataDiscrepancies }: Vehicle) =>
-  inDebugMode() && dataDiscrepancies.length
+  inDebugMode() && dataDiscrepancies.length > 0
 
 const inDebugMode = (): boolean =>
   !!new URL(document.location.href).searchParams.get("debug")

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -171,9 +171,7 @@ defmodule Concentrate.VehiclePosition do
 
     defp discrepancies(first, second) do
       attributes = [
-        {:trip_id, &VehiclePosition.trip_id/1},
-        {:route_id, &VehiclePosition.route_id/1},
-        {:headsign, &VehiclePosition.headsign/1}
+        {:trip_id, &VehiclePosition.trip_id/1}
       ]
 
       Enum.flat_map(attributes, &discrepancy(&1, first, second))

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -32,13 +32,6 @@ defmodule Concentrate.VehiclePositionTest do
                 %{id: "first", value: "trip"},
                 %{id: "second", value: nil}
               ]
-            },
-            %DataDiscrepancy{
-              attribute: :route_id,
-              sources: [
-                %{id: "first", value: "route"},
-                %{id: "second", value: nil}
-              ]
             }
           ]
         )
@@ -105,13 +98,6 @@ defmodule Concentrate.VehiclePositionTest do
                 %{id: "swiftly", value: "swiftly_trip"},
                 %{id: "busloc", value: "busloc_trip"}
               ]
-            },
-            %DataDiscrepancy{
-              attribute: :route_id,
-              sources: [
-                %{id: "swiftly", value: "swiftly_route"},
-                %{id: "busloc", value: "busloc_route"}
-              ]
             }
           ]
         )
@@ -130,13 +116,6 @@ defmodule Concentrate.VehiclePositionTest do
               sources: [
                 %{id: "busloc", value: "busloc_trip"},
                 %{id: "swiftly", value: "swiftly_trip"}
-              ]
-            },
-            %DataDiscrepancy{
-              attribute: :route_id,
-              sources: [
-                %{id: "busloc", value: "busloc_route"},
-                %{id: "swiftly", value: "swiftly_route"}
               ]
             }
           ]
@@ -183,13 +162,6 @@ defmodule Concentrate.VehiclePositionTest do
               sources: [
                 %{id: "swiftly", value: nil},
                 %{id: "busloc", value: "busloc_trip"}
-              ]
-            },
-            %DataDiscrepancy{
-              attribute: :route_id,
-              sources: [
-                %{id: "swiftly", value: nil},
-                %{id: "busloc", value: "busloc_route"}
               ]
             }
           ]


### PR DESCRIPTION
These are never set by Busloc so they were always showing up.

Ensure that discrepancy check returns a boolean value.