### PR TITLE
Block waiver icon on ladder

### DIFF
--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -80,7 +80,7 @@
       fill: $color-bg-base;
     }
 
-    .c-icon-alert-circle__circle-fill {
+    .c-icon-alert-circle__fill {
       fill: $color-component-dark;
     }
   }
@@ -91,7 +91,7 @@
       fill: $color-bg-base;
     }
 
-    .c-icon-alert-circle__circle-fill {
+    .c-icon-alert-circle__fill {
       fill: $color-component-medium;
     }
   }
@@ -102,7 +102,7 @@
       fill: $color-component-dark;
     }
 
-    .c-icon-alert-circle__circle-fill {
+    .c-icon-alert-circle__fill {
       fill: $color-component-highlight;
     }
 

--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -74,8 +74,41 @@
     }
   }
 
-  &--with-block-waivers {
-    stroke: $black;
+  &--block-waiver-black {
+    .c-icon-alert-circle__outline,
+    .c-icon-alert-circle__exclamation-point {
+      fill: $color-bg-base;
+    }
+
+    .c-icon-alert-circle__circle-fill {
+      fill: $color-component-dark;
+    }
+  }
+
+  &--block-waiver-grey {
+    .c-icon-alert-circle__outline,
+    .c-icon-alert-circle__exclamation-point {
+      fill: $color-bg-base;
+    }
+
+    .c-icon-alert-circle__circle-fill {
+      fill: $color-component-medium;
+    }
+  }
+
+  &--block-waiver-highlighted {
+    .c-icon-alert-circle__outline,
+    .c-icon-alert-circle__exclamation-point {
+      fill: $color-component-dark;
+    }
+
+    .c-icon-alert-circle__circle-fill {
+      fill: $color-component-highlight;
+    }
+
+    .m-ladder__vehicle-label-background {
+      fill: $color-component-highlight;
+    }
   }
 }
 

--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -106,15 +106,10 @@
       fill: $color-component-highlight;
     }
 
-    .m-ladder__vehicle-label-background {
+    .m-vehicle-icon__label-background {
       fill: $color-component-highlight;
     }
   }
