### PR TITLE
add ShuttleVehicles Server & Channel

### DIFF
--- a/lib/realtime/servers/route_vehicles.ex
+++ b/lib/realtime/servers/route_vehicles.ex
@@ -1,4 +1,4 @@
-defmodule Realtime.Server do
+defmodule Realtime.Servers.RouteVehicles do
   @moduledoc """
   Fetches live data from RTR, and forwards it to connected clients.
 
@@ -9,7 +9,9 @@ defmodule Realtime.Server do
   use GenServer
 
   alias Gtfs.Route
+
   alias Realtime.Vehicles
+
   require Logger
 
   @typep state :: Route.by_id(Vehicles.for_route())
@@ -20,7 +22,7 @@ defmodule Realtime.Server do
   def registry_name(), do: Realtime.Registry
 
   @spec default_name() :: GenServer.name()
-  def default_name(), do: Realtime.Server
+  def default_name(), do: __MODULE__
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(start_link_opts) do

--- a/lib/realtime/servers/shuttle_vehicles.ex
+++ b/lib/realtime/servers/shuttle_vehicles.ex
@@ -1,0 +1,115 @@
+defmodule Realtime.Servers.ShuttleVehicles do
+  @moduledoc """
+  Fetches live data from RTR, and forwards it to connected clients.
+
+  Uses a global regsitry, with the server's pid as the key.
+  Each subscriber's route_id is stored as the value of their registry entries.
+  """
+
+  use GenServer
+
+  alias Realtime.Vehicle
+
+  @typep state :: %{Vehicle.run_id() => [Vehicle.t()]}
+
+  @typep subscription_key :: :run_ids | :all_shuttles | {:run_id, Vehicle.run_id()}
+
+  @type broadcast_data :: {:shuttles, [Vehicle.t()]} | {:run_ids, [Vehicle.run_id()]}
+
+  # Client functions
+
+  @spec default_name() :: GenServer.name()
+  def default_name(), do: __MODULE__
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(start_link_opts) do
+    GenServer.start_link(__MODULE__, [], start_link_opts)
+  end
+
+  @doc """
+  The subscribing process will get a message when there's new data, with the form
+  {:new_realtime_data, {:shuttles, [Vehicle.t()]}}
+  """
+  @spec subscribe_to_run(Vehicle.run_id(), GenServer.server()) :: [Vehicle.t()]
+  def subscribe_to_run(run_id, server \\ default_name())
+      when is_binary(run_id) do
+    subscribe({:run_id, run_id}, server)
+  end
+
+  @spec subscribe_to_all_shuttles(GenServer.server()) :: [Vehicle.t()]
+  def subscribe_to_all_shuttles(server \\ default_name()) do
+    subscribe(:all_shuttles, server)
+  end
+
+  @doc """
+  The subscribing process will get a message when there's new data, with the form
+  {:new_realtime_data, {:run_ids, [Vehicle.run_id()]}}
+  """
+  @spec subscribe_to_run_ids(GenServer.server()) :: [Vehicle.run_id()]
+  def subscribe_to_run_ids(server \\ default_name()) do
+    subscribe(:run_ids, server)
+  end
+
+  @spec subscribe(subscription_key, GenServer.server()) :: [Vehicle.t()] | [Vehicle.run_id()]
+  defp subscribe(subscription_key, server) do
+    {registry_key, data} = GenServer.call(server, {:subscribe, subscription_key})
+    Registry.register(Realtime.Registry, registry_key, subscription_key)
+    data
+  end
+
+  @spec update(state) :: term()
+  def update(shuttles_by_run_id, server \\ __MODULE__) when is_map(shuttles_by_run_id) do
+    GenServer.cast(server, {:update, shuttles_by_run_id})
+  end
+
+  # GenServer callbacks
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  # If we get a reply after we've already timed out, ignore it
+  @impl true
+  def handle_info({reference, _}, state) when is_reference(reference), do: {:noreply, state}
+
+  @impl true
+  def handle_call({:subscribe, subscription_key}, _from, state) do
+    registry_key = self()
+    {_, data} = data_to_send(state, subscription_key)
+    {:reply, {registry_key, data}, state}
+  end
+
+  @impl true
+  def handle_cast({:update, shuttles_by_run_id}, _state) do
+    broadcast(shuttles_by_run_id)
+    {:noreply, shuttles_by_run_id}
+  end
+
+  @spec broadcast(state()) :: :ok
+  defp broadcast(shuttles_by_run_id) do
+    Registry.dispatch(Realtime.Registry, self(), fn entries ->
+      for {pid, subscription_key} <- entries do
+        send(pid, {:new_realtime_data, data_to_send(shuttles_by_run_id, subscription_key)})
+      end
+    end)
+  end
+
+  @spec data_to_send(state, subscription_key) :: broadcast_data
+  defp data_to_send(shuttles_by_run_id, :run_ids) do
+    {:run_ids, Map.keys(shuttles_by_run_id)}
+  end
+
+  defp data_to_send(shuttles_by_run_id, :all_shuttles) do
+    all_shuttles =
+      shuttles_by_run_id
+      |> Map.values()
+      |> List.flatten()
+
+    {:shuttles, all_shuttles}
+  end
+
+  defp data_to_send(shuttles_by_run_id, {:run_id, run_id}) do
+    {:shuttles, Map.get(shuttles_by_run_id, run_id, [])}
+  end
+end

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -12,6 +12,8 @@ defmodule Realtime.Vehicle do
         }
   @type route_status :: :incoming | :on_route
 
+  @type run_id :: String.t() | nil
+
   @type t :: %__MODULE__{
           id: String.t(),
           label: String.t(),
@@ -29,7 +31,7 @@ defmodule Realtime.Vehicle do
           block_id: Block.id() | nil,
           operator_id: String.t() | nil,
           operator_name: String.t() | nil,
-          run_id: String.t() | nil,
+          run_id: run_id,
           headway_secs: non_neg_integer() | nil,
           headway_spacing: Headway.headway_spacing() | nil,
           previous_vehicle_id: String.t() | nil,
@@ -241,6 +243,10 @@ defmodule Realtime.Vehicle do
         false
     end
   end
+
+  def shuttle?(%__MODULE__{run_id: "999" <> _}), do: true
+  def shuttle?(%__MODULE__{run_id: "555" <> _}), do: true
+  def shuttle?(%__MODULE__{}), do: false
 
   @doc """
   Check whether the vehicle is off course. If so, check if the assigned block

