### PR TITLE
Block waiver alert icon on laying over and incoming buses.

### DIFF
--- a/assets/css/_icon_alert_circle.scss
+++ b/assets/css/_icon_alert_circle.scss
@@ -1,0 +1,32 @@
+.c-icon-alert-circle--black {
+  .c-icon-alert-circle__outline,
+  .c-icon-alert-circle__exclamation-point {
+    fill: $color-bg-base;
+  }
+
+  .c-icon-alert-circle__fill {
+    fill: $color-component-dark;
+  }
+}
+
+.c-icon-alert-circle--grey {
+  .c-icon-alert-circle__outline,
+  .c-icon-alert-circle__exclamation-point {
+    fill: $color-bg-base;
+  }
+
+  .c-icon-alert-circle__fill {
+    fill: $color-component-medium;
+  }
+}
+
+.c-icon-alert-circle--highlighted {
+  .c-icon-alert-circle__outline,
+  .c-icon-alert-circle__exclamation-point {
+    fill: $color-component-dark;
+  }
+
+  .c-icon-alert-circle__fill {
+    fill: $color-component-highlight;
+  }
+}

--- a/assets/css/_icon_alert_circle.scss
+++ b/assets/css/_icon_alert_circle.scss
@@ -20,6 +20,17 @@
   }
 }
 
+.c-icon-alert-circle--grey-on-grey {
+  .c-icon-alert-circle__outline,
+  .c-icon-alert-circle__exclamation-point {
+    fill: $color-bg-medium;
+  }
+
+  .c-icon-alert-circle__fill {
+    fill: $color-component-medium;
+  }
+}
+
 .c-icon-alert-circle--highlighted {
   .c-icon-alert-circle__outline,
   .c-icon-alert-circle__exclamation-point {

--- a/assets/css/_incoming_box.scss
+++ b/assets/css/_incoming_box.scss
@@ -22,8 +22,16 @@
   &.selected {
     background-color: $color-secondary-medium;
   }
+
+  .c-icon-alert-circle {
+    width: 10px;
+  }
+}
+
+.m-incoming-box__vehicle-icon {
+  margin-right: 0.25rem;
 }
 
 .m-incoming-box__vehicle-label {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }

--- a/assets/css/_incoming_box.scss
+++ b/assets/css/_incoming_box.scss
@@ -24,6 +24,7 @@
   }
 
   .c-icon-alert-circle {
+    margin-bottom: 2px;
     width: 10px;
   }
 }

--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -78,43 +78,6 @@
       fill: $color-secondary-medium;
     }
   }
