### PR TITLE
Show all shuttles as gray, regardless of off-course status

### DIFF
--- a/assets/src/models/vehicleStatus.ts
+++ b/assets/src/models/vehicleStatus.ts
@@ -34,18 +34,23 @@ export const onTimeStatus = (scheduleAdherenceSecs: number): OnTimeStatus => {
 }
 
 export const drawnStatus = (vehicle: Vehicle): DrawnStatus => {
+  if (isShuttle(vehicle)) {
+    return "plain"
+  }
+
   if (vehicle.isOffCourse) {
     return "off-course"
-  } else if (
-    isShuttle(vehicle) ||
-    (featureIsEnabled("headway_ladder_colors") &&
-      vehicle.headwaySpacing !== null)
+  }
+
+  if (
+    featureIsEnabled("headway_ladder_colors") &&
+    vehicle.headwaySpacing !== null
   ) {
     // Headway lines give the status instead of the vehicles
     return "plain"
-  } else {
-    return onTimeStatus(vehicle.scheduleAdherenceSecs)
   }
+
+  return onTimeStatus(vehicle.scheduleAdherenceSecs)
 }
 
 export const humanReadableScheduleAdherence = (vehicle: Vehicle): string =>

--- a/assets/tests/models/vehicleStatus.test.ts
+++ b/assets/tests/models/vehicleStatus.test.ts
@@ -60,6 +60,17 @@ describe("drawnStatus", () => {
     expect(drawnStatus(vehicle)).toEqual("off-course")
   })
 
+  test("returns 'plain' for a shuttle, even if off-course", () => {
+    mockHeadwaysOff()
+    const shuttle: Vehicle = {
+      runId: "999-0555",
+      headwaySpacing: null,
+      scheduleAdherenceSecs: 0,
+      isOffCourse: true,
+    } as Vehicle
+    expect(drawnStatus(shuttle)).toEqual("plain")
+  })
+
   test("return scheduled status", () => {
     mockHeadwaysOff()
     const vehicle: Vehicle = {


### PR DESCRIPTION
Asana ticket: [🐞 Shuttle Map 555s are showing up as black](https://app.asana.com/0/1112935048846093/1148738023247977)