--- a/lib/realtime/vehicles.ex
+++ b/lib/realtime/vehicles.ex
@@ -34,6 +34,11 @@ defmodule Realtime.Vehicles do
     group_by_route_with_blocks(ungrouped_vehicles, incoming_blocks_by_route)
   end
 
+  @spec group_by_run([Vehicle.t()]) :: %{Vehicle.run_id() => [Vehicle.t()]}
+  def group_by_run(ungrouped_vehicles) do
+    Enum.group_by(ungrouped_vehicles, & &1.run_id)
+  end
+
   @doc """
   Exposed for testing
   """

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -36,8 +36,13 @@ defmodule Skate.Application do
           ]
         ]
       ),
-      {Registry, keys: :duplicate, name: Realtime.Server.registry_name()},
-      worker(Realtime.Server, [[name: Realtime.Server.default_name()]])
+      {Registry, keys: :duplicate, name: Realtime.Registry},
+      worker(Realtime.Servers.RouteVehicles, [
+        [name: Realtime.Servers.RouteVehicles.default_name()]
+      ]),
+      worker(Realtime.Servers.ShuttleVehicles, [
+        [name: Realtime.Servers.ShuttleVehicles.default_name()]
+      ])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/skate_web/channels/helpers.ex
+++ b/lib/skate_web/channels/helpers.ex
@@ -1,21 +1,14 @@
-defmodule SkateWeb.VehiclesChannel do
-  use SkateWeb, :channel
+defmodule SkateWeb.Channels.Helpers do
+  alias Phoenix.{
+    Channel,
+    Socket
+  }
 
