### PR TITLE
Log vehicle search connections

### DIFF
--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -1,5 +1,6 @@
 defmodule SkateWeb.VehiclesChannel do
   use SkateWeb, :channel
+  require Logger
 
   alias Realtime.Server
   alias SkateWeb.AuthManager
@@ -16,7 +17,11 @@ defmodule SkateWeb.VehiclesChannel do
     {:ok, vehicles_for_route, socket}
   end
 
-  def join("vehicles:search:" <> search_params, _message, socket) do
+  def join(
+        "vehicles:search:" <> search_params,
+        _message,
+        %{assigns: %{guardian_default_resource: username}} = socket
+      ) do
     subscribe_args =
       case search_params do
         "all:" <> text ->
@@ -31,6 +36,12 @@ defmodule SkateWeb.VehiclesChannel do
         "operator:" <> text ->
           [text, :operator]
       end
+
+    Logger.info(fn ->
+      "User=#{username} searched for property=#{Enum.at(subscribe_args, 1)}, text=#{
+        Enum.at(subscribe_args, 0)
+      }"
+    end)
 
     vehicles = Duration.log_duration(Server, :subscribe_to_search, subscribe_args)
 


### PR DESCRIPTION
Code changes to support: [Global Search | Track searches](https://app.asana.com/0/1112935048846093/1148748029701121)

Example log line from Dev:

`20:25:10.882 [info] node=skate-i-0457c7ef3ffd5a970@ede0fd349ad6 User=mbta-active-directory_mshanley searched for property=run, text=132`

Will build this into the Splunk dashboards.