-}
-
-.m-ladder__vehicle-label-background {
-  fill: $color-bg-base;
-  stroke: none;
 }
 
 .m-ladder__vehicle-label-text {

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -11,6 +11,7 @@ $color-component-light: $color-bg-medium;
 $color-component-medium: #8b8d91;
 $color-component-dark: #1c1e23;
 $color-component-red: #e45d32;
+$color-component-highlight: #e7ff36;
 
 $color-primary: #586f7c;
 $color-primary-dark: #465863;

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -5,7 +5,10 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { partition } from "../helpers/array"
 import vehicleLabel from "../helpers/vehicleLabel"
 import featureIsEnabled from "../laboratoryFeatures"
-import { hasBlockWaiver } from "../models/blockWaiver"
+import {
+  blockWaiverDecoratorStyle,
+  BlockWaiverDecoratorStyle,
+} from "../models/blockWaiver"
 import {
   LadderDirection,
   orderTimepoints,
@@ -144,15 +147,14 @@ const VehicleSvg = ({
   const { vehicle, x, y, vehicleDirection } = ladderVehicle
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
-  const blockWaiversClass =
-    featureIsEnabled("block_waivers") && hasBlockWaiver(vehicle)
-      ? "m-ladder__vehicle--with-block-waivers"
-      : ""
+  const [hasBlockWaiverIcon, classModifier] = blockWaiverDecoratorClass(vehicle)
+  const blockWaiverClass =
+    classModifier === "" ? "" : `m-ladder__vehicle${classModifier}`
 
   return (
     <g>
       <g
-        className={`m-ladder__vehicle ${selectedClass} ${blockWaiversClass}`}
+        className={`m-ladder__vehicle ${selectedClass} ${blockWaiverClass}`}
         transform={`translate(${x},${y})`}
         onClick={() => dispatch(selectVehicle(associatedVehicleId(vehicle.id)))}
       >
@@ -162,10 +164,26 @@ const VehicleSvg = ({
           label={vehicleLabel(vehicle, settings)}
           variant={vehicle.viaVariant}
           status={drawnStatus(vehicle)}
+          alertIcon={hasBlockWaiverIcon}
         />
       </g>
     </g>
   )
+}
+
+const blockWaiverDecoratorClass = (
+  vehicleOrGhost: VehicleOrGhost
+): [boolean, string] => {
+  switch (blockWaiverDecoratorStyle(vehicleOrGhost)) {
+    case BlockWaiverDecoratorStyle.None:
+      return [false, ""]
+    case BlockWaiverDecoratorStyle.Black:
+      return [true, "--block-waiver-black"]
+    case BlockWaiverDecoratorStyle.Grey:
+      return [true, "--block-waiver-grey"]
+    case BlockWaiverDecoratorStyle.Highlighted:
+      return [true, "--block-waiver-highlighted"]
+  }
 }
 
 // The long vertical lines on the sides of the ladder

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -5,6 +5,7 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { partition } from "../helpers/array"
 import vehicleLabel from "../helpers/vehicleLabel"
 import featureIsEnabled from "../laboratoryFeatures"
+import { hasBlockWaiver } from "../models/blockWaiver"
 import {
   LadderDirection,
   orderTimepoints,
@@ -14,7 +15,7 @@ import {
   LadderVehicle,
   ladderVehiclesFromVehicles,
 } from "../models/ladderVehicle"
-import { hasBlockWaivers, isGhost } from "../models/vehicle"
+import { isGhost } from "../models/vehicle"
 import { drawnStatus, statusClass } from "../models/vehicleStatus"
 import {
   VehicleId,
@@ -144,7 +145,7 @@ const VehicleSvg = ({
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
   const blockWaiversClass =
-    featureIsEnabled("block_waivers") && hasBlockWaivers(vehicle)
+    featureIsEnabled("block_waivers") && hasBlockWaiver(vehicle)
       ? "m-ladder__vehicle--with-block-waivers"
       : ""
 

--- a/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
+++ b/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
@@ -1,31 +1,14 @@
 import React from "react"
+import {
+  CurrentFuturePastType,
+  currentFuturePastType,
+} from "../../models/blockWaiver"
 import { BlockWaiver } from "../../realtime"
-import { now, formattedTime } from "../../util/dateTime"
+import { formattedTime } from "../../util/dateTime"
 import IconAlertCircle from "../iconAlertCircle"
 
 interface Props {
   blockWaiver: BlockWaiver
-}
-
-export enum CurrentFuturePastType {
-  Current = 1,
-  Future,
-  Past,
-}
-
-const currentFuturePastType = ({
-  startTime,
-  endTime,
-}: BlockWaiver): CurrentFuturePastType => {
-  const nowDate = now()
-
-  if (startTime > nowDate) {
-    return CurrentFuturePastType.Future
-  } else if (endTime < nowDate) {
-    return CurrentFuturePastType.Past
-  } else {
-    return CurrentFuturePastType.Current
-  }
 }
 
 const currentFuturePastClass = (blockWaiver: BlockWaiver): string => {

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import featureIsEnabled from "../../laboratoryFeatures"
-import { hasBlockWaivers } from "../../models/vehicle"
+import { hasBlockWaiver } from "../../models/blockWaiver"
 import { Ghost } from "../../realtime"
 import { Route } from "../../schedule"
 import PropertiesList from "../propertiesList"
@@ -16,7 +16,7 @@ const GhostPropertiesPanel = ({ selectedGhost, route }: Props) => (
   <div className="m-ghost-properties-panel">
     <Header vehicle={selectedGhost} route={route} />
 
-    {featureIsEnabled("block_waivers") && hasBlockWaivers(selectedGhost) && (
+    {featureIsEnabled("block_waivers") && hasBlockWaiver(selectedGhost) && (
       <BlockWaiverList blockWaivers={selectedGhost.blockWaivers} />
     )}
 

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -2,11 +2,8 @@ import React, { useState } from "react"
 import useInterval from "../../hooks/useInterval"
 import { useTripShape } from "../../hooks/useShapes"
 import featureIsEnabled from "../../laboratoryFeatures"
-import {
-  hasBlockWaivers,
-  isShuttle,
-  shouldShowHeadwayDiagram,
-} from "../../models/vehicle"
+import { hasBlockWaiver } from "../../models/blockWaiver"
+import { isShuttle, shouldShowHeadwayDiagram } from "../../models/vehicle"
 import { DataDiscrepancy, Vehicle } from "../../realtime"
 import { Route, Shape } from "../../schedule"
 import Map from "../map"
@@ -134,7 +131,7 @@ const VehiclePropertiesPanel = ({ selectedVehicle, route }: Props) => (
 
     {selectedVehicle.isOffCourse && <InvalidBanner />}
 
-    {featureIsEnabled("block_waivers") && hasBlockWaivers(selectedVehicle) && (
+    {featureIsEnabled("block_waivers") && hasBlockWaiver(selectedVehicle) && (
       <BlockWaiverList blockWaivers={selectedVehicle.blockWaivers} />
     )}
 

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { DrawnStatus, statusClass } from "../models/vehicleStatus"
+import { IconAlertCircleSvgNode } from "./iconAlertCircle"
 
 export enum Orientation {
   Up,
@@ -20,6 +21,7 @@ export interface Props {
   label?: string
   variant?: string | null
   status?: DrawnStatus
+  alertIcon?: boolean
 }
 
 /*
@@ -107,6 +109,7 @@ export const VehicleIconSvgNode = ({
   label,
   variant,
   status,
+  alertIcon,
 }: Props) => {
   status = status || "plain"
   variant = variant && variant !== "_" ? variant : undefined
@@ -138,6 +141,13 @@ export const VehicleIconSvgNode = ({
           variant={variant}
           status={status}
         />
+      ) : null}
+      {alertIcon ? (
+        status === "ghost" ? (
+          <AlertCircleIconForGhost orientation={orientation} size={size} />
+        ) : (
+          <AlertCircleIconForTriangle orientation={orientation} size={size} />
+        )
       ) : null}
     </g>
   )
@@ -331,6 +341,54 @@ const Variant = ({
     </text>
   )
 }
+
+const AlertCircleIconForTriangle = ({
+  orientation,
+  size,
+}: {
+  orientation: Orientation
+  size: Size
+}) => {
+  const scale = scaleForSize(size)
+  const [x, y] = rotate(14, 3, orientation)
+  return AlertCircleIcon(x * scale, y * scale)
+}
+
+const rotate = (
+  upX: number,
+  upY: number,
+  orientation: Orientation
+): [number, number] => {
+  switch (orientation) {
+    case Orientation.Up:
+      return [upX, upY]
+    case Orientation.Down:
+      return [-upX, -upY]
+    case Orientation.Left:
+      return [upY, -upX]
+    case Orientation.Right:
+      return [-upY, upX]
+  }
+}
+
+const AlertCircleIconForGhost = ({
+  orientation,
+  size,
+}: {
+  orientation: Orientation
+  size: Size
+}) => {
+  const scale = scaleForSize(size)
+  const y = -10
+  const x = orientation === Orientation.Down ? -15 : 15
+  return AlertCircleIcon(x * scale, y * scale)
+}
+
+const AlertCircleIcon = (x: number, y: number) => (
+  <g transform={`translate(${x}, ${y}) scale(0.2) translate(-24, -24)`}>
+    <IconAlertCircleSvgNode />
+  </g>
+)
 
 const sizeClassSuffix = (size: Size): string => {
   switch (size) {

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -1,0 +1,23 @@
+import { now } from "../util/dateTime"
+import { BlockWaiver } from "../realtime"
+
+export enum CurrentFuturePastType {
+  Current = 1,
+  Future,
+  Past,
+}
+
+export const currentFuturePastType = ({
+  startTime,
+  endTime,
+}: BlockWaiver): CurrentFuturePastType => {
+  const nowDate: Date = now()
+
+  if (startTime > nowDate) {
+    return CurrentFuturePastType.Future
+  } else if (endTime < nowDate) {
+    return CurrentFuturePastType.Past
+  } else {
+    return CurrentFuturePastType.Current
+  }
+}

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -1,5 +1,5 @@
+import { BlockWaiver, VehicleOrGhost } from "../realtime"
 import { now } from "../util/dateTime"
-import { BlockWaiver } from "../realtime"
 
 export enum CurrentFuturePastType {
   Current = 1,
@@ -21,3 +21,6 @@ export const currentFuturePastType = ({
     return CurrentFuturePastType.Current
   }
 }
+
+export const hasBlockWaiver = ({ blockWaivers }: VehicleOrGhost): boolean =>
+  blockWaivers.length !== 0

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -1,5 +1,7 @@
+import featureIsEnabled from "../laboratoryFeatures"
 import { BlockWaiver, VehicleOrGhost } from "../realtime"
 import { now } from "../util/dateTime"
+import { isGhost } from "./vehicle"
 
 export enum CurrentFuturePastType {
   Current = 1,
@@ -24,3 +26,43 @@ export const currentFuturePastType = ({
 
 export const hasBlockWaiver = ({ blockWaivers }: VehicleOrGhost): boolean =>
   blockWaivers.length !== 0
+
+export const hasCurrentBlockWaiver = ({
+  blockWaivers,
+}: VehicleOrGhost): boolean =>
+  blockWaivers.some(
+    blockWaiver =>
+      currentFuturePastType(blockWaiver) === CurrentFuturePastType.Current
+  )
+
+export enum BlockWaiverDecoratorStyle {
+  None = 0,
+  Black,
+  Grey,
+  Highlighted,
+}
+
+/**
+ * has waiver?      | ghost       | vehicle
+ * ---------------- | ----------- | -------
+ * yes, current     | black       | black
+ * yes, not current | highlighted | grey
+ * none             | highlighted | none
+ */
+export const blockWaiverDecoratorStyle = (
+  vehicleOrGhost: VehicleOrGhost
+): BlockWaiverDecoratorStyle => {
+  if (!featureIsEnabled("block_waivers")) {
+    return BlockWaiverDecoratorStyle.None
+  }
+  if (hasCurrentBlockWaiver(vehicleOrGhost)) {
+    return BlockWaiverDecoratorStyle.Black
+  }
+  if (isGhost(vehicleOrGhost)) {
+    return BlockWaiverDecoratorStyle.Highlighted
+  } else {
+    return hasBlockWaiver(vehicleOrGhost)
+      ? BlockWaiverDecoratorStyle.Grey
+      : BlockWaiverDecoratorStyle.None
+  }
+}

--- a/assets/src/models/vehicle.ts
+++ b/assets/src/models/vehicle.ts
@@ -12,9 +12,6 @@ export const isGhost = (
 export const isShuttle = (vehicle: Vehicle): boolean =>
   (vehicle.runId || "").startsWith("999")
 
-export const hasBlockWaivers = ({ blockWaivers }: VehicleOrGhost): boolean =>
-  blockWaivers.length !== 0
-
 export const shouldShowHeadwayDiagram = ({
   headwaySpacing,
   routeStatus,

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -1371,3 +1371,259 @@ exports[`ladder shows schedule line in the other direction 1`] = `
   />
 </div>
 `;
+
+exports[`ladder shows vehicles with block waivers 1`] = `
+<div
+  className="m-ladder"
+  style={
+    Object {
+      "width": 184,
+    }
+  }
+>
+  <svg
+    className="m-ladder__svg"
+    height={0}
+    viewBox="-92 -20 184 0"
+    width={184}
+  >
+    <line
+      className="m-ladder__scheduled-line on-time"
+      x1={-63}
+      x2={40}
+      y1={-25}
+      y2={-55}
+    />
+    <g>
+      <g
+        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-black"
+        onClick={[Function]}
+        transform="translate(63,0)"
+      >
+        <g
+          className="m-vehicle-icon m-vehicle-icon--medium ghost"
+        >
+          <rect
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={11.5}
+          />
+          <text
+            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={17}
+          >
+            0123
+          </text>
+          <g
+            transform="scale(0.4375) translate(-24,-23)"
+          >
+            <path
+              className="m-vehicle-icon__ghost-highlight"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+            <path
+              className="m-vehicle-icon__ghost-body"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+          </g>
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={4.5}
+          >
+            X
+          </text>
+          <g
+            transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
+          >
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
+            />
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g>
+      <g
+        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-grey"
+        onClick={[Function]}
+        transform="translate(-63,-25)"
+      >
+        <g
+          className="m-vehicle-icon m-vehicle-icon--medium on-time"
+        >
+          <rect
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={-22.5}
+          />
+          <text
+            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={-17}
+          >
+            run
+          </text>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(180) translate(-24,-22)"
+          />
+          <g
+            transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
+          >
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
+            />
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <line
+      className="m-ladder__line"
+      x1={-40}
+      x2={-40}
+      y1="0"
+      y2={-40}
+    />
+    <line
+      className="m-ladder__line"
+      x1={40}
+      x2={40}
+      y1="0"
+      y2={-40}
+    />
+    <g
+      className="m-ladder__headway-lines"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-0}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-0}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t0 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-0}
+    >
+      t0
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-20}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-20}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t1 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-20}
+    >
+      t1
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-40}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-40}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t2 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-40}
+    >
+      t2
+    </text>
+  </svg>
+  <div
+    className="__react_component_tooltip place-top type-dark"
+    data-id="tooltip"
+  />
+</div>
+`;

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -1622,7 +1622,7 @@ exports[`ladder shows vehicles with block waivers 1`] = `
     </text>
   </svg>
   <div
-    className="__react_component_tooltip place-top type-dark"
+    className="__react_component_tooltip-304517788 __react_component_tooltip place-top type-dark"
     data-id="tooltip"
   />
 </div>

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -437,19 +437,17 @@ exports[`ladder renders a ghost bus 1`] = `
           <g
             transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
           >
-            <path
+            <circle
               className="c-icon-alert-circle__outline"
-              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+              cx="24"
+              cy="24"
+              r="27"
             />
             <circle
-              className="c-icon-alert-circle__circle"
+              className="c-icon-alert-circle__fill"
               cx="24"
               cy="24"
               r="22.59"
-            />
-            <path
-              className="c-icon-alert-circle__circle-fill"
-              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
             />
             <g
               className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`ladder renders a ghost bus 1`] = `
   >
     <g>
       <g
-        className="m-ladder__vehicle  "
+        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-highlighted"
         onClick={[Function]}
         transform="translate(63,0)"
       >
@@ -434,6 +434,34 @@ exports[`ladder renders a ghost bus 1`] = `
           >
             X
           </text>
+          <g
+            transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
+          >
+            <path
+              className="c-icon-alert-circle__outline"
+              d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+            />
+            <circle
+              className="c-icon-alert-circle__circle"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <path
+              className="c-icon-alert-circle__circle-fill"
+              d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </g>
         </g>
       </g>
     </g>

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -214,6 +214,151 @@ Array [
 ]
 `;
 
+exports[`renders ghost with alert icon 1`] = `
+Array [
+  <svg
+    style={
+      Object {
+        "height": 15.2,
+        "width": 16.72,
+      }
+    }
+    viewBox="-8.36 -7.6 16.72 15.2"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small ghost"
+    >
+      <g
+        transform="scale(0.26599999999999996) translate(-24,-23)"
+      >
+        <path
+          className="m-vehicle-icon__ghost-highlight"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <path
+          className="m-vehicle-icon__ghost-body"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="19.73"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="35.29"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+      </g>
+      <g
+        transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
+    </g>
+  </svg>,
+  <svg
+    style={
+      Object {
+        "height": 25,
+        "width": 27.5,
+      }
+    }
+    viewBox="-13.75 -12.5 27.5 25"
+  >
+    <g
+      className="m-vehicle-icon m-vehicle-icon--medium ghost"
+    >
+      <g
+        transform="scale(0.4375) translate(-24,-23)"
+      >
+        <path
+          className="m-vehicle-icon__ghost-highlight"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <path
+          className="m-vehicle-icon__ghost-body"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="19.73"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="35.29"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+      </g>
+      <g
+        transform="translate(-9.375, -6.25) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
+    </g>
+  </svg>,
+]
+`;
+
 exports[`renders in all directions and sizes 1`] = `
 Array [
   <svg
@@ -608,7 +753,7 @@ Array [
 ]
 `;
 
-exports[`renders with variants and labels 1`] = `
+exports[`renders with variants, labels, and alert icons 1`] = `
 Array [
   <svg
     style={
@@ -654,6 +799,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(5.32, 1.1400000000000001) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -700,6 +873,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-1.1400000000000001, 5.32) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -746,6 +947,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-5.32, -1.1400000000000001) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -792,6 +1021,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(1.1400000000000001, -5.32) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -838,6 +1095,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(8.75, 1.875) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -884,6 +1169,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-1.875, 8.75) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -930,6 +1243,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -976,6 +1317,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(1.875, -8.75) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -1022,6 +1391,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(14, 3) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -1068,6 +1465,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-3, 14) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -1114,6 +1539,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(-14, -3) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
   <svg
@@ -1160,6 +1613,34 @@ Array [
       >
         X
       </text>
+      <g
+        transform="translate(3, -14) scale(0.2) translate(-24, -24)"
+      >
+        <path
+          className="c-icon-alert-circle__outline"
+          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+        />
+        <circle
+          className="c-icon-alert-circle__circle"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <path
+          className="c-icon-alert-circle__circle-fill"
+          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
     </g>
   </svg>,
 ]

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -259,19 +259,17 @@ Array [
       <g
         transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -329,19 +327,17 @@ Array [
       <g
         transform="translate(-9.375, -6.25) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -802,19 +798,17 @@ Array [
       <g
         transform="translate(5.32, 1.1400000000000001) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -876,19 +870,17 @@ Array [
       <g
         transform="translate(-1.1400000000000001, 5.32) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -950,19 +942,17 @@ Array [
       <g
         transform="translate(-5.32, -1.1400000000000001) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1024,19 +1014,17 @@ Array [
       <g
         transform="translate(1.1400000000000001, -5.32) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1098,19 +1086,17 @@ Array [
       <g
         transform="translate(8.75, 1.875) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1172,19 +1158,17 @@ Array [
       <g
         transform="translate(-1.875, 8.75) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1246,19 +1230,17 @@ Array [
       <g
         transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1320,19 +1302,17 @@ Array [
       <g
         transform="translate(1.875, -8.75) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1394,19 +1374,17 @@ Array [
       <g
         transform="translate(14, 3) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1468,19 +1446,17 @@ Array [
       <g
         transform="translate(-3, 14) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1542,19 +1518,17 @@ Array [
       <g
         transform="translate(-14, -3) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"
@@ -1616,19 +1590,17 @@ Array [
       <g
         transform="translate(3, -14) scale(0.2) translate(-24, -24)"
       >
-        <path
+        <circle
           className="c-icon-alert-circle__outline"
-          d="m24 0a24 24 0 1 0 17 7 23.93 23.93 0 0 0 -17-7z"
+          cx="24"
+          cy="24"
+          r="27"
         />
         <circle
-          className="c-icon-alert-circle__circle"
+          className="c-icon-alert-circle__fill"
           cx="24"
           cy="24"
           r="22.59"
-        />
-        <path
-          className="c-icon-alert-circle__circle-fill"
-          d="m23.89 46.59a22.59 22.59 0 1 0 -22.48-22.7 22.59 22.59 0 0 0 22.48 22.7z"
         />
         <g
           className="c-icon-alert-circle__exclamation-point"

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -5,9 +5,15 @@ import Ladder from "../../src/components/ladder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { LadderDirection } from "../../src/models/ladderDirection"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
-import { BlockWaiver, Ghost, Vehicle } from "../../src/realtime.d"
+import {
+  BlockWaiver,
+  Ghost,
+  Vehicle,
+  VehicleOrGhost,
+} from "../../src/realtime.d"
 import { Timepoint } from "../../src/schedule.d"
 import { initialState, selectVehicle } from "../../src/state"
+import * as dateTime from "../../src/util/dateTime"
 
 jest.mock("../../src/laboratoryFeatures", () => ({
   __esModule: true,
@@ -505,6 +511,114 @@ describe("ladder", () => {
           vehiclesAndGhosts={vehicles}
           ladderDirection={ladderDirection}
           selectedVehicleId={"upward"}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("shows vehicles with block waivers", () => {
+    jest
+      .spyOn(dateTime, "now")
+      .mockImplementation(() => new Date("2020-01-01T01:00:00.000Z"))
+    const timepoints: Timepoint[] = [
+      { id: "t0", name: "t0 name" },
+      { id: "t1", name: "t1 name" },
+      { id: "t2", name: "t2 name" },
+    ]
+    const ghostWithBlockWaiver: Ghost = {
+      id: "ghost-trip",
+      directionId: 0,
+      routeId: "route",
+      tripId: "trip",
+      headsign: "headsign",
+      blockId: "block",
+      runId: "123-0123",
+      viaVariant: "X",
+      layoverDepartureTime: null,
+      scheduledTimepointStatus: {
+        timepointId: "t0",
+        fractionUntilTimepoint: 0.0,
+      },
+      routeStatus: "on_route",
+      blockWaivers: [
+        {
+          startTime: new Date("2020-01-01T00:00:00.000Z"),
+          endTime: new Date("2020-01-01T02:00:00.000Z"),
+          remark: "test block waiver",
+        },
+      ],
+    }
+    const vehicleWithOldBlockWaiver: Vehicle = {
+      id: "id",
+      label: "label",
+      runId: "run",
+      timestamp: 0,
+      latitude: 0,
+      longitude: 0,
+      directionId: 1,
+      routeId: "route",
+      tripId: "trip",
+      headsign: null,
+      viaVariant: null,
+      operatorId: "op",
+      operatorName: "JONES",
+      operatorLogonTime: new Date("2018-08-15T13:38:21.000Z"),
+      bearing: 33,
+      blockId: "block",
+      headwaySecs: null,
+      headwaySpacing: null,
+      previousVehicleId: "",
+      scheduleAdherenceSecs: 0,
+      scheduledHeadwaySecs: 120,
+      isOffCourse: false,
+      layoverDepartureTime: null,
+      blockIsActive: true,
+      dataDiscrepancies: [],
+      stopStatus: {
+        stopId: "stop",
+        stopName: "stop",
+      },
+      timepointStatus: {
+        fractionUntilTimepoint: 0.75,
+        timepointId: "t2",
+      },
+      scheduledLocation: {
+        routeId: "route",
+        directionId: 0,
+        tripId: "scheduled trip",
+        runId: "scheduled run",
+        timeSinceTripStartTime: 0,
+        headsign: "scheduled headsign",
+        viaVariant: "scheduled via variant",
+        timepointStatus: {
+          timepointId: "t2",
+          fractionUntilTimepoint: 0.75,
+        },
+      },
+      routeStatus: "on_route",
+      endOfTripType: "another_trip",
+      blockWaivers: [
+        {
+          startTime: new Date("2019-12-31T22:00:00.000Z"),
+          endTime: new Date("2019-12-31T23:00:00.000Z"),
+          remark: "test block waiver",
+        },
+      ],
+    }
+    const vehiclesAndGhosts: VehicleOrGhost[] = [
+      ghostWithBlockWaiver,
+      vehicleWithOldBlockWaiver,
+    ]
+    const ladderDirection = LadderDirection.ZeroToOne
+
+    const tree = renderer
+      .create(
+        <Ladder
+          timepoints={timepoints}
+          vehiclesAndGhosts={vehiclesAndGhosts}
+          ladderDirection={ladderDirection}
         />
       )
       .toJSON()

--- a/assets/tests/components/vehicleIcon.test.tsx
+++ b/assets/tests/components/vehicleIcon.test.tsx
@@ -29,7 +29,7 @@ test("renders in all directions and sizes", () => {
   expect(tree).toMatchSnapshot()
 })
 
-test("renders with variants and labels", () => {
+test("renders with variants, labels, and alert icons", () => {
   const tree = renderer
     .create(
       <>
@@ -38,72 +38,84 @@ test("renders with variants and labels", () => {
           orientation={Orientation.Up}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
+          alertIcon={true}
         />
       </>
     )
@@ -265,6 +277,29 @@ test("ghost going down puts label above it", () => {
     .toJSON()
 
   expect(ghostDownWithlabel).toMatchSnapshot()
+})
+
+test("renders ghost with alert icon", () => {
+  const tree = renderer
+    .create(
+      <>
+        <VehicleIcon
+          size={Size.Small}
+          orientation={Orientation.Up}
+          status={"ghost"}
+          alertIcon={true}
+        />
+        <VehicleIcon
+          size={Size.Medium}
+          orientation={Orientation.Down}
+          status={"ghost"}
+          alertIcon={true}
+        />
+      </>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
 })
 
 test("renders an unwrapped svg node", () => {

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -1,8 +1,9 @@
 import {
   currentFuturePastType,
   CurrentFuturePastType,
+  hasBlockWaiver,
 } from "../../src/models/blockWaiver"
-import { BlockWaiver } from "../../src/realtime"
+import { BlockWaiver, Vehicle } from "../../src/realtime"
 import * as dateTime from "../../src/util/dateTime"
 
 describe("currentFuturePastType", () => {
@@ -41,5 +42,28 @@ describe("currentFuturePastType", () => {
     expect(currentFuturePastType(blockWaiver)).toEqual(
       CurrentFuturePastType.Past
     )
+  })
+})
+
+describe("hasBlockWaiver", () => {
+  test("returns true if the vehicle or ghost has block waivers", () => {
+    const vehicleWithBlockWaivers: Vehicle = {
+      blockWaivers: [
+        {
+          startTime: new Date("1970-01-01T05:05:00.000Z"),
+          endTime: new Date("1970-01-01T12:38:00.000Z"),
+          remark: "test block waiver",
+        },
+      ],
+    } as Vehicle
+
+    expect(hasBlockWaiver(vehicleWithBlockWaivers)).toBeTruthy()
+  })
+
+  test("returns false if the vehicle or ghost has no block waivers", () => {
+    const vehicleWithoutBlockWaivers: Vehicle = {
+      blockWaivers: [] as BlockWaiver[],
+    } as Vehicle
+    expect(hasBlockWaiver(vehicleWithoutBlockWaivers)).toBeFalsy()
   })
 })

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -1,45 +1,56 @@
 import {
+  blockWaiverDecoratorStyle,
+  BlockWaiverDecoratorStyle,
   currentFuturePastType,
   CurrentFuturePastType,
   hasBlockWaiver,
+  hasCurrentBlockWaiver,
 } from "../../src/models/blockWaiver"
 import { BlockWaiver, Vehicle } from "../../src/realtime"
 import * as dateTime from "../../src/util/dateTime"
 
-describe("currentFuturePastType", () => {
-  jest
-    .spyOn(dateTime, "now")
-    .mockImplementation(() => new Date("2020-02-25T16:10:00.000Z"))
+jest.mock("../../src/laboratoryFeatures", () => ({
+  __esModule: true,
+  default: jest.fn(() => true),
+}))
 
+jest
+  .spyOn(dateTime, "now")
+  .mockImplementation(() => new Date("2020-02-25T16:10:00.000Z"))
+
+const currentBlockWaiver: BlockWaiver = {
+  startTime: new Date("2020-02-25T15:53:20.000Z"),
+  endTime: new Date("2020-02-25T16:26:40.000Z"),
+  remark: "E:1106",
+}
+
+const futureBlockWaiver: BlockWaiver = {
+  startTime: new Date("2020-02-25T16:26:40.000Z"),
+  endTime: new Date("2020-02-25T16:43:20.000Z"),
+  remark: "E:1106",
+}
+
+const pastBlockWaiver: BlockWaiver = {
+  startTime: new Date("2020-02-25T15:36:40.000Z"),
+  endTime: new Date("2020-02-25T15:53:20.000Z"),
+  remark: "E:1106",
+}
+
+describe("currentFuturePastType", () => {
   test("returns current for an active waiver", () => {
-    const blockWaiver: BlockWaiver = {
-      startTime: new Date("2020-02-25T15:53:20.000Z"),
-      endTime: new Date("2020-02-25T16:26:40.000Z"),
-      remark: "E:1106",
-    }
-    expect(currentFuturePastType(blockWaiver)).toEqual(
+    expect(currentFuturePastType(currentBlockWaiver)).toEqual(
       CurrentFuturePastType.Current
     )
   })
 
   test("future for a future waiver", () => {
-    const blockWaiver: BlockWaiver = {
-      startTime: new Date("2020-02-25T16:26:40.000Z"),
-      endTime: new Date("2020-02-25T16:43:20.000Z"),
-      remark: "E:1106",
-    }
-    expect(currentFuturePastType(blockWaiver)).toEqual(
+    expect(currentFuturePastType(futureBlockWaiver)).toEqual(
       CurrentFuturePastType.Future
     )
   })
 
   test("renders past for a past waiver", () => {
-    const blockWaiver: BlockWaiver = {
-      startTime: new Date("2020-02-25T15:36:40.000Z"),
-      endTime: new Date("2020-02-25T15:53:20.000Z"),
-      remark: "E:1106",
-    }
-    expect(currentFuturePastType(blockWaiver)).toEqual(
+    expect(currentFuturePastType(pastBlockWaiver)).toEqual(
       CurrentFuturePastType.Past
     )
   })
@@ -48,13 +59,7 @@ describe("currentFuturePastType", () => {
 describe("hasBlockWaiver", () => {
   test("returns true if the vehicle or ghost has block waivers", () => {
     const vehicleWithBlockWaivers: Vehicle = {
-      blockWaivers: [
-        {
-          startTime: new Date("1970-01-01T05:05:00.000Z"),
-          endTime: new Date("1970-01-01T12:38:00.000Z"),
-          remark: "test block waiver",
-        },
-      ],
+      blockWaivers: [currentBlockWaiver],
     } as Vehicle
 
     expect(hasBlockWaiver(vehicleWithBlockWaivers)).toBeTruthy()
@@ -65,5 +70,91 @@ describe("hasBlockWaiver", () => {
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
     expect(hasBlockWaiver(vehicleWithoutBlockWaivers)).toBeFalsy()
+  })
+})
+
+describe("hasCurrentBlockWaiver", () => {
+  test("returns true if the vehicle or ghost has a current block waiver", () => {
+    const vehicleWithBlockWaivers: Vehicle = {
+      blockWaivers: [currentBlockWaiver],
+    } as Vehicle
+
+    expect(hasCurrentBlockWaiver(vehicleWithBlockWaivers)).toBeTruthy()
+  })
+
+  test("returns false if the vehicle or ghost has only non-current block waivers", () => {
+    const vehicleWithoutBlockWaivers: Vehicle = {
+      blockWaivers: [pastBlockWaiver],
+    } as Vehicle
+    expect(hasCurrentBlockWaiver(vehicleWithoutBlockWaivers)).toBeFalsy()
+  })
+
+  test("returns false if the vehicle or ghost has no block waivers", () => {
+    const vehicleWithoutBlockWaivers: Vehicle = {
+      blockWaivers: [] as BlockWaiver[],
+    } as Vehicle
+    expect(hasCurrentBlockWaiver(vehicleWithoutBlockWaivers)).toBeFalsy()
+  })
+})
+
+describe("blockWaiverDecoratorStyle", () => {
+  test("vehicle with no waiver gets no icon", () => {
+    const vehicle = {
+      id: "id",
+      blockWaivers: [] as BlockWaiver[],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.None
+    )
+  })
+
+  test("vehicle with a current waiver gets a black icon", () => {
+    const vehicle = {
+      id: "id",
+      blockWaivers: [currentBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.Black
+    )
+  })
+
+  test("vehicle with a non-current waiver gets a grey icon", () => {
+    const vehicle = {
+      id: "id",
+      blockWaivers: [pastBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.Grey
+    )
+  })
+
+  test("ghost with no waiver gets a highlighted icon", () => {
+    const vehicle = {
+      id: "ghost-id",
+      blockWaivers: [] as BlockWaiver[],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.Highlighted
+    )
+  })
+
+  test("ghost with a current waiver gets a black icon", () => {
+    const vehicle = {
+      id: "ghost-id",
+      blockWaivers: [currentBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.Black
+    )
+  })
+
+  test("ghost with a non-current waiver gets a highlighted icon", () => {
+    const vehicle = {
+      id: "ghost-id",
+      blockWaivers: [pastBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
+      BlockWaiverDecoratorStyle.Highlighted
+    )
   })
 })

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -1,0 +1,45 @@
+import {
+  currentFuturePastType,
+  CurrentFuturePastType,
+} from "../../src/models/blockWaiver"
+import { BlockWaiver } from "../../src/realtime"
+import * as dateTime from "../../src/util/dateTime"
+
+describe("currentFuturePastType", () => {
+  jest
+    .spyOn(dateTime, "now")
+    .mockImplementation(() => new Date("2020-02-25T16:10:00.000Z"))
+
+  test("returns current for an active waiver", () => {
+    const blockWaiver: BlockWaiver = {
+      startTime: new Date("2020-02-25T15:53:20.000Z"),
+      endTime: new Date("2020-02-25T16:26:40.000Z"),
+      remark: "E:1106",
+    }
+    expect(currentFuturePastType(blockWaiver)).toEqual(
+      CurrentFuturePastType.Current
+    )
+  })
+
+  test("future for a future waiver", () => {
+    const blockWaiver: BlockWaiver = {
+      startTime: new Date("2020-02-25T16:26:40.000Z"),
+      endTime: new Date("2020-02-25T16:43:20.000Z"),
+      remark: "E:1106",
+    }
+    expect(currentFuturePastType(blockWaiver)).toEqual(
+      CurrentFuturePastType.Future
+    )
+  })
+
+  test("renders past for a past waiver", () => {
+    const blockWaiver: BlockWaiver = {
+      startTime: new Date("2020-02-25T15:36:40.000Z"),
+      endTime: new Date("2020-02-25T15:53:20.000Z"),
+      remark: "E:1106",
+    }
+    expect(currentFuturePastType(blockWaiver)).toEqual(
+      CurrentFuturePastType.Past
+    )
+  })
+})

--- a/assets/tests/models/vehicle.test.ts
+++ b/assets/tests/models/vehicle.test.ts
@@ -1,5 +1,4 @@
 import {
-  hasBlockWaivers,
   isGhost,
   isShuttle,
   isVehicle,
@@ -136,27 +135,6 @@ describe("isShuttle", () => {
 
     expect(isShuttle(shuttle)).toBeTruthy()
     expect(isShuttle(notShuttle)).toBeFalsy()
-  })
-})
-
-describe("hasBlockWaivers", () => {
-  test("returns true if the vehicle or ghost has block waivers", () => {
-    const vehicleWithBlockWaivers = {
-      ...vehicle,
-      blockWaivers: [
-        {
-          startTime: new Date("1970-01-01T05:05:00.000Z"),
-          endTime: new Date("1970-01-01T12:38:00.000Z"),
-          remark: "test block waiver",
-        },
-      ],
-    }
-
-    expect(hasBlockWaivers(vehicleWithBlockWaivers)).toBeTruthy()
-  })
-
-  test("returns false if the vehicle or ghost has no block waivers", () => {
-    expect(hasBlockWaivers(vehicle)).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
~Built on top of #489 . Once that merges, this PR will be smaller.~

Asana Tasks:
* [Display markers on ghost bus ladder icons for "has waiver" and "does not have waiver"](https://app.asana.com/0/1148853526253426/1163145000751641)
* ~[Display markers on ghost bus laying over icons for "has waiver" and "does not have waiver"](https://app.asana.com/0/1148853526253426/1163145000751643)~
* [Display markers on vehicle ladder icons for "has current waiver" and "has future or past waiver"](https://app.asana.com/0/1148853526253426/1163145000751647)
* ~[Display markers on vehicle laying over icons for "has current waiver" and "has future or past waiver"](https://app.asana.com/0/1148853526253426/1163145000751649)~

It made more sense to do all of the on-ladder icons at once. To keep the size down, I split apart #485 and #489 as separate refactoring PRs instead. Adding the icon to the incoming box will be a separate future PR.

<img width="913" alt="Screen Shot 2020-03-04 at 17 20 36" src="https://user-images.githubusercontent.com/23065557/75928575-b242ea80-5e3c-11ea-81eb-3f96b869dbf8.png">

~I didn't see any block waivers on laying over vehicles right now, but I'll look for those and include a screenshot of them later.~
Edit: icons for laying over vehicles aren't in this PR.