### PR TITLE
More precise vehicle locations on the ladder

### DIFF
--- a/lib/gtfs/stop.ex
+++ b/lib/gtfs/stop.ex
@@ -6,13 +6,14 @@ defmodule Gtfs.Stop do
   @type t :: %__MODULE__{
           id: id(),
           name: String.t(),
-          parent_station_id: id() | nil
+          parent_station_id: id() | nil,
+          latitude: float() | nil,
+          longitude: float() | nil
         }
 
   @enforce_keys [
     :id,
-    :name,
-    :parent_station_id
+    :name
   ]
 
   @derive Jason.Encoder
@@ -20,7 +21,9 @@ defmodule Gtfs.Stop do
   defstruct [
     :id,
     :name,
-    :parent_station_id
+    :parent_station_id,
+    :latitude,
+    :longitude
   ]
 
   @spec parent_station_id(t() | nil) :: id() | nil
@@ -35,7 +38,13 @@ defmodule Gtfs.Stop do
     %__MODULE__{
       id: row["stop_id"],
       name: row["stop_name"],
-      parent_station_id: parent_station_id
+      parent_station_id: parent_station_id,
+      latitude: parse_lat_lon(row["stop_lat"]),
+      longitude: parse_lat_lon(row["stop_lon"])
     }
   end
+
+  @spec parse_lat_lon(String.t()) :: float() | nil
+  defp parse_lat_lon(""), do: nil
+  defp parse_lat_lon(s), do: String.to_float(s)
 end

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -104,10 +104,10 @@ defmodule Realtime.TimepointStatus do
   @spec fraction_between_points({float(), float()}, {float(), float()}, {float(), float()}) ::
           float()
   defp fraction_between_points(
-        {start_lat, start_lon},
-        {finish_lat, finish_lon},
-        {point_lat, point_lon}
-      ) do
+         {start_lat, start_lon},
+         {finish_lat, finish_lon},
+         {point_lat, point_lon}
+       ) do
     start_to_finish = {finish_lat - start_lat, finish_lon - start_lon}
     start_to_point = {point_lat - start_lat, point_lon - start_lon}
     dot_product(start_to_point, start_to_finish) / dot_product(start_to_finish, start_to_finish)

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -23,24 +23,106 @@ defmodule Realtime.TimepointStatus do
             timepoint_status: timepoint_status()
           }
 
-  @spec timepoint_status([StopTime.t()], Stop.id()) :: timepoint_status() | nil
-  def timepoint_status(stop_times, stop_id) do
+  @spec timepoint_status([StopTime.t()], Stop.id(), {float(), float()}) ::
+          timepoint_status() | nil
+  def timepoint_status(stop_times, stop_id, latlon) do
+    # future_stop_times starts with the stop that has stop_id
     {past_stop_times, future_stop_times} = Enum.split_while(stop_times, &(&1.stop_id != stop_id))
 
     case Enum.find(future_stop_times, &StopTime.is_timepoint?(&1)) do
       %StopTime{timepoint_id: next_timepoint_id} ->
-        # past_count needs +1 for the step between the current timepoint and the first of the past stops
-        past_count = count_to_timepoint(Enum.reverse(past_stop_times)) + 1
-        future_count = count_to_timepoint(future_stop_times)
+        stops_until_timepoint = count_to_timepoint(future_stop_times)
+
+        # +1 for the step between the most recent stop and the next stop
+        stops_in_this_timepoint_segment =
+          count_to_timepoint(Enum.reverse(past_stop_times)) + 1 + stops_until_timepoint
+
+        previous_stop_time = List.last(past_stop_times)
+
+        fraction_until_next_stop =
+          1.0 -
+            fraction_between_stops(
+              previous_stop_time && previous_stop_time.stop_id,
+              stop_id,
+              latlon
+            )
 
         %{
           timepoint_id: next_timepoint_id,
-          fraction_until_timepoint: future_count / (future_count + past_count)
+          fraction_until_timepoint:
+            (stops_until_timepoint + fraction_until_next_stop) / stops_in_this_timepoint_segment
         }
 
       nil ->
         nil
     end
