### PR TITLE
Ghost buses!

### DIFF
--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -50,6 +50,10 @@
       stroke: $color-secondary-light;
     }
 
+    .m-vehicle-icon__ghost-highlight {
+      stroke: $color-secondary-light;
+    }
+
     .m-vehicle-icon__label-background {
       fill: $color-secondary-light;
     }
@@ -57,6 +61,10 @@
 
   &.selected {
     .m-vehicle-icon__triangle {
+      stroke: $color-secondary-medium;
+    }
+
+    .m-vehicle-icon__ghost-highlight {
       stroke: $color-secondary-medium;
     }
 

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -30,8 +30,8 @@ $color-vehicle-normal-line: $color-component-light;
 $color-vehicle-ontime: #8bcf00;
 $color-vehicle-late: #46a5e7;
 $color-vehicle-early: $color-component-red;
-$color-vehicle-ghost: $color-bg-base;
-$color-vehicle-ghost-border: $color-component-dark;
+$color-vehicle-ghost: $white;
+$color-vehicle-ghost-border: $color-component-medium;
 $color-vehicle-nonrevenue: #8f7ed6;
 $color-vehicle-off-course: $color-component-dark;
 

--- a/assets/css/_vehicle_icon.scss
+++ b/assets/css/_vehicle_icon.scss
@@ -17,6 +17,22 @@
   }
 }
 
+.m-vehicle-icon__ghost-highlight {
+  fill: none;
+  stroke: none;
+  stroke-width: 9;
+}
+
+.m-vehicle-icon__ghost-body {
+  fill: $color-vehicle-ghost;
+  stroke: $color-vehicle-ghost-border;
+  stroke-width: 3;
+}
+
+.m-vehicle-icon__ghost-eye {
+  fill: $color-vehicle-ghost-border;
+}
+
 .m-vehicle-icon__label-background {
   fill: $color-bg-base;
 }
