### PR TITLE
Add "New" indicator to search result cards

### DIFF
--- a/assets/css/_properties_list.scss
+++ b/assets/css/_properties_list.scss
@@ -28,5 +28,9 @@
   .m-properties-list__property--last-login & {
     color: $color-font-grey;
     font-size: 0.75rem;
+
+    .m-search-results__card--new & {
+      color: $color-secondary-dark;
+    }
   }
 }

--- a/assets/css/_properties_list.scss
+++ b/assets/css/_properties_list.scss
@@ -28,9 +28,5 @@
   .m-properties-list__property--last-login & {
     color: $color-font-grey;
     font-size: 0.75rem;
-
-    .m-search-results__card--new & {
-      color: $color-secondary-dark;
-    }
   }
 }

--- a/assets/css/_search_results.scss
+++ b/assets/css/_search_results.scss
@@ -31,6 +31,11 @@
   &--new {
     border: 1px solid $color-secondary-dark;
     box-shadow: 0 2px 4px 0 rgba(77, 182, 172, 0.3);
+
+    .m-properties-list__property--last-login
+      .m-properties-list__property-value {
+      color: $color-secondary-dark;
+    }
   }
 
   .m-properties-list {

--- a/assets/css/_search_results.scss
+++ b/assets/css/_search_results.scss
@@ -17,6 +17,7 @@
   cursor: pointer;
   margin-bottom: 1rem;
   padding: 1rem 1rem 0.5rem;
+  position: relative;
 
   &--selected,
   &:hover {
@@ -27,9 +28,32 @@
     }
   }
 
+  &--new {
+    border: 1px solid $color-secondary-dark;
+  }
+
   .m-properties-list {
     padding: 0;
   }
