### PR TITLE
Bump react-tooltip from 4.0.3 to 4.1.0

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1693,6 +1693,16 @@
         }
       }
     },
+    "aphrodite-jss": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aphrodite-jss/-/aphrodite-jss-2.1.0.tgz",
+      "integrity": "sha512-25gINvLunuuVbegcnkLTXcCGKN/xeuVSW+Gl5elV5DhUeT+ueIpTghdyjaXmpiklzrQjXKZGSWbic+33DM+Q0A==",
+      "requires": {
+        "jss": "^8.1.0",
+        "jss-preset-default": "^3.0.0",
+        "murmurhash-js": "^1.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -3287,6 +3297,14 @@
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
       "dev": true
+    },
+    "css-vendor": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+      "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+      "requires": {
+        "is-in-browser": "^1.0.2"
+      }
     },
     "css-what": {
       "version": "2.1.3",
@@ -6291,6 +6309,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -8402,6 +8425,88 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-8.1.0.tgz",
+      "integrity": "sha512-NZ4CNAoPaPlM2rqHxPG5uGQbQEFZ9n1PITn0+wGIdAk2ZtA/F6el0SphLHf8So1Sx6N34hnVFFIuc32/hdsEzw==",
+      "requires": {
+        "is-in-browser": "^1.0.2",
+        "warning": "^3.0.0"
+      }
+    },
+    "jss-camel-case": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-5.0.0.tgz",
+      "integrity": "sha512-vz11ip5EIlGuevtlUo9xIgiuD+it4Ebbb0+Y4o0A4oA8eOWY4aY7ihi/L7WvkQ54xnGOjUvLZ6nm2VYch2ufYg=="
+    },
+    "jss-compose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-4.0.0.tgz",
+      "integrity": "sha512-VnsEziD2Lwrfwp10wx39FNybRLW5+RX/E2qQAXPAMbS+nHc0Jf2dC6ZiCfn5FaBGrpzLfIZ9MalTJDx4CQoMAQ==",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "jss-default-unit": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-7.0.0.tgz",
+      "integrity": "sha512-U1Oi1h45vFRuISr+g1DQ3Oua7CkNKNs47fTdiT/lHkuBMc6BBDUbPv9IbPPhk9gsEaX45Iy9TX8CAuaHLPCfEA=="
+    },
+    "jss-expand": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-4.0.1.tgz",
+      "integrity": "sha512-LRIMXXChAOgnhwSqYLJg8MS6dI98bf/sg52pAg04pbjOAtjfzyS0JTnQAiyk3PxqR3nKFR/Yv44ahpIpkdcxVA=="
+    },
+    "jss-extend": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-5.0.0.tgz",
+      "integrity": "sha512-fUp+9KipbdmzSfTxNHoT3mrFnE7fYn7EyHg3LTUexfpWrwj5Afkwb3iCfYV7GYCpg9OKDsqc18atwjHvSPWWKg==",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "jss-global": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-2.0.0.tgz",
+      "integrity": "sha512-/FSOMp4lF/vg47T/w8kKvL9tu7ka9am8N4izS63W81Qlay9hAq6xe9RxrPxygLpnn4KEb8LNbkKRoUv4SJfQsQ=="
+    },
+    "jss-nested": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-5.0.0.tgz",
+      "integrity": "sha512-9Molau+XVpSc6QEco3EC5yXmzeGMc5ZVII8+qy6jD6bvu6Y9mpfGoJ00LalR/n7xr/LC7Cxgs44UQQlLzumMBg==",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "jss-preset-default": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-3.0.0.tgz",
+      "integrity": "sha512-5wRsHsV89XjnQlUVN5jQfo6gcfcirDJmsMJL52HmWoQlV9SA+jhUtt1w3LjcJHe4e3tX4u/To/x3Btmhi+LZtQ==",
+      "requires": {
+        "jss-camel-case": "^5.0.0",
+        "jss-compose": "^4.0.0",
+        "jss-default-unit": "^7.0.0",
+        "jss-expand": "^4.0.0",
+        "jss-extend": "^5.0.0",
+        "jss-global": "^2.0.0",
+        "jss-nested": "^5.0.0",
+        "jss-props-sort": "^5.0.0",
+        "jss-vendor-prefixer": "^6.0.0"
+      }
+    },
+    "jss-props-sort": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-5.0.0.tgz",
+      "integrity": "sha512-xtoVE7BlcPaMN/dzypHPYJn+QiphLPB1skypAOp9zLkOozPbR/x0JVAFdZnd7zqmmjvg+Ma/txjSg0HN/eZsGA=="
+    },
+    "jss-vendor-prefixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-6.0.0.tgz",
+      "integrity": "sha512-leqW7B2QLXYsUNR3jsUZP3CkuOYcWXyfF8TSJc4XNxhVCNH7ztK5dcnF8nLoMnxT0w/ajloeJKcch2ty/viCAA==",
+      "requires": {
+        "css-vendor": "^0.3.8"
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -9012,6 +9117,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "nan": {
       "version": "2.14.0",
@@ -11598,11 +11708,12 @@
       }
     },
     "react-tooltip": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.0.3.tgz",
-      "integrity": "sha512-xEM+fr8tr/KJP5PZEOg/fc5bZ7ZkC658iMDgCq5DfTqHVyuIOOd5loyxQD0eAJiZ6jWdEd18owbRqd3stHtEDg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.1.0.tgz",
+      "integrity": "sha512-SA+5oinbM21YnzX9Mi6QwY8zEIfjwSTOLuO38XfrxXnfrBWjDAgV+aJXNYyaqSiDittaecGP5L/xi6T+b3M0kQ==",
       "requires": {
-        "prop-types": "^15.6.0"
+        "aphrodite-jss": "^2.1.0",
+        "prop-types": "^15.7.2"
       }
     },
     "readable-stream": {
@@ -14009,6 +14120,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -25,7 +25,7 @@
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",
-    "react-tooltip": "^4.0.3",
+    "react-tooltip": "^4.1.0",
     "resize-observer-polyfill": "^1.5.1",
     "whatwg-fetch": "^3.0.0"
   },

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`ladder filters out vehicles whose block is not active 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -363,7 +363,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -525,7 +525,7 @@ exports[`ladder renders a ghost bus 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -777,7 +777,7 @@ exports[`ladder renders a ladder 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -863,7 +863,7 @@ exports[`ladder renders a ladder with no timepoints 1`] = `
     </g>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -1025,7 +1025,7 @@ exports[`ladder renders a reversed ladder 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -1178,7 +1178,7 @@ exports[`ladder renders an off-course vehicle 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>
@@ -1340,7 +1340,7 @@ exports[`ladder shows schedule line in the other direction 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -190,7 +190,7 @@ Array [
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>,
@@ -390,7 +390,7 @@ Array [
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>,
@@ -743,7 +743,7 @@ Array [
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>,
@@ -900,7 +900,7 @@ Array [
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>,

--- a/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`renders a route ladder 1`] = `
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>
@@ -304,7 +304,7 @@ exports[`renders a route ladder 1`] = `
       </text>
     </svg>
     <div
-      className="__react_component_tooltip place-top type-dark"
+      className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
       data-id="tooltip"
     />
   </div>


### PR DESCRIPTION
This incorporates https://github.com/mbta/skate/pull/487 and updates our snapshots to account for class name changes in the tooltip library.