-  alias Realtime.{Server, Vehicles}
   alias SkateWeb.AuthManager
 
-  @impl Phoenix.Channel
-  def join("vehicles:" <> route_id, _message, socket) do
-    vehicles_for_route = Server.subscribe(route_id)
-    {:ok, vehicles_for_route, socket}
-  end
-
-  def join(topic, _message, _socket) do
-    {:error, %{message: "no such topic \"#{topic}\""}}
-  end
-
-  @impl Phoenix.Channel
-  def handle_info({:new_realtime_data, vehicles_for_route}, socket) do
+  @spec push_or_refresh(Socket.t(), (() -> {:noreply, Socket.t()})) ::
+          {:noreply, Socket.t()} | {:stop, :normal, Socket.t()}
+  def push_or_refresh(socket, callback) do
     token = Guardian.Phoenix.Socket.current_token(socket)
 
     case AuthManager.decode_and_verify(token) do
@@ -23,7 +16,7 @@ defmodule SkateWeb.VehiclesChannel do
         # Refresh a token before it expires
         {:ok, _old_claims, {_new_token, _new_claims}} = AuthManager.refresh(token)
 
-        push_vehicles(socket, vehicles_for_route)
+        callback.()
 
       {:error, :token_expired} ->
         refresh_token_store = Application.get_env(:skate, :refresh_token_store)
@@ -36,7 +29,7 @@ defmodule SkateWeb.VehiclesChannel do
         # Exchange a token of type "refresh" for a new token of type "access"
         case AuthManager.exchange(refresh_token, "refresh", "access") do
           {:ok, _old_stuff, {_new_token, _new_claims}} ->
-            push_vehicles(socket, vehicles_for_route)
+            callback.()
 
           _ ->
             {:stop, :normal, send_auth_expired_message(socket)}
@@ -47,16 +40,9 @@ defmodule SkateWeb.VehiclesChannel do
     end
   end
 
-  @spec push_vehicles(Phoenix.Socket.t(), Vehicles.for_route()) ::
-          {:noreply, Phoenix.Socket.t()}
-  defp push_vehicles(socket, vehicles) do
-    push(socket, "vehicles", vehicles)
-    {:noreply, socket}
-  end
-
-  @spec send_auth_expired_message(Phoenix.Socket.t()) :: Phoenix.Socket.t()
+  @spec send_auth_expired_message(Socket.t()) :: Socket.t()
   defp send_auth_expired_message(socket) do
-    :ok = push(socket, "auth_expired", %{})
+    :ok = Channel.push(socket, "auth_expired", %{})
     socket
   end
 end

--- a/lib/skate_web/channels/route_vehicles_channel.ex
+++ b/lib/skate_web/channels/route_vehicles_channel.ex
@@ -1,0 +1,29 @@
+defmodule SkateWeb.RouteVehiclesChannel do
+  use SkateWeb, :channel
+
+  alias Realtime.{Servers.RouteVehicles, Vehicles}
+
+  alias SkateWeb.Channels.Helpers
+
+  @impl Phoenix.Channel
+  def join("vehicles:" <> route_id, _message, socket) do
+    vehicles_for_route = RouteVehicles.subscribe(route_id)
+    {:ok, vehicles_for_route, socket}
+  end
+
+  def join(topic, _message, _socket) do
+    {:error, %{message: "no such topic \"#{topic}\""}}
+  end
+
+  @impl Phoenix.Channel
+  def handle_info({:new_realtime_data, vehicles_for_route}, socket) do
+    Helpers.push_or_refresh(socket, fn -> push_vehicles(socket, vehicles_for_route) end)
+  end
+
+  @spec push_vehicles(Phoenix.Socket.t(), Vehicles.for_route()) ::
+          {:noreply, Phoenix.Socket.t()}
+  defp push_vehicles(socket, vehicles) do
+    push(socket, "vehicles", vehicles)
+    {:noreply, socket}
+  end
+end