@@ -27,6 +43,10 @@
 
 .m-vehicle-icon__variant {
   fill: $color-font-light;
+
+  .ghost & {
+    fill: $color-vehicle-ghost-border;
+  }
 }
 
 .m-vehicle-icon--small {

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -10,7 +10,12 @@ import {
   VehicleDirection,
 } from "../models/ladderVehicle"
 import { statusClass } from "../models/vehicleStatus"
-import { Vehicle, VehicleId, VehicleTimepointStatus } from "../realtime.d"
+import {
+  Ghost,
+  Vehicle,
+  VehicleId,
+  VehicleTimepointStatus,
+} from "../realtime.d"
 import { TimepointId } from "../schedule.d"
 import { selectVehicle } from "../state"
 import HeadwayLines from "./headwayLines"
@@ -19,6 +24,7 @@ import { Orientation, Size, VehicleIconSvgNode } from "./vehicleIcon"
 export interface Props {
   timepoints: TimepointId[]
   vehicles: Vehicle[]
+  ghosts: Ghost[]
   ladderDirection: LadderDirection
   selectedVehicleId?: VehicleId
 }
@@ -47,6 +53,7 @@ const MARGIN_TOP_BOTTOM = 20 // space between the top of the route and the top o
 const Ladder = ({
   timepoints,
   vehicles,
+  ghosts,
   ladderDirection,
   selectedVehicleId,
 }: Props) => {
@@ -69,6 +76,7 @@ const Ladder = ({
 
   const { ladderVehicles, widthOfLanes } = ladderVehiclesFromVehicles(
     vehiclesWithAnActiveBlock,
+    ghosts,
     ladderDirection,
     timepointStatusY
   )
@@ -260,7 +268,7 @@ const ScheduledLine = ({
 }: {
   ladderVehicle: LadderVehicle
 }) => {
-  if (!scheduledY || status === "off-course") {
+  if (!scheduledY || status === "off-course" || status === "ghost") {
     return null
   }
 

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -105,6 +105,7 @@ const RouteLadder = ({
           <Ladder
             timepoints={timepoints}
             vehicles={vehiclesForRoute ? vehiclesForRoute.onRouteVehicles : []}
+            ghosts={vehiclesForRoute ? vehiclesForRoute.ghosts : []}
             ladderDirection={ladderDirection}
             selectedVehicleId={selectedVehicleId}
           />

--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -3,6 +3,7 @@ import { Dispatch as ReactDispatch, useEffect, useReducer } from "react"
 import { HeadwaySpacing } from "../models/vehicleStatus"
 import {
   DataDiscrepancy,
+  Ghost,
   Vehicle,
   VehicleScheduledLocation,
   VehiclesForRoute,
@@ -20,6 +21,16 @@ interface DataDiscrepancyData {
 interface DataDiscrepancySourceData {
   id: string
   value: string
+}
+
+interface GhostData {
+  id: string
+  direction_id: DirectionId
+  route_id: string
+  trip_id: string
+  block_id: string
+  via_variant: string | null
+  scheduled_timepoint_status: VehicleTimepointStatusData
 }
 
 type RawHeadwaySpacing =
@@ -83,6 +94,7 @@ interface VehicleData {
 interface VehiclesForRouteData {
   on_route_vehicles: VehicleData[]
   incoming_vehicles: VehicleData[]
+  ghosts: GhostData[]
 }
 
 interface State {
@@ -216,6 +228,18 @@ const dataDiscrepanciesFromData = (
     sources: dataDiscrepancy.sources,
   }))
 
+const ghostFromData = (ghostData: GhostData): Ghost => ({
+  id: ghostData.id,
+  directionId: ghostData.direction_id,
+  routeId: ghostData.route_id,
+  tripId: ghostData.trip_id,
+  blockId: ghostData.block_id,
+  viaVariant: ghostData.via_variant,
+  scheduledTimepointStatus: vehicleTimepointStatusFromData(
+    ghostData.scheduled_timepoint_status
+  ),
+})
+
 const vehicleScheduledLocationFromData = (
   vehicleScheduledLocationData: VehicleScheduledLocationData
 ): VehicleScheduledLocation => ({
@@ -289,6 +313,7 @@ const vehiclesForRouteFromData = (
   incomingVehicles: vehiclesForRouteData.incoming_vehicles.map(
     vehicleFromData({ isOnRoute: false })
   ),
+  ghosts: vehiclesForRouteData.ghosts.map(ghostFromData),
 })
 
 const subscribe = (

--- a/assets/src/models/vehicleStatus.ts
+++ b/assets/src/models/vehicleStatus.ts
@@ -17,7 +17,7 @@ export enum HeadwaySpacing {
 /** How the vehicle triangle should be drawn,
  * taking into account the vehicle's state and the settings
  */
-export type DrawnStatus = OnTimeStatus | "off-course" | "plain"
+export type DrawnStatus = OnTimeStatus | "off-course" | "ghost" | "plain"
 
 export const onTimeStatus = (scheduleAdherenceSecs: number): OnTimeStatus => {
   const oneMinuteInSeconds = 60

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -1,4 +1,5 @@
 import {
+  BlockId,
   DirectionId,
   RouteId,
   StopId,
@@ -19,6 +20,16 @@ interface DataDiscrepancySource {
   value: string | null
 }
 
+export interface Ghost {
+  id: string
+  directionId: DirectionId
+  routeId: RouteId
+  tripId: TripId
+  blockId: BlockId
+  viaVariant: ViaVariant | null
+  scheduledTimepointStatus: VehicleTimepointStatus
+}
+
 export type SourceId = string
 
 export interface Vehicle {
@@ -37,7 +48,7 @@ export interface Vehicle {
   operatorName: string
   bearing: number
   speed: number | null
-  blockId: string
+  blockId: BlockId
   headwaySecs: number | null
   headwaySpacing: HeadwaySpacing | null
   previousVehicleId: string
@@ -78,4 +89,5 @@ export type VehicleStatus = "in_transit_to" | "stopped_at"
 export interface VehiclesForRoute {
   onRouteVehicles: Vehicle[]
   incomingVehicles: Vehicle[]
+  ghosts: Ghost[]
 }

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -112,10 +112,12 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     case "SELECT_VEHICLE":
-      return {
-        ...state,
-        selectedVehicleId: action.payload.vehicleId,
-      }
+      return action.payload.vehicleId.startsWith("ghost-")
+        ? state
+        : {
+            ...state,
+            selectedVehicleId: action.payload.vehicleId,
+          }
     case "DESELECT_VEHICLE":
       return {
         ...state,

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -349,6 +349,158 @@ exports[`ladder highlights a selected vehicle 1`] = `
 </div>
 `;
 
+exports[`ladder renders a ghost bus 1`] = `
+<div
+  className="m-ladder"
+  style={
+    Object {
+      "width": 184,
+    }
+  }
+>
+  <svg
+    className="m-ladder__svg"
+    height={0}
+    viewBox="-92 -20 184 0"
+    width={184}
+  >
+    <g>
+      <g
+        className="m-ladder__vehicle "
+        onClick={[Function]}
+        transform="translate(63,0)"
+      >
+        <g
+          className="m-vehicle-icon m-vehicle-icon--medium ghost"
+        >
+          <rect
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={11.5}
+          />
+          <text
+            className="m-vehicle-icon__label"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={17}
+          >
+            N/A
+          </text>
+          <g
+            transform="scale(0.4375) translate(-24,-23)"
+          >
+            <path
+              className="m-vehicle-icon__ghost-highlight"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+            <path
+              className="m-vehicle-icon__ghost-body"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+          </g>
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={4.5}
+          >
+            X
+          </text>
+        </g>
+      </g>
+    </g>
+    <line
+      className="m-ladder__line"
+      x1={-40}
+      x2={-40}
+      y1="0"
+      y2={-40}
+    />
+    <line
+      className="m-ladder__line"
+      x1={40}
+      x2={40}
+      y1="0"
+      y2={-40}
+    />
+    <g
+      className="m-ladder__headway-lines"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-0}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-0}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-0}
+    >
+      t0
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-20}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-20}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-20}
+    >
+      t1
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-40}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-40}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-40}
+    >
+      t2
+    </text>
+  </svg>
+</div>
+`;
+
 exports[`ladder renders a ladder 1`] = `
 <div
   className="m-ladder"

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -490,15 +490,15 @@ Array [
     className="m-ladder"
     style={
       Object {
-        "width": 184,
+        "width": 232,
       }
     }
   >
     <svg
       className="m-ladder__svg"
       height={0}
-      viewBox="-92 -20 184 0"
-      width={184}
+      viewBox="-116 -20 232 0"
+      width={232}
     >
       <line
         className="m-ladder__scheduled-line "
@@ -511,7 +511,7 @@ Array [
         <g
           className="m-ladder__vehicle "
           onClick={[Function]}
-          transform="translate(63,-10)"
+          transform="translate(87,-10)"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--medium "
@@ -548,6 +548,64 @@ Array [
             >
               4
             </text>
+          </g>
+        </g>
+      </g>
+      <g>
+        <g
+          className="m-ladder__vehicle "
+          onClick={[Function]}
+          transform="translate(63,-40)"
+        >
+          <g
+            className="m-vehicle-icon m-vehicle-icon--medium ghost"
+          >
+            <rect
+              className="m-vehicle-icon__label-background"
+              height={11}
+              rx={5.5}
+              ry={5.5}
+              width={26}
+              x={-13}
+              y={11.5}
+            />
+            <text
+              className="m-vehicle-icon__label"
+              dominantBaseline="central"
+              textAnchor="middle"
+              x="0"
+              y={17}
+            >
+              N/A
+            </text>
+            <g
+              transform="scale(0.4375) translate(-24,-23)"
+            >
+              <path
+                className="m-vehicle-icon__ghost-highlight"
+                d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+                stroke-join="round"
+              />
+              <path
+                className="m-vehicle-icon__ghost-body"
+                d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+                stroke-join="round"
+              />
+              <ellipse
+                className="m-vehicle-icon__ghost-eye"
+                cx="19.73"
+                cy="22.8"
+                rx="3.11"
+                ry="3.03"
+              />
+              <ellipse
+                className="m-vehicle-icon__ghost-eye"
+                cx="35.29"
+                cy="22.8"
+                rx="3.11"
+                ry="3.03"
+              />
+            </g>
           </g>
         </g>
       </g>
@@ -852,11 +910,11 @@ Array [
       <svg
         style={
           Object {
-            "height": 13.68,
+            "height": 15.2,
             "width": 16.72,
           }
         }
-        viewBox="-8.36 -6.08 16.72 13.68"
+        viewBox="-8.36 -7.6 16.72 15.2"
       >
         <g
           className="m-vehicle-icon m-vehicle-icon--small "
@@ -890,11 +948,11 @@ Array [
       <svg
         style={
           Object {
-            "height": 13.68,
+            "height": 15.2,
             "width": 16.72,
           }
         }
-        viewBox="-8.36 -7.6 16.72 13.68"
+        viewBox="-8.36 -7.6 16.72 15.2"
       >
         <g
           className="m-vehicle-icon m-vehicle-icon--small "

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -1,5 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ghost going down puts label above it 1`] = `
+<svg
+  style={
+    Object {
+      "height": 36,
+      "width": 27.5,
+    }
+  }
+  viewBox="-13.75 -23.5 27.5 36"
+>
+  <g
+    className="m-vehicle-icon m-vehicle-icon--medium ghost"
+  >
+    <rect
+      className="m-vehicle-icon__label-background"
+      height={11}
+      rx={5.5}
+      ry={5.5}
+      width={26}
+      x={-13}
+      y={-22.5}
+    />
+    <text
+      className="m-vehicle-icon__label"
+      dominantBaseline="central"
+      textAnchor="middle"
+      x="0"
+      y={-17}
+    >
+      ghost
+    </text>
+    <g
+      transform="scale(0.4375) translate(-24,-23)"
+    >
+      <path
+        className="m-vehicle-icon__ghost-highlight"
+        d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+        stroke-join="round"
+      />
+      <path
+        className="m-vehicle-icon__ghost-body"
+        d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+        stroke-join="round"
+      />
+      <ellipse
+        className="m-vehicle-icon__ghost-eye"
+        cx="19.73"
+        cy="22.8"
+        rx="3.11"
+        ry="3.03"
+      />
+      <ellipse
+        className="m-vehicle-icon__ghost-eye"
+        cx="35.29"
+        cy="22.8"
+        rx="3.11"
+        ry="3.03"
+      />
+    </g>
+  </g>
+</svg>
+`;
+
+exports[`ghost with variant doesn't have eyes 1`] = `
+<svg
+  style={
+    Object {
+      "height": 25,
+      "width": 27.5,
+    }
+  }
+  viewBox="-13.75 -12.5 27.5 25"
+>
+  <g
+    className="m-vehicle-icon m-vehicle-icon--medium ghost"
+  >
+    <g
+      transform="scale(0.4375) translate(-24,-23)"
+    >
+      <path
+        className="m-vehicle-icon__ghost-highlight"
+        d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+        stroke-join="round"
+      />
+      <path
+        className="m-vehicle-icon__ghost-body"
+        d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+        stroke-join="round"
+      />
+    </g>
+    <text
+      className="m-vehicle-icon__variant"
+      dominantBaseline="alphabetic"
+      textAnchor="middle"
+      x={0}
+      y={4.5}
+    >
+      X
+    </text>
+  </g>
+</svg>
+`;
+
 exports[`renders an unwrapped svg node 1`] = `
 <svg>
   <g
@@ -37,11 +140,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 13.68,
+        "height": 15.2,
         "width": 16.72,
       }
     }
-    viewBox="-8.36 -6.08 16.72 13.68"
+    viewBox="-8.36 -7.6 16.72 15.2"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -57,10 +160,10 @@ Array [
     style={
       Object {
         "height": 16.72,
-        "width": 13.68,
+        "width": 15.2,
       }
     }
-    viewBox="-7.6 -8.36 13.68 16.72"
+    viewBox="-7.6 -8.36 15.2 16.72"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -75,11 +178,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 13.68,
+        "height": 15.2,
         "width": 16.72,
       }
     }
-    viewBox="-8.36 -7.6 16.72 13.68"
+    viewBox="-8.36 -7.6 16.72 15.2"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -95,10 +198,10 @@ Array [
     style={
       Object {
         "height": 16.72,
-        "width": 13.68,
+        "width": 15.2,
       }
     }
-    viewBox="-6.08 -8.36 13.68 16.72"
+    viewBox="-7.6 -8.36 15.2 16.72"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -113,11 +216,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -133,10 +236,10 @@ Array [
     style={
       Object {
         "height": 27.5,
-        "width": 22.5,
+        "width": 25,
       }
     }
-    viewBox="-12.5 -13.75 22.5 27.5"
+    viewBox="-12.5 -13.75 25 27.5"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -151,11 +254,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -12.5 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -171,10 +274,10 @@ Array [
     style={
       Object {
         "height": 27.5,
-        "width": 22.5,
+        "width": 25,
       }
     }
-    viewBox="-10 -13.75 22.5 27.5"
+    viewBox="-12.5 -13.75 25 27.5"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -189,11 +292,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 36,
+        "height": 40,
         "width": 44,
       }
     }
-    viewBox="-22 -16 44 36"
+    viewBox="-22 -20 44 40"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "
@@ -209,10 +312,10 @@ Array [
     style={
       Object {
         "height": 44,
-        "width": 36,
+        "width": 40,
       }
     }
-    viewBox="-20 -22 36 44"
+    viewBox="-20 -22 40 44"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "
@@ -227,11 +330,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 36,
+        "height": 40,
         "width": 44,
       }
     }
-    viewBox="-22 -20 44 36"
+    viewBox="-22 -20 44 40"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "
@@ -247,10 +350,10 @@ Array [
     style={
       Object {
         "height": 44,
-        "width": 36,
+        "width": 40,
       }
     }
-    viewBox="-16 -22 36 44"
+    viewBox="-20 -22 40 44"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "
@@ -270,11 +373,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium on-time"
@@ -289,11 +392,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium early"
@@ -308,11 +411,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium late"
@@ -327,11 +430,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium off-course"
@@ -346,11 +449,53 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium ghost"
+    >
+      <g
+        transform="scale(0.4375) translate(-24,-23)"
+      >
+        <path
+          className="m-vehicle-icon__ghost-highlight"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <path
+          className="m-vehicle-icon__ghost-body"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="19.73"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="35.29"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+      </g>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 25,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -365,11 +510,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 22.5,
+        "height": 25,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 22.5"
+    viewBox="-13.75 -12.5 27.5 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -389,11 +534,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 24.68,
+        "height": 26.200000000000003,
         "width": 26,
       }
     }
-    viewBox="-13 -6.08 26 24.68"
+    viewBox="-13 -7.6 26 26.200000000000003"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -481,11 +626,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 24.68,
+        "height": 26.200000000000003,
         "width": 26,
       }
     }
-    viewBox="-13 -18.6 26 24.68"
+    viewBox="-13 -18.6 26 26.200000000000003"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -573,11 +718,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 33.5,
+        "height": 36,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -10 27.5 33.5"
+    viewBox="-13.75 -12.5 27.5 36"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -665,11 +810,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 33.5,
+        "height": 36,
         "width": 27.5,
       }
     }
-    viewBox="-13.75 -23.5 27.5 33.5"
+    viewBox="-13.75 -23.5 27.5 36"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -757,11 +902,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 60,
+        "height": 64,
         "width": 64,
       }
     }
-    viewBox="-32 -16 64 60"
+    viewBox="-32 -20 64 64"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "
@@ -849,11 +994,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 60,
+        "height": 64,
         "width": 64,
       }
     }
-    viewBox="-32 -44 64 60"
+    viewBox="-32 -44 64 64"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large "

--- a/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -15,11 +15,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large "
@@ -307,11 +307,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large "
@@ -599,11 +599,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large "
@@ -891,11 +891,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large "
@@ -1183,11 +1183,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large off-course"
@@ -1479,11 +1479,11 @@ Array [
         <svg
           style={
             Object {
-              "height": 60,
+              "height": 64,
               "width": 64,
             }
           }
-          viewBox="-32 -16 64 60"
+          viewBox="-32 -20 64 64"
         >
           <g
             className="m-vehicle-icon m-vehicle-icon--large "

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -4,7 +4,7 @@ import renderer from "react-test-renderer"
 import Ladder, { LadderDirection } from "../../src/components/ladder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
-import { Vehicle } from "../../src/realtime.d"
+import { Ghost, Vehicle } from "../../src/realtime.d"
 import { TimepointId } from "../../src/schedule.d"
 import { initialState, selectVehicle } from "../../src/state"
 
@@ -148,6 +148,40 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
+          ladderDirection={ladderDirection}
+          selectedVehicleId={undefined}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders a ghost bus", () => {
+    const timepoints = ["t0", "t1", "t2"]
+
+    const ghost: Ghost = {
+      id: "ghost-trip",
+      directionId: 0,
+      routeId: "route",
+      tripId: "trip",
+      blockId: "block",
+      viaVariant: "X",
+      scheduledTimepointStatus: {
+        timepointId: "t0",
+        fractionUntilTimepoint: 0.0,
+      },
+    }
+
+    const ladderDirection = LadderDirection.ZeroToOne
+
+    const tree = renderer
+      .create(
+        <Ladder
+          timepoints={timepoints}
+          vehicles={[]}
+          ghosts={[ghost]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -254,6 +288,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -319,6 +354,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -425,6 +461,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={"upward"}
         />
@@ -486,6 +523,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={[vehicle]}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -547,6 +585,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -613,6 +652,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={vehicles}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -689,6 +729,7 @@ describe("ladder", () => {
         <Ladder
           timepoints={timepoints}
           vehicles={[vehicle]}
+          ghosts={[]}
           ladderDirection={ladderDirection}
           selectedVehicleId={undefined}
         />
@@ -838,6 +879,7 @@ describe("ladder", () => {
       <Ladder
         timepoints={timepoints}
         vehicles={vehicles}
+        ghosts={[]}
         ladderDirection={ladderDirection}
         selectedVehicleId={undefined}
       />

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -4,7 +4,7 @@ import renderer, { act } from "react-test-renderer"
 import RouteLadder from "../../src/components/routeLadder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
-import { Vehicle } from "../../src/realtime.d"
+import { Ghost, Vehicle } from "../../src/realtime.d"
 import { Route } from "../../src/schedule.d"
 import { deselectRoute, initialState, selectVehicle } from "../../src/state"
 
@@ -156,6 +156,20 @@ describe("routeLadder", () => {
       name: "28",
     }
     const timepoints = ["MATPN", "WELLH", "MORTN"]
+
+    const ghost: Ghost = {
+      id: "ghost-trip",
+      directionId: 0,
+      routeId: route.id,
+      tripId: "ghost trip",
+      blockId: "ghost block",
+      viaVariant: null,
+      scheduledTimepointStatus: {
+        timepointId: "MORTN",
+        fractionUntilTimepoint: 0.0,
+      },
+    }
+
     const tree = renderer
       .create(
         <RouteLadder
@@ -164,6 +178,7 @@ describe("routeLadder", () => {
           vehiclesForRoute={{
             onRouteVehicles: vehicles,
             incomingVehicles: [],
+            ghosts: [ghost],
           }}
           selectedVehicleId={undefined}
         />
@@ -188,6 +203,7 @@ describe("routeLadder", () => {
           vehiclesForRoute={{
             onRouteVehicles: [],
             incomingVehicles: vehicles,
+            ghosts: [],
           }}
           selectedVehicleId={undefined}
         />
@@ -219,6 +235,7 @@ describe("routeLadder", () => {
               { ...v1, isLayingOver: true },
               { ...v2, isLayingOver: true },
             ],
+            ghosts: [],
           }}
         />
       )
@@ -341,8 +358,8 @@ describe("routeLadder", () => {
         stopName: "stop",
       },
       timepointStatus: {
-        fractionUntilTimepoint: 0.5,
         timepointId: "MATPN",
+        fractionUntilTimepoint: 0.5,
       },
       scheduledLocation: null,
       isOnRoute: true,
@@ -356,6 +373,7 @@ describe("routeLadder", () => {
           vehiclesForRoute={{
             onRouteVehicles: [],
             incomingVehicles: [vehicle],
+            ghosts: [],
           }}
           selectedVehicleId={undefined}
         />

--- a/assets/tests/components/vehicleIcon.test.tsx
+++ b/assets/tests/components/vehicleIcon.test.tsx
@@ -139,6 +139,11 @@ test("renders with all statuses", () => {
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Up}
+          status={"ghost"}
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Up}
           status={"plain"}
         />
         <VehicleIcon size={Size.Medium} orientation={Orientation.Up} />
@@ -147,6 +152,98 @@ test("renders with all statuses", () => {
     .toJSON()
 
   expect(tree).toMatchSnapshot()
+})
+
+test("ghost with variant doesn't have eyes", () => {
+  const tree = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Up}
+        status={"ghost"}
+        variant={"X"}
+      />
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+test("ghost doesn't flip on its side", () => {
+  const up = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Up}
+        status={"ghost"}
+        label={"ghost"}
+      />
+    )
+    .toJSON()
+
+  const left = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Left}
+        status={"ghost"}
+        label={"ghost"}
+      />
+    )
+    .toJSON()
+
+  const right = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Right}
+        status={"ghost"}
+        label={"ghost"}
+      />
+    )
+    .toJSON()
+
+  expect(up).toEqual(left)
+  expect(up).toEqual(right)
+})
+
+test("ghost doesn't flip upside down", () => {
+  const upNoLabel = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Up}
+        status={"ghost"}
+      />
+    )
+    .toJSON()
+
+  const downNoLabel = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Down}
+        status={"ghost"}
+      />
+    )
+    .toJSON()
+
+  expect(upNoLabel).toEqual(downNoLabel)
+})
+
+test("ghost going down puts label above it", () => {
+  const ghostDownWithlabel = renderer
+    .create(
+      <VehicleIcon
+        size={Size.Medium}
+        orientation={Orientation.Down}
+        status={"ghost"}
+        label={"ghost"}
+      />
+    )
+    .toJSON()
+
+  expect(ghostDownWithlabel).toMatchSnapshot()
 })
 
 test("renders an unwrapped svg node", () => {

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react-hooks"
 import { Socket } from "phoenix"
 import useVehicles from "../../src/hooks/useVehicles"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
-import { Vehicle, VehicleTimepointStatus } from "../../src/realtime.d"
+import { Ghost, Vehicle, VehicleTimepointStatus } from "../../src/realtime.d"
 import { RouteId } from "../../src/schedule.d"
 
 // tslint:disable: react-hooks-nesting
@@ -222,6 +222,7 @@ describe("useVehicles", () => {
         handler({
           on_route_vehicles: vehiclesData,
           incoming_vehicles: [],
+          ghosts: [],
         })
       }
       return mockChannel
@@ -235,6 +236,7 @@ describe("useVehicles", () => {
       "1": {
         onRouteVehicles: vehicles,
         incomingVehicles: [],
+        ghosts: [],
       },
     })
   })
@@ -248,6 +250,7 @@ describe("useVehicles", () => {
         handler({
           on_route_vehicles: [],
           incoming_vehicles: vehiclesData,
+          ghosts: [],
         })
       }
       return mockChannel
@@ -266,6 +269,61 @@ describe("useVehicles", () => {
       "1": {
         onRouteVehicles: [],
         incomingVehicles,
+        ghosts: [],
+      },
+    })
+  })
+
+  test("returns ghost vehicles", async () => {
+    const ghost: Ghost = {
+      id: "ghost-trip",
+      directionId: 0,
+      routeId: "1",
+      tripId: "trip",
+      blockId: "block",
+      viaVariant: null,
+      scheduledTimepointStatus: {
+        timepointId: "t0",
+        fractionUntilTimepoint: 0.0,
+      },
+    }
+
+    const ghostData = {
+      id: "ghost-trip",
+      direction_id: 0,
+      route_id: "1",
+      trip_id: "trip",
+      block_id: "block",
+      via_variant: null,
+      scheduled_timepoint_status: {
+        timepoint_id: "t0",
+        fraction_until_timepoint: 0.0,
+      },
+    }
+
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.receive.mockImplementation((event, handler) => {
+      if (event === "ok") {
+        handler({
+          on_route_vehicles: [],
+          incoming_vehicles: [],
+          ghosts: [ghostData],
+        })
+      }
+      return mockChannel
+    })
+
+    const { result } = renderHook(() =>
+      useVehicles((mockSocket as any) as Socket, ["1"])
+    )
+
+    expect(result.current).toEqual({
+      "1": {
+        onRouteVehicles: [],
+        incomingVehicles: [],
+        ghosts: [ghost],
       },
     })
   })
@@ -279,6 +337,7 @@ describe("useVehicles", () => {
         handler({
           on_route_vehicles: vehiclesData,
           incoming_vehicles: [],
+          ghosts: [],
         })
       }
     })
@@ -291,6 +350,7 @@ describe("useVehicles", () => {
       "1": {
         onRouteVehicles: vehicles,
         incomingVehicles: [],
+        ghosts: [],
       },
     })
   })
@@ -322,6 +382,7 @@ describe("useVehicles", () => {
         handler({
           on_route_vehicles: vehiclesDataVaryingHeadway,
           incoming_vehicles: [],
+          ghosts: [],
         })
       }
     })
@@ -334,6 +395,7 @@ describe("useVehicles", () => {
       "1": {
         onRouteVehicles: expectedVehicles,
         incomingVehicles: [],
+        ghosts: [],
       },
     })
   })

--- a/assets/tests/models/vehiclesByRouteId.test.ts
+++ b/assets/tests/models/vehiclesByRouteId.test.ts
@@ -44,6 +44,7 @@ const vehiclesByRouteId: ByRouteId<VehiclesForRoute> = {
         isOnRoute: false,
       } as Vehicle,
     ],
+    ghosts: [],
   },
   "39": {
     onRouteVehicles: [
@@ -55,6 +56,7 @@ const vehiclesByRouteId: ByRouteId<VehiclesForRoute> = {
       } as Vehicle,
     ],
     incomingVehicles: [],
+    ghosts: [],
   },
 }
 

--- a/lib/gtfs/data.ex
+++ b/lib/gtfs/data.ex
@@ -127,6 +127,13 @@ defmodule Gtfs.Data do
     |> Map.new()
   end
 
+  @spec active_trips(t(), Util.Time.timestamp()) :: [Trip.t()]
+  def active_trips(data, now) do
+    data
+    |> active_trips_by_date(now, now)
+    |> Enum.flat_map(fn {_date, trips} -> trips end)
+  end
+
   @spec active_blocks(t(), Util.Time.timestamp(), Util.Time.timestamp()) :: %{
           Route.id() => [Block.id()]
         }

--- a/lib/realtime/ghost.ex
+++ b/lib/realtime/ghost.ex
@@ -1,0 +1,70 @@
+defmodule Realtime.Ghost do
+  alias Gtfs.{Block, Direction, Route, RoutePattern, StopTime, Trip}
+  alias Realtime.TimepointStatus
+  alias Realtime.Vehicle
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          direction_id: Direction.id(),
+          route_id: Route.id(),
+          trip_id: Trip.id(),
+          block_id: Block.id(),
+          via_variant: RoutePattern.via_variant() | nil,
+          scheduled_timepoint_status: TimepointStatus.timepoint_status()
+        }
+
+  @enforce_keys [
+    :id,
+    :direction_id,
+    :route_id,
+    :trip_id,
+    :block_id,
+    :scheduled_timepoint_status
+  ]
+
+  @derive Jason.Encoder
+
+  defstruct [
+    :id,
+    :direction_id,
+    :route_id,
+    :trip_id,
+    :block_id,
+    :via_variant,
+    :scheduled_timepoint_status
+  ]
+
+  @spec ghosts([Trip.t()], %{Block.id() => [Vehicle.t()]}, Util.Time.timestamp()) :: [t()]
+  def ghosts(trips, vehicles_by_block_id, now) do
+    trips
+    |> Enum.reject(fn trip ->
+      Map.has_key?(vehicles_by_block_id, trip.block_id)
+    end)
+    |> Enum.map(fn trip ->
+      timepoints = Enum.filter(trip.stop_times, &StopTime.is_timepoint?/1)
+
+      case timepoints do
+        [] ->
+          nil
+
+        _ ->
+          now_time_of_day =
+            Util.Time.next_time_of_day_for_timestamp_after(now, Trip.start_time(trip))
+
+          timepoint_status =
+            TimepointStatus.scheduled_timepoint_status(timepoints, now_time_of_day)
+
+          %__MODULE__{
+            id: "ghost-#{trip.id}",
+            direction_id: trip.direction_id,
+            route_id: trip.route_id,
+            trip_id: trip.id,
+            block_id: trip.block_id,
+            via_variant: trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id),
+            scheduled_timepoint_status: timepoint_status
+          }
+      end
+    end)
+    |> Enum.filter(& &1)
+  end
+end

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -72,13 +72,20 @@ defmodule Realtime.TimepointStatus do
 
     trip = scheduled_trip_on_block(block, now_time_of_day)
     timepoints = Enum.filter(trip.stop_times, &StopTime.is_timepoint?/1)
-    timepoint_status = scheduled_timepoint_status(timepoints, now_time_of_day)
 
-    %{
-      route_id: trip.route_id,
-      direction_id: trip.direction_id,
-      timepoint_status: timepoint_status
-    }
+    case timepoints do
+      [] ->
+        nil
+
+      _ ->
+        timepoint_status = scheduled_timepoint_status(timepoints, now_time_of_day)
+
+        %{
+          route_id: trip.route_id,
+          direction_id: trip.direction_id,
+          timepoint_status: timepoint_status
+        }
+    end
   end
 
   @spec scheduled_trip_on_block(Block.t(), Util.Time.time_of_day()) :: Trip.t()
@@ -103,7 +110,7 @@ defmodule Realtime.TimepointStatus do
   end
 
   @spec scheduled_timepoint_status([StopTime.t()], Util.Time.time_of_day()) :: timepoint_status()
-  defp scheduled_timepoint_status(timepoints, now) do
+  def scheduled_timepoint_status(timepoints, now) do
     cond do
       now <= List.first(timepoints).time ->
         # Trip isn't scheduled to have started yet

--- a/lib/realtime/vehicles.ex
+++ b/lib/realtime/vehicles.ex
@@ -1,7 +1,9 @@
 defmodule Realtime.Vehicles do
+  alias Realtime.Ghost
   alias Realtime.Vehicle
   alias Gtfs.Block
   alias Gtfs.Route
+  alias Gtfs.Trip
 
   @typedoc """
   The vehicles on one route,
@@ -9,14 +11,16 @@ defmodule Realtime.Vehicles do
   """
   @type for_route :: %{
           on_route_vehicles: [Vehicle.t()],
-          incoming_vehicles: [Vehicle.t()]
+          incoming_vehicles: [Vehicle.t()],
+          ghosts: [Ghost.t()]
         }
 
   @spec empty_vehicles_for_route() :: for_route()
   def empty_vehicles_for_route() do
     %{
       on_route_vehicles: [],
-      incoming_vehicles: []
+      incoming_vehicles: [],
+      ghosts: []
     }
   end
 
@@ -31,15 +35,21 @@ defmodule Realtime.Vehicles do
     now = Util.Time.now()
     in_fifteen_minutes = now + 15 * 60
     incoming_blocks_by_route = Gtfs.active_blocks(now, in_fifteen_minutes)
-    group_by_route_with_blocks(ungrouped_vehicles, incoming_blocks_by_route)
+    active_trips = Gtfs.active_trips(now)
+    group_by_route_with_blocks(ungrouped_vehicles, incoming_blocks_by_route, active_trips, now)
   end
 
   @doc """
   Exposed for testing
   """
-  @spec group_by_route_with_blocks([Vehicle.t()], Route.by_id([Block.id()])) ::
+  @spec group_by_route_with_blocks(
+          [Vehicle.t()],
+          Route.by_id([Block.id()]),
+          [Trip.t()],
+          Util.Time.timestamp()
+        ) ::
           Route.by_id(for_route())
-  def group_by_route_with_blocks(ungrouped_vehicles, incoming_blocks_by_route) do
+  def group_by_route_with_blocks(ungrouped_vehicles, incoming_blocks_by_route, active_trips, now) do
     vehicles_by_block = Enum.group_by(ungrouped_vehicles, fn vehicle -> vehicle.block_id end)
 
     unpartitioned_vehicles_by_route_id =
@@ -53,7 +63,23 @@ defmodule Realtime.Vehicles do
     incoming_from_another_route =
       incoming_from_another_route(incoming_blocks_by_route, vehicles_by_block)
 
-    merge(partitioned_vehicles_on_their_route, incoming_from_another_route)
+    ghosts =
+      active_trips
+      |> Realtime.Ghost.ghosts(vehicles_by_block, now)
+      |> Enum.group_by(fn ghost -> ghost.route_id end)
+      |> Helpers.map_values(fn ghosts ->
+        %{
+          on_route_vehicles: [],
+          incoming_vehicles: [],
+          ghosts: ghosts
+        }
+      end)
+
+    merge([
+      partitioned_vehicles_on_their_route,
+      incoming_from_another_route,
+      ghosts
+    ])
   end
 
   @spec partition_by_route_status([Vehicle.t()]) :: for_route()
@@ -63,7 +89,8 @@ defmodule Realtime.Vehicles do
 
     %{
       on_route_vehicles: on_route,
-      incoming_vehicles: incoming
+      incoming_vehicles: incoming,
+      ghosts: []
     }
   end
 
@@ -81,25 +108,35 @@ defmodule Realtime.Vehicles do
 
       vehicles_for_route = %{
         on_route_vehicles: [],
-        incoming_vehicles: incoming_vehicles
+        incoming_vehicles: incoming_vehicles,
+        ghosts: []
       }
 
       {route_id, vehicles_for_route}
     end)
   end
 
-  @spec merge(Route.by_id(for_route()), Route.by_id(for_route())) ::
-          Route.by_id(for_route())
-  defp merge(vehicles_by_route_id_1, vehicles_by_route_id_2) do
-    Map.merge(
-      vehicles_by_route_id_1,
-      vehicles_by_route_id_2,
-      fn _route_id, vehicles_1, vehicles_2 ->
-        %{
-          on_route_vehicles: vehicles_2.on_route_vehicles ++ vehicles_1.on_route_vehicles,
-          incoming_vehicles: vehicles_2.incoming_vehicles ++ vehicles_1.incoming_vehicles
-        }
-      end
-    )
+  @spec merge([Route.by_id(for_route())]) :: Route.by_id(for_route())
+  defp merge(vehicles_by_route_ids) do
+    vehicles_by_route_ids
+    |> merge_by_route_id()
+    |> Helpers.map_values(fn vehicles_for_routes ->
+      %{
+        on_route_vehicles: Enum.flat_map(vehicles_for_routes, & &1.on_route_vehicles),
+        incoming_vehicles: Enum.flat_map(vehicles_for_routes, & &1.incoming_vehicles),
+        ghosts: Enum.flat_map(vehicles_for_routes, & &1.ghosts)
+      }
+    end)
+  end
+
+  @spec merge_by_route_id([Route.by_id(v)]) :: Route.by_id([v]) when v: term()
+  defp merge_by_route_id(by_route_ids) do
+    Enum.reduce(by_route_ids, %{}, fn by_route_id, acc ->
+      by_route_id
+      |> Helpers.map_values(fn for_route -> [for_route] end)
+      |> Map.merge(acc, fn _route_id, [new_for_route], acc_for_routes ->
+        [new_for_route | acc_for_routes]
+      end)
+    end)
   end
 end

--- a/test/gtfs/data_test.exs
+++ b/test/gtfs/data_test.exs
@@ -456,6 +456,48 @@ defmodule Gtfs.DataTest do
     end
   end
 
+  describe "active_trips" do
+    test "returns active trips" do
+      trip = %Trip{
+        id: "trip",
+        route_id: "route",
+        service_id: "today",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop",
+            time: 2
+          },
+          %StopTime{
+            stop_id: "stop",
+            time: 4
+          }
+        ]
+      }
+
+      data = %Data{
+        routes: [],
+        route_patterns: [],
+        timepoint_ids_by_route: %{},
+        stops: [],
+        trips: %{
+          "trip" => trip
+        },
+        blocks: %{},
+        calendar: %{
+          ~D[2019-01-01] => ["today"]
+        }
+      }
+
+      # 2019-01-01 00:00:00 EST
+      time0 = 1_546_318_800
+
+      assert [%Trip{id: "trip"}] = Data.active_trips(data, time0 + 3)
+    end
+  end
+
   describe "active_blocks" do
     test "returns active blocks" do
       data = %Data{

--- a/test/gtfs_test.exs
+++ b/test/gtfs_test.exs
@@ -316,6 +316,40 @@ defmodule GtfsTest do
     end
   end
 
+  describe "active_trips" do
+    test "returns trips that are active right now" do
+      pid =
+        Gtfs.start_mocked(%{
+          "calendar.txt" => [
+            "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date",
+            "today,1,1,1,1,1,1,1,20190101,20190101",
+            "tomorrow,1,1,1,1,1,1,1,20190102,20190102"
+          ],
+          "routes.txt" => [
+            "route_id,route_type,route_short_name",
+            "route,3,route",
+            "other_route,3,other_route"
+          ],
+          "trips.txt" => [
+            "route_id,service_id,trip_id,trip_headsign,direction_id,block_id,route_pattern_id",
+            "route,today,now,headsign,0,now,",
+            "route,today,later,headsign,0,later,"
+          ],
+          "stop_times.txt" => [
+            "trip_id,arrival_time,departure_time,stop_id,stop_sequence,checkpoint_id",
+            "now,,00:00:01,stop1,1,",
+            "now,,00:00:03,stop2,2,",
+            "later,,00:00:04,stop1,1,"
+          ]
+        })
+
+      # 2019-01-01 00:00:00 EST
+      time0 = 1_546_318_800
+
+      assert [%Trip{id: "now"}] = Gtfs.active_trips(time0 + 2, pid)
+    end
+  end
+
   describe "active_blocks" do
     test "returns only blocks that are active" do
       pid =

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -1,0 +1,121 @@
+defmodule Realtime.GhostTest do
+  use ExUnit.Case
+
+  alias Gtfs.StopTime
+  alias Gtfs.Trip
+  alias Realtime.Ghost
+
+  describe "ghosts" do
+    test "makes a ghost bus for a trip that doesn't have a vehicle" do
+      trip = %Trip{
+        id: "trip",
+        route_id: "route",
+        service_id: "service",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        route_pattern_id: "route-X-0",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop1",
+            time: 1,
+            timepoint_id: "t1"
+          },
+          %StopTime{
+            stop_id: "stop2",
+            time: 3,
+            timepoint_id: "t2"
+          }
+        ]
+      }
+
+      # 2019-01-01 00:00:00 EST
+      time0 = 1_546_318_800
+
+      assert Ghost.ghosts(
+               [trip],
+               %{},
+               time0 + 2
+             ) == [
+               %Ghost{
+                 id: "ghost-trip",
+                 direction_id: 0,
+                 route_id: "route",
+                 trip_id: "trip",
+                 block_id: "block",
+                 via_variant: "X",
+                 scheduled_timepoint_status: %{
+                   timepoint_id: "t2",
+                   fraction_until_timepoint: 0.5
+                 }
+               }
+             ]
+    end
+
+    test "does not make a ghost for a trip if there's a vehicle on that block" do
+      trip = %Trip{
+        id: "trip1",
+        route_id: "route",
+        service_id: "service",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop1",
+            time: 1,
+            timepoint_id: "t1"
+          },
+          %StopTime{
+            stop_id: "stop2",
+            time: 3,
+            timepoint_id: "t2"
+          }
+        ]
+      }
+
+      vehicles_by_block = %{"block" => :vehicle}
+
+      # 2019-01-01 00:00:00 EST
+      time0 = 1_546_318_800
+
+      assert Ghost.ghosts(
+               [trip],
+               vehicles_by_block,
+               time0 + 2
+             ) == []
+    end
+
+    test "no ghosts for trips without timepoints" do
+      trip = %Trip{
+        id: "trip1",
+        route_id: "route",
+        service_id: "service",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop1",
+            time: 1,
+            timepoint_id: nil
+          },
+          %StopTime{
+            stop_id: "stop2",
+            time: 3,
+            timepoint_id: nil
+          }
+        ]
+      }
+
+      # 2019-01-01 00:00:00 EST
+      time0 = 1_546_318_800
+
+      assert Ghost.ghosts(
+               [trip],
+               %{},
+               time0 + 2
+             ) == []
+    end
+  end
+end

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -1,6 +1,9 @@
 defmodule Realtime.VehiclesTest do
   use ExUnit.Case, async: true
 
+  alias Gtfs.StopTime
+  alias Gtfs.Trip
+  alias Realtime.Ghost
   alias Realtime.Vehicle
   alias Realtime.Vehicles
 
@@ -63,11 +66,14 @@ defmodule Realtime.VehiclesTest do
 
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
-               incoming_blocks_by_route
+               incoming_blocks_by_route,
+               [],
+               0
              ) == %{
                "route" => %{
                  on_route_vehicles: [on_route_vehicle],
-                 incoming_vehicles: [incoming_vehicle]
+                 incoming_vehicles: [incoming_vehicle],
+                 ghosts: []
                }
              }
     end
@@ -130,15 +136,19 @@ defmodule Realtime.VehiclesTest do
 
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
-               incoming_blocks_by_route
+               incoming_blocks_by_route,
+               [],
+               0
              ) == %{
                "route1" => %{
                  on_route_vehicles: [vehicle],
-                 incoming_vehicles: []
+                 incoming_vehicles: [],
+                 ghosts: []
                },
                "route2" => %{
                  on_route_vehicles: [vehicle_2],
-                 incoming_vehicles: [vehicle]
+                 incoming_vehicles: [vehicle],
+                 ghosts: []
                }
              }
     end
@@ -175,11 +185,114 @@ defmodule Realtime.VehiclesTest do
 
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
-               incoming_blocks_by_route
+               incoming_blocks_by_route,
+               [],
+               0
              ) == %{
                "route2" => %{
                  on_route_vehicles: [],
-                 incoming_vehicles: [vehicle]
+                 incoming_vehicles: [vehicle],
+                 ghosts: []
+               }
+             }
+    end
+
+    test "includes trip without a vehicle as a ghost" do
+      trip = %Trip{
+        id: "trip",
+        route_id: "route",
+        service_id: "service",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop",
+            time: 0,
+            timepoint_id: "timepoint"
+          }
+        ]
+      }
+
+      assert Vehicles.group_by_route_with_blocks(
+               [],
+               %{},
+               [trip],
+               0
+             ) == %{
+               "route" => %{
+                 on_route_vehicles: [],
+                 incoming_vehicles: [],
+                 ghosts: [
+                   %Ghost{
+                     id: "ghost-trip",
+                     direction_id: 0,
+                     route_id: "route",
+                     trip_id: "trip",
+                     block_id: "block",
+                     scheduled_timepoint_status: %{
+                       timepoint_id: "timepoint",
+                       fraction_until_timepoint: 0.0
+                     }
+                   }
+                 ]
+               }
+             }
+    end
+
+    test "doesn't include trip as ghost if it has a vehicle on that block" do
+      vehicle = %Vehicle{
+        id: "on_route",
+        label: "on_route",
+        timestamp: 0,
+        latitude: 0,
+        longitude: 0,
+        direction_id: nil,
+        route_id: "route",
+        trip_id: nil,
+        bearing: 0,
+        speed: 0,
+        stop_sequence: 0,
+        block_id: "block",
+        operator_id: "",
+        operator_name: "",
+        run_id: "",
+        headway_spacing: :ok,
+        is_off_course: false,
+        is_laying_over: false,
+        layover_departure_time: nil,
+        block_is_active: true,
+        sources: "",
+        stop_status: "",
+        route_status: :on_route
+      }
+
+      trip = %Trip{
+        id: "trip",
+        route_id: "route",
+        service_id: "service",
+        headsign: "headsign",
+        direction_id: 0,
+        block_id: "block",
+        stop_times: [
+          %StopTime{
+            stop_id: "stop",
+            time: 0,
+            timepoint_id: "timepoint"
+          }
+        ]
+      }
+
+      assert Vehicles.group_by_route_with_blocks(
+               [vehicle],
+               %{},
+               [trip],
+               0
+             ) == %{
+               "route" => %{
+                 on_route_vehicles: [vehicle],
+                 incoming_vehicles: [],
+                 ghosts: []
                }
              }
     end


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1112935048846093/1128001122285985)

~Will get a little smaller after #162 (optional labels) merges, so review that one first.~

<img width="1110" alt="Screen Shot 2019-08-22 at 15 03 08" src="https://user-images.githubusercontent.com/23065557/63697585-3449bb00-c7eb-11e9-82fa-f4416f5d257c.png">

## Data

The logic for detecting ghost buses is in `ghost.ex`, which is called from `vehicles.ex`, and it just does a linear filter through all the active trips to see which trips don't have a vehicle on their block.

Adds a new `ghosts: []` field to the `{onRouteVehicles, incomingVehicles}` object.

## Drawing

Adds a new `"ghost"` status to `DrawnStatus`. If you pass a ghost status to `VehicleIcon`, it uses the 👻 icon instead of the triangle and forces the ghost to be right side up.

The variant is drawn inside just like for triangles. The eyes only show up if there is no variant.

Makes a `LadderVehicle` for each ghost so they can be put into lanes alongside the real vehicles.

## Out of scope

Doesn't include a VPP panel right now. If you click a ghost, the state reducer just ignores it. The panel is in this task: [VPP for ghosts](https://app.asana.com/0/1112935048846093/1136757413212001)

Doesn't show ghost buses for late incoming buses. That's this task: [Display a ghost bus if the incoming bus' trip has already started and it is late](https://app.asana.com/0/1112935048846093/1128954370026507)
