### PR TITLE
Make function names consistent by removing "A"

### DIFF
--- a/assets/src/components/propertiesList.tsx
+++ b/assets/src/components/propertiesList.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { intersperseString } from "../helpers/array"
 import { formattedRunNumber } from "../models/shuttle"
-import { isAVehicle, isShuttle } from "../models/vehicle"
+import { isShuttle, isVehicle } from "../models/vehicle"
 import { Ghost, Vehicle, VehicleOrGhost } from "../realtime"
 
 interface Props {
@@ -43,7 +43,7 @@ const ghostProperties = (ghost: Ghost): Property[] => [
 ]
 
 const properties = (vehicleOrGhost: VehicleOrGhost): Property[] =>
-  isAVehicle(vehicleOrGhost)
+  isVehicle(vehicleOrGhost)
     ? vehicleProperties(vehicleOrGhost)
     : ghostProperties(vehicleOrGhost)
 

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import detectSwipe, { SwipeDirection } from "../helpers/detectSwipe"
-import { isAVehicle } from "../models/vehicle"
+import { isVehicle } from "../models/vehicle"
 import { VehicleOrGhost } from "../realtime.d"
 import { Route } from "../schedule"
 import { deselectVehicle } from "../state"
@@ -40,7 +40,7 @@ const PropertiesPanel = ({ selectedVehicleOrGhost, route }: Props) => {
     <>
       <div id="m-properties-panel" className="m-properties-panel">
         <div className="m-properties-panel__vehicle-or-ghost-panel">
-          {isAVehicle(selectedVehicleOrGhost) ? (
+          {isVehicle(selectedVehicleOrGhost) ? (
             <VehiclePropertiesPanel
               selectedVehicle={selectedVehicleOrGhost}
               route={route}

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from "react"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import vehicleLabel, { ghostLabel } from "../../helpers/vehicleLabel"
 import {
-  isAVehicle,
   isShuttle,
+  isVehicle,
   shouldShowHeadwayDiagram,
 } from "../../models/vehicle"
 import {
@@ -95,7 +95,7 @@ const Header = ({ vehicle, route }: Props) => {
   return (
     <div className="m-properties-panel__header">
       <div className="m-properties-panel__label">
-        {isAVehicle(vehicle) ? (
+        {isVehicle(vehicle) ? (
           <VehicleIcon
             size={Size.Large}
             orientation={Orientation.Up}
@@ -120,10 +120,10 @@ const Header = ({ vehicle, route }: Props) => {
 
         <RouteVariantName vehicle={vehicle} />
 
-        {isAVehicle(vehicle) && shouldShowHeadwayDiagram(vehicle) ? (
+        {isVehicle(vehicle) && shouldShowHeadwayDiagram(vehicle) ? (
           <HeadwayTarget vehicle={vehicle} />
         ) : (
-          isAVehicle(vehicle) &&
+          isVehicle(vehicle) &&
           !isShuttle(vehicle) && <ScheduleAdherence vehicle={vehicle} />
         )}
       </div>

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction, useContext, useState } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { reverseIcon, reverseIconReversed } from "../helpers/icon"
-import { isAVehicle } from "../models/vehicle"
+import { isVehicle } from "../models/vehicle"
 import { Ghost, Vehicle, VehicleId, VehicleOrGhost } from "../realtime.d"
 import { DirectionId, LoadableTimepoints, Route, RouteId } from "../schedule.d"
 import { deselectRoute } from "../state"
@@ -138,7 +138,7 @@ export const groupByPosition = (
 
   return (vehiclesAndGhosts || []).reduce(
     (acc: ByPosition, current: VehicleOrGhost) => {
-      if (isAVehicle(current)) {
+      if (isVehicle(current)) {
         if (current.routeId === routeId) {
           switch (current.routeStatus) {
             case "on_route":

--- a/assets/src/components/routeVariantName.tsx
+++ b/assets/src/components/routeVariantName.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import { isAVehicle, isShuttle } from "../models/vehicle"
+import { isShuttle, isVehicle } from "../models/vehicle"
 import { VehicleOrGhost } from "../realtime"
 
 export const RouteVariantName = ({ vehicle }: { vehicle: VehicleOrGhost }) => {
-  if (isAVehicle(vehicle) && isShuttle(vehicle)) {
+  if (isVehicle(vehicle) && isShuttle(vehicle)) {
     return <div className="m-route-variant-name">Shuttle</div>
   }
 

--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -4,7 +4,7 @@ import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useSearchResults from "../hooks/useSearchResults"
 import { isValidSearch, Search } from "../models/search"
-import { isAVehicle } from "../models/vehicle"
+import { isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleId, VehicleOrGhost } from "../realtime"
 import Map from "./map"
 import PropertiesPanel from "./propertiesPanel"
@@ -25,7 +25,7 @@ const onlyVehicles = (
     return []
   }
 
-  return vehiclesOrGhosts.filter(vog => isAVehicle(vog)) as Vehicle[]
+  return vehiclesOrGhosts.filter(vog => isVehicle(vog)) as Vehicle[]
 }
 
 const findSelectedVehicle = (

--- a/assets/src/components/searchResults.tsx
+++ b/assets/src/components/searchResults.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { setSearchText } from "../models/search"
-import { isAVehicle } from "../models/vehicle"
+import { isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleOrGhost } from "../realtime"
 import { selectVehicle } from "../state"
 import PropertiesList from "./propertiesList"
@@ -50,7 +50,7 @@ const SearchResultCard = ({
         highlightText={search.text}
       />
 
-      {isAVehicle(vehicleOrGhost) && <RouteLabel vehicle={vehicleOrGhost} />}
+      {isVehicle(vehicleOrGhost) && <RouteLabel vehicle={vehicleOrGhost} />}
     </div>
   )
 }

--- a/assets/src/models/vehicle.ts
+++ b/assets/src/models/vehicle.ts
@@ -1,10 +1,14 @@
 import featureIsEnabled from "../laboratoryFeatures"
-import { Vehicle, VehicleOrGhost } from "../realtime"
+import { Ghost, Vehicle, VehicleOrGhost } from "../realtime"
 
-export const isAVehicle = (
+export const isVehicle = (
   vehicleOrGhost: VehicleOrGhost
 ): vehicleOrGhost is Vehicle =>
   (vehicleOrGhost as Vehicle).routeStatus !== undefined
+
+export const isGhost = (
+  vehicleOrGhost: VehicleOrGhost
+): vehicleOrGhost is Ghost => !isVehicle(vehicleOrGhost)
 
 export const isShuttle = (vehicle: Vehicle): boolean =>
   (vehicle.runId || "").startsWith("999")

--- a/assets/src/models/vehicleData.ts
+++ b/assets/src/models/vehicleData.ts
@@ -139,13 +139,13 @@ export const ghostFromData = (ghostData: GhostData): Ghost => ({
     vehicleTimepointStatusFromData(ghostData.scheduled_timepoint_status),
 })
 
-const isAGhost = (vehicleOrGhostData: VehicleOrGhostData): boolean =>
+const isGhost = (vehicleOrGhostData: VehicleOrGhostData): boolean =>
   !vehicleOrGhostData.hasOwnProperty("operator_id")
 
 export const vehicleOrGhostFromData = (
   vehicleOrGhostData: VehicleOrGhostData
 ): VehicleOrGhost =>
-  isAGhost(vehicleOrGhostData)
+  isGhost(vehicleOrGhostData)
     ? ghostFromData(vehicleOrGhostData as GhostData)
     : vehicleFromData(vehicleOrGhostData as VehicleData)
 

--- a/assets/src/models/vehiclesByRouteId.ts
+++ b/assets/src/models/vehiclesByRouteId.ts
@@ -1,7 +1,7 @@
 import { flatten, partition } from "../helpers/array"
 import { Vehicle, VehicleOrGhost } from "../realtime"
 import { ByRouteId, RouteId } from "../schedule"
-import { isAVehicle } from "./vehicle"
+import { isVehicle } from "./vehicle"
 
 interface NextAndPreviousVehicle {
   nextVehicle?: Vehicle
@@ -17,7 +17,7 @@ export const allVehiclesForRoute = (
   routeId: RouteId
 ): Vehicle[] =>
   (vehiclesByRouteId[routeId] || [])
-    .filter(isAVehicle)
+    .filter(isVehicle)
     .filter(vehicle => vehicle.routeId === routeId)
 
 /**

--- a/assets/src/settings.ts
+++ b/assets/src/settings.ts
@@ -1,4 +1,4 @@
-import { isAVehicle, isShuttle } from "./models/vehicle"
+import { isShuttle, isVehicle } from "./models/vehicle"
 import { VehicleOrGhost } from "./realtime"
 
 export enum VehicleLabelSetting {
@@ -20,6 +20,6 @@ export const vehicleLabelSetting = (
   settings: Settings,
   vehicle: VehicleOrGhost
 ): VehicleLabelSetting =>
-  isAVehicle(vehicle) && isShuttle(vehicle)
+  isVehicle(vehicle) && isShuttle(vehicle)
     ? settings.shuttleVehicleLabel
     : settings.ladderVehicleLabel

--- a/assets/tests/models/vehicle.test.ts
+++ b/assets/tests/models/vehicle.test.ts
@@ -1,6 +1,7 @@
 import {
-  isAVehicle,
+  isGhost,
   isShuttle,
+  isVehicle,
   shouldShowHeadwayDiagram,
 } from "../../src/models/vehicle"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
@@ -95,13 +96,23 @@ const ghost: Ghost = {
   },
 }
 
-describe("isAVehicle", () => {
+describe("isVehicle", () => {
   test("returns true for a Vehicle", () => {
-    expect(isAVehicle(vehicle)).toBeTruthy()
+    expect(isVehicle(vehicle)).toBeTruthy()
   })
 
   test("returns false for a Ghost", () => {
-    expect(isAVehicle(ghost)).toBeFalsy()
+    expect(isVehicle(ghost)).toBeFalsy()
+  })
+})
+
+describe("isGhost", () => {
+  test("returns true for a Ghost", () => {
+    expect(isGhost(ghost)).toBeTruthy()
+  })
+
+  test("returns false for a Vehicle", () => {
+    expect(isGhost(vehicle)).toBeFalsy()
   })
 })
 

--- a/assets/tests/models/vehiclesByRouteId.test.ts
+++ b/assets/tests/models/vehiclesByRouteId.test.ts
@@ -1,4 +1,4 @@
-import { isAVehicle } from "../../src/models/vehicle"
+import { isVehicle } from "../../src/models/vehicle"
 import {
   allVehiclesAndGhosts,
   allVehiclesForRoute,
@@ -140,7 +140,7 @@ describe("allVehiclesForRoute", () => {
 
 describe("byDirection", () => {
   test("partitions vehicles into direction 0 and direction 1", () => {
-    const vehicles: Vehicle[] = vehiclesByRouteId["1"].filter(isAVehicle)
+    const vehicles: Vehicle[] = vehiclesByRouteId["1"].filter(isVehicle)
 
     const [direction0Vehicles, direction1Vehicles] = byDirection(vehicles)
 
@@ -154,7 +154,7 @@ describe("byDirection", () => {
 
 describe("nextAndPreviousVehicle", () => {
   test("returns the next and previous vehicles as described by the previousVehicleId property", () => {
-    const vehicles: Vehicle[] = vehiclesByRouteId["1"].filter(isAVehicle)
+    const vehicles: Vehicle[] = vehiclesByRouteId["1"].filter(isVehicle)
     // y102
     const currentVehicle = vehicles[1]
 
@@ -170,7 +170,7 @@ describe("nextAndPreviousVehicle", () => {
   })
 
   test("returns undefined if no next and/or previous vehicle", () => {
-    const vehicles: Vehicle[] = vehiclesByRouteId["39"].filter(isAVehicle)
+    const vehicles: Vehicle[] = vehiclesByRouteId["39"].filter(isVehicle)
     const currentVehicle = vehicles[0]
 
     expect(nextAndPreviousVehicle(vehicles, currentVehicle)).toEqual({


### PR DESCRIPTION
• isAVehicle -> isVehicle
• isAGhost -> isGhost

isShuttle stays isShuttle.

No ticket, pulled forward from #333

(@skyqrose sorry, last one. It just sounds like #333 might get stuck so I want to clean it up.)