--- a/lib/skate_web/channels/shuttle_vehicles_channel.ex
+++ b/lib/skate_web/channels/shuttle_vehicles_channel.ex
@@ -1,0 +1,43 @@
+defmodule SkateWeb.ShuttleVehiclesChannel do
+  use SkateWeb, :channel
+
+  alias Realtime.{Servers.ShuttleVehicles}
+  alias SkateWeb.Channels.Helpers
+
+  @impl Phoenix.Channel
+  def join("shuttles:run_ids", _message, socket) do
+    run_ids = ShuttleVehicles.subscribe_to_run_ids()
+    {:ok, run_ids, socket}
+  end
+
+  def join("shuttles:all", _message, socket) do
+    all_shuttles = ShuttleVehicles.subscribe_to_all_shuttles()
+    {:ok, all_shuttles, socket}
+  end
+
+  def join("shuttles:" <> run_id, _message, socket) do
+    shuttles_for_run = ShuttleVehicles.subscribe_to_run(run_id)
+    {:ok, shuttles_for_run, socket}
+  end
+
+  def join(topic, _message, _socket) do
+    {:error, %{message: "no such topic \"#{topic}\""}}
+  end
+
+  @impl Phoenix.Channel
+  def handle_info({:new_realtime_data, data}, socket) do
+    Helpers.push_or_refresh(socket, fn -> push_data(socket, data) end)
+  end
+
+  @spec push_data(Phoenix.Socket.t(), ShuttleVehicles.broadcast_data()) ::
+          {:noreply, Phoenix.Socket.t()}
+  defp push_data(socket, {:shuttles, shuttles}) do
+    push(socket, "shuttles", %{data: shuttles})
+    {:noreply, socket}
+  end
+
+  defp push_data(socket, {:run_ids, run_ids}) do
+    push(socket, "run_ids", %{data: run_ids})
+    {:noreply, socket}
+  end
+end

