### PR TITLE
show trip shapes in VPP map

### DIFF
--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import useInterval from "../../hooks/useInterval"
+import useRouteShapes from "../../hooks/useRouteShapes"
 import { isShuttle, shouldShowHeadwayDiagram } from "../../models/vehicle"
 import { DataDiscrepancy, Vehicle } from "../../realtime"
 import { Route } from "../../schedule"
@@ -30,6 +31,12 @@ const directionsUrl = (
 
 const Location = ({ vehicle }: { vehicle: Vehicle }) => {
   const [epocNowInSeconds, setEpocNowInSeconds] = useState(nowInSeconds())
+
+  const loadableShapes = useRouteShapes(
+    vehicle.routeId ? [vehicle.routeId] : []
+  )
+  const shapes = (loadableShapes[vehicle.routeId] || []).filter(shape => shape)
+
   useInterval(() => setEpocNowInSeconds(nowInSeconds()), 1000)
   const secondsAgo = (epocTime: number): string =>
     `${epocNowInSeconds - epocTime}s ago`
@@ -58,7 +65,7 @@ const Location = ({ vehicle }: { vehicle: Vehicle }) => {
         Directions
       </a>
       <div className="m-vehicle-properties-panel__map">
-        <Map vehicles={[vehicle]} />
+        <Map vehicles={[vehicle]} shapes={shapes} />
       </div>
     </div>
   )

--- a/lib/gtfs/data.ex
+++ b/lib/gtfs/data.ex
@@ -308,10 +308,7 @@ defmodule Gtfs.Data do
   defp shapes_by_route_id(shapes_data, routes, trips) do
     shapes_by_id = Shape.from_file(shapes_data)
 
-    routes
-    # Only save routes for shuttle routes
-    |> Enum.filter(&Route.shuttle_route?(&1))
-    |> Map.new(fn %Route{id: route_id} ->
+    Map.new(routes, fn %Route{id: route_id} ->
       shapes =
         trips
         |> trips_for_route(route_id)


### PR DESCRIPTION
Asana Task: [Include trip shape on the VPP map](https://app.asana.com/0/1148853526253426/1134108215297992)

<img width="349" alt="Screen Shot 2020-01-14 at 13 56 59" src="https://user-images.githubusercontent.com/23065557/72373414-3ba82d00-36d6-11ea-82a3-d9ffd05af8ad.png">

This is a quick implementation that stores the state in the VPP component, which means we need to refetch it every time you open a VPP. Do you think it's worth calling `useRouteShapes` from the `AppStateWrapper` component instead so it can be cached?

Does not include stops, because we don't have any way to load those. (The stops on the subway on are hardcoded on the frontend.)

It shows both directions, all variants, which can get a bit messy on routes with lots of variants. Here's the 39:

<img width="307" alt="Screen Shot 2020-01-14 at 13 57 16" src="https://user-images.githubusercontent.com/23065557/72373442-4bc00c80-36d6-11ea-9d96-65994478b5c8.png">
