### PR TITLE
Fix map recentering on subsequent searches

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -256,11 +256,6 @@ export const autoCenter = (
       paddingTopLeft: [appState.pickerContainerIsVisible ? 220 : 20, 20],
     })
   }
-  // The move starts asynchronously.
-  // Wait until it's really started to start listening for manual moves again.
-  window.requestAnimationFrame(() => {
-    isAutoCentering.current = false
-  })
 }
 
 const recenterControl = (
@@ -332,6 +327,12 @@ export const newLeafletMap = (
     // But don't disable shouldAutoCenter if the move was triggered by an auto center.
     if (!isAutoCentering.current) {
       setShouldAutoCenter(false)
+    }
+  })
+  map.on("moveend", () => {
+    // Wait until the auto centering is finished to start listening for manual moves again.
+    if (isAutoCentering.current) {
+      isAutoCentering.current = false
     }
   })
   Leaflet.control.zoom({ position: "topright" }).addTo(map)


### PR DESCRIPTION
Wait for the auto center animation to complete before listening for
user actions.

Prevent default behavior on the Recenter Map button to make it so
that we don't get a "#" in our URL.

Asana ticket: [🐞 Fix global search map behavior when the search returns one or more result](https://app.asana.com/0/1148853526253426/1151402093845513)