### PR TITLE
Add mini-map to properties panel on shuttles page

### DIFF
--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -80,11 +80,9 @@ const Location = ({ vehicle }: { vehicle: Vehicle }) => {
       >
         Directions
       </a>
-      {!isShuttle(vehicle) && (
-        <div className="m-vehicle-properties-panel__map">
-          <Map vehicles={[vehicle]} />
-        </div>
-      )}
+      <div className="m-vehicle-properties-panel__map">
+        <Map vehicles={[vehicle]} />
+      </div>
     </div>
   )
 }

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -503,6 +503,14 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
         >
           Directions
         </a>
+        <div
+          className="m-vehicle-properties-panel__map"
+        >
+          <div
+            className="m-vehicle-map"
+            id="id-vehicle-map"
+          />
+        </div>
       </div>
       <button
         className="m-properties-panel__close-button"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -1134,6 +1134,14 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
     >
       Directions
     </a>
+    <div
+      className="m-vehicle-properties-panel__map"
+    >
+      <div
+        className="m-vehicle-map"
+        id="id-vehicle-map"
+      />
+    </div>
   </div>
   <button
     className="m-properties-panel__close-button"


### PR DESCRIPTION
Asana ticket: [Add back minimap to VPP on shuttle map.](https://app.asana.com/0/1112935048846093/1145445573523885)

![Screen Shot 2019-11-08 at 16 20 49](https://user-images.githubusercontent.com/42339/68511468-06014680-0244-11ea-897d-b87ff38dee81.png)
