### PR TITLE
load leaflet css in webpack

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -4450,6 +4450,28 @@
         "bser": "^2.0.0"
       }
     },
+    "file-loader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.1.0.tgz",
+      "integrity": "sha512-ajDk1nlByoalZAGR4b0H6oD+EGlWnyW1qbSxzaUc7RFiqmn+RbXQQRbTc72jsiUIlVusJ4Et58ltds8ZwTfnAw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
+          "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -7244,6 +7266,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
       "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
+    },
+    "leaflet-defaulticon-compatibility": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/leaflet-defaulticon-compatibility/-/leaflet-defaulticon-compatibility-0.1.1.tgz",
+      "integrity": "sha512-vDBFdlUAwjSEGep9ih8kfJilf6yN8V9zTbF5NC/1ZwLeGko3RUQepspPnGCRMFV51dY3Lb3hziboicrFz+rxQA=="
     },
     "left-pad": {
       "version": "1.3.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "leaflet": "^1.5.1",
+    "leaflet-defaulticon-compatibility": "^0.1.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "react": "^16.8.4",
@@ -40,6 +41,7 @@
     "css-loader": "^1.0.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
+    "file-loader": "^4.1.0",
     "jest": "^24.5.0",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "^4.11.0",

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -12,6 +12,8 @@ require("../css/app.scss")
 // Import dependencies
 //
 import "@babel/polyfill"
+import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
+import "leaflet/dist/leaflet.css"
 import "phoenix_html"
 import * as React from "react"
 import ReactDOM from "react-dom"

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -1,4 +1,5 @@
 import Leaflet, { Map as LeafletMap, Marker } from "leaflet"
+import "leaflet-defaulticon-compatibility" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
 import React, {
   MutableRefObject,
   ReactElement,

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -70,6 +70,10 @@ module.exports = (env, options) => ({
           },
         ],
       },
+      {
+        test: /\.png$/,
+        use: [{ loader: "file-loader" }],
+      },
     ],
   },
   resolve: {

--- a/lib/skate_web/templates/layout/app.html.eex
+++ b/lib/skate_web/templates/layout/app.html.eex
@@ -14,7 +14,6 @@
     <link rel="icon" href="<%= Routes.static_path(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
     <link rel="icon" href="<%= Routes.static_path(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
 
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
 
     <%= if record_fullstory?() do %>


### PR DESCRIPTION
There is a bug when using leaflet with webpack that prevents leaflet from being able to find its icon images. Someone wrote an npm package that fixes this bug, so we can load leaflet's CSS assets into our build instead of downloading them from an external source.