### PR TITLE
Encapsulate window.location.reload call

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1,4 +1,5 @@
 import "whatwg-fetch"
+import { reload } from "./models/browser"
 import {
   DirectionName,
   Route,
@@ -25,7 +26,7 @@ const checkResponseStatus = (response: Response) => {
   if (Math.floor(response.status / 100) === 3 || response.status === 403) {
     // If the API sends us a redirect or forbidden, the user needs to
     // re-authenticate. Reload to go through the auth flow again.
-    window.location.reload(true)
+    reload(true)
   }
 
   throw new Error(`Response error: ${response.status}`)

--- a/assets/src/components/disconnectedModal.tsx
+++ b/assets/src/components/disconnectedModal.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { reload } from "../models/browser"
 
 const DisconnectedModal = () => (
   <>
@@ -8,7 +9,7 @@ const DisconnectedModal = () => (
       </div>
       <button
         className="m-disconnected-modal__refresh-button"
-        onClick={() => window.location.reload(false)}
+        onClick={() => reload(false)}
       >
         Refresh
       </button>

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
 import { NavLink } from "react-router-dom"
 import { ladderIcon, mapIcon, refreshIcon, searchIcon } from "../helpers/icon"
+import { reload } from "../models/browser"
 
 interface Props {
   pickerContainerIsVisible: boolean
@@ -12,10 +13,7 @@ const TabBar = ({
   <div
     className={`m-tab-bar ${pickerContainerIsVisible ? "visible" : "hidden"}`}
   >
-    <button
-      className="m-tab-bar__logo"
-      onClick={() => window.location.reload()}
-    >
+    <button className="m-tab-bar__logo" onClick={() => reload()}>
       {skateLogo}
     </button>
     <ul className="m-tab-bar__links">
@@ -72,10 +70,7 @@ const TabBar = ({
         </NavLink>
       </li>
     </ul>
-    <button
-      className="m-tab-bar__refresh"
-      onClick={() => window.location.reload()}
-    >
+    <button className="m-tab-bar__refresh" onClick={() => reload()}>
       {refreshIcon("m-tab-bar__icon")}
     </button>
   </div>

--- a/assets/src/hooks/useSearchResults.ts
+++ b/assets/src/hooks/useSearchResults.ts
@@ -1,5 +1,6 @@
 import { Channel, Socket } from "phoenix"
 import { useEffect, useState } from "react"
+import { reload } from "../models/browser"
 import { SearchQuery } from "../models/searchQuery"
 import {
   VehicleOrGhostData,
@@ -37,7 +38,7 @@ const subscribe = (
       console.error("search channel join failed", reason)
     )
     .receive("timeout", () => {
-      window.location.reload(true)
+      reload(true)
     })
 
   return channel

--- a/assets/src/hooks/useShuttleVehicles.ts
+++ b/assets/src/hooks/useShuttleVehicles.ts
@@ -1,5 +1,6 @@
 import { Channel, Socket } from "phoenix"
 import { Dispatch, useEffect, useReducer } from "react"
+import { reload } from "../models/browser"
 import { VehicleData, vehicleFromData } from "../models/vehicleData"
 import { Vehicle } from "../realtime"
 
@@ -69,7 +70,7 @@ const subscribe = (socket: Socket, dispatch: Dispatch<Action>): Channel => {
       console.error("shuttle vehicles join failed", reason)
     )
     .receive("timeout", () => {
-      window.location.reload(true)
+      reload(true)
     })
 
   return channel

--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -1,5 +1,6 @@
 import { Channel, Socket } from "phoenix"
 import { Dispatch as ReactDispatch, useEffect, useReducer } from "react"
+import { reload } from "../models/browser"
 import {
   VehicleOrGhostData,
   vehicleOrGhostFromData,
@@ -129,7 +130,7 @@ const subscribe = (
 
   // Reload our session if the auth has expired
   channel.on("auth_expired", () => {
-    window.location.reload(true)
+    reload(true)
   })
 
   channel
@@ -138,7 +139,7 @@ const subscribe = (
     // tslint:disable-next-line: no-console
     .receive("error", ({ reason }) => console.error("join failed", reason))
     .receive("timeout", () => {
-      window.location.reload(true)
+      reload(true)
     })
   return channel
 }

--- a/assets/src/models/browser.ts
+++ b/assets/src/models/browser.ts
@@ -1,0 +1,3 @@
+export const reload = (forceGet: boolean = false) => {
+  window.location.reload(forceGet)
+}

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -26,6 +26,18 @@ const mockFetch = (status: number, json: any): void => {
 }
 
 describe("apiCall", () => {
+  let browserReloadSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    browserReloadSpy = jest
+      .spyOn(browser, "reload")
+      .mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    browserReloadSpy.mockRestore()
+  })
+
   test("returns parsed data", done => {
     mockFetch(200, { data: "raw" })
 
@@ -44,8 +56,6 @@ describe("apiCall", () => {
   test("reloads the page if the response status is a redirect (3xx)", done => {
     mockFetch(302, { data: null })
 
-    jest.spyOn(browser, "reload").mockImplementation(() => {})
-
     apiCall({
       url: "/",
       parser: () => null,
@@ -57,8 +67,6 @@ describe("apiCall", () => {
 
   test("reloads the page if the response status is forbidden (403)", done => {
     mockFetch(403, { data: null })
-
-    jest.spyOn(browser, "reload").mockImplementation(() => {})
 
     apiCall({
       url: "/",

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -6,6 +6,7 @@ import {
   fetchShuttleRoutes,
   fetchTimepointsForRoute,
 } from "../src/api"
+import * as browser from "../src/models/browser"
 
 // tslint:disable no-empty
 
@@ -43,13 +44,13 @@ describe("apiCall", () => {
   test("reloads the page if the response status is a redirect (3xx)", done => {
     mockFetch(302, { data: null })
 
-    window.location.reload = jest.fn()
+    jest.spyOn(browser, "reload").mockImplementation(() => {})
 
     apiCall({
       url: "/",
       parser: () => null,
     }).catch(() => {
-      expect(window.location.reload).toHaveBeenCalled()
+      expect(browser.reload).toHaveBeenCalled()
       done()
     })
   })
@@ -57,13 +58,13 @@ describe("apiCall", () => {
   test("reloads the page if the response status is forbidden (403)", done => {
     mockFetch(403, { data: null })
 
-    window.location.reload = jest.fn()
+    jest.spyOn(browser, "reload").mockImplementation(() => {})
 
     apiCall({
       url: "/",
       parser: () => null,
     }).catch(() => {
-      expect(window.location.reload).toHaveBeenCalled()
+      expect(browser.reload).toHaveBeenCalled()
       done()
     })
   })

--- a/assets/tests/components/disconnectedModal.test.tsx
+++ b/assets/tests/components/disconnectedModal.test.tsx
@@ -2,6 +2,7 @@ import { mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
 import DisconnectedModal from "../../src/components/disconnectedModal"
+import * as browser from "../../src/models/browser"
 
 // tslint:disable no-empty
 
@@ -13,8 +14,8 @@ describe("DisconnectedModal", () => {
 
   test("refreshes when you click the button", () => {
     const wrapper = mount(<DisconnectedModal />)
-    window.location.reload = jest.fn()
+    jest.spyOn(browser, "reload").mockImplementation(() => {})
     wrapper.find("button").simulate("click")
-    expect(window.location.reload).toHaveBeenCalled()
+    expect(browser.reload).toHaveBeenCalled()
   })
 })

--- a/assets/tests/components/tabBar.test.tsx
+++ b/assets/tests/components/tabBar.test.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import renderer from "react-test-renderer"
 import TabBar from "../../src/components/tabBar"
+import * as browser from "../../src/models/browser"
 
 describe("tabBar", () => {
   it("renders", () => {
@@ -39,7 +40,7 @@ describe("tabBar", () => {
 
   it("reloads the page when you click on the logo", () => {
     const reloadSpy = jest
-      .spyOn(window.location, "reload")
+      .spyOn(browser, "reload")
       .mockImplementationOnce(() => ({}))
 
     const wrapper = mount(
@@ -58,7 +59,7 @@ describe("tabBar", () => {
 
   it("reloads the page when you click on the refresh button", () => {
     const reloadSpy = jest
-      .spyOn(window.location, "reload")
+      .spyOn(browser, "reload")
       .mockImplementationOnce(() => ({}))
 
     const wrapper = mount(

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks"
 import { Socket } from "phoenix"
 import useSearchResults from "../../src/hooks/useSearchResults"
+import * as browser from "../../src/models/browser"
 import { emptySearchQuery, SearchQuery } from "../../src/models/searchQuery"
 import { VehicleData, VehicleOrGhostData } from "../../src/models/vehicleData"
 import {
@@ -327,7 +328,7 @@ describe("useSearchResults", () => {
   })
 
   test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(window.location, "reload")
+    const reloadSpy = jest.spyOn(browser, "reload")
     reloadSpy.mockImplementationOnce(() => ({}))
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("timeout")

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks"
 import { Socket } from "phoenix"
 import useShuttleVehicles from "../../src/hooks/useShuttleVehicles"
+import * as browser from "../../src/models/browser"
 import { Vehicle, VehicleTimepointStatus } from "../../src/realtime.d"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 
@@ -199,7 +200,7 @@ describe("useShuttleVehicles", () => {
   })
 
   test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(window.location, "reload")
+    const reloadSpy = jest.spyOn(browser, "reload")
     reloadSpy.mockImplementationOnce(() => ({}))
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("timeout")

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks"
 import { Socket } from "phoenix"
 import useVehicles from "../../src/hooks/useVehicles"
+import * as browser from "../../src/models/browser"
 import { VehicleData } from "../../src/models/vehicleData"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { Ghost, Vehicle, VehicleTimepointStatus } from "../../src/realtime.d"
@@ -370,7 +371,7 @@ describe("useVehicles", () => {
   })
 
   test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(window.location, "reload")
+    const reloadSpy = jest.spyOn(browser, "reload")
     reloadSpy.mockImplementationOnce(() => ({}))
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("timeout")

--- a/assets/tests/models/browser.test.ts
+++ b/assets/tests/models/browser.test.ts
@@ -1,0 +1,33 @@
+import { reload } from "../../src/models/browser"
+
+describe("reload", () => {
+  let reloadSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // Dirty: setting window.location as writable so we can spy on reload function.
+    // Doing this once here to avoid it in all other tests.
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { reload: jest.fn() },
+    })
+
+    reloadSpy = jest.spyOn(window.location, "reload")
+    reloadSpy.mockImplementation(() => ({}))
+  })
+
+  afterEach(() => {
+    reloadSpy.mockRestore()
+  })
+
+  test("calls window.location.reload", () => {
+    reload()
+
+    expect(reloadSpy).toHaveBeenCalled()
+  })
+
+  test("passes on an optional forceGet argument", () => {
+    reload(true)
+
+    expect(reloadSpy).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
No Asana ticket, this is required (but not sufficient) for https://github.com/mbta/skate/pull/428 to pass.

This allows us to add mock implementation on a function we control.
This is required in order to upgrade to Jest version 25.1.0.