### PR TITLE
Make shuttle run and route lists the same size

### DIFF
--- a/assets/css/_route_picker.scss
+++ b/assets/css/_route_picker.scss
@@ -26,7 +26,7 @@
 }
 
 .m-route-picker__route-list {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
No ticket, just a problem I noticed while showing inspectors Skate on a phone.

Before:

![1-Before](https://user-images.githubusercontent.com/42339/69564410-fe9aa680-0f80-11ea-8fba-29f606153ba2.png)

After:

![2-After](https://user-images.githubusercontent.com/42339/69564414-01959700-0f81-11ea-83f5-652ea8ff3cde.png)
