### PR TITLE
Pull out channel valid_token?

### DIFF
--- a/lib/skate_web/channels/channel_auth.ex
+++ b/lib/skate_web/channels/channel_auth.ex
@@ -1,0 +1,51 @@
+defmodule SkateWeb.ChannelAuth do
+  alias SkateWeb.AuthManager
+
+  @doc """
+  Checks wether a socket has a valid token.
+  Attempts to refresh the token.
+  Only returns false if all refreshing fails,
+  and the user needs to log in again.
+  """
+  @spec valid_token?(Phoenix.Socket.t()) :: boolean()
+  def valid_token?(socket) do
+    token = Guardian.Phoenix.Socket.current_token(socket)
+
+    case AuthManager.decode_and_verify(token) do
+      {:ok, _claims} ->
+        # Refresh a token before it expires
+        case AuthManager.refresh(token) do
+          {:ok, _old_claims, {_new_token, _new_claims}} ->
+            true
+
+          {:error, :token_expired} ->
+            valid_token_after_refresh?(socket)
+        end
+
+      {:error, :token_expired} ->
+        valid_token_after_refresh?(socket)
+
+      _ ->
+        false
+    end
+  end
+
+  @spec valid_token_after_refresh?(Phoenix.Socket.t()) :: boolean()
+  defp valid_token_after_refresh?(socket) do
+    refresh_token_store = Application.get_env(:skate, :refresh_token_store)
+
+    refresh_token =
+      socket
+      |> Guardian.Phoenix.Socket.current_resource()
+      |> refresh_token_store.get_refresh_token()
+
+    # Exchange a token of type "refresh" for a new token of type "access"
+    case AuthManager.exchange(refresh_token, "refresh", "access") do
+      {:ok, _old_stuff, {_new_token, _new_claims}} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -54,7 +54,7 @@ defmodule SkateWeb.VehiclesChannel do
   @impl Phoenix.Channel
   def handle_info({:new_realtime_data, lookup_args}, socket) do
     valid_token? =
-      Application.get_env(:skate, :valid_token?, &SkateWeb.ChannelAuth.valid_token?/1)
+      Application.get_env(:skate, :valid_token_fn, &SkateWeb.ChannelAuth.valid_token?/1)
 
     if valid_token?.(socket) do
       event_name = event_name(lookup_args)

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -53,10 +53,10 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_realtime_data, lookup_args}, socket) do
-    valid_token? =
+    valid_token_fn =
       Application.get_env(:skate, :valid_token_fn, &SkateWeb.ChannelAuth.valid_token?/1)
 
-    if valid_token?.(socket) do
+    if valid_token_fn.(socket) do
       event_name = event_name(lookup_args)
       data = Server.lookup(lookup_args)
       :ok = push(socket, event_name, %{data: data})

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -42,8 +42,6 @@ defmodule SkateWeb.VehiclesChannelTest do
 
   setup do
     reassign_env(:skate, :valid_token?, fn _socket -> true end)
-    reassign_env(:realtime, :trip_fn, fn _trip_id -> nil end)
-    reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> nil end)
 
     socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
 

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -41,7 +41,7 @@ defmodule SkateWeb.VehiclesChannelTest do
   }
 
   setup do
-    reassign_env(:skate, :valid_token?, fn _socket -> true end)
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
 
     socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
 
@@ -158,7 +158,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       ets: ets
     } do
       assert Realtime.Server.update({%{}, [@vehicle]}) == :ok
-      reassign_env(:skate, :valid_token?, fn _socket -> false end)
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")
 

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -1,6 +1,5 @@
 defmodule Realtime.ServerTest do
   use ExUnit.Case, async: true
-  import Test.Support.Helpers
 
   alias Realtime.{Ghost, Server, Vehicle}
 
@@ -66,9 +65,6 @@ defmodule Realtime.ServerTest do
 
   describe "subscribe_to_route" do
     setup do
