### PR TITLE
useChannel

### DIFF
--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -18,19 +18,16 @@ enum MobileDisplay {
 }
 
 const thereIsAnActiveSearch = (
-  vehicles: VehicleOrGhost[] | null | undefined,
+  vehicles: VehicleOrGhost[] | null,
   searchPageState: SearchPageState
-): boolean =>
-  vehicles !== null && vehicles !== undefined && searchPageState.isActive
+): boolean => vehicles !== null && searchPageState.isActive
 
 const filterVehicles = (
-  vehiclesOrGhosts: VehicleOrGhost[] | null | undefined
+  vehiclesOrGhosts: VehicleOrGhost[] | null
 ): Vehicle[] => {
-  if (vehiclesOrGhosts === null || vehiclesOrGhosts === undefined) {
-    return []
-  }
-
-  return vehiclesOrGhosts.filter(vog => isVehicle(vog)) as Vehicle[]
+  return vehiclesOrGhosts === null
+    ? []
+    : (vehiclesOrGhosts.filter(vog => isVehicle(vog)) as Vehicle[])
 }
 
 const findSelectedVehicle = (
@@ -63,7 +60,7 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
     StateDispatchContext
   )
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
-  const vehicles: VehicleOrGhost[] | null | undefined = useSearchResults(
+  const vehicles: VehicleOrGhost[] | null = useSearchResults(
     socket,
     searchPageState.isActive ? searchPageState.query : null
   )

--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -1,0 +1,64 @@
+import { Channel, Socket } from "phoenix"
+import { useEffect, useState } from "react"
+import { reload } from "../models/browser"
+
+/** Opens a channel for the given topic
+ *  and returns the latest data that's been pushed to it
+ *
+ *  Only listens for a single event
+ *  Assumes the data returned on join and the data from subsequent pushes are the same format
+ *  If topic is null, does not open a channel.
+ *  Returns offState if the channel is not open yet
+ *  Returns loadingState after the channel has been opened but before receiving the first response
+ */
+export const useChannel = <T>({
+  socket,
+  topic,
+  event,
+  parser,
+  loadingState,
+  offState,
+}: {
+  socket: Socket | undefined
+  topic: string | null
+  event: string
+  parser: (data: any) => T
+  loadingState: T
+  offState: T
+}): T => {
+  const [result, setResult] = useState<T>(offState)
+
+  useEffect(() => {
+    let channel: Channel | undefined
+
+    if (socket !== undefined && topic !== null) {
+      setResult(loadingState)
+      channel = socket.channel(topic)
+      channel.on(event, ({ data: data }) => {
+        setResult(parser(data))
+      })
+      channel
+        .join()
+        .receive("ok", ({ data: data }) => {
+          setResult(parser(data))
+        })
+        .receive("error", ({ reason }) =>
+          // tslint:disable-next-line: no-console
+          console.error(`joining topic ${topic} failed`, reason)
+        )
+        .receive("timeout", () => {
+          reload(true)
+        })
+    } else {
+      setResult(offState)
+    }
+
+    return () => {
+      if (channel !== undefined) {
+        channel.leave()
+        channel = undefined
+      }
+    }
+  }, [socket, topic, event, loadingState, offState])
+  return result
+}

--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -8,8 +8,6 @@ import { reload } from "../models/browser"
  *  Only listens for a single event
  *  Assumes the data returned on join and the data from subsequent pushes are the same format
  *  If topic is null, does not open a channel.
- *  Returns offState if the channel is not open yet
- *  Returns loadingState after the channel has been opened but before receiving the first response
  */
 export const useChannel = <T>({
   socket,
@@ -17,22 +15,20 @@ export const useChannel = <T>({
   event,
   parser,
   loadingState,
-  offState,
 }: {
   socket: Socket | undefined
   topic: string | null
   event: string
   parser: (data: any) => T
   loadingState: T
-  offState: T
 }): T => {
-  const [result, setResult] = useState<T>(offState)
+  const [result, setResult] = useState<T>(loadingState)
 
   useEffect(() => {
+    setResult(loadingState)
     let channel: Channel | undefined
 
     if (socket !== undefined && topic !== null) {
-      setResult(loadingState)
       channel = socket.channel(topic)
       channel.on(event, ({ data: data }) => {
         setResult(parser(data))
@@ -49,8 +45,6 @@ export const useChannel = <T>({
         .receive("timeout", () => {
           reload(true)
         })
-    } else {
-      setResult(offState)
     }
 
     return () => {
@@ -59,6 +53,6 @@ export const useChannel = <T>({
         channel = undefined
       }
     }
-  }, [socket, topic, event, loadingState, offState])
+  }, [socket, topic, event, loadingState])
   return result
 }

--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -22,21 +22,21 @@ export const useChannel = <T>({
   parser: (data: any) => T
   loadingState: T
 }): T => {
-  const [result, setResult] = useState<T>(loadingState)
+  const [state, setState] = useState<T>(loadingState)
 
   useEffect(() => {
-    setResult(loadingState)
+    setState(loadingState)
     let channel: Channel | undefined
 
     if (socket !== undefined && topic !== null) {
       channel = socket.channel(topic)
       channel.on(event, ({ data: data }) => {
-        setResult(parser(data))
+        setState(parser(data))
       })
       channel
         .join()
         .receive("ok", ({ data: data }) => {
-          setResult(parser(data))
+          setState(parser(data))
         })
         .receive("error", ({ reason }) =>
           // tslint:disable-next-line: no-console
@@ -54,5 +54,5 @@ export const useChannel = <T>({
       }
     }
   }, [socket, topic, event, loadingState])
-  return result
+  return state
 }

--- a/assets/src/hooks/useDataStatus.ts
+++ b/assets/src/hooks/useDataStatus.ts
@@ -1,33 +1,17 @@
-import { Channel, Socket } from "phoenix"
-import { useState, useEffect } from "react"
-import { reload } from "../models/browser"
+import { Socket } from "phoenix"
+import { useChannel } from "./useChannel"
 
 export type DataStatus = "good" | "outage"
 
-const topic = "data_status"
-
 const useDataStatus = (socket: Socket | undefined) => {
-  const [state, setState] = useState<DataStatus>("good")
-
-  useEffect(() => {
-    if (socket !== undefined) {
-      const channel: Channel = socket.channel(topic)
-      channel.on("data_status", ({ data: status }) => {
-        setState(status)
-      })
-      channel
-        .join()
-        .receive("ok", ({ data: status }) => {
-          setState(status)
-        })
-        // tslint:disable-next-line: no-console
-        .receive("error", ({ reason }) => console.error("join failed", reason))
-        .receive("timeout", () => {
-          reload(true)
-        })
-    }
-  }, [socket])
-  return state
+  return useChannel<DataStatus>({
+    socket,
+    topic: "data_status",
+    event: "data_status",
+    parser: status => status,
+    loadingState: "good",
+    offState: "good",
+  })
 }
 
 export default useDataStatus

--- a/assets/src/hooks/useDataStatus.ts
+++ b/assets/src/hooks/useDataStatus.ts
@@ -10,7 +10,6 @@ const useDataStatus = (socket: Socket | undefined) => {
     event: "data_status",
     parser: status => status,
     loadingState: "good",
-    offState: "good",
   })
 }
 

--- a/assets/src/hooks/useSearchResults.ts
+++ b/assets/src/hooks/useSearchResults.ts
@@ -13,16 +13,16 @@ const parser = (data: VehicleOrGhostData[]): VehicleOrGhost[] =>
 const useSearchResults = (
   socket: Socket | undefined,
   searchQuery: SearchQuery | null
-): VehicleOrGhost[] | null | undefined => {
+): VehicleOrGhost[] | null => {
   const topic: string | null =
     searchQuery && `vehicles:search:${searchQuery.property}:${searchQuery.text}`
-  return useChannel<VehicleOrGhost[] | null | undefined>({
+  return useChannel<VehicleOrGhost[] | null>({
     socket,
     topic,
     event: "search",
     parser,
     loadingState: null,
-    offState: undefined,
+    offState: null,
   })
 }
 

--- a/assets/src/hooks/useSearchResults.ts
+++ b/assets/src/hooks/useSearchResults.ts
@@ -22,7 +22,6 @@ const useSearchResults = (
     event: "search",
     parser,
     loadingState: null,
-    offState: null,
   })
 }
 

--- a/assets/src/hooks/useSearchResults.ts
+++ b/assets/src/hooks/useSearchResults.ts
@@ -1,81 +1,29 @@
-import { Channel, Socket } from "phoenix"
-import { useEffect, useState } from "react"
-import { reload } from "../models/browser"
+import { Socket } from "phoenix"
 import { SearchQuery } from "../models/searchQuery"
 import {
   VehicleOrGhostData,
   vehicleOrGhostFromData,
 } from "../models/vehicleData"
 import { VehicleOrGhost } from "../realtime"
+import { useChannel } from "./useChannel"
 
-interface SearchResultsPayload {
-  data: VehicleOrGhostData[]
-}
-
-const subscribe = (
-  socket: Socket,
-  searchQuery: SearchQuery,
-  setVehicles: (vehicles: VehicleOrGhost[]) => void
-): Channel => {
-  const handleSearchResults = (payload: SearchResultsPayload): void => {
-    setVehicles(
-      payload.data.map((data: VehicleOrGhostData) =>
-        vehicleOrGhostFromData(data)
-      )
-    )
-  }
-
-  const channel = socket.channel(
-    `vehicles:search:${searchQuery.property}:${searchQuery.text}`
-  )
-  channel.on("search", handleSearchResults)
-
-  channel
-    .join()
-    .receive("ok", handleSearchResults)
-    .receive("error", ({ reason }) =>
-      // tslint:disable-next-line: no-console
-      console.error("search channel join failed", reason)
-    )
-    .receive("timeout", () => {
-      reload(true)
-    })
-
-  return channel
-}
+const parser = (data: VehicleOrGhostData[]): VehicleOrGhost[] =>
+  data.map(vehicleOrGhostFromData)
 
 const useSearchResults = (
   socket: Socket | undefined,
   searchQuery: SearchQuery | null
 ): VehicleOrGhost[] | null | undefined => {
-  const [vehicles, setVehicles] = useState<VehicleOrGhost[] | null | undefined>(
-    undefined
-  )
-
-  useEffect(() => {
-    let channel: Channel | undefined
-
-    const leaveChannel = () => {
-      if (channel !== undefined) {
-        channel.leave()
-        channel = undefined
-      }
-    }
-
-    if (searchQuery === null) {
-      leaveChannel()
-      setVehicles(undefined)
-    }
-
-    if (socket && searchQuery !== null) {
-      setVehicles(null)
-      channel = subscribe(socket, searchQuery, setVehicles)
-    }
-
-    return leaveChannel
-  }, [socket, searchQuery])
-
-  return vehicles
+  const topic: string | null =
+    searchQuery && `vehicles:search:${searchQuery.property}:${searchQuery.text}`
+  return useChannel<VehicleOrGhost[] | null | undefined>({
+    socket,
+    topic,
+    event: "search",
+    parser,
+    loadingState: null,
+    offState: undefined,
+  })
 }
 
 export default useSearchResults

--- a/assets/src/hooks/useShuttleVehicles.ts
+++ b/assets/src/hooks/useShuttleVehicles.ts
@@ -12,7 +12,6 @@ const useShuttleVehicles = (socket: Socket | undefined): Vehicle[] | null => {
     event: "shuttles",
     parser,
     loadingState: null,
-    offState: null,
   })
 }
 

--- a/assets/src/hooks/useShuttleVehicles.ts
+++ b/assets/src/hooks/useShuttleVehicles.ts
@@ -1,92 +1,19 @@
-import { Channel, Socket } from "phoenix"
-import { Dispatch, useEffect, useReducer } from "react"
-import { reload } from "../models/browser"
+import { Socket } from "phoenix"
 import { VehicleData, vehicleFromData } from "../models/vehicleData"
 import { Vehicle } from "../realtime"
+import { useChannel } from "./useChannel"
 
-interface State {
-  shuttles: Vehicle[] | null
-  channel?: Channel
-}
-
-const reducer = (state: State, action: Action): State => {
-  switch (action.type) {
-    case "SET_CHANNEL":
-      return { ...state, channel: action.payload.channel }
-
-    case "SET_SHUTTLES":
-      return { ...state, shuttles: action.payload.shuttles }
-  }
-}
-
-const initialState: State = {
-  shuttles: null,
-}
-
-interface SetShuttlesAction {
-  type: "SET_SHUTTLES"
-  payload: {
-    shuttles: Vehicle[]
-  }
-}
-
-const setShuttles = (shuttles: Vehicle[]): SetShuttlesAction => ({
-  type: "SET_SHUTTLES",
-  payload: { shuttles },
-})
-
-interface SetChannelAction {
-  type: "SET_CHANNEL"
-  payload: {
-    channel: Channel
-  }
-}
-
-const setChannel = (channel: Channel): SetChannelAction => ({
-  type: "SET_CHANNEL",
-  payload: { channel },
-})
-
-type Action = SetShuttlesAction | SetChannelAction
-
-interface ChannelPayload {
-  data: VehicleData[]
-}
-
-const subscribe = (socket: Socket, dispatch: Dispatch<Action>): Channel => {
-  const handleShuttles = (payload: ChannelPayload): void => {
-    dispatch(setShuttles(payload.data.map(data => vehicleFromData(data))))
-  }
-
-  const channel = socket.channel("vehicles:shuttle:all")
-
-  channel.on("shuttles", handleShuttles)
-
-  channel
-    .join()
-    .receive("ok", handleShuttles)
-    .receive("error", ({ reason }) =>
-      // tslint:disable-next-line: no-console
-      console.error("shuttle vehicles join failed", reason)
-    )
-    .receive("timeout", () => {
-      reload(true)
-    })
-
-  return channel
-}
+const parser = (data: VehicleData[]): Vehicle[] => data.map(vehicleFromData)
 
 const useShuttleVehicles = (socket: Socket | undefined): Vehicle[] | null => {
-  const [state, dispatch] = useReducer(reducer, initialState)
-  const { channel, shuttles } = state
-  useEffect(() => {
-    if (socket && !channel) {
-      const newChannel = subscribe(socket, dispatch)
-      dispatch(setChannel(newChannel))
-    }
-  }, [socket])
-
-  return shuttles
+  return useChannel<Vehicle[] | null>({
+    socket,
+    topic: "vehicles:shuttle:all",
+    event: "shuttles",
+    parser,
+    loadingState: null,
+    offState: null,
+  })
 }
 
 export default useShuttleVehicles

--- a/assets/tests/components/searchPage.test.tsx
+++ b/assets/tests/components/searchPage.test.tsx
@@ -86,7 +86,7 @@ jest.mock("../../src/hooks/useSearchResults", () => ({
 
 describe("SearchPage", () => {
   test("renders the empty state", () => {
-    ;(useSearchResults as jest.Mock).mockImplementationOnce(() => undefined)
+    ;(useSearchResults as jest.Mock).mockImplementationOnce(() => null)
     const tree = renderer
       .create(
         <StateDispatchProvider state={initialState} dispatch={jest.fn()}>

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -75,6 +75,27 @@ describe("useChannel", () => {
     expect(result.current).toEqual("loading")
   })
 
+  test("returns data from the initial join", () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser,
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+  })
+
   test("returns data pushed to the channel", async () => {
     const parser = jest.fn(() => "parsed")
     const mockSocket = makeMockSocket()
@@ -98,6 +119,7 @@ describe("useChannel", () => {
         offState: "off",
       })
     )
+
     expect(parser).toHaveBeenCalledWith("raw")
     expect(result.current).toEqual("parsed")
   })

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -34,7 +34,7 @@ describe("useChannel", () => {
     expect(mockSocket.channel).not.toHaveBeenCalled()
   })
 
-  test("giving a topic subscribes to that topic", () => {
+  test("subscribes to the given topic", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel()
     mockSocket.channel.mockImplementationOnce(() => mockChannel)

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -1,0 +1,220 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useChannel } from "../../src/hooks/useChannel"
+import * as browser from "../../src/models/browser"
+import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
+
+// tslint:disable: react-hooks-nesting
+
+describe("useChannel", () => {
+  test("returns off state initially", () => {
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: undefined,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+    expect(result.current).toEqual("off")
+  })
+
+  test("if given no topic, doesn't open a channel and returns offState", () => {
+    const mockSocket = makeMockSocket()
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: null,
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+    expect(result.current).toEqual("off")
+    expect(mockSocket.channel).not.toHaveBeenCalled()
+  })
+
+  test("giving a topic subscribes to that topic", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+
+    expect(mockSocket.channel).toHaveBeenCalledTimes(1)
+    expect(mockSocket.channel).toHaveBeenCalledWith("topic")
+    expect(mockChannel.join).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns loadingState while loading", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+    expect(result.current).toEqual("loading")
+  })
+
+  test("returns data pushed to the channel", async () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "event") {
+        handler({
+          data: "raw",
+        })
+      }
+    })
+
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser,
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+  })
+
+  test("leaves the channel on unmount", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { unmount } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+
+    expect(mockChannel.join).toHaveBeenCalled()
+
+    unmount()
+
+    expect(mockChannel.leave).toHaveBeenCalled()
+  })
+
+  test("leaves the channel and joins a new one when the topic changes", () => {
+    const mockSocket = makeMockSocket()
+    const channel1 = makeMockChannel()
+    const channel2 = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => channel1)
+    mockSocket.channel.mockImplementationOnce(() => channel2)
+
+    const { rerender } = renderHook(
+      topic =>
+        useChannel({
+          socket: mockSocket,
+          topic,
+          event: "event",
+          parser: jest.fn(),
+          loadingState: "loading",
+          offState: "off",
+        }),
+      { initialProps: "topic1" }
+    )
+
+    rerender("topic2")
+
+    expect(channel1.leave).toHaveBeenCalled()
+    expect(channel2.join).toHaveBeenCalled()
+  })
+
+  test("leaves the channel when topic is set changed to null", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { rerender } = renderHook<string | null, any>(
+      topic =>
+        useChannel({
+          socket: mockSocket,
+          topic,
+          event: "event",
+          parser: jest.fn(),
+          loadingState: "loading",
+          offState: "off",
+        }),
+      { initialProps: "topic" }
+    )
+
+    rerender(null)
+
+    expect(mockChannel.leave).toHaveBeenCalledTimes(1)
+  })
+
+  test("console.error on join error", async () => {
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce(msg => msg)
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("error")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+
+    expect(spyConsoleError).toHaveBeenCalled()
+    spyConsoleError.mockRestore()
+  })
+
+  test("reloads the window on channel timeout", async () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("timeout")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+        offState: "off",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
+  })
+})

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -6,7 +6,7 @@ import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 // tslint:disable: react-hooks-nesting
 
 describe("useChannel", () => {
-  test("returns off state initially", () => {
+  test("returns loadingState initially", () => {
     const { result } = renderHook(() =>
       useChannel({
         socket: undefined,
@@ -14,13 +14,12 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
-    expect(result.current).toEqual("off")
+    expect(result.current).toEqual("loading")
   })
 
-  test("if given no topic, doesn't open a channel and returns offState", () => {
+  test("if given no topic, doesn't open a channel and returns loadingState", () => {
     const mockSocket = makeMockSocket()
     const { result } = renderHook(() =>
       useChannel({
@@ -29,10 +28,9 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
-    expect(result.current).toEqual("off")
+    expect(result.current).toEqual("loading")
     expect(mockSocket.channel).not.toHaveBeenCalled()
   })
 
@@ -48,7 +46,6 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
 
@@ -69,7 +66,6 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
     expect(result.current).toEqual("loading")
@@ -88,7 +84,6 @@ describe("useChannel", () => {
         event: "event",
         parser,
         loadingState: "loading",
-        offState: "off",
       })
     )
 
@@ -116,7 +111,6 @@ describe("useChannel", () => {
         event: "event",
         parser,
         loadingState: "loading",
-        offState: "off",
       })
     )
 
@@ -136,7 +130,6 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
 
@@ -162,7 +155,6 @@ describe("useChannel", () => {
           event: "event",
           parser: jest.fn(),
           loadingState: "loading",
-          offState: "off",
         }),
       { initialProps: "topic1" }
     )
@@ -186,7 +178,6 @@ describe("useChannel", () => {
           event: "event",
           parser: jest.fn(),
           loadingState: "loading",
-          offState: "off",
         }),
       { initialProps: "topic" }
     )
@@ -210,7 +201,6 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
 
@@ -232,7 +222,6 @@ describe("useChannel", () => {
         event: "event",
         parser: jest.fn(),
         loadingState: "loading",
-        offState: "off",
       })
     )
 

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -140,51 +140,55 @@ describe("useChannel", () => {
     expect(mockChannel.leave).toHaveBeenCalled()
   })
 
-  test("leaves the channel and joins a new one when the topic changes", () => {
+  test("leaves the channel, removes old data, and joins new channel when the topic changes", () => {
     const mockSocket = makeMockSocket()
-    const channel1 = makeMockChannel()
+    const channel1 = makeMockChannel("ok", { data: "raw" })
     const channel2 = makeMockChannel()
     mockSocket.channel.mockImplementationOnce(() => channel1)
     mockSocket.channel.mockImplementationOnce(() => channel2)
 
-    const { rerender } = renderHook(
+    const { rerender, result } = renderHook(
       topic =>
         useChannel({
           socket: mockSocket,
           topic,
           event: "event",
-          parser: jest.fn(),
+          parser: jest.fn(() => "parsed"),
           loadingState: "loading",
         }),
       { initialProps: "topic1" }
     )
 
+    expect(result.current).toEqual("parsed")
     rerender("topic2")
 
     expect(channel1.leave).toHaveBeenCalled()
+    expect(result.current).toEqual("loading")
     expect(channel2.join).toHaveBeenCalled()
   })
 
-  test("leaves the channel when topic is set changed to null", () => {
+  test("leaves the channel and removes old data when topic is changed to null", () => {
     const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
 
-    const { rerender } = renderHook<string | null, any>(
+    const { rerender, result } = renderHook<string | null, any>(
       topic =>
         useChannel({
           socket: mockSocket,
           topic,
           event: "event",
-          parser: jest.fn(),
+          parser: jest.fn(() => "parsed"),
           loadingState: "loading",
         }),
       { initialProps: "topic" }
     )
 
+    expect(result.current).toEqual("parsed")
     rerender(null)
 
     expect(mockChannel.leave).toHaveBeenCalledTimes(1)
+    expect(result.current).toEqual("loading")
   })
 
   test("console.error on join error", async () => {

--- a/assets/tests/hooks/useDataStatus.test.ts
+++ b/assets/tests/hooks/useDataStatus.test.ts
@@ -25,15 +25,10 @@ describe("useDataStatus", () => {
     expect(mockChannel.join).toHaveBeenCalledTimes(1)
   })
 
-  test("returns the data_status when pushed", () => {
+  test("returns the resulting data_status", () => {
     const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("ok")
+    const mockChannel = makeMockChannel("ok", { data: "outage" })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
-    mockChannel.on.mockImplementation((event, handler) => {
-      if (event === "data_status") {
-        handler({ data: "outage" })
-      }
-    })
 
     const { result } = renderHook(() => useDataStatus(mockSocket))
 

--- a/assets/tests/hooks/useDataStatus.test.ts
+++ b/assets/tests/hooks/useDataStatus.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks"
 import useDataStatus from "../../src/hooks/useDataStatus"
-import * as browser from "../../src/models/browser"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 
 // tslint:disable: react-hooks-nesting
@@ -39,31 +38,5 @@ describe("useDataStatus", () => {
     const { result } = renderHook(() => useDataStatus(mockSocket))
 
     expect(result.current).toEqual("outage")
-  })
-
-  test("console.error on join error", async () => {
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(msg => msg)
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("error")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    renderHook(() => useDataStatus(mockSocket))
-
-    expect(spyConsoleError).toHaveBeenCalled()
-    spyConsoleError.mockRestore()
-  })
-
-  test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(browser, "reload")
-    reloadSpy.mockImplementationOnce(() => ({}))
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("timeout")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    renderHook(() => useDataStatus(mockSocket))
-
-    expect(reloadSpy).toHaveBeenCalled()
-    reloadSpy.mockRestore()
   })
 })

--- a/assets/tests/hooks/useDataStatus.test.ts
+++ b/assets/tests/hooks/useDataStatus.test.ts
@@ -50,7 +50,7 @@ describe("useDataStatus", () => {
 
     renderHook(() => useDataStatus(mockSocket))
 
-    expect(spyConsoleError).toHaveBeenCalledWith("join failed", "ERROR_REASON")
+    expect(spyConsoleError).toHaveBeenCalled()
     spyConsoleError.mockRestore()
   })
 

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks"
 import useSearchResults from "../../src/hooks/useSearchResults"
-import * as browser from "../../src/models/browser"
 import { emptySearchQuery, SearchQuery } from "../../src/models/searchQuery"
 import { VehicleData, VehicleOrGhostData } from "../../src/models/vehicleData"
 import { Vehicle, VehicleOrGhost } from "../../src/realtime"
@@ -227,27 +226,6 @@ describe("useSearchResults", () => {
     expect(result.current).toEqual(vehicles)
   })
 
-  test("leaves the channel on unmount", () => {
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("ok")
-    const vehicles: Vehicle[] = []
-    mockUseStateOnce(vehicles)
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-    mockUseStateOnce(mockChannel)
-
-    const searchQuery: SearchQuery = {
-      text: "one",
-      property: "run",
-    }
-    const { unmount } = renderHook(() =>
-      useSearchResults(mockSocket, searchQuery)
-    )
-
-    unmount()
-
-    expect(mockChannel.leave).toHaveBeenCalled()
-  })
-
   test("leaves the channel and joins a new one when the search changes", () => {
     const mockSocket = makeMockSocket()
     const vehicles: Vehicle[] = []
@@ -297,41 +275,5 @@ describe("useSearchResults", () => {
     rerender(search2)
 
     expect(mockChannel.leave).toHaveBeenCalledTimes(1)
-  })
-
-  test("console.error on join error", async () => {
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(msg => msg)
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("error")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    const searchQuery: SearchQuery = {
-      text: "test",
-      property: "run",
-    }
-
-    renderHook(() => useSearchResults(mockSocket, searchQuery))
-
-    expect(spyConsoleError).toHaveBeenCalled()
-    spyConsoleError.mockRestore()
-  })
-
-  test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(browser, "reload")
-    reloadSpy.mockImplementationOnce(() => ({}))
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("timeout")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    const searchQuery: SearchQuery = {
-      text: "test",
-      property: "run",
-    }
-
-    renderHook(() => useSearchResults(mockSocket, searchQuery))
-
-    expect(reloadSpy).toHaveBeenCalled()
-    reloadSpy.mockRestore()
   })
 })

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -10,11 +10,11 @@ import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 // tslint:disable: object-literal-sort-keys
 
 describe("useSearchResults", () => {
-  test("returns undefined initially", () => {
+  test("returns null initially", () => {
     const { result } = renderHook(() =>
       useSearchResults(undefined, emptySearchQuery)
     )
-    expect(result.current).toEqual(undefined)
+    expect(result.current).toEqual(null)
   })
 
   test("initializing the hook subscribes to the search results", () => {

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -313,10 +313,7 @@ describe("useSearchResults", () => {
 
     renderHook(() => useSearchResults(mockSocket, searchQuery))
 
-    expect(spyConsoleError).toHaveBeenCalledWith(
-      "search channel join failed",
-      "ERROR_REASON"
-    )
+    expect(spyConsoleError).toHaveBeenCalled()
     spyConsoleError.mockRestore()
   })
 

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -45,7 +45,7 @@ describe("useSearchResults", () => {
     expect(mockChannel.join).toHaveBeenCalledTimes(0)
   })
 
-  test("returns results pushed to the channel", async () => {
+  test("returns results pushed to the channel", () => {
     const vehicleData: VehicleData = {
       bearing: 33,
       block_id: "block-1",
@@ -205,15 +205,8 @@ describe("useSearchResults", () => {
     const vehicles: VehicleOrGhost[] = [vehicle]
 
     const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("ok")
+    const mockChannel = makeMockChannel("ok", { data: searchResultsData })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
-    mockChannel.on.mockImplementation((event, handler) => {
-      if (event === "search") {
-        handler({
-          data: searchResultsData,
-        })
-      }
-    })
 
     const searchQuery: SearchQuery = {
       text: "test",

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -162,17 +162,10 @@ describe("useShuttleVehicles", () => {
     expect(mockChannel.join).toHaveBeenCalledTimes(1)
   })
 
-  test("returns results pushed to the channel", async () => {
+  test("returns resulting vehicles", () => {
     const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("ok")
+    const mockChannel = makeMockChannel("ok", { data: shuttlesData })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
-    mockChannel.on.mockImplementation((event, handler) => {
-      if (event === "shuttles") {
-        handler({
-          data: shuttlesData,
-        })
-      }
-    })
 
     const { result } = renderHook(() => useShuttleVehicles(mockSocket))
 

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks"
 import useShuttleVehicles from "../../src/hooks/useShuttleVehicles"
-import * as browser from "../../src/models/browser"
 import { Vehicle, VehicleTimepointStatus } from "../../src/realtime.d"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 
@@ -178,31 +177,5 @@ describe("useShuttleVehicles", () => {
     const { result } = renderHook(() => useShuttleVehicles(mockSocket))
 
     expect(result.current).toEqual(shuttles)
-  })
-
-  test("console.error on join error", async () => {
-    const spyConsoleError = jest.spyOn(console, "error")
-    spyConsoleError.mockImplementationOnce(msg => msg)
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("error")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    renderHook(() => useShuttleVehicles(mockSocket))
-
-    expect(spyConsoleError).toHaveBeenCalled()
-    spyConsoleError.mockRestore()
-  })
-
-  test("reloads the window on channel timeout", async () => {
-    const reloadSpy = jest.spyOn(browser, "reload")
-    reloadSpy.mockImplementationOnce(() => ({}))
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("timeout")
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-
-    renderHook(() => useShuttleVehicles(mockSocket))
-
-    expect(reloadSpy).toHaveBeenCalled()
-    reloadSpy.mockRestore()
   })
 })

--- a/assets/tests/hooks/useShuttleVehicles.test.ts
+++ b/assets/tests/hooks/useShuttleVehicles.test.ts
@@ -189,10 +189,7 @@ describe("useShuttleVehicles", () => {
 
     renderHook(() => useShuttleVehicles(mockSocket))
 
-    expect(spyConsoleError).toHaveBeenCalledWith(
-      "shuttle vehicles join failed",
-      "ERROR_REASON"
-    )
+    expect(spyConsoleError).toHaveBeenCalled()
     spyConsoleError.mockRestore()
   })
 

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -278,6 +278,18 @@ describe("useVehicles", () => {
     })
   })
 
+  test("returns results from the initial join", async () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: vehiclesData })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(() => useVehicles(mockSocket, ["1"]))
+
+    expect(result.current).toEqual({
+      "1": vehicles,
+    })
+  })
+
   test("returns results pushed to the channel", async () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel()
@@ -315,15 +327,10 @@ describe("useVehicles", () => {
     ]
 
     const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel()
-    mockSocket.channel.mockImplementationOnce(() => mockChannel)
-    mockChannel.on.mockImplementation((event, handler) => {
-      if (event === "vehicles") {
-        handler({
-          data: vehiclesDataVaryingHeadway,
-        })
-      }
+    const mockChannel = makeMockChannel("ok", {
+      data: vehiclesDataVaryingHeadway,
     })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
 
     const { result } = renderHook(() => useVehicles(mockSocket, ["1"]))
 

--- a/assets/tests/testHelpers/socketHelpers.ts
+++ b/assets/tests/testHelpers/socketHelpers.ts
@@ -6,7 +6,8 @@ export const makeMockSocket = (): Socket & { channel: jest.Mock } =>
   } as Socket & { channel: jest.Mock })
 
 export const makeMockChannel = (
-  expectedJoinMessage?: "ok" | "error" | "timeout"
+  expectedJoinMessage?: "ok" | "error" | "timeout",
+  expectedJoinData?: any
 ) => {
   const result = {
     join: jest.fn(),
@@ -19,6 +20,9 @@ export const makeMockChannel = (
     if (message === expectedJoinMessage) {
       switch (message) {
         case "ok":
+          if (expectedJoinData !== undefined) {
+            handler(expectedJoinData)
+          }
           return result
 
         case "error":


### PR DESCRIPTION
Follow up to #472 

While doing that PR, I noticed some inconsistencies and problems with how we do channels from the frontend. We have 3 places that use data from a single channel now. This PR unifies and polishes those implementations.

This PR:
* Removes a ton of duplication
* Fixes how we close channels. In particular, the useShuttleVehicles channel wasn’t getting closed properly, so we were still loading shuttle vehicles after clicking away from the shuttle map.
* Adds a missing test for the data returned from the initial channel join.
* Lets the channel users focus on the parts that are special for that channel instead of the channel lifecycle.

It doesn’t change the useVehicles channel, since that needs to handle and remember multiple channels, and is significantly different from the other 3 places we use channels.