### PR TITLE
Refactor: Move StopTimeUpdates storage into a new GenServer

### DIFF
--- a/lib/concentrate/consumer/stop_time_updates.ex
+++ b/lib/concentrate/consumer/stop_time_updates.ex
@@ -7,7 +7,7 @@ defmodule Concentrate.Consumer.StopTimeUpdates do
 
   alias Concentrate.{Merge, StopTimeUpdate}
   alias Gtfs.Trip
-  alias Realtime.Server
+  alias Realtime.StopTimeUpdateStore
 
   @type stop_time_updates_by_trip :: %{Trip.id() => [StopTimeUpdate.t()]}
 
@@ -29,9 +29,10 @@ defmodule Concentrate.Consumer.StopTimeUpdates do
   def handle_events(events, _from, state) do
     groups = List.last(events)
 
-    stop_time_updates_by_trip = stop_time_updates_from_groups(groups)
-
-    :ok = Server.update({:stop_time_updates, stop_time_updates_by_trip})
+    :ok =
+      groups
+      |> stop_time_updates_from_groups()
+      |> StopTimeUpdateStore.set()
 
     {:noreply, [], state}
   end

--- a/lib/concentrate/consumer/vehicle_positions.ex
+++ b/lib/concentrate/consumer/vehicle_positions.ex
@@ -37,7 +37,7 @@ defmodule Concentrate.Consumer.VehiclePositions do
     by_route = Vehicles.group_by_route(all_vehicles)
     shuttles = Enum.filter(all_vehicles, &Vehicle.shuttle?/1)
 
-    _ = Server.update({:vehicle_positions, by_route, shuttles})
+    _ = Server.update({by_route, shuttles})
     _ = DataStatusPubSub.update(data_status)
 
     {:noreply, [], state}

--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -6,7 +6,7 @@ defmodule Realtime.BlockWaiver do
 
   alias Concentrate.StopTimeUpdate
   alias Gtfs.{Block, Trip}
-  alias Realtime.Server
+  alias Realtime.StopTimeUpdateStore
 
   @type t :: %__MODULE__{
           start_time: Util.Time.time_of_day(),
@@ -41,7 +41,11 @@ defmodule Realtime.BlockWaiver do
   @spec trip_stop_time_waivers(Trip.t()) :: [trip_stop_time_waiver()]
   def trip_stop_time_waivers(trip) do
     stop_time_updates_fn =
-      Application.get_env(:realtime, :stop_time_updates_fn, &Server.stop_time_updates_for_trip/1)
+      Application.get_env(
+        :realtime,
+        :stop_time_updates_fn,
+        &StopTimeUpdateStore.stop_time_updates_for_trip/1
+      )
 
     stop_time_updates = stop_time_updates_fn.(trip.id)
 

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -88,15 +88,15 @@ defmodule Realtime.Server do
     lookup({ets, subscription_key})
   end
 
-  @spec update({:vehicle_positions, Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]}) :: term()
+  @spec update({Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]}) :: term()
   @spec update(
-          {:vehicle_positions, Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]},
+          {Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]},
           GenServer.server()
         ) :: term()
   def update(update_term, server \\ __MODULE__)
 
-  def update({:vehicle_positions, vehicles_by_route_id, shuttles}, server) do
-    GenServer.cast(server, {:update, :vehicle_positions, vehicles_by_route_id, shuttles})
+  def update({vehicles_by_route_id, shuttles}, server) do
+    GenServer.cast(server, {:update, vehicles_by_route_id, shuttles})
   end
 
   @spec lookup({:ets.tid(), {:route_id, Route.id()}}) :: [VehicleOrGhost.t()]
@@ -145,7 +145,7 @@ defmodule Realtime.Server do
 
   @impl true
   def handle_cast(
-        {:update, :vehicle_positions, vehicles_by_route_id, shuttles},
+        {:update, vehicles_by_route_id, shuttles},
         %__MODULE__{} = state
       ) do
     new_active_route_ids = Map.keys(vehicles_by_route_id)

--- a/lib/realtime/stop_time_update_store.ex
+++ b/lib/realtime/stop_time_update_store.ex
@@ -17,21 +17,24 @@ defmodule Realtime.StopTimeUpdateStore do
 
   # Client
 
+  @spec default_name() :: GenServer.name()
+  def default_name(), do: Realtime.StopTimeUpdateStore
+
   @spec start_link() :: GenServer.on_start()
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, nil, name: Keyword.get(opts, :name, __MODULE__))
+    GenServer.start_link(__MODULE__, nil, name: Keyword.get(opts, :name, default_name()))
   end
 
   @spec stop_time_updates_for_trip(Trip.id()) :: [StopTimeUpdate.t()]
   @spec stop_time_updates_for_trip(Trip.id(), GenServer.server()) :: [StopTimeUpdate.t()]
-  def stop_time_updates_for_trip(trip_id, server \\ __MODULE__) do
+  def stop_time_updates_for_trip(trip_id, server \\ default_name()) do
     GenServer.call(server, {:stop_time_updates_for_trip, trip_id})
   end
 
   @spec set(StopTimeUpdates.stop_time_updates_by_trip()) :: :ok
   @spec set(StopTimeUpdates.stop_time_updates_by_trip(), GenServer.server()) :: :ok