+}
+
+.m-search-results__card-new-badge {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}
+
+.m-search-results__card-new-badge-label {
+  @include font-label;
+  color: $color-secondary-dark;
+}
+
+.m-search-results__card-new-badge-icon {
+  display: inline-block;
+  fill: $color-secondary-dark;
+  margin-left: 0.3rem;
+  stroke: none;
+  width: 9px;
 }
 
 .m-search-results__card-route-label {

--- a/assets/css/_search_results.scss
+++ b/assets/css/_search_results.scss
@@ -30,6 +30,7 @@
 
   &--new {
     border: 1px solid $color-secondary-dark;
+    box-shadow: 0 2px 4px 0 rgba(77, 182, 172, 0.3);
   }
 
   .m-properties-list {

--- a/assets/src/components/searchResults.tsx
+++ b/assets/src/components/searchResults.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { isVehicle } from "../models/vehicle"
+import { className } from "../helpers/dom"
+import { isVehicle, isRecentlyLoggedOn } from "../models/vehicle"
 import { Vehicle, VehicleOrGhost } from "../realtime"
 import { selectVehicle } from "../state"
 import { setSearchText } from "../state/searchPageState"
@@ -16,6 +17,17 @@ const SearchResultsNote = () => (
     Please note that at this time search is limited to active vehicles and
     logged-in personnel.
   </p>
+)
+
+const NewBadge = () => (
+  <div className="m-search-results__card-new-badge">
+    <span className="m-search-results__card-new-badge-label">New</span>
+    <span className="m-search-results__card-new-badge-icon">
+      <svg viewBox="0 0 9 9" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="4.5" cy="4.5" r="4.5" />
+      </svg>
+    </span>
+  </div>
 )
 
 const RouteLabel = ({ vehicle }: { vehicle: Vehicle }) => (
@@ -37,18 +49,20 @@ const SearchResultCard = ({
     dispatch,
   ] = useContext(StateDispatchContext)
 
-  const selectedClass =
+  const classes = [
+    "m-search-results__card",
     vehicleOrGhost.id === selectedVehicleId
       ? "m-search-results__card--selected"
-      : ""
+      : "",
+    isRecentlyLoggedOn(vehicleOrGhost) ? "m-search-results__card--new" : "",
+  ]
 
   const selectVehicleOrGhost = () => dispatch(selectVehicle(vehicleOrGhost.id))
 
   return (
-    <div
-      className={`m-search-results__card ${selectedClass}`}
-      onClick={selectVehicleOrGhost}
-    >
+    <div className={className(classes)} onClick={selectVehicleOrGhost}>
+      {isRecentlyLoggedOn(vehicleOrGhost) && <NewBadge />}
+
       <PropertiesList
         vehicleOrGhost={vehicleOrGhost}
         highlightText={query.text}

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { className } from "../helpers/dom"
 import { DrawnStatus, statusClass } from "../models/vehicleStatus"
 import { IconAlertCircleSvgNode, AlertIconStyle } from "./iconAlertCircle"
 
@@ -142,7 +143,7 @@ export const VehicleIconSvgNode = ({
       : "",
   ]
   return (
-    <g className={classes.filter(className => className !== "").join(" ")}>
+    <g className={className(classes)}>
       {label ? (
         <Label size={size} orientation={orientation} label={label} />
       ) : null}

--- a/assets/src/helpers/dom.ts
+++ b/assets/src/helpers/dom.ts
@@ -1,0 +1,2 @@
+export const className = (classes: string[]): string =>
+  classes.filter(c => c !== "").join(" ")

--- a/assets/src/models/vehicle.ts
+++ b/assets/src/models/vehicle.ts
@@ -1,5 +1,6 @@
 import featureIsEnabled from "../laboratoryFeatures"
 import { Ghost, Vehicle, VehicleOrGhost } from "../realtime"
+import { now } from "../util/dateTime"
 
 export const isVehicle = (
   vehicleOrGhost: VehicleOrGhost
@@ -14,6 +15,18 @@ export const isLateVehicleIndicator = ({ id }: Ghost): boolean =>
 
 export const isShuttle = (vehicle: Vehicle): boolean =>
   (vehicle.runId || "").startsWith("999")
+
+export const isRecentlyLoggedOn = (vehicleOrGhost: VehicleOrGhost): boolean => {
+  if (isGhost(vehicleOrGhost) || !vehicleOrGhost.operatorLogonTime) {
+    return false
+  }
+
+  const thirtyMinutesInMs = 30 * 60 * 1000
+  const timeDiffInMs =
+    now().valueOf() - vehicleOrGhost.operatorLogonTime.valueOf()
+
+  return timeDiffInMs <= thirtyMinutesInMs
+}
 
 export const shouldShowHeadwayDiagram = ({
   headwaySpacing,

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
     className="m-search-results__list"
   >
     <div
-      className="m-search-results__card "
+      className="m-search-results__card"
       onClick={[Function]}
     >
       <div
@@ -37,7 +37,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
       </div>
     </div>
     <div
-      className="m-search-results__card "
+      className="m-search-results__card"
       onClick={[Function]}
     >
       <div
@@ -138,7 +138,7 @@ exports[`SearchResults renders a selected result card 1`] = `
     className="m-search-results__list"
   >
     <div
-      className="m-search-results__card "
+      className="m-search-results__card"
       onClick={[Function]}
     >
       <div
@@ -288,6 +288,130 @@ exports[`SearchResults renders no results 1`] = `
     >
       Clear search
     </button>
+  </div>
+</div>
+`;
+
+exports[`SearchResults renders vehicles that have logged in within the past 30 minutes 1`] = `
+<div
+  className="m-search-results"
+>
+  <div
+    className="m-search-results__list"
+  >
+    <div
+      className="m-search-results__card m-search-results__card--new"
+      onClick={[Function]}
+    >
+      <div
+        className="m-search-results__card-new-badge"
+      >
+        <span
+          className="m-search-results__card-new-badge-label"
+        >
+          New
+        </span>
+        <span
+          className="m-search-results__card-new-badge-icon"
+        >
+          <svg
+            viewBox="0 0 9 9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="4.5"
+              cy="4.5"
+              r="4.5"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        className="m-properties-list"
+      >
+        <table
+          className="m-properties-list__table"
+        >
+          <tbody>
+            <tr
+              className="m-properties-list__property "
+            >
+              <td
+                className="m-properties-list__property-label"
+              >
+                Run
+              </td>
+              <td
+                className="m-properties-list__property-value"
+              >
+                run-1
+              </td>
+            </tr>
+            <tr
+              className="m-properties-list__property "
+            >
+              <td
+                className="m-properties-list__property-label"
+              >
+                Vehicle
+              </td>
+              <td
+                className="m-properties-list__property-value"
+              >
+                v1-label
+              </td>
+            </tr>
+            <tr
+              className="m-properties-list__property "
+            >
+              <td
+                className="m-properties-list__property-label"
+              >
+                Operator
+              </td>
+              <td
+                className="m-properties-list__property-value"
+              >
+                SMITH #op1
+              </td>
+            </tr>
+            <tr
+              className="m-properties-list__property m-properties-list__property--last-login"
+            >
+              <td
+                className="m-properties-list__property-label"
+              >
+                Last Login
+              </td>
+              <td
+                className="m-properties-list__property-value"
+              >
+                1m; 5:40pm
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        className="m-search-results__card-route-label"
+      >
+        <div
+          className="m-route-variant-name"
+        >
+          <span
+            className="m-route-variant-name__route-id"
+          >
+            39_X
+          </span>
+           Forest Hills
+        </div>
+      </div>
+    </div>
+    <p
+      className="m-search-results__note"
+    >
+      Please note that at this time search is limited to active vehicles and logged-in personnel.
+    </p>
   </div>
 </div>
 `;

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`SearchResults renders no results 1`] = `
 </div>
 `;
 
-exports[`SearchResults renders vehicles that have logged in within the past 30 minutes 1`] = `
+exports[`SearchResults shows the new badge for vehicle that have logged in within the past 30 minutes 1`] = `
 <div
   className="m-search-results"
 >

--- a/assets/tests/components/searchResults.test.tsx
+++ b/assets/tests/components/searchResults.test.tsx
@@ -120,6 +120,72 @@ describe("SearchResults", () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test("renders vehicles that have logged in within the past 30 minutes", () => {
+    const vehicle: Vehicle = {
+      id: "v1",
+      label: "v1-label",
+      runId: "run-1",
+      timestamp: 123,
+      latitude: 0,
+      longitude: 0,
+      directionId: 0,
+      routeId: "39",
+      tripId: "t1",
+      headsign: "Forest Hills",
+      viaVariant: "X",
+      operatorId: "op1",
+      operatorName: "SMITH",
+      operatorLogonTime: new Date("2018-08-15T17:40:21.000Z"),
+      bearing: 33,
+      blockId: "block-1",
+      headwaySecs: 859.1,
+      headwaySpacing: HeadwaySpacing.Ok,
+      previousVehicleId: "v2",
+      scheduleAdherenceSecs: 0,
+      scheduledHeadwaySecs: 120,
+      isOffCourse: false,
+      layoverDepartureTime: null,
+      blockIsActive: false,
+      dataDiscrepancies: [
+        {
+          attribute: "trip_id",
+          sources: [
+            {
+              id: "swiftly",
+              value: "swiftly-trip-id",
+            },
+            {
+              id: "busloc",
+              value: "busloc-trip-id",
+            },
+          ],
+        },
+      ],
+      stopStatus: {
+        stopId: "s1",
+        stopName: "Stop Name",
+      },
+      timepointStatus: {
+        fractionUntilTimepoint: 0.5,
+        timepointId: "tp1",
+      },
+      scheduledLocation: null,
+      routeStatus: "on_route",
+      endOfTripType: "another_trip",
+      blockWaivers: [],
+    }
+
+    const tree = renderer
+      .create(
+        <StateDispatchProvider state={state} dispatch={jest.fn()}>
+          <SearchResults vehicles={[vehicle]} />
+        </StateDispatchProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
   test("sorts vehicles by most recent operator logon time, ghosts at the top", () => {
     const oldVehicle: Vehicle = {
       id: "old",

--- a/assets/tests/components/searchResults.test.tsx
+++ b/assets/tests/components/searchResults.test.tsx
@@ -120,7 +120,7 @@ describe("SearchResults", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders vehicles that have logged in within the past 30 minutes", () => {
+  test("shows the new badge for vehicle that have logged in within the past 30 minutes", () => {
     const vehicle: Vehicle = {
       id: "v1",
       label: "v1-label",

--- a/assets/tests/helpers/dom.test.ts
+++ b/assets/tests/helpers/dom.test.ts
@@ -1,0 +1,11 @@
+import { className } from "../../src/helpers/dom"
+
+describe("className", () => {
+  test("combine a list of class names into a single string", () => {
+    expect(className(["foo", "bar"])).toEqual("foo bar")
+  })
+
+  test("filters out empty strings", () => {
+    expect(className(["foo", "bar", ""])).toEqual("foo bar")
+  })
+})

--- a/assets/tests/models/vehicle.test.ts
+++ b/assets/tests/models/vehicle.test.ts
@@ -1,12 +1,18 @@
 import {
   isGhost,
   isLateVehicleIndicator,
+  isRecentlyLoggedOn,
   isShuttle,
   isVehicle,
   shouldShowHeadwayDiagram,
 } from "../../src/models/vehicle"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { Ghost, Vehicle, VehicleTimepointStatus } from "../../src/realtime"
+import * as dateTime from "../../src/util/dateTime"
+
+jest
+  .spyOn(dateTime, "now")
+  .mockImplementation(() => new Date("2020-03-17T12:00:00.000Z"))
 
 jest.mock("../../src/laboratoryFeatures", () => ({
   __esModule: true,
@@ -154,6 +160,39 @@ describe("isShuttle", () => {
 
     expect(isShuttle(shuttle)).toBeTruthy()
     expect(isShuttle(notShuttle)).toBeFalsy()
+  })
+})
+
+describe("isRecentlyLoggedOn", () => {
+  test("true if the operatorLogonTime is within the past 30 minutes", () => {
+    const recentVehicle = {
+      id: "1",
+      operatorLogonTime: new Date("2020-03-17T11:31:00.000Z"),
+    } as Vehicle
+
+    expect(isRecentlyLoggedOn(recentVehicle)).toBeTruthy()
+  })
+
+  test("false if the operatorLogonTime is more than 30 minutes ago", () => {
+    const oldVehicle = {
+      id: "1",
+      operatorLogonTime: new Date("2020-03-17T11:29:00.000Z"),
+    } as Vehicle
+
+    expect(isRecentlyLoggedOn(oldVehicle)).toBeFalsy()
+  })
+
+  test("false if operatorLogonTime is null", () => {
+    const vehicleMissingLogonTime = {
+      id: "1",
+      operatorLogonTime: null,
+    } as Vehicle
+
+    expect(isRecentlyLoggedOn(vehicleMissingLogonTime)).toBeFalsy()
+  })
+
+  test("false if given a ghost", () => {
+    expect(isRecentlyLoggedOn(ghost)).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
For buses that have logged in within the last 30 minutes.

Asana ticket: [Add "New" indicator to search result cards for buses that have logged in within last 30 min](https://app.asana.com/0/1148853526253426/1160813278503797)

<img width="452" alt="Screen Shot 2020-03-18 at 19 09 00" src="https://user-images.githubusercontent.com/42339/77016000-cf9faa80-694c-11ea-95cf-a6784bd18c8a.png">
