### PR TITLE
LadderVehicle uses whole vehicle instead of taking a few fields

### DIFF
--- a/assets/src/components/headwayLines.tsx
+++ b/assets/src/components/headwayLines.tsx
@@ -3,6 +3,8 @@ import { VehicleDirection } from "../models/ladderDirection"
 import { LadderVehicle } from "../models/ladderVehicle"
 import { HeadwaySpacing, headwaySpacingToString } from "../models/vehicleStatus"
 import { CENTER_TO_LINE } from "./ladder"
+import { VehicleOrGhost } from "../realtime"
+import { isVehicle } from "../models/vehicle"
 
 interface Props {
   height: number
@@ -21,32 +23,35 @@ const drawHeadwayLine = (
     return acc
   }
 
-  const [currentVehicle, ...rest] = ladderVehicles
+  const [currentLadderVehicle, ...rest] = ladderVehicles
+  const vehicle: VehicleOrGhost = currentLadderVehicle.vehicle
+  const headwaySpacing =
+    isVehicle(vehicle) && !vehicle.isOffCourse ? vehicle.headwaySpacing : null
 
-  if (currentVehicle.headwaySpacing === null) {
+  if (headwaySpacing === null) {
     return drawHeadwayLine(rest, yStart, acc)
   }
 
   const centerToLine =
-    currentVehicle.vehicleDirection === VehicleDirection.Down
+    currentLadderVehicle.vehicleDirection === VehicleDirection.Down
       ? -CENTER_TO_LINE
       : CENTER_TO_LINE
 
   const newAcc = acc.concat([
     <line
-      key={`${currentVehicle.vehicleId}-headway-line`}
-      id={currentVehicle.vehicleId}
+      key={`${vehicle.id}-headway-line`}
+      id={vehicle.id}
       className={`m-ladder__line
                   m-ladder__headway-line
-                  ${headwayClass(currentVehicle.headwaySpacing)}`}
+                  ${headwayClass(headwaySpacing)}`}
       x1={centerToLine}
       y1={yStart}
       x2={centerToLine}
-      y2={currentVehicle.y}
+      y2={currentLadderVehicle.y}
     />,
   ])
 
-  return drawHeadwayLine(rest, currentVehicle.y, newAcc)
+  return drawHeadwayLine(rest, currentLadderVehicle.y, newAcc)
 }
 
 interface VehiclesByDirection {

--- a/assets/src/models/ladderVehicle.ts
+++ b/assets/src/models/ladderVehicle.ts
@@ -1,5 +1,4 @@
 import { TimepointStatusYFunc } from "../components/ladder"
-import { partition } from "../helpers/array"
 import { Ghost, Vehicle, VehicleOrGhost } from "../realtime"
 import {
   directionOnLadder,
@@ -58,22 +57,14 @@ export const ladderVehiclesFromVehicles = (
   ladderVehicles: LadderVehicle[]
   widthOfLanes: number
 } => {
-  const [vehicles, ghosts]: [Vehicle[], Ghost[]] = partition(
-    vehiclesAndGhosts,
-    isVehicle
+  const vehiclesOnLadder: VehicleOnLadder[] = vehiclesAndGhosts.map(
+    vehicleOrGhost =>
+      isVehicle(vehicleOrGhost)
+        ? vehicleOnLadder(vehicleOrGhost, ladderDirection, timepointStatusYFunc)
+        : ghostOnLadder(vehicleOrGhost, ladderDirection, timepointStatusYFunc)
   )
 
-  const vehiclesOnLadder: VehicleOnLadder[] = vehicles.map(vehicle =>
-    vehicleOnLadder(vehicle, ladderDirection, timepointStatusYFunc)
-  )
-
-  const ghostsOnLadder: VehicleOnLadder[] = ghosts.map(ghost =>
-    ghostOnLadder(ghost, ladderDirection, timepointStatusYFunc)
-  )
-
-  const vehiclesInLane: VehicleInLane[] = putIntoLanes(
-    vehiclesOnLadder.concat(ghostsOnLadder)
-  )
+  const vehiclesInLane: VehicleInLane[] = putIntoLanes(vehiclesOnLadder)
 
   const maxOccupiedLane: number = numOccupiedLanes(vehiclesInLane)
   const ladderVehicleHorizontalOffset: number = horizontalOffsetForLanes(

--- a/assets/tests/components/headwayLines.test.tsx
+++ b/assets/tests/components/headwayLines.test.tsx
@@ -4,45 +4,40 @@ import HeadwayLines from "../../src/components/headwayLines"
 import { VehicleDirection } from "../../src/models/ladderDirection"
 import { LadderVehicle } from "../../src/models/ladderVehicle"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
+import { Vehicle } from "../../src/realtime"
 
 describe("HeadwayLines", () => {
   test("renders", () => {
     const vehicles: LadderVehicle[] = [
       {
-        vehicleId: "1",
-        label: "1",
-        viaVariant: null,
-        status: "on-time",
-        hasBlockWaivers: false,
-        headwaySpacing: HeadwaySpacing.Ok,
+        vehicle: {
+          id: "1",
+          label: "1",
+          headwaySpacing: HeadwaySpacing.Ok,
+        } as Vehicle,
         x: 1,
         y: 1,
         vehicleDirection: VehicleDirection.Up,
-        lane: 0,
       },
       {
-        vehicleId: "2",
-        label: "2",
-        viaVariant: null,
-        status: "on-time",
-        hasBlockWaivers: false,
-        headwaySpacing: HeadwaySpacing.Bunched,
+        vehicle: {
+          id: "2",
+          label: "2",
+          headwaySpacing: HeadwaySpacing.Bunched,
+        } as Vehicle,
         x: 1,
         y: 100,
         vehicleDirection: VehicleDirection.Up,
-        lane: 0,
       },
       {
-        vehicleId: "3",
-        label: "3",
-        viaVariant: null,
-        status: "on-time",
-        hasBlockWaivers: false,
-        headwaySpacing: HeadwaySpacing.Gapped,
+        vehicle: {
+          id: "3",
+          label: "3",
+          headwaySpacing: HeadwaySpacing.Gapped,
+        } as Vehicle,
         x: 1,
         y: 300,
         vehicleDirection: VehicleDirection.Down,
-        lane: 0,
       },
     ]
     const tree = renderer

--- a/assets/tests/models/ladderVehicle.test.ts
+++ b/assets/tests/models/ladderVehicle.test.ts
@@ -6,58 +6,34 @@ import {
   LadderVehicle,
   putIntoLanes,
 } from "../../src/models/ladderVehicle"
-import { DrawnStatus, HeadwaySpacing } from "../../src/models/vehicleStatus"
+import { Vehicle } from "../../src/realtime"
+
+// tslint:disable:object-literal-sort-keys
 
 describe("putIntoLanes", () => {
   test("adds lane properties", () => {
-    const status: DrawnStatus = "on-time"
-    const headwaySpacing: HeadwaySpacing = HeadwaySpacing.Ok
-    const original = [
+    const original: LadderVehicle[] = [
       {
-        headwaySpacing,
-        isOffCourse: false,
-        label: "v1-label",
-        status,
-        hasBlockWaivers: false,
+        vehicle: { id: "v1" } as Vehicle,
         vehicleDirection: VehicleDirection.Up,
-        vehicleId: "v1",
-        viaVariant: "2",
         x: 0,
         y: 10,
       },
       {
-        headwaySpacing,
-        isOffCourse: false,
-        label: "v2-label",
-        status,
-        hasBlockWaivers: false,
+        vehicle: { id: "v2" } as Vehicle,
         vehicleDirection: VehicleDirection.Up,
-        vehicleId: "v2",
-        viaVariant: "2",
         x: 0,
         y: 20,
       },
       {
-        headwaySpacing,
-        isOffCourse: false,
-        label: "v3-label",
-        status,
-        hasBlockWaivers: false,
+        vehicle: { id: "v3" } as Vehicle,
         vehicleDirection: VehicleDirection.Down,
-        vehicleId: "v3",
-        viaVariant: "2",
         x: 0,
         y: 20,
       },
       {
-        headwaySpacing,
-        isOffCourse: false,
-        label: "v4-label",
-        status,
-        hasBlockWaivers: false,
+        vehicle: { id: "v4" } as Vehicle,
         vehicleDirection: VehicleDirection.Down,
-        vehicleId: "v4",
-        viaVariant: "2",
         x: 0,
         y: 10,
       },


### PR DESCRIPTION
[Display block waiver markers on ghost bus ladder icons](https://app.asana.com/0/1148853526253426/1163145000751641) will require `ladder.tsx` to check the block waivers to decide what kind of icon to draw. Rather than adding all the block waivers to the `LadderVehicle`, or checking the styling when creating the `LadderVehicle`, it's probably easier pass the whole vehicle through.

Old `LadderVehicle`:
```ts
export interface LadderVehicle {
  vehicleId: VehicleId
  label: string
  viaVariant: ViaVariant | null
  status: DrawnStatus
  hasBlockWaivers: boolean
  headwaySpacing: HeadwaySpacing | null
  x: number
  y: number
  vehicleDirection: VehicleDirection
  scheduledY?: number
  scheduledVehicleDirection?: VehicleDirection
  lane: number
} 
```
new `LadderVehicle`:
```ts
export interface LadderVehicle {
  vehicle: VehicleOrGhost
  x: number
  y: number
  vehicleDirection: VehicleDirection
  scheduledY?: number
  scheduledVehicleDirection?: VehicleDirection
}
```