-  def set(stop_time_updates_by_trip, server \\ __MODULE__) do
+  def set(stop_time_updates_by_trip, server \\ default_name()) do
     GenServer.cast(server, {:set, stop_time_updates_by_trip})
   end
 

--- a/lib/realtime/stop_time_update_store.ex
+++ b/lib/realtime/stop_time_update_store.ex
@@ -13,7 +13,7 @@ defmodule Realtime.StopTimeUpdateStore do
           stop_time_updates_by_trip: StopTimeUpdates.stop_time_updates_by_trip()
         }
 
-  defstruct stop_time_updates_by_trip: []
+  defstruct stop_time_updates_by_trip: %{}
 
   # Client
 

--- a/lib/realtime/stop_time_update_store.ex
+++ b/lib/realtime/stop_time_update_store.ex
@@ -1,0 +1,63 @@
+defmodule Realtime.StopTimeUpdateStore do
+  @moduledoc """
+  Server for setting and getting StopTimeUpdates.
+  """
+
+  use GenServer
+
+  alias Concentrate.Consumer.StopTimeUpdates
+  alias Concentrate.StopTimeUpdate
+  alias Gtfs.Trip
+
+  @type t :: %__MODULE__{
+          stop_time_updates_by_trip: StopTimeUpdates.stop_time_updates_by_trip()
+        }
+
+  defstruct stop_time_updates_by_trip: []
+
+  # Client
+
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, nil, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @spec stop_time_updates_for_trip(Trip.id()) :: [StopTimeUpdate.t()]
+  @spec stop_time_updates_for_trip(Trip.id(), GenServer.server()) :: [StopTimeUpdate.t()]
+  def stop_time_updates_for_trip(trip_id, server \\ __MODULE__) do
+    GenServer.call(server, {:stop_time_updates_for_trip, trip_id})
+  end
+
+  @spec set(StopTimeUpdates.stop_time_updates_by_trip()) :: :ok
+  @spec set(StopTimeUpdates.stop_time_updates_by_trip(), GenServer.server()) :: :ok
+  def set(stop_time_updates_by_trip, server \\ __MODULE__) do
+    GenServer.cast(server, {:set, stop_time_updates_by_trip})
+  end
+
+  # Server
+
+  @impl GenServer
+  def init(_) do
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl true
+  def handle_call(
+        {:stop_time_updates_for_trip, trip_id},
+        _from,
+        %__MODULE__{stop_time_updates_by_trip: stop_time_updates_by_trip} = state
+      ) do
+    stop_time_updates = Map.get(stop_time_updates_by_trip, trip_id, [])
+
+    {:reply, stop_time_updates, state}
+  end
+
+  @impl true
+  def handle_cast(
+        {:set, stop_time_updates_by_trip},
+        %__MODULE__{} = state
+      ) do
+    {:noreply, Map.put(state, :stop_time_updates_by_trip, stop_time_updates_by_trip)}
+  end
+end

