### PR TITLE
Let phoenix router know about /search client route

### DIFF
--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -54,6 +54,7 @@ defmodule SkateWeb.Router do
     get "/", PageController, :index
     get "/shuttle-map", PageController, :index
     get "/about", PageController, :index
+    get "/search", PageController, :index
     get "/settings", PageController, :index
   end
 

--- a/test/skate_web/router_test.exs
+++ b/test/skate_web/router_test.exs
@@ -29,6 +29,19 @@ defmodule SkateWeb.RouterTest do
     end
   end
 
+  describe "GET /search (client-side route)" do
+    test "shows you the app, letting the client handle routing", %{conn: conn} do
+      {:ok, token, _} = AuthManager.encode_and_sign("FAKE_UID")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "bearer: " <> token)
+        |> get("/search")
+
+      assert html_response(conn, 200) =~ "div id=\"app\""
+    end
+  end
+
   describe "GET /settings (client-side route)" do
     test "shows you the app, letting the client handle routing", %{conn: conn} do
       {:ok, token, _} = AuthManager.encode_and_sign("FAKE_UID")


### PR DESCRIPTION
No ticket. Putting in a little piece we missed in https://github.com/mbta/skate/pull/223.