### PR TITLE
Fix direction logic for off-course vehicles

### DIFF
--- a/assets/src/models/ladderVehicle.ts
+++ b/assets/src/models/ladderVehicle.ts
@@ -154,7 +154,7 @@ const vehicleOnLadder = (
   )
 
   const vehicleDirection: VehicleDirection =
-    isOffCourse && scheduledVehicleDirection
+    isOffCourse && scheduledVehicleDirection !== undefined
       ? scheduledVehicleDirection
       : directionOnLadder(vehicle.directionId, ladderDirection)
 


### PR DESCRIPTION
Asana ticket: [🐞 Off course buses might be on the wrong side?](https://app.asana.com/0/1112935048846093/1131695373496765)

Before change (observe the N/A vehicle):

![Screen Shot 2019-08-22 at 10 29 37](https://user-images.githubusercontent.com/42339/63526136-e07a6180-c4cc-11e9-9820-65756204de0c.png)
![Screen Shot 2019-08-22 at 10 29 41](https://user-images.githubusercontent.com/42339/63526142-e2442500-c4cc-11e9-81c6-55d6b60dd607.png)

After change:

![Screen Shot 2019-08-22 at 10 29 54](https://user-images.githubusercontent.com/42339/63526158-e83a0600-c4cc-11e9-8721-d5ce36ac9f96.png)
![Screen Shot 2019-08-22 at 10 29 59](https://user-images.githubusercontent.com/42339/63526160-ea03c980-c4cc-11e9-8ef5-6e05326946d8.png)
