### PR TITLE
Add diskusage_logger as a dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Skate.MixProject do
 
     apps =
       if Mix.env() == :prod do
-        [:ehmon | apps]
+        [:ehmon, :diskusage_logger | apps]
       else
         apps
       end
@@ -66,6 +66,7 @@ defmodule Skate.MixProject do
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       {:distillery, "~> 2.0", runtime: false},
       {:ehmon, github: "mbta/ehmon", only: :prod},
+      {:diskusage_logger, "~> 0.2.0"},
       {:httpoison, "~> 1.5.0"},
       {:bypass, "~> 1.0.0", only: :test},
       {:csv, "~> 2.3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
   "csv": {:hex, :csv, "2.3.0", "e30e4bbe633653a5c2da43cab42a61623e0acc80ef40c321bc29f0d698697bd3", [:mix], [{:parallel_stream, "~> 1.0.4", [hex: :parallel_stream, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "diskusage_logger": {:hex, :diskusage_logger, "0.2.0", "04fc48b538fe4de43153542a71ea94f623d54707d85844123baacfceedf625c3", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "2.0.12", "6e78fe042df82610ac3fa50bd7d2d8190ad287d120d3cd1682d83a44e8b34dfb", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
   "ehmon": {:git, "https://github.com/mbta/ehmon.git", "1fb603262bd02d74a16183bd8f344dcace9d7561", []},
   "excoveralls": {:hex, :excoveralls, "0.10.6", "e2b9718c9d8e3ef90bc22278c3f76c850a9f9116faf4ebe9678063310742edc2", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},

--- a/rel/Dockerfile
+++ b/rel/Dockerfile
@@ -7,6 +7,9 @@ RUN apk add --update bash \
 # Install curl so we can query for our instance ID
 RUN apk add --no-cache --update curl
 
+# Install coreutils so we can call df to get disk space (through Erlang os_mon)
+RUN apk add --no-cache --update coreutils
+
 WORKDIR /root
 
 # Set exposed ports


### PR DESCRIPTION
Install coreutils so that `df` is available to os_mon.

Asana ticket: [Monitor disk space in Splunk and alert on too high](https://app.asana.com/0/1112935048846093/1138232006430277)

~~We'll still need to create the graph and alert in Splunk once this is deployed.~~ Graph and alert have been created, but they will be empty / not triggered until this is deployed.