### PR TITLE
Strip the overload suffix from trip IDs

### DIFF
--- a/lib/gtfs/trip.ex
+++ b/lib/gtfs/trip.ex
@@ -96,6 +96,11 @@ defmodule Gtfs.Trip do
       start_time_of_day < end_time(trip)
   end
 
+  @spec id_sans_overload(id() | nil) :: id() | nil
+  def id_sans_overload(nil), do: nil
+
+  def id_sans_overload(id), do: String.replace(id, ~r/-OL.+$/, "")
+
   @spec time_of_stop_matching([StopTime.t()], [Stop.id()]) :: Util.Time.time_of_day()
   defp time_of_stop_matching(stop_times, stop_ids) do
     stop_times

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -117,7 +117,7 @@ defmodule Realtime.Vehicle do
         &BlockWaiverStore.block_waivers_for_block_and_service/2
       )
 
-    trip_id = VehiclePosition.trip_id(vehicle_position)
+    trip_id = vehicle_position |> VehiclePosition.trip_id() |> Trip.id_sans_overload()
     block_id_with_overload = VehiclePosition.block_id(vehicle_position)
     block_id = Block.id_sans_overload(block_id_with_overload)
     stop_id = VehiclePosition.stop_id(vehicle_position)

--- a/test/gtfs/trip_test.exs
+++ b/test/gtfs/trip_test.exs
@@ -133,4 +133,18 @@ defmodule Gtfs.TripTest do
       refute Trip.is_active(@trip, 1, 2)
     end
   end
+
+  describe "id_sans_overload/1" do
+    test "removes the overload portion of the ID" do
+      assert Trip.id_sans_overload("44169914-OL1") == "44169914"
+    end
+
+    test "does not change an ID without an overload" do
+      assert Trip.id_sans_overload("44169914") == "44169914"
+    end
+
+    test "returns nil when given nil" do
+      assert Trip.id_sans_overload(nil) == nil
+    end
+  end
 end


### PR DESCRIPTION
Asana ticket: [Handle overloaded trip IDs](https://app.asana.com/0/1148853526253420/1168499414230753)