### PR TITLE
fix intermittent test failure

### DIFF
--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -7,7 +7,11 @@ defmodule Test.Support.Helpers do
       Application.put_env(unquote(app), unquote(var), unquote(value))
 
       on_exit(fn ->
-        Application.put_env(unquote(app), unquote(var), old_value)
+        if old_value == nil do
+          Application.delete_env(unquote(app), unquote(var))
+        else
+          Application.put_env(unquote(app), unquote(var), old_value)
+        end
       end)
     end
   end


### PR DESCRIPTION
when the :active_blocks_fn was unassigned, it got the value nil
which means Application.get_env returns nil instead of the default

this caused intermittent test failures depending on the order of tests
example of a failing seed beforehand: commit ceb6330, mix test --seed 145576

deleting the value instead of assigning nil means that future calls to
get_env will use their default values

Fixes the failing build in #475 and others.