### PR TITLE
don't return data on initial vehicle channel join

### DIFF
--- a/assets/src/hooks/useShuttleVehicles.ts
+++ b/assets/src/hooks/useShuttleVehicles.ts
@@ -67,7 +67,10 @@ const subscribe = (socket: Socket, dispatch: Dispatch<Action>): Channel => {
 
   channel
     .join()
-    .receive("ok", handleShuttles)
+    .receive("ok", () => {
+      // tslint:disable-next-line: no-console
+      console.log("successfully joined shuttle channel")
+    })
     // tslint:disable-next-line: no-console
     .receive("error", ({ reason }) => console.error("join failed", reason))
     .receive("timeout", () => {

--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -150,7 +150,10 @@ const subscribe = (
 
   channel
     .join()
-    .receive("ok", handleVehicles)
+    .receive("ok", () => {
+      // tslint:disable-next-line: no-console
+      console.log(`successfully joined vehicle channel for route ${routeId}`)
+    })
     // tslint:disable-next-line: no-console
     .receive("error", ({ reason }) => console.error("join failed", reason))
     .receive("timeout", () => {

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -21,7 +21,8 @@ const makeMockChannel = (expectedJoinMessage: "ok" | "error" | "timeout") => {
     if (message === expectedJoinMessage) {
       switch (message) {
         case "ok":
-          return result
+          handler("ok")
+          break
 
         case "error":
           handler({ reason: "ERROR_REASON" })
@@ -195,6 +196,8 @@ describe("useShuttleVehicles", () => {
   })
 
   test("initializing the hook subscribes to the shuttles channel", () => {
+    const spyConsoleLog = jest.spyOn(console, "log")
+    spyConsoleLog.mockImplementationOnce(msg => msg)
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok")
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -209,9 +212,14 @@ describe("useShuttleVehicles", () => {
     expect(mockSocket.channel).toHaveBeenCalledTimes(1)
     expect(mockSocket.channel).toHaveBeenCalledWith("vehicles:shuttle:all")
     expect(mockChannel.join).toHaveBeenCalledTimes(1)
+    expect(spyConsoleLog).toHaveBeenCalledWith(
+      "successfully joined shuttle channel"
+    )
   })
 
   test("returns results pushed to the channel", async () => {
+    const spyConsoleLog = jest.spyOn(console, "log")
+    spyConsoleLog.mockImplementationOnce(msg => msg)
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok")
     mockSocket.channel.mockImplementationOnce(() => mockChannel)

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -6,13 +6,13 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def join("vehicles:shuttle:all", _message, socket) do
-    shuttles = Server.subscribe_to_all_shuttles()
-    {:ok, %{data: shuttles}, socket}
+    _ = Server.subscribe_to_all_shuttles()
+    {:ok, :ok, socket}
   end
 
   def join("vehicles:route:" <> route_id, _message, socket) do
-    vehicles_for_route = Server.subscribe_to_route(route_id)
-    {:ok, vehicles_for_route, socket}
+    _ = Server.subscribe_to_route(route_id)
+    {:ok, :ok, socket}
   end
 
   def join(topic, _message, _socket) do

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -19,22 +19,19 @@ defmodule SkateWeb.VehiclesChannelTest do
   end
 
   describe "join/3" do
-    test "subscribes to vehicles for a route ID and returns the current list of vehicles", %{
+    test "subscribes to vehicles for a route ID and returns :ok", %{
       socket: socket
     } do
-      assert {:ok, %{on_route_vehicles: on_route_vehicles}, %Socket{} = socket} =
+      assert {:ok, :ok, %Socket{} = socket} =
                subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")
-
-      assert is_list(on_route_vehicles)
-      assert Enum.all?(on_route_vehicles, &(%Vehicle{} = &1))
     end
 
-    test "subscribes to all shuttles", %{socket: socket} do
-      assert {:ok, %{data: []}, %Socket{}} =
+    test "subscribes to all shuttles and returns :ok", %{socket: socket} do
+      assert {:ok, :ok, %Socket{}} =
                subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
     end
 
-    test "returns an error when joining a non-existant topic", %{socket: socket} do
+    test "returns an error when joining a non-existent topic", %{socket: socket} do
       assert {:error, %{message: "no such topic \"rooms:1\""}} =
                subscribe_and_join(socket, VehiclesChannel, "rooms:1")
     end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -67,9 +67,8 @@ defmodule Realtime.ServerTest do
       %{server_pid: server_pid}
     end
 
-    test "clients get vehicles when subscribing", %{server_pid: server_pid} do
-      vehicles_for_route = Server.subscribe_to_route("1", server_pid)
-      assert vehicles_for_route == @vehicles_for_route
+    test "clients get :ok when subscribing", %{server_pid: server_pid} do
+      assert Server.subscribe_to_route("1", server_pid) == :ok
     end
 
     test "clients subscribed to a route get data pushed to them", %{server_pid: server_pid} do
@@ -121,8 +120,8 @@ defmodule Realtime.ServerTest do
       %{server_pid: server_pid}
     end
 
-    test "clients get all shuttles upon subscribing", %{server_pid: pid} do
-      assert Server.subscribe_to_all_shuttles(pid) == [@shuttle]
+    test "clients get :ok upon subscribing", %{server_pid: pid} do
+      assert Server.subscribe_to_all_shuttles(pid) == :ok
     end
 
     test "clients get updated data pushed to them", %{server_pid: pid} do


### PR DESCRIPTION
Asana ticket: [🐞 Timeouts on joining vehicle channels](https://app.asana.com/0/1112935048846093/1140305520008297/f)

Channel joins are often timing out -- presumably because the call to fetch initial vehicles is timing out. This change makes it so that joining a channel does not attempt to return data, it just returns `:ok`.

The downside to this is that the route ladders not have vehicles to show until the next push comes through. This can mean that the ladders look like something might be wrong for a few seconds. I spoke with Logan and he thinks this is an acceptable interim state if it means there will be less timeouts overall. It would be good to either add a "loading vehicles" message to the ladder, or have the channel request vehicles after joining. I've added an asana ticket (https://app.asana.com/0/1112935048846093/1139836080415721) to address that.