### PR TITLE
clean up how we handle picker container sizing

### DIFF
--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -1,3 +1,10 @@
 .m-ladder-page {
-  @include page;
+  // leave space for the picker container tab, which is always visible
+  padding-left: 2rem;
+
+  transition: margin-left 0.2s ease-in-out;
+
+  .m-tab-bar.visible + & {
+    margin-left: $tab-bar-width + $picker-width-narrow;
+  }
 }

--- a/assets/css/_page.scss
+++ b/assets/css/_page.scss
@@ -1,6 +1,6 @@
 .c-page {
-  @include page;
   background: $color-bg-medium;
+  margin-left: $tab-bar-width;
 }
 
 .c-page__container {

--- a/assets/css/_picker_container.scss
+++ b/assets/css/_picker_container.scss
@@ -1,8 +1,6 @@
-$narrow-width: 7.5rem;
-$wide-width: $narrow-width + 2.6;
-
 .m-picker-container {
   background-color: $color-bg-medium;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -12,11 +10,11 @@ $wide-width: $narrow-width + 2.6;
   position: fixed;
   top: inherit;
   transition: left 0.2s ease-in-out;
-  width: $narrow-width;
+  width: $picker-width-narrow;
   z-index: 1;
 
   &--wide {
-    width: $wide-width;
+    width: $picker-width-wide;
   }
 
   &.visible {
@@ -24,11 +22,11 @@ $wide-width: $narrow-width + 2.6;
   }
 
   &.hidden {
-    left: -($narrow-width + 2);
+    left: -$picker-width-narrow;
   }
 
   &--wide.hidden {
-    left: -($wide-width + 2);
+    left: -$picker-width-wide;
   }
 }
 
@@ -36,14 +34,14 @@ $wide-width: $narrow-width + 2.6;
   background-color: $color-bg-medium;
   border-top-right-radius: 1rem;
   border-bottom-right-radius: 1rem;
-  left: $narrow-width + 2;
+  left: $picker-width-narrow;
   padding: 1.5rem 0.3rem;
   position: absolute;
   top: 1.625rem;
   width: fit-content;
 
   .m-picker-container--wide & {
-    left: $wide-width + 2;
+    left: $picker-width-wide;
   }
 }
 

--- a/assets/css/_route_ladders.scss
+++ b/assets/css/_route_ladders.scss
@@ -10,10 +10,5 @@
     [m-layover-box--bottom] minmax(auto, max-content)
     [m-incoming-box] max-content;
   height: 100vh;
-  padding: 1rem 1rem 1rem 3rem;
-  transition: padding-left 0.2s ease-in-out;
-
-  .m-picker-container.visible + & {
-    padding-left: 12.5rem;
-  }
+  padding: 1rem;
 }

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -190,10 +190,6 @@ $color-stop-stroke: $black;
   }
 }
 
-@mixin page {
-  margin-left: $tab-bar-width;
-}
-
 // input styles
 
 select {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,4 +1,6 @@
 $tab-bar-width: 3rem;
+$picker-width-narrow: 9.5rem;
+$picker-width-wide: $picker-width-narrow + 2.6;
 
 @import "base";
 @import "inter_ui";


### PR DESCRIPTION
Asana Task: none

While attempting to set up [adjust map fitBounds margins around visible or hidden picker](https://github.com/mbta/skate/pull/222/commits/c23b6278a799aa805d1efc1b7f837dc17573ae14) c23b627 , I tried playing around with how the ladder page and shuttle page adjust around the tab bar / picker when it's open or closed. I ended up taking a different approach there (just adjusting the fitBounds margins), but some of the refactoring is still worth keeping.

* Move the picker container widths to `app.scss` alongside `$tab-bar-width` so other scss files (`_ladder_page.scss`) can access them. Remove hardcoded ladder margin.
* Set the picker container `box-sizing` to `border-box` so that `$picker-width-` is really the width, and the `+2` for the margins can be removed from many places.
* Move the ladder margins from `.m-route-ladders` to `.m-ladder-page`. `.m-route-ladders` shouldn't have to think about the picker and other things on the page, but it's fine if `.m-ladder-page` does.
* Remove the extra `margin-left: $tab-bar-width` that the ladders had even when the tab bar was closed. This fixes the small visual bug where the ladders would be too far from the edge.