### PR TITLE
Upgrade tslint from 5.20.1 to 6.0.0

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13378,9 +13378,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.0.0.tgz",
+      "integrity": "sha512-9nLya8GBtlFmmFMW7oXXwoXS1NkrccqTqAtwXzdPV9e2mqSEvCki6iHL/Fbzi5oqbugshzgGPk7KBb2qNP1DSA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -13394,8 +13394,16 @@
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.10.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+          "dev": true
+        }
       }
     },
     "tslint-config-prettier": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -55,7 +55,7 @@
     "svgo-loader": "^2.2.1",
     "ts-jest": "^25.2.1",
     "ts-loader": "^6.2.1",
-    "tslint": "^5.20.1",
+    "tslint": "^6.0.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-react": "^4.2.0",
     "tslint-react-hooks": "^2.2.1",

--- a/assets/src/components/headwayLines.tsx
+++ b/assets/src/components/headwayLines.tsx
@@ -15,8 +15,8 @@ const headwayClass = (spacing: HeadwaySpacing | null): string =>
 const drawHeadwayLine = (
   ladderVehicles: LadderVehicle[],
   yStart: number,
-  acc: Array<ReactElement<SVGPathElement>>
-): Array<ReactElement<SVGPathElement>> => {
+  acc: ReactElement<SVGPathElement>[]
+): ReactElement<SVGPathElement>[] => {
   if (ladderVehicles.length === 0) {
     return acc
   }

--- a/assets/src/helpers/array.ts
+++ b/assets/src/helpers/array.ts
@@ -1,7 +1,7 @@
 export function partition<T, U extends T>(
   items: T[],
   predicate: (value: T) => value is U
-): [U[], Array<Exclude<T, U>>]
+): [U[], Exclude<T, U>[]]
 export function partition<T>(
   items: T[],
   predicate: (value: T) => boolean


### PR DESCRIPTION
Make formatting changes required by the new version.

Combines the version bump from https://github.com/mbta/skate/pull/454 with formatting changes required to pass our checks.