### PR TITLE
Ignore handle_info reference calls after we've timed out

### DIFF
--- a/lib/concentrate/consumer/vehicle_positions.ex
+++ b/lib/concentrate/consumer/vehicle_positions.ex
@@ -17,6 +17,11 @@ defmodule Concentrate.Consumer.VehiclePositions do
     {:consumer, :the_state_does_not_matter, opts}
   end
 
+  # If we get a reply after we've already timed out, ignore it
+  @impl GenStage
+  def handle_info({reference, _}, state) when is_reference(reference),
+    do: {:noreply, [], state}
+
   @impl GenStage
   def handle_events(events, _from, state) do
     groups = List.last(events)

--- a/test/concentrate/consumer/vehicle_positions_test.exs
+++ b/test/concentrate/consumer/vehicle_positions_test.exs
@@ -88,4 +88,14 @@ defmodule Concentrate.Supervisor.VehiclePositionsTest do
       assert response == {:noreply, [], %{}}
     end
   end
+
+  describe "backend implementation" do
+    test "handles reference info calls that come in after a timeout" do
+      state = %{}
+
+      response = VehiclePositions.handle_info({make_ref(), %{}}, state)
+
+      assert response == {:noreply, [], state}
+    end
+  end
 end


### PR DESCRIPTION
Asana ticket: [🐞 VehiclePositions unhandled message](https://app.asana.com/0/1112935048846093/1145932018565185)