### PR TITLE
fix iphone height bug

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -39,6 +39,14 @@ $picker-width-wide: $picker-width-narrow + 3.1;
 @import "vehicle_icon";
 @import "vehicle_map";
 
+html,
+body,
+main,
+#app,
+.m-app {
+  height: 100%;
+}
+
 body {
   background-color: $color-bg-base;
   color: $color-font-dark;
@@ -47,7 +55,6 @@ body {
 }
 
 .m-app {
-  height: 100vh;
   display: flex;
   flex-direction: column;
   width: 100vw;


### PR DESCRIPTION
No Asana Task. Fixes an issue raised in #492 

on iphone, 100vh includes height for the address bar,
which causes a small vertical scroll.

using height: 100% instead gives the behavior we want,
where we the address bar doesn't overlap the app,
but it has to be specified all the way up the heirarchy.

Before:
![IMG_0023](https://user-images.githubusercontent.com/23065557/76236504-285f9c80-6203-11ea-9413-e46e4c33ba1a.PNG)

After:
![IMG_0024](https://user-images.githubusercontent.com/23065557/76236514-2d245080-6203-11ea-95e5-d5c13a727933.PNG)

This was a pre-existing issue, even before the safari bug that #492 addresses was introduced in #472. It's currently visible on prod: The route ladder in this screenshot has that small amount of scroll (though before #472, including what's on prod now, the tab bar and route picker avoided the problem by being `fixed`, which is why it became more noticable in #472.)
![IMG_0025](https://user-images.githubusercontent.com/23065557/76236492-239ae880-6203-11ea-982f-00efd2b48b32.PNG)