-
-  &--block-waiver-black {
-    .c-icon-alert-circle__outline,
-    .c-icon-alert-circle__exclamation-point {
-      fill: $color-bg-base;
-    }
-
-    .c-icon-alert-circle__fill {
-      fill: $color-component-dark;
-    }
-  }
-
-  &--block-waiver-grey {
-    .c-icon-alert-circle__outline,
-    .c-icon-alert-circle__exclamation-point {
-      fill: $color-bg-base;
-    }
-
-    .c-icon-alert-circle__fill {
-      fill: $color-component-medium;
-    }
-  }
-
-  &--block-waiver-highlighted {
-    .c-icon-alert-circle__outline,
-    .c-icon-alert-circle__exclamation-point {
-      fill: $color-component-dark;
-    }
-
-    .c-icon-alert-circle__fill {
-      fill: $color-component-highlight;
-    }
-
-    .m-vehicle-icon__label-background {
-      fill: $color-component-highlight;
-    }
-  }
 }
 
 .m-ladder__vehicle-label-text {

--- a/assets/css/_vehicle_icon.scss
+++ b/assets/css/_vehicle_icon.scss
@@ -35,6 +35,10 @@
 
 .m-vehicle-icon__label-background {
   fill: $color-bg-base;
+
+  .m-vehicle-icon--highlighted & {
+    fill: $color-component-highlight;
+  }
 }
 
 .m-vehicle-icon__label {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -12,6 +12,7 @@ $picker-width-wide: $picker-width-narrow + 3.1;
 @import "close_button";
 @import "data_status_banner";
 @import "disconnected_modal";
+@import "icon_alert_circle";
 @import "incoming_box";
 @import "ladder";
 @import "ladder_page";

--- a/assets/css/properties_panel/_block_waiver_banner.scss
+++ b/assets/css/properties_panel/_block_waiver_banner.scss
@@ -27,29 +27,6 @@
   width: 15px;
 }
 
-.m-block-waiver-banner--current {
-  .c-icon-alert-circle__fill {
-    fill: $color-component-dark;
-  }
-
-  .c-icon-alert-circle__outline,
-  .c-icon-alert-circle__exclamation-point {
-    fill: $white;
-  }
-}
-
-.m-block-waiver-banner--future,
-.m-block-waiver-banner--past {
-  .c-icon-alert-circle__fill {
-    fill: $color-component-medium;
-  }
-
-  .c-icon-alert-circle__outline,
-  .c-icon-alert-circle__exclamation-point {
-    fill: $color-bg-medium;
-  }
-}
-
 .m-block-waiver-banner__title {
   @include font-body;
   margin-bottom: 0.8rem;

--- a/assets/css/properties_panel/_ghost_properties_panel.scss
+++ b/assets/css/properties_panel/_ghost_properties_panel.scss
@@ -26,15 +26,6 @@
   display: block;
   margin-right: 0.3rem;
   width: 15px;
-
-  .c-icon-alert-circle__fill {
-    fill: $color-component-highlight;
-  }
-
-  .c-icon-alert-circle__outline,
-  .c-icon-alert-circle__exclamation-point {
-    fill: $color-component-dark;
-  }
 }
 
 .m-ghost-properties-panel__no-waiver-banner-title {

--- a/assets/src/components/iconAlertCircle.tsx
+++ b/assets/src/components/iconAlertCircle.tsx
@@ -3,6 +3,7 @@ import React from "react"
 export enum AlertIconStyle {
   Black = 1,
   Grey,
+  GreyOnGrey,
   Highlighted,
 }
 
@@ -12,6 +13,8 @@ const styleClass = (style: AlertIconStyle): string => {
       return "--black"
     case AlertIconStyle.Grey:
       return "--grey"
+    case AlertIconStyle.GreyOnGrey:
+      return "--grey-on-grey"
     case AlertIconStyle.Highlighted:
       return "--highlighted"
   }

--- a/assets/src/components/iconAlertCircle.tsx
+++ b/assets/src/components/iconAlertCircle.tsx
@@ -1,20 +1,41 @@
 import React from "react"
 
-const IconAlertCircle = () => (
+export enum AlertIconStyle {
+  Black = 1,
+  Grey,
+  Highlighted,
+}
+
+const styleClass = (style: AlertIconStyle): string => {
+  switch (style) {
+    case AlertIconStyle.Black:
+      return "--black"
+    case AlertIconStyle.Grey:
+      return "--grey"
+    case AlertIconStyle.Highlighted:
+      return "--highlighted"
+  }
+}
+
+export interface Props {
+  style: AlertIconStyle
+}
+
+const IconAlertCircle = (props: Props) => (
   <svg viewBox="-3 -3 54 54" className="c-icon-alert-circle">
-    <IconAlertCircleSvgNode />
+    <IconAlertCircleSvgNode {...props} />
   </svg>
 )
 
-export const IconAlertCircleSvgNode = () => (
-  <>
+export const IconAlertCircleSvgNode = ({ style }: Props) => (
+  <g className={`c-icon-alert-circle${styleClass(style)}`}>
     <circle cx="24" cy="24" className="c-icon-alert-circle__outline" r="27" />
     <circle cx="24" cy="24" className="c-icon-alert-circle__fill" r="22.59" />
     <g className="c-icon-alert-circle__exclamation-point">
       <path d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11" />
       <path d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93" />
     </g>
-  </>
+  </g>
 )
 
 export default IconAlertCircle

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -10,7 +10,7 @@ import {
 import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { selectVehicle } from "../state"
-import IconAlertCircle from "./iconAlertCircle"
+import IconAlertCircle, { AlertIconStyle } from "./iconAlertCircle"
 import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
 
 const IncomingBoxVehicle = ({
@@ -30,7 +30,9 @@ const IncomingBoxVehicle = ({
     VehicleDirection.Down
       ? Orientation.Down
       : Orientation.Up
-  const alertIconStyle = blockWaiverDecoratorStyle(vehicleOrGhost)
+  const alertIconStyle: AlertIconStyle | undefined = blockWaiverDecoratorStyle(
+    vehicleOrGhost
+  )
 
   return (
     <button
@@ -45,7 +47,9 @@ const IncomingBoxVehicle = ({
           status={drawnStatus(vehicleOrGhost)}
         />
       </div>
-      {alertIconStyle ? <IconAlertCircle style={alertIconStyle} /> : null}
+      {alertIconStyle === undefined ? null : (
+        <IconAlertCircle style={alertIconStyle} />
+      )}
       <div className="m-incoming-box__vehicle-label">
         {vehicleLabel(vehicleOrGhost, settings)}
       </div>

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -10,6 +10,8 @@ import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { selectVehicle } from "../state"
 import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
+import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
+import IconAlertCircle from "./iconAlertCircle"
 
 const IncomingBoxVehicle = ({
   vehicleOrGhost,
@@ -28,6 +30,7 @@ const IncomingBoxVehicle = ({
     VehicleDirection.Down
       ? Orientation.Down
       : Orientation.Up
+  const alertIconStyle = blockWaiverDecoratorStyle(vehicleOrGhost)
 
   return (
     <button
@@ -42,6 +45,7 @@ const IncomingBoxVehicle = ({
           status={drawnStatus(vehicleOrGhost)}
         />
       </div>
+      {alertIconStyle ? <IconAlertCircle style={alertIconStyle} /> : null}
       <div className="m-incoming-box__vehicle-label">
         {vehicleLabel(vehicleOrGhost, settings)}
       </div>

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import vehicleLabel from "../helpers/vehicleLabel"
-import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
+import { blockWaiverAlertStyle } from "../models/blockWaiver"
 import {
   directionOnLadder,
   LadderDirection,
@@ -30,7 +30,7 @@ const IncomingBoxVehicle = ({
     VehicleDirection.Down
       ? Orientation.Down
       : Orientation.Up
-  const alertIconStyle: AlertIconStyle | undefined = blockWaiverDecoratorStyle(
+  const alertIconStyle: AlertIconStyle | undefined = blockWaiverAlertStyle(
     vehicleOrGhost
   )
 

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -34,12 +34,14 @@ const IncomingBoxVehicle = ({
       className={`m-incoming-box__vehicle ${selectedClass}`}
       onClick={() => dispatch(selectVehicle(vehicleOrGhost.id))}
     >
-      <VehicleIcon
-        size={Size.Small}
-        orientation={orientation}
-        variant={vehicleOrGhost.viaVariant}
-        status={drawnStatus(vehicleOrGhost)}
-      />
+      <div className="m-incoming-box__vehicle-icon">
+        <VehicleIcon
+          size={Size.Small}
+          orientation={orientation}
+          variant={vehicleOrGhost.viaVariant}
+          status={drawnStatus(vehicleOrGhost)}
+        />
+      </div>
       <div className="m-incoming-box__vehicle-label">
         {vehicleLabel(vehicleOrGhost, settings)}
       </div>

--- a/assets/src/components/incomingBox.tsx
+++ b/assets/src/components/incomingBox.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import vehicleLabel from "../helpers/vehicleLabel"
+import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
 import {
   directionOnLadder,
   LadderDirection,
@@ -9,9 +10,8 @@ import {
 import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { selectVehicle } from "../state"
-import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
-import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
 import IconAlertCircle from "./iconAlertCircle"
+import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
 
 const IncomingBoxVehicle = ({
   vehicleOrGhost,

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -5,10 +5,7 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { partition } from "../helpers/array"
 import vehicleLabel from "../helpers/vehicleLabel"
 import featureIsEnabled from "../laboratoryFeatures"
-import {
-  blockWaiverDecoratorStyle,
-  BlockWaiverDecoratorStyle,
-} from "../models/blockWaiver"
+import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
 import {
   LadderDirection,
   orderTimepoints,
@@ -147,14 +144,12 @@ const VehicleSvg = ({
   const { vehicle, x, y, vehicleDirection } = ladderVehicle
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
-  const [hasBlockWaiverIcon, classModifier] = blockWaiverDecoratorClass(vehicle)
-  const blockWaiverClass =
-    classModifier === "" ? "" : `m-ladder__vehicle${classModifier}`
+  const alertIconStyle = blockWaiverDecoratorStyle(vehicle)
 
   return (
     <g>
       <g
-        className={`m-ladder__vehicle ${selectedClass} ${blockWaiverClass}`}
+        className={`m-ladder__vehicle ${selectedClass} `}
         transform={`translate(${x},${y})`}
         onClick={() => dispatch(selectVehicle(associatedVehicleId(vehicle.id)))}
       >
@@ -164,26 +159,11 @@ const VehicleSvg = ({
           label={vehicleLabel(vehicle, settings)}
           variant={vehicle.viaVariant}
           status={drawnStatus(vehicle)}
-          alertIcon={hasBlockWaiverIcon}
+          alertIcon={alertIconStyle}
         />
       </g>
     </g>
   )
-}
-
-const blockWaiverDecoratorClass = (
-  vehicleOrGhost: VehicleOrGhost
-): [boolean, string] => {
-  switch (blockWaiverDecoratorStyle(vehicleOrGhost)) {
-    case BlockWaiverDecoratorStyle.None:
-      return [false, ""]
-    case BlockWaiverDecoratorStyle.Black:
-      return [true, "--block-waiver-black"]
-    case BlockWaiverDecoratorStyle.Grey:
-      return [true, "--block-waiver-grey"]
-    case BlockWaiverDecoratorStyle.Highlighted:
-      return [true, "--block-waiver-highlighted"]
-  }
 }
 
 // The long vertical lines on the sides of the ladder

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -159,7 +159,7 @@ const VehicleSvg = ({
           label={vehicleLabel(vehicle, settings)}
           variant={vehicle.viaVariant}
           status={drawnStatus(vehicle)}
-          alertIcon={alertIconStyle}
+          alertIconStyle={alertIconStyle}
         />
       </g>
     </g>

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -5,7 +5,7 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { partition } from "../helpers/array"
 import vehicleLabel from "../helpers/vehicleLabel"
 import featureIsEnabled from "../laboratoryFeatures"
-import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
+import { blockWaiverAlertStyle } from "../models/blockWaiver"
 import {
   LadderDirection,
   orderTimepoints,
@@ -144,7 +144,7 @@ const VehicleSvg = ({
   const { vehicle, x, y, vehicleDirection } = ladderVehicle
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
   const selectedClass = vehicle.id === selectedVehicleId ? "selected" : ""
-  const alertIconStyle = blockWaiverDecoratorStyle(vehicle)
+  const alertIconStyle = blockWaiverAlertStyle(vehicle)
 
   return (
     <g>

--- a/assets/src/components/layoverBox.tsx
+++ b/assets/src/components/layoverBox.tsx
@@ -39,7 +39,7 @@ const LayoverVehicle = ({
         size={Size.Small}
         status={drawnStatus(vehicleOrGhost)}
         variant={vehicleOrGhost.viaVariant}
-        alertIcon={alertIconStyle}
+        alertIconStyle={alertIconStyle}
       />
     </div>
   )

--- a/assets/src/components/layoverBox.tsx
+++ b/assets/src/components/layoverBox.tsx
@@ -5,7 +5,7 @@ import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleOrGhost } from "../realtime"
 import { selectVehicle } from "../state"
 import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
-import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
+import { blockWaiverAlertStyle } from "../models/blockWaiver"
 
 export enum LayoverBoxPosition {
   Top = 1,
@@ -25,7 +25,7 @@ const LayoverVehicle = ({
   isBottomLayoverBox: boolean
 }): ReactElement<HTMLDivElement> => {
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
-  const alertIconStyle = blockWaiverDecoratorStyle(vehicleOrGhost)
+  const alertIconStyle = blockWaiverAlertStyle(vehicleOrGhost)
 
   return (
     <div

--- a/assets/src/components/layoverBox.tsx
+++ b/assets/src/components/layoverBox.tsx
@@ -5,6 +5,7 @@ import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleOrGhost } from "../realtime"
 import { selectVehicle } from "../state"
 import VehicleIcon, { Orientation, Size } from "./vehicleIcon"
+import { blockWaiverDecoratorStyle } from "../models/blockWaiver"
 
 export enum LayoverBoxPosition {
   Top = 1,
@@ -24,6 +25,7 @@ const LayoverVehicle = ({
   isBottomLayoverBox: boolean
 }): ReactElement<HTMLDivElement> => {
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
+  const alertIconStyle = blockWaiverDecoratorStyle(vehicleOrGhost)
 
   return (
     <div
@@ -37,6 +39,7 @@ const LayoverVehicle = ({
         size={Size.Small}
         status={drawnStatus(vehicleOrGhost)}
         variant={vehicleOrGhost.viaVariant}
+        alertIcon={alertIconStyle}
       />
     </div>
   )

--- a/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
+++ b/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
@@ -40,9 +40,9 @@ const alertIconStyle = (blockWaiver: BlockWaiver): AlertIconStyle => {
     case CurrentFuturePastType.Current:
       return AlertIconStyle.Black
     case CurrentFuturePastType.Future:
-      return AlertIconStyle.Grey
+      return AlertIconStyle.GreyOnGrey
     case CurrentFuturePastType.Past:
-      return AlertIconStyle.Grey
+      return AlertIconStyle.GreyOnGrey
   }
 }
 

--- a/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
+++ b/assets/src/components/propertiesPanel/blockWaiverBanner.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../models/blockWaiver"
 import { BlockWaiver } from "../../realtime"
 import { formattedTime } from "../../util/dateTime"
-import IconAlertCircle from "../iconAlertCircle"
+import IconAlertCircle, { AlertIconStyle } from "../iconAlertCircle"
 
 interface Props {
   blockWaiver: BlockWaiver
@@ -32,6 +32,17 @@ const currentFuturePastTitle = (blockWaiver: BlockWaiver): string => {
       return "Future"
     case CurrentFuturePastType.Past:
       return "Past"
+  }
+}
+
+const alertIconStyle = (blockWaiver: BlockWaiver): AlertIconStyle => {
+  switch (currentFuturePastType(blockWaiver)) {
+    case CurrentFuturePastType.Current:
+      return AlertIconStyle.Black
+    case CurrentFuturePastType.Future:
+      return AlertIconStyle.Grey
+    case CurrentFuturePastType.Past:
+      return AlertIconStyle.Grey
   }
 }
 
@@ -85,7 +96,7 @@ const BlockWaiverBanner = ({ blockWaiver }: Props) => (
   >
     <div className="m-block-waiver-banner__header">
       <span className="m-block-waiver-banner__alert-icon">
-        <IconAlertCircle />
+        <IconAlertCircle style={alertIconStyle(blockWaiver)} />
       </span>
       <div className="m-block-waiver-banner__title">
         Dispatcher Note - {currentFuturePastTitle(blockWaiver)}

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -6,7 +6,7 @@ import { Route } from "../../schedule"
 import PropertiesList from "../propertiesList"
 import BlockWaiverList from "./blockWaiverList"
 import Header from "./header"
-import IconAlertCircle from "../iconAlertCircle"
+import IconAlertCircle, { AlertIconStyle } from "../iconAlertCircle"
 
 interface Props {
   selectedGhost: Ghost
@@ -17,7 +17,7 @@ const NoWaiverBanner = () => (
   <div className="m-ghost-properties-panel__no-waiver-banner">
     <div className="m-ghost-properties-panel__no-waiver-banner-header">
       <span className="m-ghost-properties-panel__no-waiver-banner-alert-icon">
-        <IconAlertCircle />
+        <IconAlertCircle style={AlertIconStyle.Highlighted} />
       </span>
       <div className="m-ghost-properties-panel__no-waiver-banner-title">
         Unknown Ghost Bus - No Dispatcher Note

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { DrawnStatus, statusClass } from "../models/vehicleStatus"
-import { IconAlertCircleSvgNode } from "./iconAlertCircle"
+import { IconAlertCircleSvgNode, AlertIconStyle } from "./iconAlertCircle"
 
 export enum Orientation {
   Up,
@@ -21,7 +21,7 @@ export interface Props {
   label?: string
   variant?: string | null
   status?: DrawnStatus
-  alertIcon?: boolean
+  alertIcon?: AlertIconStyle
 }
 
 /*
@@ -144,9 +144,17 @@ export const VehicleIconSvgNode = ({
       ) : null}
       {alertIcon ? (
         status === "ghost" ? (
-          <AlertCircleIconForGhost orientation={orientation} size={size} />
+          <AlertCircleIconForGhost
+            orientation={orientation}
+            size={size}
+            alertIconStyle={alertIcon}
+          />
         ) : (
-          <AlertCircleIconForTriangle orientation={orientation} size={size} />
+          <AlertCircleIconForTriangle
+            orientation={orientation}
+            size={size}
+            alertIconStyle={alertIcon}
+          />
         )
       ) : null}
     </g>
@@ -345,13 +353,21 @@ const Variant = ({
 const AlertCircleIconForTriangle = ({
   orientation,
   size,
+  alertIconStyle,
 }: {
   orientation: Orientation
   size: Size
+  alertIconStyle: AlertIconStyle
 }) => {
   const scale = scaleForSize(size)
   const [x, y] = rotate(14, 3, orientation)
-  return AlertCircleIcon(x * scale, y * scale)
+  return (
+    <AlertCircleIcon
+      x={x * scale}
+      y={y * scale}
+      alertIconStyle={alertIconStyle}
+    />
+  )
 }
 
 const rotate = (
@@ -374,19 +390,35 @@ const rotate = (
 const AlertCircleIconForGhost = ({
   orientation,
   size,
+  alertIconStyle,
 }: {
   orientation: Orientation
   size: Size
+  alertIconStyle: AlertIconStyle
 }) => {
   const scale = scaleForSize(size)
   const y = -10
   const x = orientation === Orientation.Down ? -15 : 15
-  return AlertCircleIcon(x * scale, y * scale)
+  return (
+    <AlertCircleIcon
+      x={x * scale}
+      y={y * scale}
+      alertIconStyle={alertIconStyle}
+    />
+  )
 }
 
-const AlertCircleIcon = (x: number, y: number) => (
+const AlertCircleIcon = ({
+  x,
+  y,
+  alertIconStyle,
+}: {
+  x: number
+  y: number
+  alertIconStyle: AlertIconStyle
+}) => (
   <g transform={`translate(${x}, ${y}) scale(0.2) translate(-24, -24)`}>
-    <IconAlertCircleSvgNode />
+    <IconAlertCircleSvgNode style={alertIconStyle} />
   </g>
 )
 

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -372,7 +372,7 @@ const alertIconXY = (
     const x = orientation === Orientation.Down ? -15 : 15
     return [x * scale, y * scale]
   } else {
-    let [x, y] = size === Size.Small ? [14, -2] : [14, 3]
+    let [x, y] = size === Size.Small ? [13, -5] : [14, 3]
     ;[x, y] = rotate(x, y, orientation)
     return [x * scale, y * scale]
   }

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -105,10 +105,11 @@ const viewBox = ({
   // expand to fit the alert icon
   if (alertIconStyle !== undefined) {
     const [alertIconX, alertIconY] = alertIconXY(size, orientation, status)
-    left = Math.min(left, alertIconX - ALERT_ICON_RADIUS * 0.2)
-    right = Math.max(right, alertIconX + ALERT_ICON_RADIUS * 0.2)
-    top = Math.min(top, alertIconY - ALERT_ICON_RADIUS * 0.2)
-    bottom = Math.max(bottom, alertIconY + ALERT_ICON_RADIUS * 0.2)
+    const alertIconRadius = ALERT_ICON_RADIUS * alertCircleIconScale(size)
+    left = Math.min(left, alertIconX - alertIconRadius)
+    right = Math.max(right, alertIconX + alertIconRadius)
+    top = Math.min(top, alertIconY - alertIconRadius)
+    bottom = Math.max(bottom, alertIconY + alertIconRadius)
   }
   const width = right - left
   const height = bottom - top
@@ -371,7 +372,8 @@ const alertIconXY = (
     const x = orientation === Orientation.Down ? -15 : 15
     return [x * scale, y * scale]
   } else {
-    const [x, y] = rotate(14, 3, orientation)
+    let [x, y] = size === Size.Small ? [14, -2] : [14, 3]
+    ;[x, y] = rotate(x, y, orientation)
     return [x * scale, y * scale]
   }
 }
@@ -405,11 +407,23 @@ const AlertCircleIcon = ({
   alertIconStyle: AlertIconStyle
 }) => {
   const [x, y] = alertIconXY(size, orientation, status)
+  const scale = alertCircleIconScale(size)
   return (
-    <g transform={`translate(${x}, ${y}) scale(0.2) translate(-24, -24)`}>
+    <g transform={`translate(${x}, ${y}) scale(${scale}) translate(-24, -24)`}>
       <IconAlertCircleSvgNode style={alertIconStyle} />
     </g>
   )
+}
+
+const alertCircleIconScale = (size: Size): number => {
+  switch (size) {
+    case Size.Small:
+      return 0.16
+    case Size.Medium:
+      return 0.2
+    case Size.Large:
+      return 0.3
+  }
 }
 
 const sizeClassSuffix = (size: Size): string => {

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -132,12 +132,16 @@ export const VehicleIconSvgNode = ({
   ) {
     orientation = Orientation.Up
   }
+  const classes: string[] = [
+    "m-vehicle-icon",
+    `m-vehicle-icon${sizeClassSuffix(size)}`,
+    statusClass(status),
+    alertIcon === AlertIconStyle.Highlighted
+      ? "m-vehicle-icon--highlighted"
+      : "",
+  ]
   return (
-    <g
-      className={`m-vehicle-icon m-vehicle-icon${sizeClassSuffix(
-        size
-      )} ${statusClass(status)}`}
-    >
+    <g className={classes.filter(className => className !== "").join(" ")}>
       {label ? (
         <Label size={size} orientation={orientation} label={label} />
       ) : null}

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -21,7 +21,7 @@ export interface Props {
   label?: string
   variant?: string | null
   status?: DrawnStatus
-  alertIcon?: AlertIconStyle
+  alertIconStyle?: AlertIconStyle
 }
 
 /*
@@ -63,7 +63,7 @@ const viewBox = ({
   orientation,
   label,
   status,
-  alertIcon,
+  alertIconStyle,
 }: Props): { left: number; top: number; width: number; height: number } => {
   // shrink the viewbox to fit around the triangle and label
   const scale = scaleForSize(size)
@@ -103,7 +103,7 @@ const viewBox = ({
   left = Math.min(left, -labelBgWidth / 2)
   right = Math.max(right, labelBgWidth / 2)
   // expand to fit the alert icon
-  if (alertIcon !== undefined) {
+  if (alertIconStyle !== undefined) {
     const [alertIconX, alertIconY] = alertIconXY(size, orientation, status)
     left = Math.min(left, alertIconX - ALERT_ICON_RADIUS * 0.2)
     right = Math.max(right, alertIconX + ALERT_ICON_RADIUS * 0.2)
@@ -121,7 +121,7 @@ export const VehicleIconSvgNode = ({
   label,
   variant,
   status,
-  alertIcon,
+  alertIconStyle,
 }: Props) => {
   status = status || "plain"
   variant = variant && variant !== "_" ? variant : undefined
@@ -136,7 +136,7 @@ export const VehicleIconSvgNode = ({
     "m-vehicle-icon",
     `m-vehicle-icon${sizeClassSuffix(size)}`,
     statusClass(status),
-    alertIcon === AlertIconStyle.Highlighted
+    alertIconStyle === AlertIconStyle.Highlighted
       ? "m-vehicle-icon--highlighted"
       : "",
   ]
@@ -159,12 +159,12 @@ export const VehicleIconSvgNode = ({
         />
       ) : null}
 
-      {alertIcon ? (
+      {alertIconStyle ? (
         <AlertCircleIcon
           size={size}
           orientation={orientation}
           status={status}
-          alertIcon={alertIcon}
+          alertIconStyle={alertIconStyle}
         />
       ) : null}
     </g>
@@ -397,17 +397,17 @@ const AlertCircleIcon = ({
   size,
   orientation,
   status,
-  alertIcon,
+  alertIconStyle,
 }: {
   size: Size
   orientation: Orientation
   status: DrawnStatus
-  alertIcon: AlertIconStyle
+  alertIconStyle: AlertIconStyle
 }) => {
   const [x, y] = alertIconXY(size, orientation, status)
   return (
     <g transform={`translate(${x}, ${y}) scale(0.2) translate(-24, -24)`}>
-      <IconAlertCircleSvgNode style={alertIcon} />
+      <IconAlertCircleSvgNode style={alertIconStyle} />
     </g>
   )
 }

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -43,7 +43,7 @@ export const hasCurrentBlockWaiver = ({
  * yes, not current | highlighted | grey
  * none             | highlighted | none
  */
-export const blockWaiverDecoratorStyle = (
+export const blockWaiverAlertStyle = (
   vehicleOrGhost: VehicleOrGhost
 ): AlertIconStyle | undefined => {
   if (!featureIsEnabled("block_waivers")) {

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -2,6 +2,7 @@ import featureIsEnabled from "../laboratoryFeatures"
 import { BlockWaiver, VehicleOrGhost } from "../realtime"
 import { now } from "../util/dateTime"
 import { isGhost } from "./vehicle"
+import { AlertIconStyle } from "../components/iconAlertCircle"
 
 export enum CurrentFuturePastType {
   Current = 1,
@@ -35,13 +36,6 @@ export const hasCurrentBlockWaiver = ({
       currentFuturePastType(blockWaiver) === CurrentFuturePastType.Current
   )
 
-export enum BlockWaiverDecoratorStyle {
-  None = 0,
-  Black,
-  Grey,
-  Highlighted,
-}
-
 /**
  * has waiver?      | ghost       | vehicle
  * ---------------- | ----------- | -------
@@ -51,18 +45,16 @@ export enum BlockWaiverDecoratorStyle {
  */
 export const blockWaiverDecoratorStyle = (
   vehicleOrGhost: VehicleOrGhost
-): BlockWaiverDecoratorStyle => {
+): AlertIconStyle | undefined => {
   if (!featureIsEnabled("block_waivers")) {
-    return BlockWaiverDecoratorStyle.None
+    return undefined
   }
   if (hasCurrentBlockWaiver(vehicleOrGhost)) {
-    return BlockWaiverDecoratorStyle.Black
+    return AlertIconStyle.Black
   }
   if (isGhost(vehicleOrGhost)) {
-    return BlockWaiverDecoratorStyle.Highlighted
+    return AlertIconStyle.Highlighted
   } else {
-    return hasBlockWaiver(vehicleOrGhost)
-      ? BlockWaiverDecoratorStyle.Grey
-      : BlockWaiverDecoratorStyle.None
+    return hasBlockWaiver(vehicleOrGhost) ? AlertIconStyle.Grey : undefined
   }
 }

--- a/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
@@ -99,6 +99,40 @@ exports[`renders grey 1`] = `
 </svg>
 `;
 
+exports[`renders greyOnGrey 1`] = `
+<svg
+  className="c-icon-alert-circle"
+  viewBox="-3 -3 54 54"
+>
+  <g
+    className="c-icon-alert-circle--grey-on-grey"
+  >
+    <circle
+      className="c-icon-alert-circle__outline"
+      cx="24"
+      cy="24"
+      r="27"
+    />
+    <circle
+      className="c-icon-alert-circle__fill"
+      cx="24"
+      cy="24"
+      r="22.59"
+    />
+    <g
+      className="c-icon-alert-circle__exclamation-point"
+    >
+      <path
+        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+      />
+      <path
+        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+      />
+    </g>
+  </g>
+</svg>
+`;
+
 exports[`renders highlighted 1`] = `
 <svg
   className="c-icon-alert-circle"

--- a/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
@@ -1,58 +1,134 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders 1`] = `
-<svg
-  className="c-icon-alert-circle"
-  viewBox="-3 -3 54 54"
->
-  <circle
-    className="c-icon-alert-circle__outline"
-    cx="24"
-    cy="24"
-    r="27"
-  />
-  <circle
-    className="c-icon-alert-circle__fill"
-    cx="24"
-    cy="24"
-    r="22.59"
-  />
+exports[`renders an unwrapped svg node 1`] = `
+<svg>
   <g
-    className="c-icon-alert-circle__exclamation-point"
+    className="c-icon-alert-circle--black"
   >
-    <path
-      d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+    <circle
+      className="c-icon-alert-circle__outline"
+      cx="24"
+      cy="24"
+      r="27"
     />
-    <path
-      d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+    <circle
+      className="c-icon-alert-circle__fill"
+      cx="24"
+      cy="24"
+      r="22.59"
     />
+    <g
+      className="c-icon-alert-circle__exclamation-point"
+    >
+      <path
+        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+      />
+      <path
+        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+      />
+    </g>
   </g>
 </svg>
 `;
 
-exports[`renders an unwrapped svg node 1`] = `
-<svg>
-  <circle
-    className="c-icon-alert-circle__outline"
-    cx="24"
-    cy="24"
-    r="27"
-  />
-  <circle
-    className="c-icon-alert-circle__fill"
-    cx="24"
-    cy="24"
-    r="22.59"
-  />
+exports[`renders black 1`] = `
+<svg
+  className="c-icon-alert-circle"
+  viewBox="-3 -3 54 54"
+>
   <g
-    className="c-icon-alert-circle__exclamation-point"
+    className="c-icon-alert-circle--black"
   >
-    <path
-      d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+    <circle
+      className="c-icon-alert-circle__outline"
+      cx="24"
+      cy="24"
+      r="27"
     />
-    <path
-      d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+    <circle
+      className="c-icon-alert-circle__fill"
+      cx="24"
+      cy="24"
+      r="22.59"
     />
+    <g
+      className="c-icon-alert-circle__exclamation-point"
+    >
+      <path
+        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+      />
+      <path
+        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+      />
+    </g>
+  </g>
+</svg>
+`;
+
+exports[`renders grey 1`] = `
+<svg
+  className="c-icon-alert-circle"
+  viewBox="-3 -3 54 54"
+>
+  <g
+    className="c-icon-alert-circle--grey"
+  >
+    <circle
+      className="c-icon-alert-circle__outline"
+      cx="24"
+      cy="24"
+      r="27"
+    />
+    <circle
+      className="c-icon-alert-circle__fill"
+      cx="24"
+      cy="24"
+      r="22.59"
+    />
+    <g
+      className="c-icon-alert-circle__exclamation-point"
+    >
+      <path
+        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+      />
+      <path
+        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+      />
+    </g>
+  </g>
+</svg>
+`;
+
+exports[`renders highlighted 1`] = `
+<svg
+  className="c-icon-alert-circle"
+  viewBox="-3 -3 54 54"
+>
+  <g
+    className="c-icon-alert-circle--highlighted"
+  >
+    <circle
+      className="c-icon-alert-circle__outline"
+      cx="24"
+      cy="24"
+      r="27"
+    />
+    <circle
+      className="c-icon-alert-circle__fill"
+      cx="24"
+      cy="24"
+      r="22.59"
+    />
+    <g
+      className="c-icon-alert-circle__exclamation-point"
+    >
+      <path
+        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+      />
+      <path
+        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+      />
+    </g>
   </g>
 </svg>
 `;

--- a/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
@@ -8,43 +8,47 @@ exports[`IncomingBox renders a ghost 1`] = `
     className="m-incoming-box__vehicle "
     onClick={[Function]}
   >
-    <svg
-      style={
-        Object {
-          "height": 15.2,
-          "width": 16.72,
-        }
-      }
-      viewBox="-8.36 -7.6 16.72 15.2"
+    <div
+      className="m-incoming-box__vehicle-icon"
     >
-      <g
-        className="m-vehicle-icon m-vehicle-icon--small ghost"
+      <svg
+        style={
+          Object {
+            "height": 15.2,
+            "width": 16.72,
+          }
+        }
+        viewBox="-8.36 -7.6 16.72 15.2"
       >
         <g
-          transform="scale(0.26599999999999996) translate(-24,-23)"
+          className="m-vehicle-icon m-vehicle-icon--small ghost"
         >
-          <path
-            className="m-vehicle-icon__ghost-highlight"
-            d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-            stroke-join="round"
-          />
-          <path
-            className="m-vehicle-icon__ghost-body"
-            d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-            stroke-join="round"
-          />
+          <g
+            transform="scale(0.26599999999999996) translate(-24,-23)"
+          >
+            <path
+              className="m-vehicle-icon__ghost-highlight"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+            <path
+              className="m-vehicle-icon__ghost-body"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-join="round"
+            />
+          </g>
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={3.5999999999999996}
+          >
+            5
+          </text>
         </g>
-        <text
-          className="m-vehicle-icon__variant"
-          dominantBaseline="alphabetic"
-          textAnchor="middle"
-          x={0}
-          y={3.5999999999999996}
-        >
-          5
-        </text>
-      </g>
-    </svg>
+      </svg>
+    </div>
     <div
       className="m-incoming-box__vehicle-label"
     >
@@ -62,34 +66,38 @@ exports[`IncomingBox renders a vehicle 1`] = `
     className="m-incoming-box__vehicle "
     onClick={[Function]}
   >
-    <svg
-      style={
-        Object {
-          "height": 15.2,
-          "width": 16.72,
-        }
-      }
-      viewBox="-8.36 -7.6 16.72 15.2"
+    <div
+      className="m-incoming-box__vehicle-icon"
     >
-      <g
-        className="m-vehicle-icon m-vehicle-icon--small on-time"
+      <svg
+        style={
+          Object {
+            "height": 15.2,
+            "width": 16.72,
+          }
+        }
+        viewBox="-8.36 -7.6 16.72 15.2"
       >
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          transform="scale(0.38) rotate(0) translate(-24,-22)"
-        />
-        <text
-          className="m-vehicle-icon__variant"
-          dominantBaseline="alphabetic"
-          textAnchor="middle"
-          x={0}
-          y={5.6}
+        <g
+          className="m-vehicle-icon m-vehicle-icon--small on-time"
         >
-          5
-        </text>
-      </g>
-    </svg>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.38) rotate(0) translate(-24,-22)"
+          />
+          <text
+            className="m-vehicle-icon__variant"
+            dominantBaseline="alphabetic"
+            textAnchor="middle"
+            x={0}
+            y={5.6}
+          >
+            5
+          </text>
+        </g>
+      </svg>
+    </div>
     <div
       className="m-incoming-box__vehicle-label"
     >

--- a/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
@@ -49,6 +49,37 @@ exports[`IncomingBox renders a ghost 1`] = `
         </g>
       </svg>
     </div>
+    <svg
+      className="c-icon-alert-circle"
+      viewBox="-3 -3 54 54"
+    >
+      <g
+        className="c-icon-alert-circle--highlighted"
+      >
+        <circle
+          className="c-icon-alert-circle__outline"
+          cx="24"
+          cy="24"
+          r="27"
+        />
+        <circle
+          className="c-icon-alert-circle__fill"
+          cx="24"
+          cy="24"
+          r="22.59"
+        />
+        <g
+          className="c-icon-alert-circle__exclamation-point"
+        >
+          <path
+            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          />
+          <path
+            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          />
+        </g>
+      </g>
+    </svg>
     <div
       className="m-incoming-box__vehicle-label"
     >
@@ -79,7 +110,7 @@ exports[`IncomingBox renders a vehicle 1`] = `
         viewBox="-8.36 -7.6 16.72 15.2"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time"
+          className="m-vehicle-icon m-vehicle-icon--small "
         >
           <path
             className="m-vehicle-icon__triangle"

--- a/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`IncomingBox renders a vehicle 1`] = `
         viewBox="-8.36 -7.6 16.72 15.2"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <path
             className="m-vehicle-icon__triangle"

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`ladder renders a ghost bus 1`] = `
   >
     <g>
       <g
-        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-highlighted"
+        className="m-ladder__vehicle  "
         onClick={[Function]}
         transform="translate(63,0)"
       >
@@ -437,27 +437,31 @@ exports[`ladder renders a ghost bus 1`] = `
           <g
             transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
-            />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
-            />
             <g
-              className="c-icon-alert-circle__exclamation-point"
+              className="c-icon-alert-circle--highlighted"
             >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              <circle
+                className="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              <circle
+                className="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
+              <g
+                className="c-icon-alert-circle__exclamation-point"
+              >
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+                />
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+                />
+              </g>
             </g>
           </g>
         </g>
@@ -1396,7 +1400,7 @@ exports[`ladder shows vehicles with block waivers 1`] = `
     />
     <g>
       <g
-        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-black"
+        className="m-ladder__vehicle  "
         onClick={[Function]}
         transform="translate(63,0)"
       >
@@ -1447,27 +1451,31 @@ exports[`ladder shows vehicles with block waivers 1`] = `
           <g
             transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
-            />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
-            />
             <g
-              className="c-icon-alert-circle__exclamation-point"
+              className="c-icon-alert-circle--black"
             >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              <circle
+                className="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              <circle
+                className="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
+              <g
+                className="c-icon-alert-circle__exclamation-point"
+              >
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+                />
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+                />
+              </g>
             </g>
           </g>
         </g>
@@ -1475,7 +1483,7 @@ exports[`ladder shows vehicles with block waivers 1`] = `
     </g>
     <g>
       <g
-        className="m-ladder__vehicle  m-ladder__vehicle--block-waiver-grey"
+        className="m-ladder__vehicle  "
         onClick={[Function]}
         transform="translate(-63,-25)"
       >
@@ -1508,27 +1516,31 @@ exports[`ladder shows vehicles with block waivers 1`] = `
           <g
             transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
-            />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
-            />
             <g
-              className="c-icon-alert-circle__exclamation-point"
+              className="c-icon-alert-circle--grey"
             >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              <circle
+                className="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              <circle
+                className="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
+              <g
+                className="c-icon-alert-circle__exclamation-point"
+              >
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+                />
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+                />
+              </g>
             </g>
           </g>
         </g>

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`ladder filters out vehicles whose block is not active 1`] = `
         transform="translate(-63,-25)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -191,7 +191,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
         transform="translate(-63,-25)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -226,7 +226,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
         transform="translate(63,-30)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -391,7 +391,7 @@ exports[`ladder renders a ghost bus 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium ghost"
+          className="m-vehicle-icon m-vehicle-icon--medium ghost m-vehicle-icon--highlighted"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -590,7 +590,7 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(63,-30)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -625,7 +625,7 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(-87,-25)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -660,7 +660,7 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(-63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -835,7 +835,7 @@ exports[`ladder renders a ladder with no timepoints 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -928,7 +928,7 @@ exports[`ladder renders a reversed ladder 1`] = `
         transform="translate(63,-30)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -1243,7 +1243,7 @@ exports[`ladder shows schedule line in the other direction 1`] = `
         transform="translate(-63,15)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"

--- a/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`LayoverBox renders 1`] = `
       viewBox="-20 -8.36 40 27.72"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--small "
+        className="m-vehicle-icon m-vehicle-icon--small"
       >
         <rect
           className="m-vehicle-icon__label-background"
@@ -60,7 +60,7 @@ exports[`LayoverBox renders 1`] = `
       viewBox="-20 -8.36 40 27.72"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--small "
+        className="m-vehicle-icon m-vehicle-icon--small"
       >
         <rect
           className="m-vehicle-icon__label-background"
@@ -109,7 +109,7 @@ exports[`LayoverBox renders ghost 1`] = `
       viewBox="-20 -9.2 40 27.8"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--small ghost"
+        className="m-vehicle-icon m-vehicle-icon--small ghost m-vehicle-icon--highlighted"
       >
         <rect
           className="m-vehicle-icon__label-background"

--- a/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`LayoverBox renders 1`] = `
       viewBox="-20 -8.36 40 27.72"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--small on-time"
+        className="m-vehicle-icon m-vehicle-icon--small "
       >
         <rect
           className="m-vehicle-icon__label-background"
@@ -60,7 +60,7 @@ exports[`LayoverBox renders 1`] = `
       viewBox="-20 -8.36 40 27.72"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--small on-time"
+        className="m-vehicle-icon m-vehicle-icon--small "
       >
         <rect
           className="m-vehicle-icon__label-background"
@@ -156,6 +156,36 @@ exports[`LayoverBox renders ghost 1`] = `
             rx="3.11"
             ry="3.03"
           />
+        </g>
+        <g
+          transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
+        >
+          <g
+            className="c-icon-alert-circle--highlighted"
+          >
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
+            />
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
+            />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
+          </g>
         </g>
       </g>
     </svg>

--- a/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
@@ -102,11 +102,11 @@ exports[`LayoverBox renders ghost 1`] = `
     <svg
       style={
         Object {
-          "height": 27.8,
+          "height": 26.720000000000002,
           "width": 40,
         }
       }
-      viewBox="-20 -9.2 40 27.8"
+      viewBox="-20 -8.120000000000001 40 26.720000000000002"
     >
       <g
         className="m-vehicle-icon m-vehicle-icon--small ghost m-vehicle-icon--highlighted"
@@ -158,7 +158,7 @@ exports[`LayoverBox renders ghost 1`] = `
           />
         </g>
         <g
-          transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
+          transform="translate(5.7, -3.8) scale(0.16) translate(-24, -24)"
         >
           <g
             className="c-icon-alert-circle--highlighted"

--- a/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
@@ -102,11 +102,11 @@ exports[`LayoverBox renders ghost 1`] = `
     <svg
       style={
         Object {
-          "height": 26.200000000000003,
+          "height": 27.8,
           "width": 40,
         }
       }
-      viewBox="-20 -7.6 40 26.200000000000003"
+      viewBox="-20 -9.2 40 27.8"
     >
       <g
         className="m-vehicle-icon m-vehicle-icon--small ghost"

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -914,34 +914,38 @@ Array [
       className="m-incoming-box__vehicle "
       onClick={[Function]}
     >
-      <svg
-        style={
-          Object {
-            "height": 15.2,
-            "width": 16.72,
-          }
-        }
-        viewBox="-8.36 -7.6 16.72 15.2"
+      <div
+        className="m-incoming-box__vehicle-icon"
       >
-        <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time"
+        <svg
+          style={
+            Object {
+              "height": 15.2,
+              "width": 16.72,
+            }
+          }
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-            transform="scale(0.38) rotate(0) translate(-24,-22)"
-          />
-          <text
-            className="m-vehicle-icon__variant"
-            dominantBaseline="alphabetic"
-            textAnchor="middle"
-            x={0}
-            y={5.6}
+          <g
+            className="m-vehicle-icon m-vehicle-icon--small on-time"
           >
-            4
-          </text>
-        </g>
-      </svg>
+            <path
+              className="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              transform="scale(0.38) rotate(0) translate(-24,-22)"
+            />
+            <text
+              className="m-vehicle-icon__variant"
+              dominantBaseline="alphabetic"
+              textAnchor="middle"
+              x={0}
+              y={5.6}
+            >
+              4
+            </text>
+          </g>
+        </svg>
+      </div>
       <div
         className="m-incoming-box__vehicle-label"
       >
@@ -952,25 +956,29 @@ Array [
       className="m-incoming-box__vehicle "
       onClick={[Function]}
     >
-      <svg
-        style={
-          Object {
-            "height": 15.2,
-            "width": 16.72,
-          }
-        }
-        viewBox="-8.36 -7.6 16.72 15.2"
+      <div
+        className="m-incoming-box__vehicle-icon"
       >
-        <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time"
+        <svg
+          style={
+            Object {
+              "height": 15.2,
+              "width": 16.72,
+            }
+          }
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-            transform="scale(0.38) rotate(180) translate(-24,-22)"
-          />
-        </g>
-      </svg>
+          <g
+            className="m-vehicle-icon m-vehicle-icon--small on-time"
+          >
+            <path
+              className="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              transform="scale(0.38) rotate(180) translate(-24,-22)"
+            />
+          </g>
+        </svg>
+      </div>
       <div
         className="m-incoming-box__vehicle-label"
       >

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
             viewBox="-32 -20 64 64"
           >
             <g
-              className="m-vehicle-icon m-vehicle-icon--large "
+              className="m-vehicle-icon m-vehicle-icon--large"
             >
               <rect
                 className="m-vehicle-icon__label-background"

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -219,11 +219,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 16.799999999999997,
-        "width": 19.46,
+        "height": 15.72,
+        "width": 18.38,
       }
     }
-    viewBox="-8.36 -9.2 19.46 16.799999999999997"
+    viewBox="-8.36 -8.120000000000001 18.38 15.72"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small ghost"
@@ -257,7 +257,7 @@ Array [
         />
       </g>
       <g
-        transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
+        transform="translate(5.7, -3.8) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -804,7 +804,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(5.32, 1.1400000000000001) scale(0.2) translate(-24, -24)"
+        transform="translate(5.32, -0.76) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -880,7 +880,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-1.1400000000000001, 5.32) scale(0.2) translate(-24, -24)"
+        transform="translate(0.76, 5.32) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -956,7 +956,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-5.32, -1.1400000000000001) scale(0.2) translate(-24, -24)"
+        transform="translate(-5.32, 0.76) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -990,11 +990,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 30.08,
+        "height": 29,
         "width": 26,
       }
     }
-    viewBox="-13 -10.72 26 30.08"
+    viewBox="-13 -9.64 26 29"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small"
@@ -1032,7 +1032,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(1.1400000000000001, -5.32) scale(0.2) translate(-24, -24)"
+        transform="translate(-0.76, -5.32) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -1412,7 +1412,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(14, 3) scale(0.2) translate(-24, -24)"
+        transform="translate(14, 3) scale(0.3) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -1488,7 +1488,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-3, 14) scale(0.2) translate(-24, -24)"
+        transform="translate(-3, 14) scale(0.3) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -1564,7 +1564,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-14, -3) scale(0.2) translate(-24, -24)"
+        transform="translate(-14, -3) scale(0.3) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -1598,11 +1598,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 68,
+        "height": 68.1,
         "width": 64,
       }
     }
-    viewBox="-32 -22 64 68"
+    viewBox="-32 -22.1 64 68.1"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--large"
@@ -1640,7 +1640,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(3, -14) scale(0.2) translate(-24, -24)"
+        transform="translate(3, -14) scale(0.3) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -804,7 +804,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(5.32, -0.76) scale(0.16) translate(-24, -24)"
+        transform="translate(4.94, -1.9) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -880,7 +880,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(0.76, 5.32) scale(0.16) translate(-24, -24)"
+        transform="translate(1.9, 4.94) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -956,7 +956,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-5.32, 0.76) scale(0.16) translate(-24, -24)"
+        transform="translate(-4.94, 1.9) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"
@@ -990,11 +990,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 29,
+        "height": 28.62,
         "width": 26,
       }
     }
-    viewBox="-13 -9.64 26 29"
+    viewBox="-13 -9.260000000000002 26 28.62"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small"
@@ -1032,7 +1032,7 @@ Array [
         X
       </text>
       <g
-        transform="translate(-0.76, -5.32) scale(0.16) translate(-24, -24)"
+        transform="translate(-1.9, -4.94) scale(0.16) translate(-24, -24)"
       >
         <g
           className="c-icon-alert-circle--black"

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -259,27 +259,31 @@ Array [
       <g
         transform="translate(5.7, -3.8) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -327,27 +331,31 @@ Array [
       <g
         transform="translate(-9.375, -6.25) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--highlighted"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -798,27 +806,31 @@ Array [
       <g
         transform="translate(5.32, 1.1400000000000001) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -870,27 +882,31 @@ Array [
       <g
         transform="translate(-1.1400000000000001, 5.32) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -942,27 +958,31 @@ Array [
       <g
         transform="translate(-5.32, -1.1400000000000001) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1014,27 +1034,31 @@ Array [
       <g
         transform="translate(1.1400000000000001, -5.32) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1086,27 +1110,31 @@ Array [
       <g
         transform="translate(8.75, 1.875) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1158,27 +1186,31 @@ Array [
       <g
         transform="translate(-1.875, 8.75) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1230,27 +1262,31 @@ Array [
       <g
         transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1302,27 +1338,31 @@ Array [
       <g
         transform="translate(1.875, -8.75) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1374,27 +1414,31 @@ Array [
       <g
         transform="translate(14, 3) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1446,27 +1490,31 @@ Array [
       <g
         transform="translate(-3, 14) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1518,27 +1566,31 @@ Array [
       <g
         transform="translate(-14, -3) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>
@@ -1590,27 +1642,31 @@ Array [
       <g
         transform="translate(3, -14) scale(0.2) translate(-24, -24)"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </g>
     </g>

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -219,11 +219,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 15.2,
-        "width": 16.72,
+        "height": 16.799999999999997,
+        "width": 19.46,
       }
     }
-    viewBox="-8.36 -7.6 16.72 15.2"
+    viewBox="-8.36 -9.2 19.46 16.799999999999997"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small ghost"
@@ -292,10 +292,10 @@ Array [
     style={
       Object {
         "height": 25,
-        "width": 27.5,
+        "width": 28.525,
       }
     }
-    viewBox="-13.75 -12.5 27.5 25"
+    viewBox="-14.775 -12.5 28.525 25"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium ghost"
@@ -990,11 +990,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 27.72,
+        "height": 30.08,
         "width": 26,
       }
     }
-    viewBox="-13 -8.36 26 27.72"
+    viewBox="-13 -10.72 26 30.08"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--small "
@@ -1067,10 +1067,10 @@ Array [
     style={
       Object {
         "height": 36,
-        "width": 27.5,
+        "width": 27.9,
       }
     }
-    viewBox="-13.75 -12.5 27.5 36"
+    viewBox="-13.75 -12.5 27.9 36"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -1219,10 +1219,10 @@ Array [
     style={
       Object {
         "height": 36,
-        "width": 27.5,
+        "width": 27.9,
       }
     }
-    viewBox="-13.75 -23.5 27.5 36"
+    viewBox="-14.15 -23.5 27.9 36"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "
@@ -1294,11 +1294,11 @@ Array [
   <svg
     style={
       Object {
-        "height": 38.5,
+        "height": 38.9,
         "width": 26,
       }
     }
-    viewBox="-13 -13.75 26 38.5"
+    viewBox="-13 -14.15 26 38.9"
   >
     <g
       className="m-vehicle-icon m-vehicle-icon--medium "

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`ghost with variant doesn't have eyes 1`] = `
 exports[`renders an unwrapped svg node 1`] = `
 <svg>
   <g
-    className="m-vehicle-icon m-vehicle-icon--medium "
+    className="m-vehicle-icon m-vehicle-icon--medium"
   >
     <rect
       className="m-vehicle-icon__label-background"
@@ -147,7 +147,7 @@ Array [
     viewBox="-36 -20 72 64"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -184,7 +184,7 @@ Array [
     viewBox="-36 -20 72 64"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -298,7 +298,7 @@ Array [
     viewBox="-14.775 -12.5 28.525 25"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium ghost"
+      className="m-vehicle-icon m-vehicle-icon--medium ghost m-vehicle-icon--highlighted"
     >
       <g
         transform="scale(0.4375) translate(-24,-23)"
@@ -375,7 +375,7 @@ Array [
     viewBox="-8.36 -7.6 16.72 15.2"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -394,7 +394,7 @@ Array [
     viewBox="-7.6 -8.36 15.2 16.72"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -413,7 +413,7 @@ Array [
     viewBox="-8.36 -7.6 16.72 15.2"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -432,7 +432,7 @@ Array [
     viewBox="-7.6 -8.36 15.2 16.72"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -451,7 +451,7 @@ Array [
     viewBox="-13.75 -12.5 27.5 25"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -470,7 +470,7 @@ Array [
     viewBox="-12.5 -13.75 25 27.5"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -489,7 +489,7 @@ Array [
     viewBox="-13.75 -12.5 27.5 25"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -508,7 +508,7 @@ Array [
     viewBox="-12.5 -13.75 25 27.5"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -527,7 +527,7 @@ Array [
     viewBox="-22 -20 44 40"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -546,7 +546,7 @@ Array [
     viewBox="-20 -22 40 44"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -565,7 +565,7 @@ Array [
     viewBox="-22 -20 44 40"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -584,7 +584,7 @@ Array [
     viewBox="-20 -22 40 44"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -726,7 +726,7 @@ Array [
     viewBox="-13.75 -12.5 27.5 25"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -745,7 +745,7 @@ Array [
     viewBox="-13.75 -12.5 27.5 25"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <path
         className="m-vehicle-icon__triangle"
@@ -769,7 +769,7 @@ Array [
     viewBox="-13 -7.6 26 26.200000000000003"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -845,7 +845,7 @@ Array [
     viewBox="-13 -8.36 26 27.72"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -921,7 +921,7 @@ Array [
     viewBox="-13 -18.6 26 26.200000000000003"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -997,7 +997,7 @@ Array [
     viewBox="-13 -10.72 26 30.08"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--small "
+      className="m-vehicle-icon m-vehicle-icon--small"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1073,7 +1073,7 @@ Array [
     viewBox="-13.75 -12.5 27.9 36"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1149,7 +1149,7 @@ Array [
     viewBox="-13 -13.75 26 38.5"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1225,7 +1225,7 @@ Array [
     viewBox="-14.15 -23.5 27.9 36"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1301,7 +1301,7 @@ Array [
     viewBox="-13 -14.15 26 38.9"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium "
+      className="m-vehicle-icon m-vehicle-icon--medium"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1377,7 +1377,7 @@ Array [
     viewBox="-32 -20 64 64"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1453,7 +1453,7 @@ Array [
     viewBox="-32 -22 64 68"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1529,7 +1529,7 @@ Array [
     viewBox="-32 -44 64 64"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"
@@ -1605,7 +1605,7 @@ Array [
     viewBox="-32 -22 64 68"
   >
     <g
-      className="m-vehicle-icon m-vehicle-icon--large "
+      className="m-vehicle-icon m-vehicle-icon--large"
     >
       <rect
         className="m-vehicle-icon__label-background"

--- a/assets/tests/components/iconAlertCircle.test.tsx
+++ b/assets/tests/components/iconAlertCircle.test.tsx
@@ -2,10 +2,27 @@ import React from "react"
 import renderer from "react-test-renderer"
 import IconAlertCircle, {
   IconAlertCircleSvgNode,
+  AlertIconStyle,
 } from "../../src/components/iconAlertCircle"
 
-test("renders", () => {
-  const tree = renderer.create(<IconAlertCircle />).toJSON()
+test("renders black", () => {
+  const tree = renderer
+    .create(<IconAlertCircle style={AlertIconStyle.Black} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test("renders grey", () => {
+  const tree = renderer
+    .create(<IconAlertCircle style={AlertIconStyle.Grey} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test("renders highlighted", () => {
+  const tree = renderer
+    .create(<IconAlertCircle style={AlertIconStyle.Highlighted} />)
+    .toJSON()
   expect(tree).toMatchSnapshot()
 })
 
@@ -13,7 +30,7 @@ test("renders an unwrapped svg node", () => {
   const tree = renderer
     .create(
       <svg>
-        <IconAlertCircleSvgNode />
+        <IconAlertCircleSvgNode style={AlertIconStyle.Black} />
       </svg>
     )
     .toJSON()

--- a/assets/tests/components/iconAlertCircle.test.tsx
+++ b/assets/tests/components/iconAlertCircle.test.tsx
@@ -19,6 +19,13 @@ test("renders grey", () => {
   expect(tree).toMatchSnapshot()
 })
 
+test("renders greyOnGrey", () => {
+  const tree = renderer
+    .create(<IconAlertCircle style={AlertIconStyle.GreyOnGrey} />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
 test("renders highlighted", () => {
   const tree = renderer
     .create(<IconAlertCircle style={AlertIconStyle.Highlighted} />)

--- a/assets/tests/components/incomingBox.test.tsx
+++ b/assets/tests/components/incomingBox.test.tsx
@@ -5,6 +5,11 @@ import { LadderDirection } from "../../src/models/ladderDirection"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { Ghost, Vehicle } from "../../src/realtime"
 
+jest.mock("../../src/laboratoryFeatures", () => ({
+  __esModule: true,
+  default: () => true,
+}))
+
 describe("IncomingBox", () => {
   test("renders empty state", () => {
     const tree = renderer

--- a/assets/tests/components/layoverBox.test.tsx
+++ b/assets/tests/components/layoverBox.test.tsx
@@ -10,6 +10,11 @@ import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { Ghost, Vehicle, VehicleOrGhost } from "../../src/realtime.d"
 import { initialState, selectVehicle } from "../../src/state"
 
+jest.mock("../../src/laboratoryFeatures", () => ({
+  __esModule: true,
+  default: () => true,
+}))
+
 const vehicles: Vehicle[] = [
   {
     id: "y1818",

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -14,27 +14,31 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
         className="c-icon-alert-circle"
         viewBox="-3 -3 54 54"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--black"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </svg>
     </span>
@@ -180,27 +184,31 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         className="c-icon-alert-circle"
         viewBox="-3 -3 54 54"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--grey"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </svg>
     </span>
@@ -346,27 +354,31 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         className="c-icon-alert-circle"
         viewBox="-3 -3 54 54"
       >
-        <circle
-          className="c-icon-alert-circle__outline"
-          cx="24"
-          cy="24"
-          r="27"
-        />
-        <circle
-          className="c-icon-alert-circle__fill"
-          cx="24"
-          cy="24"
-          r="22.59"
-        />
         <g
-          className="c-icon-alert-circle__exclamation-point"
+          className="c-icon-alert-circle--grey"
         >
-          <path
-            d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
+          <g
+            className="c-icon-alert-circle__exclamation-point"
+          >
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            />
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            />
+          </g>
         </g>
       </svg>
     </span>

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         viewBox="-3 -3 54 54"
       >
         <g
-          className="c-icon-alert-circle--grey"
+          className="c-icon-alert-circle--grey-on-grey"
         >
           <circle
             className="c-icon-alert-circle__outline"
@@ -355,7 +355,7 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         viewBox="-3 -3 54 54"
       >
         <g
-          className="c-icon-alert-circle--grey"
+          className="c-icon-alert-circle--grey-on-grey"
         >
           <circle
             className="c-icon-alert-circle__outline"

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`BlockWaiverList renders 1`] = `
           viewBox="-3 -3 54 54"
         >
           <g
-            className="c-icon-alert-circle--grey"
+            className="c-icon-alert-circle--grey-on-grey"
           >
             <circle
               className="c-icon-alert-circle__outline"

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -17,27 +17,31 @@ exports[`BlockWaiverList renders 1`] = `
           className="c-icon-alert-circle"
           viewBox="-3 -3 54 54"
         >
-          <circle
-            className="c-icon-alert-circle__outline"
-            cx="24"
-            cy="24"
-            r="27"
-          />
-          <circle
-            className="c-icon-alert-circle__fill"
-            cx="24"
-            cy="24"
-            r="22.59"
-          />
           <g
-            className="c-icon-alert-circle__exclamation-point"
+            className="c-icon-alert-circle--grey"
           >
-            <path
-              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
             />
-            <path
-              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
             />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
           </g>
         </svg>
       </span>

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             viewBox="-3 -3 54 54"
           >
             <g
-              className="c-icon-alert-circle--grey"
+              className="c-icon-alert-circle--grey-on-grey"
             >
               <circle
                 className="c-icon-alert-circle__outline"

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -112,27 +112,31 @@ exports[`GhostPropertiesPanel renders 1`] = `
           className="c-icon-alert-circle"
           viewBox="-3 -3 54 54"
         >
-          <circle
-            className="c-icon-alert-circle__outline"
-            cx="24"
-            cy="24"
-            r="27"
-          />
-          <circle
-            className="c-icon-alert-circle__fill"
-            cx="24"
-            cy="24"
-            r="22.59"
-          />
           <g
-            className="c-icon-alert-circle__exclamation-point"
+            className="c-icon-alert-circle--highlighted"
           >
-            <path
-              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
             />
-            <path
-              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
             />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
           </g>
         </svg>
       </span>
@@ -286,27 +290,31 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             className="c-icon-alert-circle"
             viewBox="-3 -3 54 54"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
-            />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
-            />
             <g
-              className="c-icon-alert-circle__exclamation-point"
+              className="c-icon-alert-circle--grey"
             >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              <circle
+                className="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              <circle
+                className="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
+              <g
+                className="c-icon-alert-circle__exclamation-point"
+              >
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+                />
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+                />
+              </g>
             </g>
           </svg>
         </span>
@@ -576,27 +584,31 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
           className="c-icon-alert-circle"
           viewBox="-3 -3 54 54"
         >
-          <circle
-            className="c-icon-alert-circle__outline"
-            cx="24"
-            cy="24"
-            r="27"
-          />
-          <circle
-            className="c-icon-alert-circle__fill"
-            cx="24"
-            cy="24"
-            r="22.59"
-          />
           <g
-            className="c-icon-alert-circle__exclamation-point"
+            className="c-icon-alert-circle--highlighted"
           >
-            <path
-              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+            <circle
+              className="c-icon-alert-circle__outline"
+              cx="24"
+              cy="24"
+              r="27"
             />
-            <path
-              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+            <circle
+              className="c-icon-alert-circle__fill"
+              cx="24"
+              cy="24"
+              r="22.59"
             />
+            <g
+              className="c-icon-alert-circle__exclamation-point"
+            >
+              <path
+                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              />
+              <path
+                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              />
+            </g>
           </g>
         </svg>
       </span>

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -466,7 +466,7 @@ exports[`Header renders for a shuttle 1`] = `
       viewBox="-36 -20 72 64"
     >
       <g
-        className="m-vehicle-icon m-vehicle-icon--large "
+        className="m-vehicle-icon m-vehicle-icon--large"
       >
         <rect
           className="m-vehicle-icon__label-background"

--- a/assets/tests/components/propertiesPanel/__snapshots__/headwayDiagram.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/headwayDiagram.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HeadwayDiagram renders a gapped vehicle 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -82,7 +82,7 @@ exports[`HeadwayDiagram renders a gapped vehicle 1`] = `
         viewBox="-13 -13.75 26 38.5"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -141,7 +141,7 @@ exports[`HeadwayDiagram renders a gapped vehicle 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -197,7 +197,7 @@ exports[`HeadwayDiagram renders an ok headway vehicle 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -255,7 +255,7 @@ exports[`HeadwayDiagram renders an ok headway vehicle 1`] = `
         viewBox="-13 -13.75 26 38.5"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -314,7 +314,7 @@ exports[`HeadwayDiagram renders an ok headway vehicle 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -370,7 +370,7 @@ exports[`HeadwayDiagram renders with next and previous vehicles 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -428,7 +428,7 @@ exports[`HeadwayDiagram renders with next and previous vehicles 1`] = `
         viewBox="-13 -13.75 26 38.5"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -487,7 +487,7 @@ exports[`HeadwayDiagram renders with next and previous vehicles 1`] = `
         viewBox="-13 -8.36 26 27.72"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small "
+          className="m-vehicle-icon m-vehicle-icon--small"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -559,7 +559,7 @@ exports[`HeadwayDiagram renders with no next or previous vehicles 1`] = `
         viewBox="-13 -13.75 26 38.5"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium "
+          className="m-vehicle-icon m-vehicle-icon--medium"
         >
           <rect
             className="m-vehicle-icon__label-background"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -1353,7 +1353,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             viewBox="-3 -3 54 54"
           >
             <g
-              className="c-icon-alert-circle--grey"
+              className="c-icon-alert-circle--grey-on-grey"
             >
               <circle
                 className="c-icon-alert-circle__outline"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -1352,27 +1352,31 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             className="c-icon-alert-circle"
             viewBox="-3 -3 54 54"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
-            />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
-            />
             <g
-              className="c-icon-alert-circle__exclamation-point"
+              className="c-icon-alert-circle--grey"
             >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+              <circle
+                className="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+              <circle
+                className="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
+              <g
+                className="c-icon-alert-circle__exclamation-point"
+              >
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
+                />
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
+                />
+              </g>
             </g>
           </svg>
         </span>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -144,7 +144,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -328,7 +328,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -452,7 +452,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -636,7 +636,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -760,7 +760,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -944,7 +944,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
         viewBox="-36 -20 72 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -1063,7 +1063,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
           viewBox="-20 -13.75 40 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -1251,7 +1251,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -1546,7 +1546,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -1730,7 +1730,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -1854,7 +1854,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -2172,7 +2172,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"
@@ -2360,7 +2360,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         viewBox="-32 -20 64 64"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--large "
+          className="m-vehicle-icon m-vehicle-icon--large"
         >
           <rect
             className="m-vehicle-icon__label-background"
@@ -2484,7 +2484,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
           viewBox="-13 -13.75 26 38.5"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium "
+            className="m-vehicle-icon m-vehicle-icon--medium"
           >
             <rect
               className="m-vehicle-icon__label-background"

--- a/assets/tests/components/vehicleIcon.test.tsx
+++ b/assets/tests/components/vehicleIcon.test.tsx
@@ -5,6 +5,7 @@ import VehicleIcon, {
   Size,
   VehicleIconSvgNode,
 } from "../../src/components/vehicleIcon"
+import { AlertIconStyle } from "../../src/components/iconAlertCircle"
 
 test("renders in all directions and sizes", () => {
   const tree = renderer
@@ -38,84 +39,84 @@ test("renders with variants, labels, and alert icons", () => {
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
       </>
     )
@@ -287,13 +288,13 @@ test("renders ghost with alert icon", () => {
           size={Size.Small}
           orientation={Orientation.Up}
           status={"ghost"}
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Down}
           status={"ghost"}
-          alertIcon={true}
+          alertIcon={AlertIconStyle.Highlighted}
         />
       </>
     )

--- a/assets/tests/components/vehicleIcon.test.tsx
+++ b/assets/tests/components/vehicleIcon.test.tsx
@@ -39,84 +39,84 @@ test("renders with variants, labels, and alert icons", () => {
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Small}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Up}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Right}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Down}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Large}
           orientation={Orientation.Left}
           label="0617"
           variant="X"
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
       </>
     )
@@ -288,13 +288,13 @@ test("renders ghost with alert icon", () => {
           size={Size.Small}
           orientation={Orientation.Up}
           status={"ghost"}
-          alertIcon={AlertIconStyle.Black}
+          alertIconStyle={AlertIconStyle.Black}
         />
         <VehicleIcon
           size={Size.Medium}
           orientation={Orientation.Down}
           status={"ghost"}
-          alertIcon={AlertIconStyle.Highlighted}
+          alertIconStyle={AlertIconStyle.Highlighted}
         />
       </>
     )

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -1,6 +1,6 @@
 import { AlertIconStyle } from "../../src/components/iconAlertCircle"
 import {
-  blockWaiverDecoratorStyle,
+  blockWaiverAlertStyle,
   currentFuturePastType,
   CurrentFuturePastType,
   hasBlockWaiver,
@@ -97,13 +97,13 @@ describe("hasCurrentBlockWaiver", () => {
   })
 })
 
-describe("blockWaiverDecoratorStyle", () => {
+describe("blockWaiverAlertStyle", () => {
   test("vehicle with no waiver gets no icon", () => {
     const vehicle = {
       id: "id",
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(undefined)
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(undefined)
   })
 
   test("vehicle with a current waiver gets a black icon", () => {
@@ -111,7 +111,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "id",
       blockWaivers: [currentBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Black)
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Black)
   })
 
   test("vehicle with a non-current waiver gets a grey icon", () => {
@@ -119,7 +119,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "id",
       blockWaivers: [pastBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Grey)
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Grey)
   })
 
   test("ghost with no waiver gets a highlighted icon", () => {
@@ -127,9 +127,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "ghost-id",
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      AlertIconStyle.Highlighted
-    )
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Highlighted)
   })
 
   test("ghost with a current waiver gets a black icon", () => {
@@ -137,7 +135,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "ghost-id",
       blockWaivers: [currentBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Black)
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Black)
   })
 
   test("ghost with a non-current waiver gets a highlighted icon", () => {
@@ -145,8 +143,6 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "ghost-id",
       blockWaivers: [pastBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      AlertIconStyle.Highlighted
-    )
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Highlighted)
   })
 })

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -1,6 +1,6 @@
+import { AlertIconStyle } from "../../src/components/iconAlertCircle"
 import {
   blockWaiverDecoratorStyle,
-  BlockWaiverDecoratorStyle,
   currentFuturePastType,
   CurrentFuturePastType,
   hasBlockWaiver,
@@ -103,9 +103,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "id",
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.None
-    )
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(undefined)
   })
 
   test("vehicle with a current waiver gets a black icon", () => {
@@ -113,9 +111,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "id",
       blockWaivers: [currentBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.Black
-    )
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Black)
   })
 
   test("vehicle with a non-current waiver gets a grey icon", () => {
@@ -123,9 +119,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "id",
       blockWaivers: [pastBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.Grey
-    )
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Grey)
   })
 
   test("ghost with no waiver gets a highlighted icon", () => {
@@ -134,7 +128,7 @@ describe("blockWaiverDecoratorStyle", () => {
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
     expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.Highlighted
+      AlertIconStyle.Highlighted
     )
   })
 
@@ -143,9 +137,7 @@ describe("blockWaiverDecoratorStyle", () => {
       id: "ghost-id",
       blockWaivers: [currentBlockWaiver],
     } as Vehicle
-    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.Black
-    )
+    expect(blockWaiverDecoratorStyle(vehicle)).toEqual(AlertIconStyle.Black)
   })
 
   test("ghost with a non-current waiver gets a highlighted icon", () => {
@@ -154,7 +146,7 @@ describe("blockWaiverDecoratorStyle", () => {
       blockWaivers: [pastBlockWaiver],
     } as Vehicle
     expect(blockWaiverDecoratorStyle(vehicle)).toEqual(
-      BlockWaiverDecoratorStyle.Highlighted
+      AlertIconStyle.Highlighted
     )
   })
 })


### PR DESCRIPTION
Asana Tasks:
[Display markers on vehicle laying over icons for "has current waiver" and "has future or past waiver"](https://app.asana.com/0/1148853526253426/1163145000751649)
[Display markers on ghost bus laying over icons for "has waiver" and "does not have waiver"](https://app.asana.com/0/1148853526253426/1163145000751643)
[Display markers on vehicle incoming icons for "has current waiver" and "has future or past waiver"](https://app.asana.com/0/1148853526253426/1163145000751651)
[Display markers on ghost bus incoming icons for "has waiver" and "does not have waiver"](https://app.asana.com/0/1148853526253426/1163145000751645)

<img width="493" alt="Screen Shot 2020-03-11 at 14 53 09" src="https://user-images.githubusercontent.com/23065557/76453978-30a60c00-63aa-11ea-8ecc-63e68419474f.png">
<img width="233" alt="Screen Shot 2020-03-11 at 15 27 45" src="https://user-images.githubusercontent.com/23065557/76456113-e8d4b400-63ac-11ea-966b-d2873d53de83.png">
<img width="181" alt="Screen Shot 2020-03-11 at 15 28 35" src="https://user-images.githubusercontent.com/23065557/76456167-01dd6500-63ad-11ea-8097-a4b32e9258e3.png">


The actual change is like 6 lines in `layoverBox.tsx` and `incomingBox.tsx`, but there's some stuff that needed to change to make that happen:
* Writing the same classes and css to color the icon in like 4 places was getting a little ridiculous, so I moved the coloring to be an argument passed into the `<IconAlertCircle>` component.
* The viewbox for the vehicle icon needed to be expanded to make room for the extra icon.
* New classes wrap the vehicle icon in the incoming box and around the alert icon. Sorry, these really mess up the snapshot diffs.
* The way the ghosts highlighted the label moved from `ladder.scss` to `vehicle_icon.scss`.