### PR TITLE
start HeadwaySpacing enum at 1

### DIFF
--- a/assets/src/models/vehicleStatus.ts
+++ b/assets/src/models/vehicleStatus.ts
@@ -3,7 +3,7 @@ import { ScheduleAdherenceStatus, Vehicle } from "../realtime.d"
 export type VehicleAdherenceStatus = ScheduleAdherenceStatus | "off-course"
 
 export enum HeadwaySpacing {
-  VeryBunched,
+  VeryBunched = 1,
   Bunched,
   Ok,
   Gapped,


### PR DESCRIPTION
Starting the enum at 1 will make it safe to do checks like `headwaySpacing ? "foo" : "bar"` when headwaySpacing is `HeadwaySpacing | null`.