### PR TITLE
be resilient to loading lots of routes at once

### DIFF
--- a/assets/src/hooks/useTimepoints.ts
+++ b/assets/src/hooks/useTimepoints.ts
@@ -8,20 +8,20 @@ const useTimepoints = (selectedRouteIds: RouteId[]): TimepointsByRouteId => {
   >({})
 
   const setLoadingTimepointsForRoute = (routeId: RouteId): void => {
-    setTimepointsByRouteId({
-      ...timepointsByRouteId,
+    setTimepointsByRouteId(previousTimepointsByRouteId => ({
+      ...previousTimepointsByRouteId,
       [routeId]: null,
-    })
+    }))
   }
 
   const setTimepointsForRoute = (
     routeId: RouteId,
     timepoints: Timepoint[]
   ): void => {
-    setTimepointsByRouteId({
-      ...timepointsByRouteId,
+    setTimepointsByRouteId(previousTimepointsByRouteId => ({
+      ...previousTimepointsByRouteId,
       [routeId]: timepoints,
-    })
+    }))
   }
 
   useEffect(() => {


### PR DESCRIPTION
Asana Task: None

I tried to open a whole bunch of routes at once, and got into an infinite refetching loop because making a whole bunch of `setState` calls at once would overwrite previous state.

By passing a function instead of a value into the `setState` calls, React will be able to handle multiple updates that are close to each other.