### PR TITLE
Update distillery release command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ WORKDIR /root
 RUN mix phx.digest
 
 WORKDIR /root
-RUN mix release --verbose
+RUN mix distillery.release --verbose

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,10 +7,10 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
-  # This sets the default release built by `mix release`
+use Distillery.Releases.Config,
+  # This sets the default release built by `mix distillery.release`
   default_release: :default,
-  # This sets the default environment used by `mix release`
+  # This sets the default environment used by `mix distillery.release`
   default_environment: :prod
 
 # For a full list of config options for both releases
@@ -29,7 +29,7 @@ end
 
 # You may define one or more releases in this file.
 # If you have not set a default release, or selected one
-# when running `mix release`, the first release in the file
+# when running `mix distillery.release`, the first release in the file
 # will be used by default
 
 release :skate do


### PR DESCRIPTION
The command was changed in version 2.1.0:
https://hexdocs.pm/distillery/changelog.html

No ticket.