### PR TITLE
Don't show a schedule line on route ladders for overloaded buses

### DIFF
--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -42,6 +42,9 @@ export type TimepointStatusYFunc = (
 export const CENTER_TO_LINE = 40 // x-distance between the center of the ladder and the center of the line
 const MARGIN_TOP_BOTTOM = 20 // space between the top of the route and the top of the viewbox
 
+const notOverload = ({ vehicle }: LadderVehicle): boolean =>
+  isGhost(vehicle) || !vehicle.isOverload
+
 const Ladder = ({
   timepoints,
   vehiclesAndGhosts,
@@ -87,7 +90,7 @@ const Ladder = ({
         width={width}
         height={height}
       >
-        {ladderVehicles.map((ladderVehicle) => (
+        {ladderVehicles.filter(notOverload).map((ladderVehicle) => (
           <ScheduledLine
             key={`line-${ladderVehicle.vehicle.id}`}
             ladderVehicle={ladderVehicle}

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -1101,6 +1101,146 @@ exports[`ladder renders an off-course vehicle 1`] = `
 </div>
 `;
 
+exports[`ladder renders an overload vehicle 1`] = `
+<div
+  className="m-ladder"
+  style={
+    Object {
+      "width": 184,
+    }
+  }
+>
+  <svg
+    className="m-ladder__svg"
+    height={0}
+    viewBox="-92 -20 184 0"
+    width={184}
+  >
+    <g>
+      <g
+        className="m-ladder__vehicle  "
+        onClick={[Function]}
+        transform="translate(63,-30)"
+      >
+        <g
+          className="m-vehicle-icon m-vehicle-icon--medium on-time"
+        >
+          <rect
+            className="m-vehicle-icon__label-background"
+            height={11}
+            rx={5.5}
+            ry={5.5}
+            width={26}
+            x={-13}
+            y={11.5}
+          />
+          <text
+            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominantBaseline="central"
+            textAnchor="middle"
+            x="0"
+            y={17}
+          >
+            1
+          </text>
+          <path
+            className="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+        </g>
+      </g>
+    </g>
+    <line
+      className="m-ladder__line"
+      x1={-40}
+      x2={-40}
+      y1="0"
+      y2={-40}
+    />
+    <line
+      className="m-ladder__line"
+      x1={40}
+      x2={40}
+      y1="0"
+      y2={-40}
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-0}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-0}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t0 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-0}
+    >
+      t0
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-20}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-20}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t1 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-20}
+    >
+      t1
+    </text>
+    <circle
+      className="m-ladder__stop-circle"
+      cx={-40}
+      cy={-40}
+      r="3"
+    />
+    <circle
+      className="m-ladder__stop-circle"
+      cx={40}
+      cy={-40}
+      r="3"
+    />
+    <text
+      className="m-ladder__timepoint-name"
+      data-event="click"
+      data-tip="t2 name"
+      dominantBaseline="middle"
+      textAnchor="middle"
+      x="0"
+      y={-40}
+    >
+      t2
+    </text>
+  </svg>
+  <div
+    className="mock-react-tooltip"
+  />
+</div>
+`;
+
 exports[`ladder shows schedule line in the other direction 1`] = `
 <div
   className="m-ladder"

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -961,4 +961,69 @@ describe("ladder", () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  test("renders an overload vehicle", () => {
+    const timepoints: Timepoint[] = [
+      { id: "t0", name: "t0 name" },
+      { id: "t1", name: "t1 name" },
+      { id: "t2", name: "t2 name" },
+    ]
+    const vehicles: Vehicle[] = [
+      {
+        id: "upward",
+        label: "upward",
+        runId: "run-1",
+        timestamp: 0,
+        latitude: 0,
+        longitude: 0,
+        directionId: 0,
+        routeId: "route",
+        tripId: "trip",
+        headsign: null,
+        viaVariant: null,
+        operatorId: "op1",
+        operatorName: "SMITH",
+        operatorLogonTime: new Date("2018-08-15T13:38:21.000Z"),
+        bearing: 33,
+        blockId: "block-1",
+        headwaySecs: 859.1,
+        headwaySpacing: HeadwaySpacing.Ok,
+        previousVehicleId: "v2",
+        scheduleAdherenceSecs: 0,
+        scheduledHeadwaySecs: 120,
+        isShuttle: false,
+        isOverload: true,
+        isOffCourse: false,
+        layoverDepartureTime: null,
+        blockIsActive: true,
+        dataDiscrepancies: [],
+        stopStatus: {
+          stopId: "stop",
+          stopName: "stop",
+        },
+        timepointStatus: {
+          fractionUntilTimepoint: 0.5,
+          timepointId: "t1",
+        },
+        scheduledLocation: null,
+        routeStatus: "on_route",
+        endOfTripType: "another_trip",
+        blockWaivers: [],
+      },
+    ]
+    const ladderDirection = LadderDirection.ZeroToOne
+
+    const tree = renderer
+      .create(
+        <Ladder
+          timepoints={timepoints}
+          vehiclesAndGhosts={vehicles}
+          ladderDirection={ladderDirection}
+          selectedVehicleId={undefined}
+        />
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Asana ticket: [Don't show a schedule line on route ladders for overloaded buses](https://app.asana.com/0/1148853526253426/1169592928381121)

![Screen Shot 2020-04-06 at 16 24 14](https://user-images.githubusercontent.com/42339/78602677-d96a4e80-7824-11ea-822d-783faa302d39.png)
