### PR TITLE
Only create block waivers for stop time updates with a “remark”

### DIFF
--- a/assets/src/models/vehicleData.ts
+++ b/assets/src/models/vehicleData.ts
@@ -109,7 +109,7 @@ interface VehicleTimepointStatusData {
 interface BlockWaiverData {
   start_time: number
   end_time: number
-  remark: string | null
+  remark: string
 }
 
 export const vehicleFromData = (vehicleData: VehicleData): Vehicle => ({

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -13,7 +13,7 @@ import { HeadwaySpacing } from "./models/vehicleStatus"
 export interface BlockWaiver {
   startTime: Date
   endTime: Date
-  remark: string | null
+  remark: string
 }
 
 export interface DataDiscrepancy {

--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -11,12 +11,13 @@ defmodule Realtime.BlockWaiver do
   @type t :: %__MODULE__{
           start_time: Util.Time.time_of_day(),
           end_time: Util.Time.time_of_day(),
-          remark: String.t() | nil
+          remark: String.t()
         }
 
   @enforce_keys [
     :start_time,
-    :end_time
+    :end_time,
+    :remark
   ]
 
   @derive Jason.Encoder
@@ -45,7 +46,11 @@ defmodule Realtime.BlockWaiver do
 
     Enum.map(trip.stop_times, fn stop_time ->
       {stop_time.time,
-       Enum.find(stop_time_updates, &(StopTimeUpdate.stop_id(&1) == stop_time.stop_id))}
+       Enum.find(
+         stop_time_updates,
+         &(StopTimeUpdate.stop_id(&1) == stop_time.stop_id && StopTimeUpdate.remark(&1) != nil &&
+             StopTimeUpdate.remark(&1) != "")
+       )}
     end)
   end
 

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -120,6 +120,31 @@ defmodule Realtime.BlockWaiverTest do
 
       assert BlockWaiver.trip_stop_time_waivers(@trip1, @stop_time_updates_by_trip) == expected
     end
+
+    test "does not include stop time updates without remarks" do
+      trip1stop1UpdateNilRemark = %{
+        @trip1stop1Update
+        | remark: nil
+      }
+
+      trip1stop2UpdateEmptyRemark = %{
+        @trip1stop2Update
+        | remark: ""
+      }
+
+      stop_time_updates_by_trip = %{
+        @stop_time_updates_by_trip
+        | @trip1.id => [trip1stop1UpdateNilRemark, trip1stop2UpdateEmptyRemark]
+      }
+
+      expected = [
+        {1, nil},
+        {2, nil},
+        {3, nil}
+      ]
+
+      assert BlockWaiver.trip_stop_time_waivers(@trip1, stop_time_updates_by_trip) == expected
+    end
   end
 
   describe "group_consecutive_sequences/1" do


### PR DESCRIPTION
This field indicates a block waiver, as opposed to a prediction or other
types of stop time update.

Require block waivers to include a remark.

Asana ticket: [Only create block waivers for stop time updates with a “remark”](https://app.asana.com/0/1148853526253426/1168716458967945)