### PR TITLE
bugfix route picker scrolls

### DIFF
--- a/assets/css/_route_picker.scss
+++ b/assets/css/_route_picker.scss
@@ -1,5 +1,12 @@
+.m-route-picker {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .m-route-picker__selected-routes {
   display: flex;
+  flex: 0 0 auto;
   flex-shrink: 0;
   flex-wrap: wrap;
   margin-bottom: 1rem;
@@ -7,15 +14,16 @@
   min-height: 2rem;
 }
 
-.m-route-picker__route-list {
-  overflow-y: scroll;
-}
-
 .m-route-picker__selected-routes-button {
   @include button-primary;
   margin-bottom: 0.25rem;
   margin-right: 0.25rem;
   min-width: 2rem;
+}
+
+.m-route-picker__route-list {
+  flex: 1 1 auto;
+  overflow-y: scroll;
 }
 
 .m-route-picker__route-list-button {


### PR DESCRIPTION
Asana Task:
[🐞 Can't scroll route picker](https://app.asana.com/0/1112935048846093/1137379464755481)

This was caused by the route list expanding thousands of pixels past the bottom of the screen. It thought it was all visible, so didn't need to be scrollable.

By making the route picker use flexbox, the height of the route list is capped by the end of the route picker.