+  end
+
+  @doc """
+  How far a bus is between two stops.
+  0.0 means the bus is still at the first stop.
+  1.0 means it's at the second stop.
+  0.5 means it's halfway between.
+  If either stop is missing lat lon data, default to being at the second stop.
+
+  Approximates the path between the stops as a straight line.
+  If the bus is not directly between the two stops,
+  measures from the closest point to the bus that is between the stops.
+  """
+  @spec fraction_between_stops(Stop.id() | nil, Stop.id() | nil, {float(), float()}) :: float()
+  def fraction_between_stops(start_id, finish_id, {lat, lon}) do
+    stop_fn = Application.get_env(:skate, :stop_fn, &Gtfs.stop/1)
+    start = start_id && stop_fn.(start_id)
+    finish = finish_id && stop_fn.(finish_id)
+
+    if start &&
+         finish &&
+         start.latitude &&
+         start.longitude &&
+         finish.latitude &&
+         finish.longitude do
+      # Treating the latlons as if they're cartesian coordinates works fine at this scale.
+      # We don't need fancy great circle distance measurements around the globe
+      # A degree of longitude is smaller than a degree of latitude,
+      # but if the bus is directly between the stops, that has no effect at all
+      # and if the bus is not on that straight line, it will have an acceptably small effect.
+      clamp(
+        fraction_between_points(
+          {start.latitude, start.longitude},
+          {finish.latitude, finish.longitude},
+          {lat, lon}
+        ),
+        0.0,
+        1.0
+      )
+    else
+      1.0
+    end
+  end
+
+  # Projects the point onto the straight line between the start and finish
+  @spec fraction_between_points({float(), float()}, {float(), float()}, {float(), float()}) ::
+          float()
+  defp fraction_between_points(
+        {start_lat, start_lon},
+        {finish_lat, finish_lon},
+        {point_lat, point_lon}
+      ) do
+    start_to_finish = {finish_lat - start_lat, finish_lon - start_lon}
+    start_to_point = {point_lat - start_lat, point_lon - start_lon}
+    dot_product(start_to_point, start_to_finish) / dot_product(start_to_finish, start_to_finish)
+  end
+
+  @spec dot_product({float(), float()}, {float(), float()}) :: float()
+  defp dot_product({x1, y1}, {x2, y2}) do
+    x1 * x2 + y1 * y2
+  end
+
+  @spec clamp(float(), float(), float()) :: float()
+  defp clamp(f, min, max) do
+    f
+    |> min(max)
+    |> max(min)
   end
 
   @doc """

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -1,6 +1,8 @@
 defmodule Realtime.TimepointStatus do
   alias Gtfs.{Block, Direction, RoutePattern, Run, Stop, StopTime, Route, Trip}
 
+  @typep point :: {float(), float()}
+
   @typedoc """
   fraction_until_timepoint ranges
     from 0.0 (inclusive) if the vehicle is at the given timepoint
@@ -23,7 +25,7 @@ defmodule Realtime.TimepointStatus do
             timepoint_status: timepoint_status()
           }
 
-  @spec timepoint_status([StopTime.t()], Stop.id(), {float(), float()}) ::
+  @spec timepoint_status([StopTime.t()], Stop.id(), point()) ::
           timepoint_status() | nil
   def timepoint_status(stop_times, stop_id, latlon) do
     # future_stop_times starts with the stop that has stop_id
@@ -69,7 +71,7 @@ defmodule Realtime.TimepointStatus do
   If the bus is not directly between the two stops,
   measures from the closest point to the bus that is between the stops.
   """
-  @spec fraction_between_stops({float(), float()}, Stop.id() | nil, Stop.id() | nil) :: float()
+  @spec fraction_between_stops(point(), Stop.id() | nil, Stop.id() | nil) :: float()
   def fraction_between_stops(latlon, start_id, finish_id) do
     stop_fn = Application.get_env(:skate, :stop_fn, &Gtfs.stop/1)
     start = start_id && stop_fn.(start_id)
@@ -98,7 +100,7 @@ defmodule Realtime.TimepointStatus do
   end
 
   # Projects the point onto the straight line between the start and finish
-  @spec fraction_between_points({float(), float()}, {float(), float()}, {float(), float()}) ::
+  @spec fraction_between_points(point(), point(), point()) ::
           float()
   defp fraction_between_points(
          {point_lat, point_lon},
@@ -110,7 +112,7 @@ defmodule Realtime.TimepointStatus do
     dot_product(start_to_point, start_to_finish) / dot_product(start_to_finish, start_to_finish)
   end
 
-  @spec dot_product({float(), float()}, {float(), float()}) :: float()
+  @spec dot_product(point(), point()) :: float()
   defp dot_product({x1, y1}, {x2, y2}) do
     x1 * x2 + y1 * y2
   end

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -71,7 +71,7 @@ defmodule Realtime.TimepointStatus do
   If the bus is not directly between the two stops,
   measures from the closest point to the bus that is between the stops.
   """
