### PR TITLE
move iconAlertCircle to a component so it can be used inside an SVG

### DIFF
--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -25,25 +25,28 @@
   display: block;
   margin-right: 0.3rem;
   width: 15px;
+}
 
-  .c-icon-alert-circle__outline {
-    fill: $white;
-  }
-
-  .c-icon-alert-circle__circle-fill {
+.m-block-waiver-banner--current {
+  .c-icon-alert-circle__fill {
     fill: $color-component-dark;
-
-    .m-block-waiver-banner--past & {
-      fill: $color-component-medium;
-    }
   }
 
+  .c-icon-alert-circle__outline,
   .c-icon-alert-circle__exclamation-point {
     fill: $white;
+  }
+}
 
-    .m-block-waiver-banner--past & {
-      fill: $color-bg-medium;
-    }
+.m-block-waiver-banner--future,
+.m-block-waiver-banner--past {
+  .c-icon-alert-circle__fill {
+    fill: $color-component-medium;
+  }
+
+  .c-icon-alert-circle__outline,
+  .c-icon-alert-circle__exclamation-point {
+    fill: $color-bg-medium;
   }
 }
 

--- a/assets/src/components/iconAlertCircle.tsx
+++ b/assets/src/components/iconAlertCircle.tsx
@@ -1,22 +1,15 @@
 import React from "react"
 
 const IconAlertCircle = () => (
-  <svg viewBox="0 0 48 48" className="c-icon-alert-circle">
+  <svg viewBox="-3 -3 54 54" className="c-icon-alert-circle">
     <IconAlertCircleSvgNode />
   </svg>
 )
 
 export const IconAlertCircleSvgNode = () => (
   <>
-    <path
-      d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
-      className="c-icon-alert-circle__outline"
-    />
-    <circle cx="24" cy="24" className="c-icon-alert-circle__circle" r="22.59" />
-    <path
-      d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
-      className="c-icon-alert-circle__circle-fill"
-    />
+    <circle cx="24" cy="24" className="c-icon-alert-circle__outline" r="27" />
+    <circle cx="24" cy="24" className="c-icon-alert-circle__fill" r="22.59" />
     <g className="c-icon-alert-circle__exclamation-point">
       <path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11" />
       <path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" />

--- a/assets/src/components/iconAlertCircle.tsx
+++ b/assets/src/components/iconAlertCircle.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+
+const IconAlertCircle = () => (
+  <svg viewBox="0 0 48 48" className="c-icon-alert-circle">
+    <IconAlertCircleSvgNode />
+  </svg>
+)
+
+export const IconAlertCircleSvgNode = () => (
+  <>
+    <path
+      d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+      className="c-icon-alert-circle__outline"
+    />
+    <circle cx="24" cy="24" className="c-icon-alert-circle__circle" r="22.59" />
+    <path
+      d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+      className="c-icon-alert-circle__circle-fill"
+    />
+    <g className="c-icon-alert-circle__exclamation-point">
+      <path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11" />
+      <path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" />
+    </g>
+  </>
+)
+
+export default IconAlertCircle

--- a/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
+++ b/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { alertCircleIcon } from "../../helpers/icon"
 import { BlockWaiver } from "../../realtime"
 import { now, formattedTime } from "../../util/dateTime"
+import IconAlertCircle from "../iconAlertCircle"
 
 interface Props {
   blockWaiver: BlockWaiver
@@ -57,7 +57,9 @@ const BlockWaiverBanner = ({ blockWaiver }: Props) => (
     )}`}
   >
     <div className="m-block-waiver-banner__header">
-      {alertCircleIcon("m-block-waiver-banner__alert-icon")}
+      <span className="m-block-waiver-banner__alert-icon">
+        <IconAlertCircle />
+      </span>
       <div className="m-block-waiver-banner__title">
         Dispatcher Note - {currentFuturePastTitle(blockWaiver)}
       </div>

--- a/assets/src/helpers/icon.tsx
+++ b/assets/src/helpers/icon.tsx
@@ -1,6 +1,4 @@
 // @ts-ignore
-import alertCircleIconSvg from "../../static/images/icon-alert-circle.svg"
-// @ts-ignore
 import blueLineIconSvg from "../../static/images/icon-blue-line.svg"
 // @ts-ignore
 import collapseIconSvg from "../../static/images/icon-caret-left.svg"
@@ -41,9 +39,6 @@ import reverseIconReversedSvg from "../../static/images/icon-reverse-reversed.sv
 // @ts-ignore
 import searchIconSvg from "../../static/images/icon-search.svg"
 import renderSvg from "./renderSvg"
-
-export const alertCircleIcon = (className: string = ""): JSX.Element =>
-  renderSvg(className, alertCircleIconSvg)
 
 export const blueLineIcon = (className: string = ""): JSX.Element =>
   renderSvg(className, blueLineIconSvg)

--- a/assets/static/images/icon-alert-circle.svg
+++ b/assets/static/images/icon-alert-circle.svg
@@ -1,9 +1,0 @@
-<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" class="c-icon-alert-circle">
-  <path d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z" class="c-icon-alert-circle__outline" fill-rule="evenodd"/>
-  <circle cx="24" cy="24" class="c-icon-alert-circle__circle" r="22.59"/>
-  <path d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z" class="c-icon-alert-circle__circle-fill"  fill-rule="evenodd"/>
-  <g class="c-icon-alert-circle__exclamation-point">
-    <path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"/>
-    <path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" fill-rule="evenodd"/>
-  </g>
-</svg>

--- a/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `
+<svg
+  className="c-icon-alert-circle"
+  viewBox="0 0 48 48"
+>
+  <path
+    className="c-icon-alert-circle__outline"
+    d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+  />
+  <circle
+    className="c-icon-alert-circle__circle"
+    cx="24"
+    cy="24"
+    r="22.59"
+  />
+  <path
+    className="c-icon-alert-circle__circle-fill"
+    d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+  />
+  <g
+    className="c-icon-alert-circle__exclamation-point"
+  >
+    <path
+      d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+    />
+    <path
+      d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+    />
+  </g>
+</svg>
+`;
+
+exports[`renders an unwrapped svg node 1`] = `
+<svg>
+  <path
+    className="c-icon-alert-circle__outline"
+    d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+  />
+  <circle
+    className="c-icon-alert-circle__circle"
+    cx="24"
+    cy="24"
+    r="22.59"
+  />
+  <path
+    className="c-icon-alert-circle__circle-fill"
+    d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+  />
+  <g
+    className="c-icon-alert-circle__exclamation-point"
+  >
+    <path
+      d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+    />
+    <path
+      d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+    />
+  </g>
+</svg>
+`;

--- a/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
@@ -3,21 +3,19 @@
 exports[`renders 1`] = `
 <svg
   className="c-icon-alert-circle"
-  viewBox="0 0 48 48"
+  viewBox="-3 -3 54 54"
 >
-  <path
+  <circle
     className="c-icon-alert-circle__outline"
-    d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+    cx="24"
+    cy="24"
+    r="27"
   />
   <circle
-    className="c-icon-alert-circle__circle"
+    className="c-icon-alert-circle__fill"
     cx="24"
     cy="24"
     r="22.59"
-  />
-  <path
-    className="c-icon-alert-circle__circle-fill"
-    d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
   />
   <g
     className="c-icon-alert-circle__exclamation-point"
@@ -34,19 +32,17 @@ exports[`renders 1`] = `
 
 exports[`renders an unwrapped svg node 1`] = `
 <svg>
-  <path
+  <circle
     className="c-icon-alert-circle__outline"
-    d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+    cx="24"
+    cy="24"
+    r="27"
   />
   <circle
-    className="c-icon-alert-circle__circle"
+    className="c-icon-alert-circle__fill"
     cx="24"
     cy="24"
     r="22.59"
-  />
-  <path
-    className="c-icon-alert-circle__circle-fill"
-    d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
   />
   <g
     className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/iconAlertCircle.test.tsx
+++ b/assets/tests/components/iconAlertCircle.test.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import renderer from "react-test-renderer"
+import IconAlertCircle, {
+  IconAlertCircleSvgNode,
+} from "../../src/components/iconAlertCircle"
+
+test("renders", () => {
+  const tree = renderer.create(<IconAlertCircle />).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test("renders an unwrapped svg node", () => {
+  const tree = renderer
+    .create(
+      <svg>
+        <IconAlertCircleSvgNode />
+      </svg>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -9,12 +9,37 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
   >
     <span
       className="m-block-waiver-banner__alert-icon"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "SVG",
-        }
-      }
-    />
+    >
+      <svg
+        className="c-icon-alert-circle"
+        viewBox="0 0 48 48"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </svg>
+    </span>
     <div
       className="m-block-waiver-banner__title"
     >
@@ -76,12 +101,37 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
   >
     <span
       className="m-block-waiver-banner__alert-icon"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "SVG",
-        }
-      }
-    />
+    >
+      <svg
+        className="c-icon-alert-circle"
+        viewBox="0 0 48 48"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </svg>
+    </span>
     <div
       className="m-block-waiver-banner__title"
     >
@@ -143,12 +193,37 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
   >
     <span
       className="m-block-waiver-banner__alert-icon"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "SVG",
-        }
-      }
-    />
+    >
+      <svg
+        className="c-icon-alert-circle"
+        viewBox="0 0 48 48"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </svg>
+    </span>
     <div
       className="m-block-waiver-banner__title"
     >

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -12,21 +12,19 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
     >
       <svg
         className="c-icon-alert-circle"
-        viewBox="0 0 48 48"
+        viewBox="-3 -3 54 54"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -104,21 +102,19 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
     >
       <svg
         className="c-icon-alert-circle"
-        viewBox="0 0 48 48"
+        viewBox="-3 -3 54 54"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -196,21 +192,19 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
     >
       <svg
         className="c-icon-alert-circle"
-        viewBox="0 0 48 48"
+        viewBox="-3 -3 54 54"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -12,12 +12,37 @@ exports[`BlockWaiverList renders 1`] = `
     >
       <span
         className="m-block-waiver-banner__alert-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "SVG",
-          }
-        }
-      />
+      >
+        <svg
+          className="c-icon-alert-circle"
+          viewBox="0 0 48 48"
+        >
+          <path
+            className="c-icon-alert-circle__outline"
+            d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          />
+          <circle
+            className="c-icon-alert-circle__circle"
+            cx="24"
+            cy="24"
+            r="22.59"
+          />
+          <path
+            className="c-icon-alert-circle__circle-fill"
+            d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+          />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
+        </svg>
+      </span>
       <div
         className="m-block-waiver-banner__title"
       >

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -15,21 +15,19 @@ exports[`BlockWaiverList renders 1`] = `
       >
         <svg
           className="c-icon-alert-circle"
-          viewBox="0 0 48 48"
+          viewBox="-3 -3 54 54"
         >
-          <path
+          <circle
             className="c-icon-alert-circle__outline"
-            d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+            cx="24"
+            cy="24"
+            r="27"
           />
           <circle
-            className="c-icon-alert-circle__circle"
+            className="c-icon-alert-circle__fill"
             cx="24"
             cy="24"
             r="22.59"
-          />
-          <path
-            className="c-icon-alert-circle__circle-fill"
-            d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
           />
           <g
             className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -239,21 +239,19 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
         >
           <svg
             className="c-icon-alert-circle"
-            viewBox="0 0 48 48"
+            viewBox="-3 -3 54 54"
           >
-            <path
+            <circle
               className="c-icon-alert-circle__outline"
-              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+              cx="24"
+              cy="24"
+              r="27"
             />
             <circle
-              className="c-icon-alert-circle__circle"
+              className="c-icon-alert-circle__fill"
               cx="24"
               cy="24"
               r="22.59"
-            />
-            <path
-              className="c-icon-alert-circle__circle-fill"
-              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
             />
             <g
               className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -236,12 +236,37 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
       >
         <span
           className="m-block-waiver-banner__alert-icon"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
+        >
+          <svg
+            className="c-icon-alert-circle"
+            viewBox="0 0 48 48"
+          >
+            <path
+              className="c-icon-alert-circle__outline"
+              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+            />
+            <circle
+              className="c-icon-alert-circle__circle"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <path
+              className="c-icon-alert-circle__circle-fill"
+              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </svg>
+        </span>
         <div
           className="m-block-waiver-banner__title"
         >

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -1350,21 +1350,19 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         >
           <svg
             className="c-icon-alert-circle"
-            viewBox="0 0 48 48"
+            viewBox="-3 -3 54 54"
           >
-            <path
+            <circle
               className="c-icon-alert-circle__outline"
-              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+              cx="24"
+              cy="24"
+              r="27"
             />
             <circle
-              className="c-icon-alert-circle__circle"
+              className="c-icon-alert-circle__fill"
               cx="24"
               cy="24"
               r="22.59"
-            />
-            <path
-              className="c-icon-alert-circle__circle-fill"
-              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
             />
             <g
               className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -1347,12 +1347,37 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       >
         <span
           className="m-block-waiver-banner__alert-icon"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
+        >
+          <svg
+            className="c-icon-alert-circle"
+            viewBox="0 0 48 48"
+          >
+            <path
+              className="c-icon-alert-circle__outline"
+              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+            />
+            <circle
+              className="c-icon-alert-circle__circle"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <path
+              className="c-icon-alert-circle__circle-fill"
+              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </svg>
+        </span>
         <div
           className="m-block-waiver-banner__title"
         >

--- a/assets/tests/helpers/icon.test.tsx
+++ b/assets/tests/helpers/icon.test.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import {
-  alertCircleIcon,
   blueLineIcon,
   closeIcon,
   commuterRailIcon,
@@ -16,40 +15,6 @@ import {
   redLineIcon,
   reverseIcon,
 } from "../../src/helpers/icon"
-
-describe("alertCircleIcon", () => {
-  it("renders an icon with a class name", () => {
-    const className = "test-class-name"
-
-    const expected = (
-      <span
-        className={className}
-        dangerouslySetInnerHTML={{
-          __html: "SVG",
-        }}
-      />
-    )
-
-    const result = alertCircleIcon(className)
-
-    expect(result).toEqual(expected)
-  })
-
-  it("renders without a class name", () => {
-    const expected = (
-      <span
-        className=""
-        dangerouslySetInnerHTML={{
-          __html: "SVG",
-        }}
-      />
-    )
-
-    const result = alertCircleIcon()
-
-    expect(result).toEqual(expected)
-  })
-})
 
 describe("blueLineIcon", () => {
   it("renders an icon with a class name", () => {


### PR DESCRIPTION
The big ladder svg can't use an svg from a file, so in order to do [Display block waiver markers on ghost bus ladder icons](https://app.asana.com/0/1148853526253426/1163145000751641) I moved the icon into its own component.

I figured this was a big enough piece to be worth breaking out before the main PR.

Other svg changes:
* Remove the `fill-rule` from the svg. (There's no complex shapes, so it didn't do anything.)
* `<circle class="c-icon-alert-circle__circle"/>` and `<path class="c-icon-alert-circle__circle-fill"/>` were the same shape, so I consolidated them into `__fill`.
* Changed the outline to a circle instead of a path.

User-visible changes:
* Made the outline thicker (radius 24->27).
* Fixed the outline of the grey icon from white (accidentally inherited from the black icon) to light grey.

Screenshots (includes sneak previews of the on-ladder icon, so you can see the new width there).
<img width="407" alt="Screen Shot 2020-03-04 at 16 11 26" src="https://user-images.githubusercontent.com/23065557/75925808-617cc300-5e37-11ea-98fb-ef9a24854d39.png">
<img width="477" alt="Screen Shot 2020-03-04 at 16 12 08" src="https://user-images.githubusercontent.com/23065557/75925813-62155980-5e37-11ea-83a3-a0a6c789080c.png">
<img width="38" alt="Screen Shot 2020-03-04 at 16 11 09" src="https://user-images.githubusercontent.com/23065557/75925846-6c375800-5e37-11ea-912c-b9c39d79b4de.png">

Before:
(You can just barely see that both have a thin white outline.)
<img width="366" alt="Screen Shot 2020-03-04 at 16 50 16" src="https://user-images.githubusercontent.com/23065557/75926328-5b3b1680-5e38-11ea-8a28-0529df527ec3.png">
<img width="364" alt="Screen Shot 2020-03-04 at 16 51 02" src="https://user-images.githubusercontent.com/23065557/75926329-5bd3ad00-5e38-11ea-87c6-6fec18eb93df.png">