--- a/lib/skate_web/channels/user_socket.ex
+++ b/lib/skate_web/channels/user_socket.ex
@@ -2,7 +2,8 @@ defmodule SkateWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel("vehicles:*", SkateWeb.VehiclesChannel)
+  channel("vehicles:*", SkateWeb.RouteVehiclesChannel)
+  channel("shuttles:*", SkateWeb.ShuttleVehiclesChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/test/channels/shuttle_vehicles_channel_test.exs
+++ b/test/channels/shuttle_vehicles_channel_test.exs
@@ -1,0 +1,146 @@
+defmodule SkateWeb.ShuttleVehiclesChannelTest do
+  use SkateWeb.ChannelCase
+  import Test.Support.Helpers
+
+  alias Phoenix.Socket
+
+  alias Realtime.{
+    Servers.ShuttleVehicles,
+    Vehicle
+  }
+
+  alias SkateWeb.{
+    AuthManager,
+    ShuttleVehiclesChannel,
+    UserSocket
+  }
+
+  @vehicle %Vehicle{
+    id: "",
+    run_id: "",
+    label: "",
+    timestamp: "",
+    latitude: 0.0,
+    longitude: 0.0,
+    direction_id: 0,
+    bearing: 0,
+    speed: 0,
+    stop_sequence: 0,
+    block_id: "",
+    operator_id: "",
+    operator_name: "",
+    headway_spacing: :ok,
+    is_off_course: false,
+    is_laying_over: false,
+    block_is_active: true,
+    sources: [],
+    stop_status: %{},
+    route_status: :on_route
+  }
+
+  @shuttles %{
+    "9990555" => [
+      %{@vehicle | id: "shuttle-1", label: "Shuttle 1", run_id: "9990555"},
+      %{@vehicle | id: "shuttle-2", label: "Shuttle 2", run_id: "9990555"}
+    ],
+    "9990000" => [
+      %{@vehicle | id: "shuttle-3", label: "Shuttle 3", run_id: "9990000"}
+    ]
+  }
+
+  setup do
+    reassign_env(
+      :skate,
+      :refresh_token_store,
+      FakeRefreshTokenStore
+    )
+
+    :ok = ShuttleVehicles.update(@shuttles)
+    socket = socket(UserSocket, "", %{})
+
+    {:ok, socket: socket}
+  end
+
+  describe "join/3" do
+    test "shuttles:all subscribes to all shuttles and returns current list of all shuttles", %{
+      socket: socket
+    } do
+      assert {:ok, all_shuttles, %Socket{}} =
+               subscribe_and_join(socket, ShuttleVehiclesChannel, "shuttles:all")
+
+      assert all_shuttles == @shuttles |> Map.values() |> List.flatten()
+    end
+
+    test "shuttles:{run_id} subscribes to shuttles for a run ID and returns the current list of shuttles",
+         %{
+           socket: socket
+         } do
+      assert {:ok, shuttles, %Socket{}} =
+               subscribe_and_join(socket, ShuttleVehiclesChannel, "shuttles:9990555")
+
+      assert shuttles == Map.fetch!(@shuttles, "9990555")
+    end
+
+    test "shuttles:run_ids subscribes to run id list and returns the list of current run ids", %{
+      socket: socket
+    } do
+      assert {:ok, run_ids, %Socket{}} =
+               subscribe_and_join(socket, ShuttleVehiclesChannel, "shuttles:run_ids")
+
+      assert run_ids == ["9990000", "9990555"]
+    end
+  end
+
+  describe "handle_info/2" do
+    test "sends a message when shuttles are updated", %{socket: socket} do
+      {:ok, token, claims} =
+        AuthManager.encode_and_sign("test-authed@mbta.com", %{
+          "exp" => System.system_time(:second) + 500
+        })
+
+      assert {:ok, _, socket} = subscribe_and_join(socket, ShuttleVehiclesChannel, "shuttles:all")
+
+      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "test-authed@mbta.com", token, claims)
+
+      ShuttleVehiclesChannel.handle_info({:new_realtime_data, {:shuttles, [@vehicle]}}, socket)
+
+      assert_push("shuttles", %{data: [@vehicle]})
+    end
+
+    test "sends a message when run ids are updated", %{socket: socket} do
+      {:ok, token, claims} =
+        AuthManager.encode_and_sign("test-authed@mbta.com", %{
+          "exp" => System.system_time(:second) + 500
+        })
+
+      assert {:ok, _, socket} =
+               subscribe_and_join(socket, ShuttleVehiclesChannel, "shuttles:run_ids")
+
+      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "test-authed@mbta.com", token, claims)
+
+      ShuttleVehiclesChannel.handle_info({:new_realtime_data, {:run_ids, ["9990002"]}}, socket)
+
+      assert_push("run_ids", %{data: ["9990002"]})
+    end
+  end
+
+  test "join/3 returns an error when joining a non-existant topic", %{socket: socket} do
+    assert {:error, %{message: "no such topic \"vehicles:1\""}} =
+             subscribe_and_join(socket, ShuttleVehiclesChannel, "vehicles:1")
+  end
+
+  defmodule FakeRefreshTokenStore do
+    def get_refresh_token("test-authed@mbta.com") do
+      {:ok, token, _claims} =
+        AuthManager.encode_and_sign(
+          "test-authed@mbta.com",
+          %{
+            "exp" => System.system_time(:second) + 500
+          },
+          token_type: "refresh"
+        )
+
+      token
+    end
+  end
+end

--- a/test/realtime/servers/route_vehicles_test.exs
+++ b/test/realtime/servers/route_vehicles_test.exs
@@ -1,8 +1,9 @@
-defmodule Realtime.ServerTest do
+defmodule Realtime.Servers.RouteVehiclesTest do
   use ExUnit.Case, async: true
   import Test.Support.Helpers
 