-  @spec fraction_between_stops(point(), Stop.id() | nil, Stop.id() | nil) :: float()
+  @spec fraction_between_stops(point(), Stop.id() | nil, Stop.id()) :: float()
   def fraction_between_stops(vehicle_latlon, start_id, finish_id) do
     start_latlon = stop_latlon(start_id)
     finish_latlon = stop_latlon(finish_id)

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -120,7 +120,14 @@ defmodule Realtime.Vehicle do
     via_variant = trip && trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id)
     stop_times_on_trip = (trip && trip.stop_times) || []
     stop_name = stop_name(vehicle_position, stop_id)
-    timepoint_status = TimepointStatus.timepoint_status(stop_times_on_trip, stop_id)
+
+    timepoint_status =
+      TimepointStatus.timepoint_status(
+        stop_times_on_trip,
+        stop_id,
+        {VehiclePosition.latitude(vehicle_position), VehiclePosition.longitude(vehicle_position)}
+      )
+
     scheduled_location = TimepointStatus.scheduled_location(block, now_fn.())
 
     # If a vehicle is scheduled to be on another line, don't draw any line.

--- a/test/gtfs/stop_test.exs
+++ b/test/gtfs/stop_test.exs
@@ -17,7 +17,7 @@ defmodule Gtfs.StopTid do
     "stop_url" => "https://www.mbta.com/stops/1",
     "level_id" => "",
     "location_type" => "0",
-    "parent_station" => "",
+    "parent_station" => "place-asmnl",
     "wheelchair_boarding" => "1"
   }
 
@@ -52,7 +52,24 @@ defmodule Gtfs.StopTid do
       assert Stop.from_csv_row(@csv_row) == %Stop{
                id: "1",
                name: "Washington St opp Ruggles St",
-               parent_station_id: nil
+               parent_station_id: "place-asmnl",
+               latitude: 42.330957,
+               longitude: -71.082754
+             }
+    end
+
+    test "tolerates missing optional fields" do
+      assert Stop.from_csv_row(
+               @csv_row
+               |> Map.put("parent_station", "")
+               |> Map.put("stop_lat", "")
+               |> Map.put("stop_lon", "")
+             ) == %Stop{
+               id: "1",
+               name: "Washington St opp Ruggles St",
+               parent_station_id: nil,
+               latitude: nil,
+               longitude: nil
              }
     end
   end

--- a/test/gtfs_test.exs
+++ b/test/gtfs_test.exs
@@ -205,9 +205,9 @@ defmodule GtfsTest do
         Gtfs.start_mocked(%{
           gtfs: %{
             "stops.txt" => [
-              "stop_id,stop_name,parent_station",
-              "1,One,",
-              "2,Two,3"
+              "stop_id,stop_name,stop_lat,stop_lon,parent_station",
+              "1,One,1.0,1.5,",
+              "2,Two,2.0,2.5,3"
             ]
           }
         })
@@ -215,7 +215,9 @@ defmodule GtfsTest do
       assert Gtfs.stop("2", pid) == %Stop{
                id: "2",
                name: "Two",
-               parent_station_id: "3"
+               parent_station_id: "3",
+               latitude: 2.0,
+               longitude: 2.5
              }
     end
 

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -200,7 +200,7 @@ defmodule Realtime.TimepointStatusTest do
       end)
     end
 
-    test "if either stop is missing, return 1.0 (at the second stop)" do
+    test "if either stop or latlon is missing, default to 1.0 (at the second stop)" do
       latlon = {42.5, -71.5}
       assert TimepointStatus.fraction_between_stops(latlon, "stop1", nil) == 1.0
       assert TimepointStatus.fraction_between_stops(latlon, "stop1", "missing") == 1.0

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -202,25 +202,25 @@ defmodule Realtime.TimepointStatusTest do
 
     test "if either stop is missing, return 1.0 (at the second stop)" do
       latlon = {42.5, -71.5}