-      reassign_env(:realtime, :trip_fn, fn _trip_id -> nil end)
-      reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> nil end)
-
       {:ok, server_pid} = Server.start_link([])
 
       Server.update({@vehicles_by_route_id, []}, server_pid)
@@ -134,9 +130,6 @@ defmodule Realtime.ServerTest do
 
   describe "subscribe_to_all_shuttles" do
     setup do
-      reassign_env(:realtime, :trip_fn, fn _trip_id -> nil end)
-      reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> nil end)
-
       {:ok, server_pid} = Server.start_link([])
 
       :ok = Server.update({%{}, [@shuttle]}, server_pid)
@@ -160,9 +153,6 @@ defmodule Realtime.ServerTest do
 
   describe "subscribe_to_search" do
     setup do
-      reassign_env(:realtime, :trip_fn, fn _trip_id -> nil end)
-      reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> nil end)
-
       {:ok, server_pid} = Server.start_link([])
 
       :ok = Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -1,0 +1,79 @@
+defmodule SkateWeb.ChannelAuthTest do
+  use SkateWeb.ChannelCase
+  import Test.Support.Helpers
+
+  alias SkateWeb.{AuthManager, ChannelAuth, UserSocket}
+
+  setup do
+    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+
+    {:ok, socket: socket}
+  end
+
+  describe "handle_info/2" do
+    setup do
+      reassign_env(
+        :skate,
+        :refresh_token_store,
+        __MODULE__.FakeRefreshTokenStore
+      )
+    end
+
+    test "returns true when socket is authenticated", %{
+      socket: socket
+    } do
+      {:ok, token, claims} =
+        AuthManager.encode_and_sign("test-authed@mbta.com", %{
+          "exp" => System.system_time(:second) + 500
+        })
+
+      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "test-authed@mbta.com", token, claims)
+
+      assert ChannelAuth.valid_token?(socket) == true
+    end
+
+    test "refreshes the authentication using the refresh token if we have one", %{
+      socket: socket
+    } do
+      {:ok, token, claims} =
+        AuthManager.encode_and_sign("test-expired@mbta.com", %{
+          "exp" => System.system_time(:second) - 100
+        })
+
+      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "test-expired@mbta.com", token, claims)
+
+      assert ChannelAuth.valid_token?(socket) == true
+    end
+
+    test "returns false when socket is not authenticated", %{
+      socket: socket
+    } do
+      {:ok, token, claims} =
+        AuthManager.encode_and_sign("test-not-authed@mbta.com", %{
+          "exp" => System.system_time(:second) - 100
+        })
+
+      socket =
+        Guardian.Phoenix.Socket.assign_rtc(socket, "test-not-authed@mbta.com", token, claims)
+
+      assert ChannelAuth.valid_token?(socket) == false
+    end
+  end
+
+  defmodule FakeRefreshTokenStore do
+    def get_refresh_token("test-expired@mbta.com") do
+      {:ok, token, _claims} =
+        AuthManager.encode_and_sign(
+          "test-expired@mbta.com",
+          %{
+            "exp" => System.system_time(:second) + 500
+          },
+          token_type: "refresh"
+        )
+
+      token
+    end
+
+    def get_refresh_token(_), do: nil
+  end
+end


### PR DESCRIPTION
In prep for [Let users know when Skate data is stale/we have lost live data connection](https://app.asana.com/0/1148853526253426/1156122231748753)

That task will make a new `_channel.ex` file. To make that easier, this PR pulls a `ChannelAuth.valid_token?()` function out of `vehicles_channel.ex`.

Also a bit of other cleanup:
* Removes a couple `reassign_env(:realtime, :trip_fn/:block_fn)` calls that I don't think were doing anything.
* When vehicles_channel starts a new subscription, does the lookup in the channel process instead of the Server process, to avoid passing the data between processes. (The duration logging is still there.)