### PR TITLE
fix virtual ghost block waiver alert icon

### DIFF
--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -1,8 +1,8 @@
+import { AlertIconStyle } from "../components/iconAlertCircle"
 import featureIsEnabled from "../laboratoryFeatures"
 import { BlockWaiver, VehicleOrGhost } from "../realtime"
 import { now } from "../util/dateTime"
-import { isGhost } from "./vehicle"
-import { AlertIconStyle } from "../components/iconAlertCircle"
+import { isGhost, isLateVehicleIndicator } from "./vehicle"
 
 export enum CurrentFuturePastType {
   Current = 1,
@@ -37,8 +37,8 @@ export const hasCurrentBlockWaiver = ({
   )
 
 /**
- * has waiver?      | ghost       | vehicle
- * ---------------- | ----------- | -------
+ * has waiver?      | ghost       | vehicle and late indicator ghosts
+ * ---------------- | ----------- | ---------------------------------
  * yes, current     | black       | black
  * yes, not current | highlighted | grey
  * none             | highlighted | none
@@ -52,7 +52,7 @@ export const blockWaiverAlertStyle = (
   if (hasCurrentBlockWaiver(vehicleOrGhost)) {
     return AlertIconStyle.Black
   }
-  if (isGhost(vehicleOrGhost)) {
+  if (isGhost(vehicleOrGhost) && !isLateVehicleIndicator(vehicleOrGhost)) {
     return AlertIconStyle.Highlighted
   } else {
     return hasBlockWaiver(vehicleOrGhost) ? AlertIconStyle.Grey : undefined

--- a/assets/src/models/vehicle.ts
+++ b/assets/src/models/vehicle.ts
@@ -9,6 +9,9 @@ export const isGhost = (
   vehicleOrGhost: VehicleOrGhost
 ): vehicleOrGhost is Ghost => vehicleOrGhost.id.startsWith("ghost")
 
+export const isLateVehicleIndicator = ({ id }: Ghost): boolean =>
+  id.startsWith("ghost-incoming-")
+
 export const isShuttle = (vehicle: Vehicle): boolean =>
   (vehicle.runId || "").startsWith("999")
 

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -123,26 +123,44 @@ describe("blockWaiverAlertStyle", () => {
   })
 
   test("ghost with no waiver gets a highlighted icon", () => {
-    const vehicle = {
+    const ghost = {
       id: "ghost-id",
       blockWaivers: [] as BlockWaiver[],
     } as Vehicle
-    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Highlighted)
+    expect(blockWaiverAlertStyle(ghost)).toEqual(AlertIconStyle.Highlighted)
   })
 
   test("ghost with a current waiver gets a black icon", () => {
-    const vehicle = {
+    const ghost = {
       id: "ghost-id",
       blockWaivers: [currentBlockWaiver],
     } as Vehicle
-    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Black)
+    expect(blockWaiverAlertStyle(ghost)).toEqual(AlertIconStyle.Black)
   })
 
   test("ghost with a non-current waiver gets a highlighted icon", () => {
-    const vehicle = {
+    const ghost = {
       id: "ghost-id",
       blockWaivers: [pastBlockWaiver],
     } as Vehicle
-    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Highlighted)
+    expect(blockWaiverAlertStyle(ghost)).toEqual(AlertIconStyle.Highlighted)
+  })
+
+  test("late indicator ghost whose vehicle has no waiver gets no alert", () => {
+    const lateIndicatorGhost = {
+      id: "ghost-incoming-id",
+      blockWaivers: [] as BlockWaiver[],
+    } as Vehicle
+    expect(blockWaiverAlertStyle(lateIndicatorGhost)).toEqual(undefined)
+  })
+
+  test("late indicator ghost whose vehicle has a waiver gets an alert", () => {
+    const lateIndicatorGhost = {
+      id: "ghost-incoming-id",
+      blockWaivers: [pastBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverAlertStyle(lateIndicatorGhost)).toEqual(
+      AlertIconStyle.Grey
+    )
   })
 })

--- a/assets/tests/models/vehicle.test.ts
+++ b/assets/tests/models/vehicle.test.ts
@@ -1,5 +1,6 @@
 import {
   isGhost,
+  isLateVehicleIndicator,
   isShuttle,
   isVehicle,
   shouldShowHeadwayDiagram,
@@ -125,6 +126,24 @@ describe("isGhost", () => {
 
   test("returns false for a Vehicle", () => {
     expect(isGhost(vehicle)).toBeFalsy()
+  })
+})
+
+describe("isLateVehicleIndicator", () => {
+  test("returns true for a late vehicle indicator", () => {
+    const lateVehicleIndicatorGhost: Ghost = {
+      id: "ghost-incoming-123",
+    } as Ghost
+
+    expect(isLateVehicleIndicator(lateVehicleIndicatorGhost)).toBeTruthy()
+  })
+
+  test("returns false for a normal ghost", () => {
+    const regularGhost: Ghost = {
+      id: "ghost-123",
+    } as Ghost
+
+    expect(isLateVehicleIndicator(regularGhost)).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
Asana Task: [Only show waiver icons on virtual ghosts when a waiver exists](https://app.asana.com/0/1148853526253426/1165660305468153)

virtual ghosts indicating a late vehicle show block waivers alerts like their vehicle, not like a ghost

9028 and 9042 are virtual and don't have the icon anymore. 1181 and 1516 are dropped trips and do get an icon:
<img width="476" alt="Screen Shot 2020-03-12 at 16 42 41" src="https://user-images.githubusercontent.com/23065557/76659400-bb267100-654c-11ea-9981-5e2ab26582a1.png">
<img width="243" alt="Screen Shot 2020-03-12 at 16 43 08" src="https://user-images.githubusercontent.com/23065557/76659404-bbbf0780-654c-11ea-92ac-42725b2eabba.png">
