### PR TITLE
adjust map marker label background to length of label

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -79,10 +79,12 @@ const makeLabelIcon = (
   selectedVehicleId?: VehicleId
 ): Leaflet.DivIcon => {
   const labelString = vehicleLabelString(vehicle, settings)
+  const labelBackgroundWidth = labelString.length <= 4 ? 40 : 62
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
+
   return Leaflet.divIcon({
     className: `m-vehicle-map__label ${selectedClass}`,
-    html: `<svg viewBox="0 0 62 16" width="62" height="16">
+    html: `<svg viewBox="0 0 ${labelBackgroundWidth} 16" width="${labelBackgroundWidth}" height="16">
             <rect
                 class="m-vehicle-icon__label-background"
                 width="100%" height="100%"
@@ -92,7 +94,7 @@ const makeLabelIcon = (
               ${labelString}
             </text>
           </svg>`,
-    iconAnchor: [31, -16],
+    iconAnchor: [labelBackgroundWidth / 2, -16],
   })
 }
 


### PR DESCRIPTION
No asana task. It was quicker to just do this task than to file it in inbound.

Before: The labels on the map were a bit oversized, so that they would have room for the long "SW-OFF" label, but it leaves lots of extra space for run numbers.
<img width="159" alt="Screen Shot 2020-02-14 at 11 58 19" src="https://user-images.githubusercontent.com/23065557/74565797-07779480-4f40-11ea-814b-78746f35923d.png">

After: The label shrinks for short run numbers.
<img width="144" alt="Screen Shot 2020-02-14 at 12 20 25" src="https://user-images.githubusercontent.com/23065557/74565800-08102b00-4f40-11ea-8e70-3778b7a502c3.png">
After: And stays wide for long labels.
<img width="114" alt="Screen Shot 2020-02-14 at 12 20 57" src="https://user-images.githubusercontent.com/23065557/74565802-08102b00-4f40-11ea-836d-18328a883c6c.png">

This is the same strategy that we do for the label backgrounds on the ladder.