### PR TITLE
Move VPP header X button to top-right corner

### DIFF
--- a/assets/css/properties_panel/_header.scss
+++ b/assets/css/properties_panel/_header.scss
@@ -4,6 +4,11 @@
   .m-route-variant-name {
     @include font-header;
   }
+
+  .m-close-button {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .m-properties-panel__label {
@@ -49,12 +54,15 @@
   .on-time & {
     fill: $color-vehicle-ontime;
   }
+
   .early & {
     fill: $color-vehicle-early;
   }
+
   .late & {
     fill: $color-vehicle-late;
   }
+
   .off-course & {
     fill: $color-vehicle-off-course;
   }


### PR DESCRIPTION
Asana ticket: [🐞 Vehicle Properties Panel X button should be in top-right corner](https://app.asana.com/0/1148853526253437/1132591973236754)

![Screen Shot 2019-11-18 at 14 46 25](https://user-images.githubusercontent.com/42339/69084507-634e8200-0a12-11ea-9de8-20bd8316566d.png)
