### PR TITLE
HASTUS export script for minischedules

### DIFF
--- a/hastus_oig/skate.id
+++ b/hastus_oig/skate.id
@@ -14,7 +14,7 @@ file trips
       {
       item half_header
          {
-         value ' "schedule_id;area;run_id;route_id;trip_id;block_id" '
+         value ' "schedule_id;area;run_id;route_id;trip_id;block_id;start_time;end_time;start_place;end_place" '
          }
       }
 
@@ -35,6 +35,47 @@ file trips
          item trp_route { value 'trp_route' }
          item trp_int_number { value 'trp_int_number' }
          item trp_block { value 'trp_block' }
+         item trp_time_start { value 'trp_time_start' } { mask "_0hh'mm" }
+         item trp_time_end { value 'trp_time_end' } { mask "_0hh'mm" }
+         item trp_place_start { value 'trp_place_start' }
+         item trp_place_end { value 'trp_place_end' }
          }
       }
    } #file trips
+
+file activities
+   {
+   name ' "activities.csv" '
+
+   line header_half
+      {
+      item halfheader
+         {
+         value ' "schedule_id;area;run_id;start_time;end_time;start_place;end_place;activity_name;activity_type" '
+         }
+      }
+
+   foreach duty_activity
+      {
+      sort_by duty_activitySort
+         {
+         criteria csc_name { value 'Get(crew_schedule).csc_name' }
+         criteria csc_gar_rating_area { value 'Get(crew_schedule).csc_gar_rating_area' }
+         criteria dty_number { value 'dty_number' }
+         criteria dty_act_start_time { value 'dty_act_start_time' }
+         }
+
+      line duty_activity
+         {
+         item csc_name { value 'Get(crew_schedule).csc_name' }
+         item csc_gar_rating_area { value 'Get(crew_schedule).csc_gar_rating_area' }
+         item dty_number { value 'dty_number' }
+         item dty_act_start_time { value 'dty_act_start_time' } { mask "_0hh'mm" }
+         item dty_act_end_time { value 'dty_act_end_time' } { mask "_0hh'mm" }
+         item dty_act_start_place { value 'dty_act_start_place' }
+         item dty_act_end_place { value 'dty_act_end_place' }
+         item dty_act_name { value 'dty_act_name' }
+         item dty_act_activity { value 'dty_act_activity' }
+         }
+      }
+   } #file activities

--- a/hastus_oig/skate.id
+++ b/hastus_oig/skate.id
@@ -6,16 +6,19 @@
 
 att hide_inaccessible_values
 
-file trip_runs
+file trips
    {
    name ' "trips.csv" '
-   
+
    line header_half
-    {item half_header
-       { value ' "schedule_id;area;run_id;route_id;trip_id;block_id" ' }
-    }
-   
-      foreach trip
+      {
+      item half_header
+         {
+         value ' "schedule_id;area;run_id;route_id;trip_id;block_id" '
+         }
+      }
+
+   foreach trip
       {
       sort_by tripSort
          {
@@ -34,4 +37,4 @@ file trip_runs
          item trp_block { value 'trp_block' }
          }
       }
-    } #file trips.csv
+   } #file trips

--- a/hastus_oig/skate.id
+++ b/hastus_oig/skate.id
@@ -14,7 +14,7 @@ file trips
       {
       item half_header
          {
-         value ' "schedule_id;area;run_id;route_id;trip_id;block_id;start_time;end_time;start_place;end_place" '
+         value ' "schedule_id;area;run_id;block_id;start_time;end_time;start_place;end_place;route_id;trip_id" '
          }
       }
 
@@ -32,13 +32,13 @@ file trips
          item csc_name { value 'Get(crew_schedule).csc_name' }
          item csc_gar_rating_area { value 'Get(crew_schedule).csc_gar_rating_area' }
          item dty_number { value 'Get(duty).dty_number' }
-         item trp_route { value 'trp_route' }
-         item trp_int_number { value 'trp_int_number' }
          item trp_block { value 'trp_block' }
          item trp_time_start { value 'trp_time_start' } { mask "_0hh'mm" }
          item trp_time_end { value 'trp_time_end' } { mask "_0hh'mm" }
          item trp_place_start { value 'trp_place_start' }
          item trp_place_end { value 'trp_place_end' }
+         item trp_route { value 'trp_route' }
+         item trp_int_number { value 'trp_int_number' }
          }
       }
    } #file trips
@@ -60,7 +60,6 @@ file activities
       sort_by duty_activitySort
          {
          criteria csc_name { value 'Get(crew_schedule).csc_name' }
-         criteria csc_gar_rating_area { value 'Get(crew_schedule).csc_gar_rating_area' }
          criteria dty_number { value 'dty_number' }
          criteria dty_act_start_time { value 'dty_act_start_time' }
          }


### PR DESCRIPTION
Asana Task: [Adapt the HASTUS export to include all our new mini-schedule-related data](https://app.asana.com/0/1148853526253426/1166438708199676)

Old:
```
trips.csv
schedule_id;area;run_id;route_id;trip_id;block_id
aba20021;123;    1501;;   43858890; 57 - 11
aba20021;123;    1501;  193;   43857919; 57 - 11
```

New:
```
trips.csv
schedule_id;area;run_id;block_id;start_time;end_time;start_place;end_place;route_id;trip_id
aba20021;123;    1501; 57 - 11;04:15;04:30;albny;wtryd;;   43858890
aba20021;123;    1501; 57 - 11;04:30;05:05;wtryd;hayms;  193;   43857919
```
```
activities.csv
schedule_id;area;run_id;start_time;end_time;start_place;end_place;activity_name;activity_type
aba20021;123;    1501;04:05;04:15;albny;albny;Sign-on;Sign-on
aba20021;123;    1501;04:15;09:29;albny;albny; 57 - 11;Operator
```