-  alias Realtime.{Server, Vehicle}
+  alias Realtime.Servers.RouteVehicles, as: Server
+  alias Realtime.Vehicle
 
   @vehicles_for_route %{
     on_route_vehicles: [

--- a/test/realtime/servers/shuttle_vehicles_test.exs
+++ b/test/realtime/servers/shuttle_vehicles_test.exs
@@ -1,0 +1,79 @@
+defmodule Realtime.Servers.ShuttleVehiclesTest do
+  use ExUnit.Case, async: true
+  alias Realtime.Servers.ShuttleVehicles, as: Server
+  alias Realtime.Vehicle
+
+  @vehicle %Vehicle{
+    id: "",
+    run_id: "",
+    label: "",
+    timestamp: "",
+    latitude: 0.0,
+    longitude: 0.0,
+    direction_id: 0,
+    bearing: 0,
+    speed: 0,
+    stop_sequence: 0,
+    block_id: "",
+    operator_id: "",
+    operator_name: "",
+    headway_spacing: :ok,
+    is_off_course: false,
+    is_laying_over: false,
+    block_is_active: true,
+    sources: [],
+    stop_status: %{},
+    route_status: :on_route
+  }
+
+  @shuttles %{
+    "9990555" => [
+      %{@vehicle | id: "shuttle-1", label: "Shuttle 1", run_id: "9990555"},
+      %{@vehicle | id: "shuttle-2", label: "Shuttle 2", run_id: "9990555"}
+    ],
+    "9990000" => [
+      %{@vehicle | id: "shuttle-3", label: "Shuttle 3", run_id: "9990000"}
+    ]
+  }
+
+  setup do
+    {:ok, pid} = Server.start_link([])
+    Server.update(@shuttles, pid)
+    {:ok, pid: pid}
+  end
+
+  test "subscribe_to_run_ids", %{pid: pid} do
+    assert Server.subscribe_to_run_ids(pid) == ["9990000", "9990555"]
+
+    assert :ok =
+             @shuttles
+             |> Map.put("9990001", [@vehicle])
+             |> Server.update(pid)
+
+    assert_receive {:new_realtime_data, {:run_ids, ["9990000", "9990001", "9990555"]}},
+                   2000
+  end
+
+  test "subscribe_to_all_shuttles", %{pid: pid} do
+    assert [%Vehicle{}, %Vehicle{}, %Vehicle{}] = Server.subscribe_to_all_shuttles(pid)
+
+    assert :ok =
+             @shuttles
+             |> Map.put("9990001", [@vehicle])
+             |> Server.update(pid)
+
+    assert_receive {:new_realtime_data,
+                    {:shuttles, [%Vehicle{}, %Vehicle{}, %Vehicle{}, %Vehicle{}]}}
+  end
+
+  test "subscribe_to_run", %{pid: pid} do
+    assert [%Vehicle{}] = Server.subscribe_to_run("9990000", pid)
+
+    assert :ok =
+             @shuttles
+             |> Map.put("9990000", [@vehicle, @vehicle])
+             |> Server.update(pid)
+
+    assert_receive {:new_realtime_data, {:shuttles, [%Vehicle{}, %Vehicle{}]}}
+  end
+end


### PR DESCRIPTION
This is just the back-end portion, not connected to the front-end yet.

- Renames and moves the existing `Realtime.Server` to `Realtime.Servers.RouteVehicles`
- Adds a new `Realtime.Servers.ShuttleVehicles` module to store and broadcast shuttle vehicles by run id
- Adds a new `ShuttleVehiclesChannel` that can handle subscribing to all shuttles, subscribing to a specific run, or subscribing to updates to the run list (which will power the picker on the shuttle map page).
- Moves the `push_or_refresh` socket functionality into a helper module