### PR TITLE
fix map on safari

### DIFF
--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -1,5 +1,6 @@
 .m-ladder-page {
   box-sizing: border-box;
+  height: 100%;
   position: relative;
   transition: $transition-slide;
 

--- a/assets/css/_page.scss
+++ b/assets/css/_page.scss
@@ -2,7 +2,6 @@
   height: 100%;
   margin-left: $tab-bar-width;
   overflow: scroll;
-  width: 100%;
 }
 
 .c-page__container {

--- a/assets/css/_route_ladders.scss
+++ b/assets/css/_route_ladders.scss
@@ -11,7 +11,7 @@
     [m-incoming-box] max-content;
   height: 100%;
   max-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
   padding: 1rem;
   // leave space for the picker container tab, which is always visible
   padding-left: 3rem;

--- a/assets/css/_shuttle_map.scss
+++ b/assets/css/_shuttle_map.scss
@@ -2,7 +2,6 @@
   height: 100%;
   position: relative;
   transition: $transition-slide;
-  width: 100%;
 
   .m-picker-container {
     z-index: 620;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -60,12 +60,11 @@ body {
 
 .m-app__banner {
   width: 100%;
-  flex: 0 0 auto;
+  flex: 0 0 0;
 }
 
 .m-app__main {
-  display: flex;
   position: relative;
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
 }


### PR DESCRIPTION
Asana Task: [🐞 Layout issues in Safari](https://app.asana.com/0/1148853526253426/1164221537676417)

`height: 100%` didn't work on children with `flex-basis: auto` in safari

also:
* remove width: 100% that caused the page to be slightly too wide (because of margins)
* hide route ladders scroll bar if the page is narrow (overflow-x: auto)