### PR TITLE
Prevent default behavior on the Recenter Map button

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -295,7 +295,8 @@ const recenterControl = (
       link.setAttribute("role", "button")
       link.setAttribute("aria-label", "Recenter map")
       Leaflet.DomEvent.disableClickPropagation(link)
-      link.onclick = () => {
+      link.onclick = e => {
+        e.preventDefault()
         setShouldAutoCenter(true)
       }
       return container


### PR DESCRIPTION
Make it so that we don't get a "#" in our URL.

No ticket.