-      assert TimepointStatus.fraction_between_stops("stop1", nil, latlon) == 1.0
-      assert TimepointStatus.fraction_between_stops("stop1", "missing", latlon) == 1.0
-      assert TimepointStatus.fraction_between_stops("stop1", "without_latlon", latlon) == 1.0
-      assert TimepointStatus.fraction_between_stops(nil, "stop1", latlon) == 1.0
-      assert TimepointStatus.fraction_between_stops("missing", "stop1", latlon) == 1.0
-      assert TimepointStatus.fraction_between_stops("without_latlon", "stop1", latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, "stop1", nil) == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, "stop1", "missing") == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, "stop1", "without_latlon") == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, nil, "stop1") == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, "missing", "stop1") == 1.0
+      assert TimepointStatus.fraction_between_stops(latlon, "without_latlon", "stop1") == 1.0
     end
 
     test "returns a fraction when the bus is directly between the points" do
-      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {42.75, -71.25}) == 0.75
+      assert TimepointStatus.fraction_between_stops({42.75, -71.25}, "stop1", "stop2") == 0.75
     end
 
     test "returns a fraction when the bus is not between the points" do
-      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {42.0, -71.0}) == 0.5
+      assert TimepointStatus.fraction_between_stops({42.0, -71.0}, "stop1", "stop2") == 0.5
     end
 
     test "the bus can't be before the first stop or after the second" do
-      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {41.0, -73.0}) == 0.0
-      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {44.0, -70.0}) == 1.0
+      assert TimepointStatus.fraction_between_stops({41.0, -73.0}, "stop1", "stop2") == 0.0
+      assert TimepointStatus.fraction_between_stops({44.0, -70.0}, "stop1", "stop2") == 1.0
     end
   end
 

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -1,16 +1,19 @@
 defmodule Realtime.TimepointStatusTest do
   use ExUnit.Case
+  import Test.Support.Helpers
 
-  alias Gtfs.{StopTime, Trip}
+  alias Gtfs.{Stop, StopTime, Trip}
   alias Realtime.TimepointStatus
 
-  describe "timepoint_status/2" do
+  describe "timepoint_status" do
     test "returns 0.0 if the stop is a timepoint, plus the timepoint" do
