### PR TITLE
Only delete inactive routes from realtime ETS table

### DIFF
--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -136,7 +136,7 @@ defmodule Realtime.Server do
     removed_route_ids = active_route_ids -- new_active_route_ids
 
     for route_id <- removed_route_ids do
-      _ = :ets.delete_object(ets, {:route_id, route_id})
+      _ = :ets.delete(ets, {:route_id, route_id})
     end
 
     for {route_id, vehicles} <- vehicles_by_route_id do

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -107,6 +107,24 @@ defmodule Realtime.ServerTest do
 
       assert Server.lookup(lookup_args) == @vehicles_for_route
     end
+
+    test "inactive routes have all their vehicle data removed", %{server_pid: server_pid} do
+      Server.subscribe_to_route("1", server_pid)
+
+      Server.update({%{}, []}, server_pid)
+
+      assert_receive(
+        {:new_realtime_data, :vehicles, lookup_args},
+        200,
+        "Client received vehicle positions"
+      )
+
+      assert Server.lookup(lookup_args) == %{
+               ghosts: [],
+               incoming_vehicles: [],
+               on_route_vehicles: []
+             }
+    end
   end
 
   describe "subscribe_to_all_shuttles" do


### PR DESCRIPTION
Deleting the entire table before repopulating it was creating a period
of time during each update when the table was completely empty and we
were experiencing a lot of lookup failures for data we should have.

I'm hoping this helps with [🐞 Timeouts on joining vehicle channels](https://app.asana.com/0/1112935048846093/1140305520008297), but it seems like an improvement even if it doesn't.

<img width="1132" alt="Screen Shot 2019-10-11 at 13 53 18" src="https://user-images.githubusercontent.com/42339/66675251-ef5ed400-ec32-11e9-9c6c-e56ac1f9dbad.png">
