### PR TITLE
Style past and future block waivers

### DIFF
--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -26,6 +26,26 @@
   fill: $black;
   margin-right: 0.3rem;
   width: 15px;
+
+  .c-icon-alert-circle__outline {
+    fill: $white;
+  }
+
+  .c-icon-alert-circle__circle-fill {
+    fill: $color-component-dark;
+
+    .m-block-waiver-banner--past & {
+      fill: $color-component-medium;
+    }
+  }
+
+  .c-icon-alert-circle__exclamation-point {
+    fill: $white;
+
+    .m-block-waiver-banner--past & {
+      fill: $color-bg-medium;
+    }
+  }
 }
 
 .m-block-waiver-banner__title {
@@ -38,6 +58,13 @@
 
   td {
     padding-bottom: 0.3rem;
+  }
+}
+
+.m-block-waiver-banner__detail-label,
+.m-block-waiver-banner__detail-value {
+  .m-block-waiver-banner--past & {
+    color: $color-font-grey;
   }
 }
 

--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -1,7 +1,18 @@
 .m-block-waiver-banner {
   background-color: $color-secondary-light;
-  border: 1px solid $color-secondary-dark;
+  border: 1px solid;
   padding: 1rem 1rem 1rem 2rem;
+
+  &--current {
+    background-color: $color-secondary-light;
+    border-color: $color-secondary-dark;
+  }
+
+  &--past,
+  &--future {
+    background-color: $color-bg-medium;
+    border-color: $color-component-medium;
+  }
 }
 
 .m-block-waiver-banner__header {
@@ -40,6 +51,14 @@
 .m-block-waiver-banner__detail-value {
   @include font-body;
   margin-bottom: 1rem;
+}
+
+.m-block-waiver-banner__detail-label--start-time,
+.m-block-waiver-banner__detail-value--start-time {
+  .m-block-waiver-banner--future & {
+    color: $color-font-dark;
+    font-weight: 700;
+  }
 }
 
 .m-block-waiver-banner__detail-label--end-time,

--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -63,8 +63,12 @@
 
 .m-block-waiver-banner__detail-label--end-time,
 .m-block-waiver-banner__detail-value--end-time {
+  .m-block-waiver-banner--current &,
+  .m-block-waiver-banner--past & {
+    font-weight: 700;
+  }
+
   .m-block-waiver-banner--current & {
     color: $color-font-dark;
-    font-weight: 700;
   }
 }

--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -23,7 +23,6 @@
 
 .m-block-waiver-banner__alert-icon {
   display: block;
-  fill: $black;
   margin-right: 0.3rem;
   width: 15px;
 

--- a/assets/static/images/icon-alert-circle.svg
+++ b/assets/static/images/icon-alert-circle.svg
@@ -1,1 +1,9 @@
-<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z" fill="#fff" fill-rule="evenodd"/><circle cx="24" cy="24" fill="#606060" r="22.59"/><path d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z" fill-rule="evenodd"/><g fill="#fff"><path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"/><path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" fill-rule="evenodd"/></g></svg>
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="c-icon-alert-circle">
+  <path d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z" class="c-icon-alert-circle__outline" fill-rule="evenodd"/>
+  <circle cx="24" cy="24" class="c-icon-alert-circle__circle" r="22.59"/>
+  <path d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z" class="c-icon-alert-circle__circle-fill"  fill-rule="evenodd"/>
+  <g class="c-icon-alert-circle__exclamation-point">
+    <path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"/>
+    <path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" fill-rule="evenodd"/>
+  </g>
+</svg>


### PR DESCRIPTION
Asana ticket: [Future & Past block waiver banner treatment](https://app.asana.com/0/1148853526253426/1162089955688355)

Make the background and border gray.

Make the start time bold for future waivers.

Depends on https://github.com/mbta/skate/pull/457

![Screen Shot 2020-02-20 at 14 58 54](https://user-images.githubusercontent.com/42339/74973672-d260bb80-53f1-11ea-84ee-af5f5a7ebd09.png)