+      reassign_env(:skate, :stop_fn, fn _ -> nil end)
+
       stop_times = [
         %StopTime{
           stop_id: "s1",
           time: 0,
-          timepoint_id: "tp1"
+          timepoint_id: "first"
         },
         %StopTime{
           stop_id: "s2",
@@ -20,7 +23,7 @@ defmodule Realtime.TimepointStatusTest do
         %StopTime{
           stop_id: "s3",
           time: 0,
-          timepoint_id: "tp3"
+          timepoint_id: "middle"
         },
         %StopTime{
           stop_id: "s4",
@@ -35,19 +38,29 @@ defmodule Realtime.TimepointStatusTest do
         %StopTime{
           stop_id: "s6",
           time: 0,
-          timepoint_id: "tp2"
+          timepoint_id: "last"
         }
       ]
 
-      stop_id = "s3"
+      assert TimepointStatus.timepoint_status(stop_times, "s1", {0.0, 0.0}) == %{
+               timepoint_id: "first",
+               fraction_until_timepoint: 0.0
+             }
 
-      assert TimepointStatus.timepoint_status(stop_times, stop_id) == %{
-               timepoint_id: "tp3",
+      assert TimepointStatus.timepoint_status(stop_times, "s3", {0.0, 0.0}) == %{
+               timepoint_id: "middle",
+               fraction_until_timepoint: 0.0
+             }
+
+      assert TimepointStatus.timepoint_status(stop_times, "s6", {0.0, 0.0}) == %{
+               timepoint_id: "last",
                fraction_until_timepoint: 0.0
              }
     end
 
     test "returns the ratio of stops to next timepoint vs stops to last timepoint if the stop is not a timepoint, plus the next timepoint" do
+      reassign_env(:skate, :stop_fn, fn _ -> nil end)
+
       stop_times = [
         %StopTime{
           stop_id: "s1",
@@ -83,13 +96,13 @@ defmodule Realtime.TimepointStatusTest do
 
       stop_id = "s3"
 
-      assert TimepointStatus.timepoint_status(stop_times, stop_id) == %{
+      assert TimepointStatus.timepoint_status(stop_times, stop_id, {0.0, 0.0}) == %{
                timepoint_id: "tp2",
                fraction_until_timepoint: 0.6
              }
     end
 
-    test "returns 0.0 if the stop is the first timepoint" do
+    test "takes into account the position between the stops" do
       stop_times = [
         %StopTime{
           stop_id: "s1",
@@ -104,19 +117,39 @@ defmodule Realtime.TimepointStatusTest do
         %StopTime{
           stop_id: "s3",
           time: 0,
-          timepoint_id: "tp3"
+          timepoint_id: "tp2"
         }
       ]
 
-      stop_id = "s1"
+      reassign_env(:skate, :stop_fn, fn stop_id ->
+        case stop_id do
+          "s2" ->
+            %Stop{
+              id: "s2",
+              name: "s2",
+              latitude: 42.0,
+              longitude: -72.0
+            }
 
-      assert TimepointStatus.timepoint_status(stop_times, stop_id) == %{
-               timepoint_id: "tp1",
-               fraction_until_timepoint: 0.0
+          "s3" ->
+            %Stop{
+              id: "s3",
+              name: "s3",
+              latitude: 43.0,
+              longitude: -71.0
+            }
+        end
+      end)
+
+      assert TimepointStatus.timepoint_status(stop_times, "s3", {42.75, -71.25}) == %{
+               timepoint_id: "tp2",
+               fraction_until_timepoint: 0.125
              }
     end
 
     test "returns nil if on a route without timepoints" do
+      reassign_env(:skate, :stop_fn, fn _ -> nil end)
+
       stop_times = [
         %StopTime{
           stop_id: "s1",
@@ -132,7 +165,62 @@ defmodule Realtime.TimepointStatusTest do
 
       stop_id = "s2"
 
-      assert TimepointStatus.timepoint_status(stop_times, stop_id) == nil
+      assert TimepointStatus.timepoint_status(stop_times, stop_id, {0.0, 0.0}) == nil
+    end
+  end
+
+  describe "fraction_between_stops" do
+    setup do
+      stop1 = %Stop{
+        id: "stop1",
+        name: "stop1",
+        latitude: 42.0,
+        longitude: -72.0
+      }
+
+      stop2 = %Stop{
+        id: "stop2",
+        name: "stop2",
+        latitude: 43.0,
+        longitude: -71.0
+      }
+
+      stop_without_latlon = %Stop{
+        id: "without_latlon",
+        name: "without_latlon"
+      }
+
+      reassign_env(:skate, :stop_fn, fn stop_id ->
+        case stop_id do
+          "stop1" -> stop1
+          "stop2" -> stop2
+          "without_latlon" -> stop_without_latlon
+          "missing" -> nil
+        end
+      end)
+    end
+
+    test "if either stop is missing, return 1.0 (at the second stop)" do
+      latlon = {42.5, -71.5}
+      assert TimepointStatus.fraction_between_stops("stop1", nil, latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops("stop1", "missing", latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops("stop1", "without_latlon", latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops(nil, "stop1", latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops("missing", "stop1", latlon) == 1.0
+      assert TimepointStatus.fraction_between_stops("without_latlon", "stop1", latlon) == 1.0
+    end
+
+    test "returns a fraction when the bus is directly between the points" do
+      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {42.75, -71.25}) == 0.75
+    end
+
+    test "returns a fraction when the bus is not between the points" do
+      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {42.0, -71.0}) == 0.5
+    end
+
+    test "the bus can't be before the first stop or after the second" do
+      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {41.0, -73.0}) == 0.0
+      assert TimepointStatus.fraction_between_stops("stop1", "stop2", {44.0, -70.0}) == 1.0
     end
   end
 


### PR DESCRIPTION
Asana Task: [Increase the precision of where vehicles are drawn on the ladder by interpolating the lat/lng between the stop in front and the stop behind.](https://app.asana.com/0/1148853526253426/1133314986995053)

<img width="898" alt="Screen Shot 2020-02-10 at 19 20 13" src="https://user-images.githubusercontent.com/23065557/74252995-8197e700-4cbc-11ea-99bb-974fac4c7060.png">

Buses in that screenshot where this is useful:
- 9063 (the late run), which is still crossing the Tobin, not on the other side.
- 9060 , which is not quite at BELSQ yet.
- 1440 / 1044, which are much closer to THCHE than BWYBC.