### PR TITLE
Configure prod to use our CDN for static assets

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,6 +13,12 @@ config :skate, SkateWeb.Endpoint,
   server: true,
   http: [:inet6, port: System.get_env("PORT") || 4000],
   url: [host: {:system, "HOST"}, port: 80],
+  static_url: [
+    scheme: {:system, "STATIC_SCHEME"},
+    host: {:system, "STATIC_HOST"},
+    port: {:system, "STATIC_PORT"},
+    path: {:system, "STATIC_PATH"}
+  ],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :skate, :websocket_check_origin, [

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -10,6 +10,13 @@ defmodule Skate.Application do
 
     runtime_config()
 
+    # Pull the STATIC_SCHEME variable out of the environment
+    Application.put_env(
+      :skate,
+      SkateWeb.Endpoint,
+      update_static_url(Application.get_env(:skate, SkateWeb.Endpoint))
+    )
+
     # List all child processes to be supervised
     children = [
       # Start the endpoint when the application starts
@@ -58,6 +65,7 @@ defmodule Skate.Application do
 
   # Tell Phoenix to update the endpoint configuration
   # whenever the application is updated.
+  @spec config_change(any, any, any) :: :ok
   def config_change(changed, _new, removed) do
     SkateWeb.Endpoint.config_change(changed, removed)
     :ok
@@ -70,4 +78,23 @@ defmodule Skate.Application do
       value -> value
     end
   end
+
+  @spec update_static_url(list(tuple())) :: list(tuple())
+  def update_static_url([{:static_url, static_url_parts} | rest]) do
+    static_url_parts =
+      Enum.map(static_url_parts, fn {key, value} -> {key, update_static_url_part(value)} end)
+
+    [{:static_url, static_url_parts} | update_static_url(rest)]
+  end
+
+  def update_static_url([first | rest]) do
+    [first | update_static_url(rest)]
+  end
+
+  def update_static_url([]) do
+    []
+  end
+
+  defp update_static_url_part({:system, env_var}), do: System.get_env(env_var)
+  defp update_static_url_part(value), do: value
 end

--- a/lib/skate_web/templates/layout/app.html.eex
+++ b/lib/skate_web/templates/layout/app.html.eex
@@ -10,11 +10,11 @@
 
     <title>Skate</title>
 
-    <link rel="apple-touch-icon" href="<%= Routes.static_path(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
-    <link rel="icon" href="<%= Routes.static_path(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
-    <link rel="icon" href="<%= Routes.static_path(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
+    <link rel="apple-touch-icon" href="<%= Routes.static_url(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
+    <link rel="icon" href="<%= Routes.static_url(@conn, "/images/mbta-logo-t-favicon.png") %>" sizes="32x32" type="image/png">
+    <link rel="icon" href="<%= Routes.static_url(@conn, "/favicon.ico") %>" sizes="16x16" type="image/vnd.microsoft.icon">
 
-    <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <link rel="stylesheet" href="<%= Routes.static_url(@conn, "/css/app.css") %>"/>
 
     <%= if record_fullstory?() do %>
       <%= render "_fullstory.html", assigns %>
@@ -25,6 +25,6 @@
     <main role="main" class="container">
       <%= render @view_module, @view_template, assigns %>
     </main>
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_url(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/test/skate/application_test.exs
+++ b/test/skate/application_test.exs
@@ -10,4 +10,41 @@ defmodule Skate.ApplicationTest do
       assert Skate.Application.get_config_string(:test_string) == "TEST VALUE"
     end
   end
+
+  describe "update_static_url/1" do
+    setup do
+      System.put_env("STATIC_SCHEME", "TEST_STATIC_SCHEME_VALUE")
+      System.put_env("STATIC_HOST", "TEST_STATIC_HOST_VALUE")
+      System.put_env("STATIC_PORT", "TEST_STATIC_PORT_VALUE")
+    end
+
+    test "parses static_url configuration from env variables" do
+      initial_endpoint_config = [
+        url: [host: "localhost"],
+        http: [port: 4000],
+        static_url: [
+          scheme: {:system, "STATIC_SCHEME"},
+          host: {:system, "STATIC_HOST"},
+          port: {:system, "STATIC_PORT"},
+          path: "RAW_TEST_STATIC_PATH_VALUE"
+        ],
+        debug_errors: true
+      ]
+
+      expected_endpoint_config = [
+        url: [host: "localhost"],
+        http: [port: 4000],
+        static_url: [
+          scheme: "TEST_STATIC_SCHEME_VALUE",
+          host: "TEST_STATIC_HOST_VALUE",
+          port: "TEST_STATIC_PORT_VALUE",
+          path: "RAW_TEST_STATIC_PATH_VALUE"
+        ],
+        debug_errors: true
+      ]
+
+      assert Skate.Application.update_static_url(initial_endpoint_config) ==
+               expected_endpoint_config
+    end
+  end
 end


### PR DESCRIPTION
Asana ticket: [Configure Skate to use the S3 bucket for static assets in production](https://app.asana.com/0/1112935048846093/1132374591821770)

Use `static_url` instead of `static_path`.

Parse static URL settings for the endpoint.

__NB:__ We need to add the env vars to the prod server before merging this. [Infrastructure ticket](https://app.asana.com/0/1113179098808463/1134131521035432)