### PR TITLE
rotate VPP icon to match orientation on ladder

### DIFF
--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -4,8 +4,8 @@ import vehicleLabel from "../../helpers/vehicleLabel"
 import {
   directionOnLadder,
   getLadderDirectionForRoute,
-  LadderDirections,
   LadderDirection,
+  LadderDirections,
   VehicleDirection,
 } from "../../models/ladderDirection"
 import {

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -2,6 +2,13 @@ import React, { useContext } from "react"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import vehicleLabel from "../../helpers/vehicleLabel"
 import {
+  directionOnLadder,
+  VehicleDirection,
+  getLadderDirectionForRoute,
+  LadderDirections,
+  LadderDirection,
+} from "../../models/ladderDirection"
+import {
   isShuttle,
   isVehicle,
   shouldShowHeadwayDiagram,
@@ -88,7 +95,9 @@ const directionName = (
 ): string => (route ? route.directionNames[directionId] : "")
 
 const Header = ({ vehicle, route }: Props) => {
-  const [{ settings }, dispatch] = useContext(StateDispatchContext)
+  const [{ ladderDirections, settings }, dispatch] = useContext(
+    StateDispatchContext
+  )
 
   const hideMe = () => dispatch(deselectVehicle())
 
@@ -97,7 +106,7 @@ const Header = ({ vehicle, route }: Props) => {
       <div className="m-properties-panel__label">
         <VehicleIcon
           size={Size.Large}
-          orientation={Orientation.Up}
+          orientation={vehicleOrientation(vehicle, ladderDirections)}
           label={vehicleLabel(vehicle, settings)}
           variant={vehicle.viaVariant}
           status={drawnStatus(vehicle)}
@@ -120,6 +129,34 @@ const Header = ({ vehicle, route }: Props) => {
       <CloseButton onClick={hideMe} />
     </div>
   )
+}
+
+const vehicleOrientation = (
+  vehicle: VehicleOrGhost,
+  ladderDirections: LadderDirections
+): Orientation => {
+  if (vehicle.routeId !== null && vehicle.directionId !== null) {
+    const ladderDirection: LadderDirection = getLadderDirectionForRoute(
+      ladderDirections,
+      vehicle.routeId
+    )
+    const vehicleDirection: VehicleDirection = directionOnLadder(
+      vehicle.directionId,
+      ladderDirection
+    )
+
+    if (vehicle.routeStatus === "laying_over") {
+      return vehicleDirection === VehicleDirection.Down
+        ? Orientation.Left
+        : Orientation.Right
+    } else {
+      return vehicleDirection === VehicleDirection.Down
+        ? Orientation.Down
+        : Orientation.Up
+    }
+  } else {
+    return Orientation.Up
+  }
 }
 
 export default Header

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -3,10 +3,10 @@ import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import vehicleLabel from "../../helpers/vehicleLabel"
 import {
   directionOnLadder,
-  VehicleDirection,
   getLadderDirectionForRoute,
   LadderDirections,
   LadderDirection,
+  VehicleDirection,
 } from "../../models/ladderDirection"
 import {
   isShuttle,

--- a/assets/src/components/propertiesPanel/headwayDiagram.tsx
+++ b/assets/src/components/propertiesPanel/headwayDiagram.tsx
@@ -58,7 +58,7 @@ const HeadwayDiagram = ({ vehicle }: { vehicle: Vehicle }) => {
     VehiclesByRouteIdContext
   )
   const { nextVehicle, previousVehicle } = nextAndPreviousVehicle(
-    allVehiclesForRoute(vehiclesByRouteId, vehicle.routeId),
+    allVehiclesForRoute(vehiclesByRouteId, vehicle.routeId!),
     vehicle
   )
   const {

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -50,8 +50,8 @@ export interface Vehicle {
   latitude: number
   longitude: number
   directionId: DirectionId
-  routeId: RouteId
-  tripId: TripId
+  routeId: RouteId | null
+  tripId: TripId | null
   headsign: string | null
   viaVariant: ViaVariant | null
   operatorId: string

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -179,19 +179,32 @@ describe("Header", () => {
   })
 
   test("renders pointing sideways for a laying over vehicle", () => {
-    const wrapper = mount(
+    const rightFacing = mount(
       <Header
-        vehicle={{ ...vehicle, routeStatus: "laying_over" }}
+        vehicle={{ ...vehicle, directionId: 0, routeStatus: "laying_over" }}
+        route={undefined}
+      />
+    )
+    const leftFacing = mount(
+      <Header
+        vehicle={{ ...vehicle, directionId: 1, routeStatus: "laying_over" }}
         route={undefined}
       />
     )
 
-    const transform = wrapper
+    const rightFacingTransform = rightFacing
       .find(".m-vehicle-icon")
       .find("path")
       .getDOMNode()
       .getAttribute("transform")
-    expect(transform).toEqual(expect.stringContaining("rotate(90)"))
+    expect(rightFacingTransform).toEqual(expect.stringContaining("rotate(90)"))
+
+    const leftFacingTransform = leftFacing
+      .find(".m-vehicle-icon")
+      .find("path")
+      .getDOMNode()
+      .getAttribute("transform")
+    expect(leftFacingTransform).toEqual(expect.stringContaining("rotate(270)"))
   })
 
   test("renders a vehicle that's moving down on the ladder as pointing down", () => {

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -4,9 +4,9 @@ import renderer from "react-test-renderer"
 import Header from "../../../src/components/propertiesPanel/header"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
 import {
-  LadderDirections,
-  flipLadderDirectionForRoute,
   emptyLadderDirectionsByRouteId,
+  flipLadderDirectionForRoute,
+  LadderDirections,
 } from "../../../src/models/ladderDirection"
 import { HeadwaySpacing } from "../../../src/models/vehicleStatus"
 import { Ghost, Vehicle } from "../../../src/realtime"
@@ -202,7 +202,7 @@ describe("Header", () => {
 
     const wrapper = mount(
       <StateDispatchProvider
-        state={{ ...initialState, ladderDirections: ladderDirections }}
+        state={{ ...initialState, ladderDirections }}
         dispatch={jest.fn()}
       >
         <Header vehicle={vehicle} route={undefined} />

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -197,7 +197,7 @@ describe("Header", () => {
   test("renders a vehicle that's moving down on the ladder as pointing down", () => {
     const ladderDirections: LadderDirections = flipLadderDirectionForRoute(
       emptyLadderDirectionsByRouteId,
-      vehicle.routeId
+      vehicle.routeId!
     )
 
     const wrapper = mount(
@@ -215,6 +215,23 @@ describe("Header", () => {
       .getDOMNode()
       .getAttribute("transform")
     expect(transform).toEqual(expect.stringContaining("rotate(180)"))
+  })
+
+  test("renders a shuttle triangle as pointing up", () => {
+    const shuttleVehicle: Vehicle = {
+      ...vehicle,
+      runId: "999-0555",
+      routeId: null,
+      tripId: null,
+    }
+    const wrapper = mount(<Header vehicle={shuttleVehicle} route={undefined} />)
+
+    const transform = wrapper
+      .find(".m-vehicle-icon")
+      .find("path")
+      .getDOMNode()
+      .getAttribute("transform")
+    expect(transform).toEqual(expect.stringContaining("rotate(0)"))
   })
 
   test("clicking the X close button deselects the vehicle", () => {

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -3,6 +3,11 @@ import React from "react"
 import renderer from "react-test-renderer"
 import Header from "../../../src/components/propertiesPanel/header"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
+import {
+  LadderDirections,
+  flipLadderDirectionForRoute,
+  emptyLadderDirectionsByRouteId,
+} from "../../../src/models/ladderDirection"
 import { HeadwaySpacing } from "../../../src/models/vehicleStatus"
 import { Ghost, Vehicle } from "../../../src/realtime"
 import { Route } from "../../../src/schedule"
@@ -171,6 +176,45 @@ describe("Header", () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  test("renders pointing sideways for a laying over vehicle", () => {
+    const wrapper = mount(
+      <Header
+        vehicle={{ ...vehicle, routeStatus: "laying_over" }}
+        route={undefined}
+      />
+    )
+
+    const transform = wrapper
+      .find(".m-vehicle-icon")
+      .find("path")
+      .getDOMNode()
+      .getAttribute("transform")
+    expect(transform).toEqual(expect.stringContaining("rotate(90)"))
+  })
+
+  test("renders a vehicle that's moving down on the ladder as pointing down", () => {
+    const ladderDirections: LadderDirections = flipLadderDirectionForRoute(
+      emptyLadderDirectionsByRouteId,
+      vehicle.routeId
+    )
+
+    const wrapper = mount(
+      <StateDispatchProvider
+        state={{ ...initialState, ladderDirections: ladderDirections }}
+        dispatch={jest.fn()}
+      >
+        <Header vehicle={vehicle} route={undefined} />
+      </StateDispatchProvider>
+    )
+
+    const transform = wrapper
+      .find(".m-vehicle-icon")
+      .find("path")
+      .getDOMNode()
+      .getAttribute("transform")
+    expect(transform).toEqual(expect.stringContaining("rotate(180)"))
   })
 
   test("clicking the X close button deselects the vehicle", () => {


### PR DESCRIPTION
Asana Task: [Orient triangle in VPP to match the ladder](https://app.asana.com/0/1148853526253426/1126875696911113)

<img width="299" alt="Screen Shot 2020-01-15 at 17 28 28" src="https://user-images.githubusercontent.com/23065557/72476946-800df880-37bc-11ea-83f5-39cd9403e759.png">
<img width="323" alt="Screen Shot 2020-01-15 at 17 28 39" src="https://user-images.githubusercontent.com/23065557/72476947-800df880-37bc-11ea-9b57-4f27b731f742.png">
