### PR TITLE
initialize tile layer when map is initialized

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -73,20 +73,6 @@ export const updateMap = (
   vehicleLabel.setIcon(label)
 }
 
-// exported for tests only.
-export const mapOptions = {
-  layers: [
-    Leaflet.tileLayer(
-      `https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png`,
-      {
-        attribution:
-          '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-      }
-    ),
-  ],
-  zoom: 16,
-}
-
 const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const containerRef: MutableRefObject<HTMLDivElement | null> = useRef(null)
   const [state, updateState] = useState<State>({
@@ -100,7 +86,20 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
       return
     }
 
-    const map = state.map || Leaflet.map(containerRef.current, mapOptions)
+    const map =
+      state.map ||
+      Leaflet.map(containerRef.current, {
+        layers: [
+          Leaflet.tileLayer(
+            `https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles/{z}/{x}/{y}.png`,
+            {
+              attribution:
+                '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+            }
+          ),
+        ],
+        zoom: 16,
+      })
 
     const vehicleIcon =
       state.vehicleIcon ||

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -1,7 +1,7 @@
 import Leaflet from "leaflet"
 import React from "react"
 import renderer from "react-test-renderer"
-import Map, { mapOptions, updateMap } from "../../src/components/map"
+import Map, { updateMap } from "../../src/components/map"
 
 describe("map", () => {
   test("renders", () => {
@@ -24,7 +24,7 @@ describe("map", () => {
 describe("updateMap", () => {
   test("updates lat/lng values for map & markers", () => {
     document.body.innerHTML = "<div id='map'></div>"
-    const map = Leaflet.map("map", mapOptions)
+    const map = Leaflet.map("map", {})
     const vehicleIcon = Leaflet.marker([43, -72]).addTo(map)
     const vehicleLabel = Leaflet.marker([43, -72])
     updateMap(


### PR DESCRIPTION
Asana ticket: [🐞 Map tiles only shows up on the first vehicle you click, not on following ones](https://app.asana.com/0/1112935048846093/1132059249417762)

Turns out, the tile layer needs to be re-initialized every time a new map is drawn, otherwise the tiles will only show up on the first render.