### PR TITLE
use application env to turn off gtfs and realtime process in test

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,7 @@ config :skate,
   swiftly_realtime_vehicles_url: {:system, "SWIFTLY_REALTIME_VEHICLES_URL"},
   secret: {:system, "SKATE_SECRET"},
   signed_secret: {:system, "SKATE_SIGNED_SECRET"},
+  start_data_processes: true,
   record_fullstory: false,
   log_duration_timing: true,
   refresh_token_store: RefreshTokenStore

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :skate,
+  start_data_processes: false
+
 config :skate, Gtfs.CacheFile, cache_filename: "test_cache.terms"
 
 # We don't run a server during test. If one is required,

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -17,19 +17,18 @@ defmodule Skate.Application do
 
     # List all child processes to be supervised
     children =
-      if Mix.env() == :test do
-        [
-          SkateWeb.Endpoint,
-          RefreshTokenStore
-        ]
-      else
-        [
-          SkateWeb.Endpoint,
-          Gtfs.Supervisor,
-          Realtime.Supervisor,
-          RefreshTokenStore
-        ]
-      end
+      [
+        SkateWeb.Endpoint,
+        RefreshTokenStore
+      ] ++
+        if Application.get_env(:skate, :start_data_processes) do
+          [
+            Gtfs.Supervisor,
+            Realtime.Supervisor
+          ]
+        else
+          []
+        end
 
     Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
   end


### PR DESCRIPTION
fixes the bug introduced by bfe6066 #171 
Mix.env can't be used at runtime

This should unbreak deploys.
Discussion: https://mbtace.slack.com/archives/CESHREAS1/p1567610316045200?thread_ts=1567610266.045100&cid=CESHREAS1