### PR TITLE
remove useless current_status field

### DIFF
--- a/assets/src/models/vehicleData.ts
+++ b/assets/src/models/vehicleData.ts
@@ -4,7 +4,6 @@ import {
   Ghost,
   Vehicle,
   VehicleScheduledLocation,
-  VehicleStatus,
   VehicleStopStatus,
   VehicleTimepointStatus,
 } from "../realtime.d"
@@ -79,7 +78,6 @@ interface VehicleScheduledLocationData {
 }
 
 interface VehicleStopStatusData {
-  status: VehicleStatus
   stop_id: string
   stop_name: string
 }
@@ -184,7 +182,6 @@ const vehicleScheduledLocationFromData = (
 const vehicleStopStatusFromData = (
   vehicleStopStatusData: VehicleStopStatusData
 ): VehicleStopStatus => ({
-  status: vehicleStopStatusData.status,
   stopId: vehicleStopStatusData.stop_id,
   stopName: vehicleStopStatusData.stop_name,
 })

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -74,7 +74,6 @@ export type VehicleOrGhost = Vehicle | Ghost
 export type VehicleId = string
 
 export interface VehicleStopStatus {
-  status: VehicleStatus
   stopId: StopId
   stopName: string
 }
@@ -88,8 +87,6 @@ export interface VehicleTimepointStatus {
   timepointId: TimepointId
   fractionUntilTimepoint: number
 }
-
-export type VehicleStatus = "in_transit_to" | "stopped_at"
 
 export interface VehiclesForRoute {
   onRouteVehicles: Vehicle[]

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -45,7 +45,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -84,7 +83,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -129,7 +127,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -221,7 +218,6 @@ describe("ladder", () => {
         blockIsActive: false,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -260,7 +256,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -326,7 +321,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -391,7 +385,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -430,7 +423,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -497,7 +489,6 @@ describe("ladder", () => {
       blockIsActive: true,
       dataDiscrepancies: [],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "stop",
         stopName: "stop",
       },
@@ -558,7 +549,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -618,7 +608,6 @@ describe("ladder", () => {
         blockIsActive: true,
         dataDiscrepancies: [],
         stopStatus: {
-          status: "in_transit_to",
           stopId: "stop",
           stopName: "stop",
         },
@@ -696,7 +685,6 @@ describe("ladder", () => {
         },
       ],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "stop",
         stopName: "stop",
       },

--- a/assets/tests/components/layoverBox.test.tsx
+++ b/assets/tests/components/layoverBox.test.tsx
@@ -36,7 +36,6 @@ const vehicles: Vehicle[] = [
     blockIsActive: true,
     dataDiscrepancies: [],
     stopStatus: {
-      status: "in_transit_to",
       stopId: "57",
       stopName: "57",
     },
@@ -75,7 +74,6 @@ const vehicles: Vehicle[] = [
     blockIsActive: true,
     dataDiscrepancies: [],
     stopStatus: {
-      status: "in_transit_to",
       stopId: "59",
       stopName: "59",
     },

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -64,7 +64,6 @@ const vehicle: Vehicle = {
     },
   ],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "s1",
     stopName: "Stop Name",
   },

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -62,7 +62,6 @@ describe("PropertiesPanel", () => {
         },
       ],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "s1",
         stopName: "Stop Name",
       },

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -52,7 +52,6 @@ const vehicle: Vehicle = {
     },
   ],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "s1",
     stopName: "Stop Name",
   },

--- a/assets/tests/components/propertiesPanel/headwayDiagram.test.tsx
+++ b/assets/tests/components/propertiesPanel/headwayDiagram.test.tsx
@@ -35,7 +35,6 @@ const vehicle: Vehicle = {
   blockIsActive: true,
   dataDiscrepancies: [],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "77",
     stopName: "Massachusetts Ave @ Marlborough St",
   },
@@ -104,7 +103,6 @@ describe("HeadwayDiagram", () => {
       blockIsActive: true,
       dataDiscrepancies: [],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "72",
         stopName: "Massachusetts Ave @ Pearl St",
       },
@@ -155,7 +153,6 @@ describe("HeadwayDiagram", () => {
       blockIsActive: true,
       dataDiscrepancies: [],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "11413",
         stopName: "Columbus Ave @ Walnut Ave",
       },

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -61,7 +61,6 @@ const vehicle: Vehicle = {
     },
   ],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "s1",
     stopName: "Stop Name",
   },

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -44,7 +44,6 @@ const vehicles: Vehicle[] = [
     blockIsActive: true,
     dataDiscrepancies: [],
     stopStatus: {
-      status: "in_transit_to",
       stopId: "57",
       stopName: "57",
     },
@@ -83,7 +82,6 @@ const vehicles: Vehicle[] = [
     blockIsActive: true,
     dataDiscrepancies: [],
     stopStatus: {
-      status: "in_transit_to",
       stopId: "59",
       stopName: "59",
     },
@@ -352,7 +350,6 @@ describe("routeLadder", () => {
       blockIsActive: true,
       dataDiscrepancies: [],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "stop",
         stopName: "stop",
       },

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -37,7 +37,6 @@ const shuttle: Vehicle = {
   blockIsActive: true,
   dataDiscrepancies: [],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "57",
     stopName: "57",
   },

--- a/assets/tests/components/shuttlePicker.test.tsx
+++ b/assets/tests/components/shuttlePicker.test.tsx
@@ -48,7 +48,6 @@ const vehicle: Vehicle = {
   blockIsActive: true,
   dataDiscrepancies: [],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "57",
     stopName: "57",
   },

--- a/assets/tests/helpers/vehicleLabel.test.ts
+++ b/assets/tests/helpers/vehicleLabel.test.ts
@@ -35,7 +35,6 @@ const vehicle: Vehicle = {
   blockIsActive: true,
   dataDiscrepancies: [],
   stopStatus: {
-    status: "in_transit_to",
     stopId: "59",
     stopName: "59",
   },

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -98,7 +98,6 @@ const shuttlesData = [
     },
     sources: ["swiftly", "busloc"],
     stop_status: {
-      status: "in_transit_to",
       stop_id: "s1",
       stop_name: "Stop Name",
     },
@@ -167,7 +166,6 @@ const shuttles: Vehicle[] = [
       },
     ],
     stopStatus: {
-      status: "in_transit_to",
       stopId: "s1",
       stopName: "Stop Name",
     },

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -102,7 +102,6 @@ describe("useVehicles", () => {
       },
       sources: ["swiftly", "busloc"],
       stop_status: {
-        status: "in_transit_to",
         stop_id: "s1",
         stop_name: "Stop Name",
       },
@@ -171,7 +170,6 @@ describe("useVehicles", () => {
         },
       ],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "s1",
         stopName: "Stop Name",
       },

--- a/assets/tests/models/vehicle.test.ts
+++ b/assets/tests/models/vehicle.test.ts
@@ -68,7 +68,6 @@ describe("isAVehicle", () => {
         },
       ],
       stopStatus: {
-        status: "in_transit_to",
         stopId: "s1",
         stopName: "Stop Name",
       },

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -71,7 +71,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
             bearing: Map.get(position, "bearing"),
             speed: Map.get(position, "speed"),
             odometer: Map.get(position, "odometer"),
-            status: vehicle_status(Map.get(vp, "current_status")),
+            current_status: current_status(Map.get(vp, "current_status")),
             stop_sequence: Map.get(vp, "current_stop_sequence"),
             last_updated: Map.get(vp, "timestamp"),
             block_id: Map.get(vp, "block_id"),
@@ -134,11 +134,11 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     defp schedule_relationship(unquote(Atom.to_string(relationship))), do: unquote(relationship)
   end
 
-  @spec vehicle_status(String.t() | nil) :: atom()
+  @spec current_status(String.t() | nil) :: atom()
   # default
-  defp vehicle_status(nil), do: :IN_TRANSIT_TO
+  defp current_status(nil), do: :IN_TRANSIT_TO
 
   for status <- ~w(INCOMING_AT STOPPED_AT IN_TRANSIT_TO)a do
-    defp vehicle_status(unquote(Atom.to_string(status))), do: unquote(status)
+    defp current_status(unquote(Atom.to_string(status))), do: unquote(status)
   end
 end

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -39,7 +39,7 @@ defmodule Concentrate.VehiclePosition do
     :scheduled_headway_secs,
     :sources,
     :data_discrepancies,
-    status: :IN_TRANSIT_TO
+    current_status: :IN_TRANSIT_TO
   ])
 
   def new(opts) do

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -29,7 +29,6 @@ defmodule SkateWeb.VehiclesChannelTest do
     sources: MapSet.new(["swiftly"]),
     data_discrepancies: [],
     stop_status: %{
-      status: :in_transit_to,
       stop_id: "567",
       stop_name: "567"
     },

--- a/test/concentrate/consumer/vehicle_positions_test.exs
+++ b/test/concentrate/consumer/vehicle_positions_test.exs
@@ -36,7 +36,7 @@ defmodule Concentrate.Supervisor.VehiclePositionsTest do
                 operator_name: "FRANK",
                 run_id: "123-9048",
                 speed: nil,
-                status: :IN_TRANSIT_TO,
+                current_status: :IN_TRANSIT_TO,
                 stop_id: "6551",
                 stop_sequence: 1,
                 trip_id: "39984755"
@@ -68,7 +68,7 @@ defmodule Concentrate.Supervisor.VehiclePositionsTest do
                 operator_name: "PANIAGUA",
                 run_id: "126-1430",
                 speed: 0.0,
-                status: :IN_TRANSIT_TO,
+                current_status: :IN_TRANSIT_TO,
                 stop_id: "8310",
                 stop_sequence: 1,
                 trip_id: "40155689"

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -127,7 +127,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  operator_id: "2841",
                  operator_name: "EVANS",
                  run_id: "128-1007",
-                 status: :STOPPED_AT,
+                 current_status: :STOPPED_AT,
                  last_updated: 1_534_340_406,
                  sources: MapSet.new(["busloc"]),
                  data_discrepancies: nil

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -27,7 +27,6 @@ defmodule Realtime.ServerTest do
     sources: MapSet.new(["swiftly"]),
     data_discrepancies: [],
     stop_status: %{
-      status: :in_transit_to,
       stop_id: "s1"
     },
     timepoint_status: %{

--- a/test/realtime/vehicle_or_ghost_test.exs
+++ b/test/realtime/vehicle_or_ghost_test.exs
@@ -26,7 +26,6 @@ defmodule Realtime.VehicleOrGhostTest do
     sources: MapSet.new(["swiftly"]),
     data_discrepancies: [],
     stop_status: %{
-      status: :in_transit_to,
       stop_id: "s1"
     },
     timepoint_status: %{

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -23,7 +23,7 @@ defmodule Realtime.VehicleTest do
     is_laying_over: false,
     layover_departure_time: nil,
     speed: 0.0,
-    status: :IN_TRANSIT_TO,
+    current_status: :IN_TRANSIT_TO,
     stop_id: "392",
     stop_sequence: 25,
     trip_id: "39984755",
@@ -134,7 +134,6 @@ defmodule Realtime.VehicleTest do
           }
         ],
         stop_status: %{
-          status: :in_transit_to,
           stop_id: "392",
           stop_name: "392"
         },
@@ -318,19 +317,15 @@ defmodule Realtime.VehicleTest do
     end
 
     test "returns :incoming if the trip is nil" do
-      assert Vehicle.route_status(:in_transit_to, "s1", nil) == :incoming
+      assert Vehicle.route_status("s1", nil) == :incoming
     end
 
-    test "returns :on_route if :stopped_at any stop", %{trip: trip} do
-      assert Vehicle.route_status(:stopped_at, "s1", trip) == :on_route
+    test "returns :incoming if the next stop is the first stop of the trip", %{trip: trip} do
+      assert Vehicle.route_status("s1", trip) == :incoming
     end
 
-    test "returns :incoming if :in_transit_to the first stop of the trip", %{trip: trip} do
-      assert Vehicle.route_status(:in_transit_to, "s1", trip) == :incoming
-    end
-
-    test "returns :on_route if :in_transit_to any other stop", %{trip: trip} do
-      assert Vehicle.route_status(:in_transit_to, "s2", trip) == :on_route
+    test "returns :on_route if the next stop is any other stop", %{trip: trip} do
+      assert Vehicle.route_status("s2", trip) == :on_route
     end
   end
 
@@ -376,7 +371,6 @@ defmodule Realtime.VehicleTest do
           }
         ],
         stop_status: %{
-          status: :in_transit_to,
           stop_id: "392",
           stop_name: "392"
         },


### PR DESCRIPTION
The `current_status` field (that's `incoming_at`, `in_transit_to`, or `stopped_at`) isn't used. busloc doesn't assign vehicles to stops, so doesn't produce it. And it's nowhere in the swiftly API. I checked [the MBTA v3 API](https://api-v3.mbta.com/vehicles?filter[route_type]=3) and all 500 buses that are out right now have `current_status: IN_TRANSIT_TO`.

This should have no effect on the app, but will reduce the cognitive load of working with vehicle positions.

Like in #250 , I left it in VehiclePosition to stay closer to the GTFS-RT spec. (renamed from `status` to `current_status`.)