--- a/lib/realtime/supervisor.ex
+++ b/lib/realtime/supervisor.ex
@@ -12,7 +12,7 @@ defmodule Realtime.Supervisor do
   def init(:ok) do
     children = [
       {Registry, keys: :duplicate, name: registry_name()},
-      {Realtime.StopTimeUpdateStore, name: Realtime.Server.default_name()},
+      {Realtime.StopTimeUpdateStore, name: Realtime.StopTimeUpdateStore.default_name()},
       {Realtime.Server, name: Realtime.Server.default_name()},
       {Realtime.DataStatusPubSub, name: Realtime.DataStatusPubSub.default_name()},
       {Concentrate.Supervisor,

--- a/lib/realtime/supervisor.ex
+++ b/lib/realtime/supervisor.ex
@@ -12,6 +12,7 @@ defmodule Realtime.Supervisor do
   def init(:ok) do
     children = [
       {Registry, keys: :duplicate, name: registry_name()},
+      {Realtime.StopTimeUpdateStore, name: Realtime.Server.default_name()},
       {Realtime.Server, name: Realtime.Server.default_name()},
       {Realtime.DataStatusPubSub, name: Realtime.DataStatusPubSub.default_name()},
       {Concentrate.Supervisor,

--- a/test/channels/vehicles_channel_test.exs
+++ b/test/channels/vehicles_channel_test.exs
@@ -103,7 +103,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({:vehicle_positions, %{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")
 
@@ -121,7 +121,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({:vehicle_positions, %{}, [@vehicle]}) == :ok
+      assert Realtime.Server.update({%{}, [@vehicle]}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
 
@@ -139,7 +139,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({:vehicle_positions, %{}, [@vehicle]}) == :ok
+      assert Realtime.Server.update({%{}, [@vehicle]}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:search:all:507")
 
@@ -157,7 +157,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({:vehicle_positions, %{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -71,7 +71,7 @@ defmodule Realtime.ServerTest do
     end
 
     test "accepts vehicle positions", %{server_pid: server_pid} do
-      assert Server.update({:vehicle_positions, @vehicles_by_route_id, []}, server_pid) == :ok
+      assert Server.update({@vehicles_by_route_id, []}, server_pid) == :ok
     end
   end
 
@@ -79,7 +79,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      Server.update({:vehicle_positions, @vehicles_by_route_id, []}, server_pid)
+      Server.update({@vehicles_by_route_id, []}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -92,7 +92,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to a route get data pushed to them", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({:vehicle_positions, @vehicles_by_route_id, []}, server_pid)
+      Server.update({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -106,7 +106,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to a route get repeated messages", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({:vehicle_positions, @vehicles_by_route_id, []}, server_pid)
+      Server.update({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, _},
@@ -114,7 +114,7 @@ defmodule Realtime.ServerTest do
         "Client didn't receive vehicle positions the first time"
       )
 
-      Server.update({:vehicle_positions, @vehicles_by_route_id, []}, server_pid)
+      Server.update({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -128,7 +128,7 @@ defmodule Realtime.ServerTest do
     test "inactive routes have all their vehicle data removed", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({:vehicle_positions, %{}, []}, server_pid)
+      Server.update({%{}, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -144,7 +144,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      :ok = Server.update({:vehicle_positions, %{}, [@shuttle]}, server_pid)
+      :ok = Server.update({%{}, [@shuttle]}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -156,7 +156,7 @@ defmodule Realtime.ServerTest do
     test "clients get updated data pushed to them", %{server_pid: pid} do
       Server.subscribe_to_all_shuttles(pid)
 
-      Server.update({:vehicle_positions, %{}, [@shuttle, @shuttle]}, pid)
+      Server.update({%{}, [@shuttle, @shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle, @shuttle]
@@ -167,7 +167,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      :ok = Server.update({:vehicle_positions, @vehicles_by_route_id, [@shuttle]}, server_pid)
+      :ok = Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -183,7 +183,7 @@ defmodule Realtime.ServerTest do
     test "clients get updated search results pushed to them", %{server_pid: pid} do
       Server.subscribe_to_search("90", :all, pid)
 
-      Server.update({:vehicle_positions, %{}, [@shuttle]}, pid)
+      Server.update({%{}, [@shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle]
@@ -192,7 +192,7 @@ defmodule Realtime.ServerTest do
     test "does not receive duplicate vehicles", %{server_pid: pid} do
       Server.subscribe_to_search("90", :all, pid)
 
-      Server.update({:vehicle_positions, %{}, [@shuttle, @shuttle]}, pid)
+      Server.update({%{}, [@shuttle, @shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle]

--- a/test/realtime/stop_time_update_store_test.exs
+++ b/test/realtime/stop_time_update_store_test.exs
@@ -1,0 +1,65 @@
+defmodule StopTimeUpdateStoreTest do
+  use ExUnit.Case, async: true
+
+  alias Concentrate.StopTimeUpdate
+  alias Realtime.StopTimeUpdateStore
+
+  @stop_time_updates [
+    StopTimeUpdate.new(
+      trip_id: "trip1",
+      stop_id: "stop1",
+      stop_sequence: 1,
+      arrival_time: 1,
+      departure_time: 4,
+      status: "status",
+      track: "track",
+      schedule_relationship: :SKIPPED,
+      platform_id: "platform",
+      uncertainty: 300,
+      remark: "B"
+    )
+  ]
+  @stop_time_updates_by_trip %{
+    "trip1" => @stop_time_updates
+  }
+
+  describe "start_link/1" do
+    test "starts up and lives" do
+      {:ok, server} = StopTimeUpdateStore.start_link(name: :start_link)
+
+      Process.sleep(10)
+
+      assert Process.alive?(server)
+    end
+  end
+
+  describe "stop_time_updates_for_trip/1" do
+    setup do
+      {:ok, server} = StopTimeUpdateStore.start_link(name: :stop_time_updates_for_trip)
+
+      {:ok, server: server}
+    end
+
+    test "get the StopTimeUpdates for the requested trip ID", %{server: server} do
+      :sys.replace_state(server, fn state ->
+        Map.put(state, :stop_time_updates_by_trip, @stop_time_updates_by_trip)
+      end)
+
+      assert StopTimeUpdateStore.stop_time_updates_for_trip("trip1", server) == @stop_time_updates
+    end
+  end
+
+  describe "set/1" do
+    setup do
+      {:ok, server} = StopTimeUpdateStore.start_link(name: :set)
+
+      {:ok, server: server}
+    end
+
+    test "stores the StopTimeUpdates by trip ID", %{server: server} do
+      assert StopTimeUpdateStore.set(@stop_time_updates_by_trip, server) == :ok
+
+      assert %{stop_time_updates_by_trip: @stop_time_updates_by_trip} = :sys.get_state(server)
+    end
+  end
+end


### PR DESCRIPTION
Asana ticket: [Refactor: Move StopTimeUpdates storage into a new GenServer](https://app.asana.com/0/1148853526253426/1163344518291743)