### PR TITLE
don't use trip_update in vehicle

### DIFF
--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -2,11 +2,11 @@ defmodule Realtime.VehicleTest do
   use ExUnit.Case
   import Test.Support.Helpers
 
-  alias Concentrate.{DataDiscrepancy, TripUpdate, VehiclePosition}
+  alias Concentrate.{DataDiscrepancy, VehiclePosition}
   alias Gtfs.{StopTime, Trip}
   alias Realtime.Vehicle
 
-  describe "from_vehicle_position_and_trip_update/2" do
+  describe "from_vehicle_position" do
     setup do
       trip = %Trip{
         id: "39984755",
@@ -50,7 +50,7 @@ defmodule Realtime.VehicleTest do
       end)
     end
 
-    test "translates Concentrate VehiclePosition and TripUpdate data into a Vehicle struct" do
+    test "translates Concentrate VehiclePosition into a Vehicle struct" do
       vehicle_position = %VehiclePosition{
         bearing: 0,
         block_id: "S28-2",
@@ -91,15 +91,6 @@ defmodule Realtime.VehicleTest do
             ]
           }
         ]
-      }
-
-      trip_update = %TripUpdate{
-        direction_id: 1,
-        route_id: "28",
-        schedule_relationship: :SCHEDULED,
-        start_date: {2019, 5, 20},
-        start_time: nil,
-        trip_id: "39984755"
       }
 
       expected_result = %Vehicle{
@@ -160,142 +151,9 @@ defmodule Realtime.VehicleTest do
         route_status: :on_route
       }
 
-      result = Vehicle.from_vehicle_position_and_trip_update(vehicle_position, trip_update)
+      result = Vehicle.from_vehicle_position(vehicle_position)
 
       assert result == expected_result
-    end
-
-    test "takes direction_id and route_id values from TripUpdate if they aren't present on VehiclePosition" do
-      vehicle_position = %VehiclePosition{
-        bearing: 0,
-        block_id: "S28-2",
-        id: "y1261",
-        label: "1261",
-        last_updated: 1_558_364_020,
-        latitude: 42.31777347,
-        license_plate: nil,
-        longitude: -71.08206019,
-        odometer: nil,
-        operator_id: "72032",
-        operator_name: "MAUPIN",
-        run_id: "138-1038",
-        speed: 0.0,
-        # Expected headway is 628
-        headway_secs: 600,
-        is_laying_over: false,
-        layover_departure_time: nil,
-        status: :IN_TRANSIT_TO,
-        stop_id: "392",
-        stop_sequence: 25,
-        trip_id: "39984755",
-        sources: MapSet.new(["swiftly"]),
-        data_discrepancies: []
-      }
-
-      trip_update = %TripUpdate{
-        direction_id: 1,
-        route_id: "28",
-        schedule_relationship: :SCHEDULED,
-        start_date: {2019, 5, 20},
-        start_time: nil,
-        trip_id: "39984755"
-      }
-
-      expected_result = %Vehicle{
-        id: "y1261",
-        label: "1261",
-        timestamp: 1_558_364_020,
-        latitude: 42.31777347,
-        longitude: -71.08206019,
-        direction_id: 1,
-        route_id: "28",
-        trip_id: "39984755",
-        headsign: "headsign",
-        via_variant: "_",
-        bearing: 0,
-        speed: 0.0,
-        stop_sequence: 25,
-        block_id: "S28-2",
-        operator_id: "72032",
-        operator_name: "MAUPIN",
-        run_id: "138-1038",
-        headway_secs: 600,
-        headway_spacing: :ok,
-        is_off_course: false,
-        is_laying_over: false,
-        layover_departure_time: nil,
-        block_is_active: true,
-        sources: MapSet.new(["swiftly"]),
-        data_discrepancies: [],
-        stop_status: %{
-          status: :in_transit_to,
-          stop_id: "392",
-          stop_name: "392"
-        },
-        timepoint_status: nil,
-        scheduled_location: %{
-          route_id: "28",
-          direction_id: 1,
-          timepoint_status: %{
-            timepoint_id: "tp1",
-            fraction_until_timepoint: 0.0
-          }
-        },
-        route_status: :on_route
-      }
-
-      result = Vehicle.from_vehicle_position_and_trip_update(vehicle_position, trip_update)
-
-      assert result == expected_result
-    end
-
-    test "returns nil if not given a VehiclePosition" do
-      vehicle_position = nil
-
-      trip_update = %TripUpdate{
-        direction_id: 1,
-        route_id: "28",
-        schedule_relationship: :SCHEDULED,
-        start_date: {2019, 5, 20},
-        start_time: nil,
-        trip_id: "39984755"
-      }
-
-      result = Vehicle.from_vehicle_position_and_trip_update(vehicle_position, trip_update)
-
-      assert result == nil
-    end
-
-    test "returns a Vehicle struct even if not given a TripUpdate" do
-      vehicle_position = %VehiclePosition{
-        bearing: 0,
-        block_id: "S28-2",
-        id: "y1261",
-        is_laying_over: false,
-        label: "1261",
-        last_updated: 1_558_364_020,
-        latitude: 42.31777347,
-        layover_departure_time: nil,
-        license_plate: nil,
-        longitude: -71.08206019,
-        odometer: nil,
-        operator_id: "72032",
-        operator_name: "MAUPIN",
-        route_id: "28",
-        direction_id: 1,
-        run_id: "138-1038",
-        speed: 0.0,
-        status: :IN_TRANSIT_TO,
-        stop_id: "392",
-        stop_sequence: 25,
-        trip_id: "39984755"
-      }
-
-      trip_update = nil
-
-      result = Vehicle.from_vehicle_position_and_trip_update(vehicle_position, trip_update)
-
-      assert %Vehicle{} = result
     end
   end
 


### PR DESCRIPTION
No Asana task.

I noticed that the only uses of `trip_update` when building vehicles are for the `route_id` and the `direction_id`, which both already exist in the `vehicle_position` and the `trip`, so I figured we could simplify some things by using those instead.

There was a test specifically about using the `trip_update` when the `vehicle_position` was missing those fields. Do you know in what cases we expect that to happen? Would using the GTFS trip adequately cover that?

I think there's still a bunch of complexity around passing the trip updates through concentrate, but I'm not familiar enough with that code to remove it from there, so I left it there, in the same way that `StopTimeUpdate` is there but unused.