### PR TITLE
return default for failed api calls instead of crashing

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -33,15 +33,21 @@ const checkResponseStatus = (response: Response) => {
 
 const parseJson = (response: Response) => response.json()
 
-export const apiCall = <T>(url: string, parser: (data: any) => T): Promise<T> =>
+export const apiCall = <T>(url: string, parser: (data: any) => T, defaultResult?: T): Promise<T> =>
   fetch(url)
     .then(checkResponseStatus)
     .then(parseJson)
     .then(({ data: data }: { data: any }) => parser(data))
     .catch(error => {
-      // tslint:disable-next-line: no-console
-      console.error(error)
-      throw error
+      if (defaultResult === undefined) {
+        // tslint:disable-next-line: no-console
+        console.error(error)
+        throw error
+      } else {
+        // tslint:disable-next-line: no-console
+        console.warn(error)
+        return defaultResult
+      }
     })
 
 const parseRouteData = ({ id, direction_names, name }: RouteData): Route => ({
@@ -57,18 +63,19 @@ export const fetchRoutes = (): Promise<Route[]> =>
   apiCall("/api/routes", parseRoutesData)
 
 export const fetchShapeForRoute = (routeId: RouteId): Promise<Shape[]> =>
-  apiCall(`/api/shapes/route/${routeId}`, (shapes: Shape[]) => shapes)
+  apiCall(`/api/shapes/route/${routeId}`, (shapes: Shape[]) => shapes, [])
 
 export const fetchShapeForTrip = (tripId: TripId): Promise<Shape | null> =>
-  apiCall(`/api/shapes/trip/${tripId}`, (shape: Shape | null) => shape)
+  apiCall(`/api/shapes/trip/${tripId}`, (shape: Shape | null) => shape, null)
 
 export const fetchShuttleRoutes = (): Promise<Route[]> =>
-  apiCall("/api/shuttles", parseRoutesData)
+  apiCall("/api/shuttles", parseRoutesData, [])
 
 export const fetchTimepointsForRoute = (
   routeId: RouteId
 ): Promise<TimepointId[]> =>
   apiCall(
     `/api/routes/${routeId}`,
-    (timepointIds: TimepointId[]) => timepointIds
+    (timepointIds: TimepointId[]) => timepointIds,
+    []
   )

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -33,7 +33,15 @@ const checkResponseStatus = (response: Response) => {
 
 const parseJson = (response: Response) => response.json()
 
-export const apiCall = <T>(url: string, parser: (data: any) => T, defaultResult?: T): Promise<T> =>
+export const apiCall = <T>({
+  url,
+  parser,
+  defaultResult,
+}: {
+  url: string
+  parser: (data: any) => T
+  defaultResult?: T
+}): Promise<T> =>
   fetch(url)
     .then(checkResponseStatus)
     .then(parseJson)
@@ -60,22 +68,37 @@ const parseRoutesData = (routesData: RouteData[]): Route[] =>
   routesData.map(parseRouteData)
 
 export const fetchRoutes = (): Promise<Route[]> =>
-  apiCall("/api/routes", parseRoutesData)
+  apiCall({
+    url: "/api/routes",
+    parser: parseRoutesData,
+  })
 
 export const fetchShapeForRoute = (routeId: RouteId): Promise<Shape[]> =>
-  apiCall(`/api/shapes/route/${routeId}`, (shapes: Shape[]) => shapes, [])
+  apiCall({
+    url: `/api/shapes/route/${routeId}`,
+    parser: (shapes: Shape[]) => shapes,
+    defaultResult: [],
+  })
 
 export const fetchShapeForTrip = (tripId: TripId): Promise<Shape | null> =>
-  apiCall(`/api/shapes/trip/${tripId}`, (shape: Shape | null) => shape, null)
+  apiCall({
+    url: `/api/shapes/trip/${tripId}`,
+    parser: (shape: Shape | null) => shape,
+    defaultResult: null,
+  })
 
 export const fetchShuttleRoutes = (): Promise<Route[]> =>
-  apiCall("/api/shuttles", parseRoutesData, [])
+  apiCall({
+    url: "/api/shuttles",
+    parser: parseRoutesData,
+    defaultResult: [],
+  })
 
 export const fetchTimepointsForRoute = (
   routeId: RouteId
 ): Promise<TimepointId[]> =>
-  apiCall(
-    `/api/routes/${routeId}`,
-    (timepointIds: TimepointId[]) => timepointIds,
-    []
-  )
+  apiCall({
+    url: `/api/routes/${routeId}`,
+    parser: (timepointIds: TimepointId[]) => timepointIds,
+    defaultResult: [],
+  })

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -48,12 +48,8 @@ export const apiCall = <T>({
     .then(({ data: data }: { data: any }) => parser(data))
     .catch(error => {
       if (defaultResult === undefined) {
-        // tslint:disable-next-line: no-console
-        console.error(error)
         throw error
       } else {
-        // tslint:disable-next-line: no-console
-        console.warn(error)
         return defaultResult
       }
     })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -1,4 +1,5 @@
 import {
+  apiCall,
   fetchRoutes,
   fetchShapeForRoute,
   fetchShapeForTrip,
@@ -22,6 +23,67 @@ const mockFetch = (status: number, json: any): void => {
       status,
     } as Response)
 }
+
+describe("apiCall", () => {
+  test("returns parsed data", done => {
+    mockFetch(200, { data: "raw" })
+
+    const parse = jest.fn(() => "parsed")
+
+    apiCall("/", parse).then(parsed => {
+      expect(parse).toHaveBeenCalledWith("raw")
+      expect(parsed).toEqual("parsed")
+      done()
+    })
+  })
+
+  test("reloads the page if the response status is a redirect (3xx)", () => {
+    mockFetch(302, { data: null })
+
+    window.location.reload = jest.fn()
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(() => {})
+
+    apiCall("/", () => null)
+      .then(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+      .catch(() => ({}))
+  })
+
+  test("reloads the page if the response status is forbidden (403)", () => {
+    mockFetch(403, { data: null })
+
+    window.location.reload = jest.fn()
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(() => {})
+
+    apiCall("/", () => null)
+      .then(() => {
+        expect(window.location.reload).toHaveBeenCalled()
+      })
+      .catch(() => ({}))
+  })
+
+  test("throws an error for any other response status", done => {
+    mockFetch(500, { data: null })
+
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(() => {})
+
+    apiCall("/", () => null)
+      .then(() => {
+        spyConsoleError.mockRestore()
+        done("fetchRoutes did not throw an error")
+      })
+      .catch(error => {
+        expect(error).not.toBeUndefined()
+        expect(spyConsoleError).toHaveBeenCalled()
+        spyConsoleError.mockRestore()
+        done()
+      })
+  })
+})
 
 describe("fetchRoutes", () => {
   test("fetches a list of routes", done => {
@@ -78,53 +140,6 @@ describe("fetchRoutes", () => {
       done()
     })
   })
-
-  test("reloads the page if the response status is a redirect (3xx)", () => {
-    mockFetch(302, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchRoutes()
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("reloads the page if the response status is forbidden (403)", () => {
-    mockFetch(403, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchRoutes()
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("throws an error for any other response status", done => {
-    mockFetch(500, { data: null })
-
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchRoutes()
-      .then(() => {
-        spyConsoleError.mockRestore()
-        done("fetchRoutes did not throw an error")
-      })
-      .catch(error => {
-        expect(error).not.toBeUndefined()
-        expect(spyConsoleError).toHaveBeenCalled()
-        spyConsoleError.mockRestore()
-        done()
-      })
-  })
 })
 
 describe("fetchShapeForRoute", () => {
@@ -160,53 +175,6 @@ describe("fetchShapeForRoute", () => {
       expect(response).toEqual(shapes)
       done()
     })
-  })
-
-  test("reloads the page if the response status is a redirect (3xx)", () => {
-    mockFetch(302, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchShapeForRoute("28")
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("reloads the page if the response status is forbidden (403)", () => {
-    mockFetch(403, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchShapeForRoute("28")
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("throws an error for any other response status", done => {
-    mockFetch(500, { data: null })
-
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchShapeForRoute("28")
-      .then(() => {
-        spyConsoleError.mockRestore()
-        done("fetchShapeForRoute did not throw an error")
-      })
-      .catch(error => {
-        expect(error).not.toBeUndefined()
-        expect(spyConsoleError).toHaveBeenCalled()
-        spyConsoleError.mockRestore()
-        done()
-      })
   })
 })
 
@@ -288,47 +256,6 @@ describe("fetchShuttleRoutes", () => {
       done()
     })
   })
-
-  test("reloads the page if the response status is a redirect (3xx)", () => {
-    mockFetch(302, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchShuttleRoutes()
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("reloads the page if the response status is forbidden (403)", () => {
-    mockFetch(403, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchShuttleRoutes()
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("throws an error for any other response status", done => {
-    mockFetch(500, { data: null })
-
-    fetchShuttleRoutes()
-      .then(() => {
-        done("fetchRoutes did not throw an error")
-      })
-      .catch(error => {
-        expect(error).not.toBeUndefined()
-        done()
-      })
-  })
 })
 
 describe("fetchTimepointsForRoute", () => {
@@ -339,52 +266,5 @@ describe("fetchTimepointsForRoute", () => {
       expect(timepoints).toEqual(["MATPN", "WELLH", "MORTN"])
       done()
     })
-  })
-
-  test("reloads the page if the response status is a redirect (3xx)", () => {
-    mockFetch(302, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchTimepointsForRoute("28")
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("reloads the page if the response status is forbidden (403)", () => {
-    mockFetch(403, { data: null })
-
-    window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchTimepointsForRoute("28")
-      .then(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-      })
-      .catch(() => ({}))
-  })
-
-  test("throws an error for any other response status", done => {
-    mockFetch(500, { data: null })
-
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
-    fetchTimepointsForRoute("28")
-      .then(() => {
-        spyConsoleError.mockRestore()
-        done("fetchTimepointsForRoute did not throw an error")
-      })
-      .catch(error => {
-        expect(error).not.toBeUndefined()
-        expect(spyConsoleError).toHaveBeenCalled()
-        spyConsoleError.mockRestore()
-        done()
-      })
   })
 })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -92,7 +92,7 @@ describe("apiCall", () => {
         done("fetchRoutes did not throw an error")
       })
       .catch(error => {
-        expect(error).not.toBeUndefined()
+        expect(error).toBeDefined()
         done()
       })
   })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -65,7 +65,21 @@ describe("apiCall", () => {
       .catch(() => ({}))
   })
 
-  test("throws an error for any other response status", done => {
+  test("returns a default and warns for any other response", done => {
+    mockFetch(500, { data: null })
+
+    const spyConsoleWarn = jest.spyOn(console, "warn")
+    spyConsoleWarn.mockImplementationOnce(() => {})
+
+    apiCall("/", () => null, "default")
+      .then(result => {
+        expect(result).toEqual("default")
+        expect(spyConsoleWarn).toHaveBeenCalled()
+        done()
+      })
+  })
+
+  test("throws an error for any other response status if there's no default", done => {
     mockFetch(500, { data: null })
 
     const spyConsoleError = jest.spyOn(console, "error")
@@ -176,6 +190,18 @@ describe("fetchShapeForRoute", () => {
       done()
     })
   })
+
+  test("defaults to [] if there's an error", done => {
+    mockFetch(500, { data: null })
+
+    const spyConsoleWarn = jest.spyOn(console, "warn")
+    spyConsoleWarn.mockImplementationOnce(() => {})
+
+    fetchShapeForRoute("28").then(result => {
+      expect(result).toEqual([])
+      done()
+    })
+  })
 })
 
 describe("fetchShapeForTrip", () => {
@@ -196,6 +222,18 @@ describe("fetchShapeForTrip", () => {
 
     fetchShapeForTrip("trip").then(response => {
       expect(response).toEqual(shape)
+      done()
+    })
+  })
+
+  test("defaults to null if there's an error", done => {
+    mockFetch(500, { data: null })
+
+    const spyConsoleWarn = jest.spyOn(console, "warn")
+    spyConsoleWarn.mockImplementationOnce(() => {})
+
+    fetchShapeForTrip("28").then(result => {
+      expect(result).toEqual(null)
       done()
     })
   })
@@ -264,6 +302,18 @@ describe("fetchTimepointsForRoute", () => {
 
     fetchTimepointsForRoute("28").then(timepoints => {
       expect(timepoints).toEqual(["MATPN", "WELLH", "MORTN"])
+      done()
+    })
+  })
+
+  test("defaults to [] if there's an error", done => {
+    mockFetch(500, { data: null })
+
+    const spyConsoleWarn = jest.spyOn(console, "warn")
+    spyConsoleWarn.mockImplementationOnce(() => {})
+
+    fetchTimepointsForRoute("28").then(result => {
+      expect(result).toEqual([])
       done()
     })
   })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -48,11 +48,10 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: () => null,
+    }).catch(() => {
+      expect(window.location.reload).toHaveBeenCalled()
+      done()
     })
-      .catch(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-        done()
-      })
   })
 
   test("reloads the page if the response status is forbidden (403)", done => {
@@ -63,11 +62,10 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: () => null,
+    }).catch(() => {
+      expect(window.location.reload).toHaveBeenCalled()
+      done()
     })
-      .catch(() => {
-        expect(window.location.reload).toHaveBeenCalled()
-        done()
-      })
   })
 
   test("returns a default for any other response", done => {

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -33,12 +33,11 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: parse,
+    }).then(parsed => {
+      expect(parse).toHaveBeenCalledWith("raw")
+      expect(parsed).toEqual("parsed")
+      done()
     })
-      .then(parsed => {
-        expect(parse).toHaveBeenCalledWith("raw")
-        expect(parsed).toEqual("parsed")
-        done()
-      })
   })
 
   test("reloads the page if the response status is a redirect (3xx)", () => {
@@ -85,12 +84,11 @@ describe("apiCall", () => {
       url: "/",
       parser: () => null,
       defaultResult: "default",
+    }).then(result => {
+      expect(result).toEqual("default")
+      expect(spyConsoleWarn).toHaveBeenCalled()
+      done()
     })
-      .then(result => {
-        expect(result).toEqual("default")
-        expect(spyConsoleWarn).toHaveBeenCalled()
-        done()
-      })
   })
 
   test("throws an error for any other response status if there's no default", done => {

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -44,8 +44,6 @@ describe("apiCall", () => {
     mockFetch(302, { data: null })
 
     window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
 
     apiCall({
       url: "/",
@@ -61,8 +59,6 @@ describe("apiCall", () => {
     mockFetch(403, { data: null })
 
     window.location.reload = jest.fn()
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
 
     apiCall({
       url: "/",
@@ -74,11 +70,8 @@ describe("apiCall", () => {
       .catch(() => ({}))
   })
 
-  test("returns a default and warns for any other response", done => {
+  test("returns a default for any other response", done => {
     mockFetch(500, { data: null })
-
-    const spyConsoleWarn = jest.spyOn(console, "warn")
-    spyConsoleWarn.mockImplementationOnce(() => {})
 
     apiCall({
       url: "/",
@@ -86,7 +79,6 @@ describe("apiCall", () => {
       defaultResult: "default",
     }).then(result => {
       expect(result).toEqual("default")
-      expect(spyConsoleWarn).toHaveBeenCalled()
       done()
     })
   })
@@ -94,21 +86,15 @@ describe("apiCall", () => {
   test("throws an error for any other response status if there's no default", done => {
     mockFetch(500, { data: null })
 
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(() => {})
-
     apiCall({
       url: "/",
       parser: () => null,
     })
       .then(() => {
-        spyConsoleError.mockRestore()
         done("fetchRoutes did not throw an error")
       })
       .catch(error => {
         expect(error).not.toBeUndefined()
-        expect(spyConsoleError).toHaveBeenCalled()
-        spyConsoleError.mockRestore()
         done()
       })
   })
@@ -209,9 +195,6 @@ describe("fetchShapeForRoute", () => {
   test("defaults to [] if there's an error", done => {
     mockFetch(500, { data: null })
 
-    const spyConsoleWarn = jest.spyOn(console, "warn")
-    spyConsoleWarn.mockImplementationOnce(() => {})
-
     fetchShapeForRoute("28").then(result => {
       expect(result).toEqual([])
       done()
@@ -243,9 +226,6 @@ describe("fetchShapeForTrip", () => {
 
   test("defaults to null if there's an error", done => {
     mockFetch(500, { data: null })
-
-    const spyConsoleWarn = jest.spyOn(console, "warn")
-    spyConsoleWarn.mockImplementationOnce(() => {})
 
     fetchShapeForTrip("28").then(result => {
       expect(result).toEqual(null)
@@ -323,9 +303,6 @@ describe("fetchTimepointsForRoute", () => {
 
   test("defaults to [] if there's an error", done => {
     mockFetch(500, { data: null })
-
-    const spyConsoleWarn = jest.spyOn(console, "warn")
-    spyConsoleWarn.mockImplementationOnce(() => {})
 
     fetchTimepointsForRoute("28").then(result => {
       expect(result).toEqual([])

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -30,11 +30,15 @@ describe("apiCall", () => {
 
     const parse = jest.fn(() => "parsed")
 
-    apiCall("/", parse).then(parsed => {
-      expect(parse).toHaveBeenCalledWith("raw")
-      expect(parsed).toEqual("parsed")
-      done()
+    apiCall({
+      url: "/",
+      parser: parse,
     })
+      .then(parsed => {
+        expect(parse).toHaveBeenCalledWith("raw")
+        expect(parsed).toEqual("parsed")
+        done()
+      })
   })
 
   test("reloads the page if the response status is a redirect (3xx)", () => {
@@ -44,7 +48,10 @@ describe("apiCall", () => {
     const spyConsoleError = jest.spyOn(console, "error")
     spyConsoleError.mockImplementationOnce(() => {})
 
-    apiCall("/", () => null)
+    apiCall({
+      url: "/",
+      parser: () => null,
+    })
       .then(() => {
         expect(window.location.reload).toHaveBeenCalled()
       })
@@ -58,7 +65,10 @@ describe("apiCall", () => {
     const spyConsoleError = jest.spyOn(console, "error")
     spyConsoleError.mockImplementationOnce(() => {})
 
-    apiCall("/", () => null)
+    apiCall({
+      url: "/",
+      parser: () => null,
+    })
       .then(() => {
         expect(window.location.reload).toHaveBeenCalled()
       })
@@ -71,7 +81,11 @@ describe("apiCall", () => {
     const spyConsoleWarn = jest.spyOn(console, "warn")
     spyConsoleWarn.mockImplementationOnce(() => {})
 
-    apiCall("/", () => null, "default")
+    apiCall({
+      url: "/",
+      parser: () => null,
+      defaultResult: "default",
+    })
       .then(result => {
         expect(result).toEqual("default")
         expect(spyConsoleWarn).toHaveBeenCalled()
@@ -85,7 +99,10 @@ describe("apiCall", () => {
     const spyConsoleError = jest.spyOn(console, "error")
     spyConsoleError.mockImplementationOnce(() => {})
 
-    apiCall("/", () => null)
+    apiCall({
+      url: "/",
+      parser: () => null,
+    })
       .then(() => {
         spyConsoleError.mockRestore()
         done("fetchRoutes did not throw an error")

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -40,7 +40,7 @@ describe("apiCall", () => {
     })
   })
 
-  test("reloads the page if the response status is a redirect (3xx)", () => {
+  test("reloads the page if the response status is a redirect (3xx)", done => {
     mockFetch(302, { data: null })
 
     window.location.reload = jest.fn()
@@ -49,13 +49,13 @@ describe("apiCall", () => {
       url: "/",
       parser: () => null,
     })
-      .then(() => {
+      .catch(() => {
         expect(window.location.reload).toHaveBeenCalled()
+        done()
       })
-      .catch(() => ({}))
   })
 
-  test("reloads the page if the response status is forbidden (403)", () => {
+  test("reloads the page if the response status is forbidden (403)", done => {
     mockFetch(403, { data: null })
 
     window.location.reload = jest.fn()
@@ -64,10 +64,10 @@ describe("apiCall", () => {
       url: "/",
       parser: () => null,
     })
-      .then(() => {
+      .catch(() => {
         expect(window.location.reload).toHaveBeenCalled()
+        done()
       })
-      .catch(() => ({}))
   })
 
   test("returns a default for any other response", done => {


### PR DESCRIPTION
Deduplicates a lot of work writing and testing api calls.

Followup to https://github.com/mbta/skate/pull/415#discussion_r367615946

It's built on top of the branch for that PR, so until it merges, this PR will be a bit messy. The only new changes are in `api.ts` and `api.test.ts`.