### PR TITLE
Sign the user out and redirect home on auth failure

### DIFF
--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -22,6 +22,13 @@ defmodule SkateWeb.AuthController do
   end
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
-    send_resp(conn, 403, "unauthenticated")
+    # Users are sometimes seeing unexpected Ueberauth failures of unknown provenance.
+    # Instead of sending a 403 unauthenticated response, we are signing them out and
+    # sending them to the home page to start the auth path over again.
+    # We should be on the lookout for users getting trapped in a loop because of this.
+    # If we observe that happening we should rethink this remedy. -- MSS 2019-07-03
+    conn
+    |> Guardian.Plug.sign_out(AuthManager, [])
+    |> redirect(to: Helpers.page_path(conn, :index))
   end
 end

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -26,13 +26,13 @@ defmodule SkateWeb.AuthControllerTest do
       assert redirected_to(conn) == "/"
     end
 
-    test "sends unauthenticated for an ueberauth failure", %{conn: conn} do
+    test "redirects home for an ueberauth failure", %{conn: conn} do
       conn =
         conn
         |> assign(:ueberauth_failure, "failed")
         |> get("/auth/cognito/callback")
 
-      assert response(conn, 403) == "unauthenticated"
+      assert redirected_to(conn) == "/"
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [🐞Unauthorized screen sometimes appears after Cognito login](https://app.asana.com/0/1112935048846093/1129718872336334)

Users are sometimes seeing unexpected Ueberauth failures of unknown
provenance. Instead of sending a 403 unauthenticated response, we are
signing them out and sending them to the home page to start the auth
path over again.

We should be on the lookout for users getting trapped in a loop because
of this. If we observe that happening we should rethink this remedy.