### PR TITLE
Make centerOnVehicle property optional

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -18,7 +18,7 @@ import { Dispatch, selectVehicle as selectVehicleAction, State } from "../state"
 
 interface Props {
   vehicles: Vehicle[]
-  centerOnVehicle: string | null
+  centerOnVehicle?: string
   initialZoom?: number
   shapes?: Shape[]
 }
@@ -237,10 +237,10 @@ export const defaultCenter: [number, number] = [42.360718, -71.05891]
 
 export const recenterMap = (
   map: LeafletMap,
-  centerOnVehicle: VehicleId | null,
+  centerOnVehicle: VehicleId | undefined,
   vehiclesById: { [id: string]: Vehicle }
 ): void => {
-  if (centerOnVehicle !== null) {
+  if (centerOnVehicle !== undefined) {
     const vehicle: Vehicle | undefined = vehiclesById[centerOnVehicle]
     if (vehicle !== undefined) {
       map.setView([vehicle.latitude, vehicle.longitude], map.getZoom())

--- a/assets/src/components/shuttleMapPage.tsx
+++ b/assets/src/components/shuttleMapPage.tsx
@@ -62,12 +62,7 @@ const ShuttleMapPage = ({}): ReactElement<HTMLDivElement> => {
           width: window.innerWidth,
         }}
       >
-        <Map
-          vehicles={selectedShuttles}
-          centerOnVehicle={null}
-          initialZoom={13}
-          shapes={shapes}
-        />
+        <Map vehicles={selectedShuttles} initialZoom={13} shapes={shapes} />
       </div>
 
       {selectedVehicle && (

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -255,10 +255,10 @@ describe("recenterMap", () => {
     expect(map.getCenter()).toEqual({ lat: 42, lng: -71 })
   })
 
-  test("does not center the map if centerOnVehicle is null", () => {
+  test("does not center the map if centerOnVehicle is undefined", () => {
     document.body.innerHTML = "<div id='map'></div>"
     const map = Leaflet.map("map", { center: defaultCenter, zoom: 16 })
-    recenterMap(map, null, { [vehicle.id]: vehicle })
+    recenterMap(map, undefined, { [vehicle.id]: vehicle })
     expect(map.getCenter()).toEqual({
       lat: defaultCenter[0],
       lng: defaultCenter[1],


### PR DESCRIPTION
Avoids an awkward call with `null`.

No ticket.