### PR TITLE
Make Minischedules data from HASTUS data

### DIFF
--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -215,8 +215,8 @@ defmodule Schedule.Data do
     hastus_trips = Schedule.Hastus.Trip.parse(hastus_files["trips.csv"])
 
     %{
-      runs: minischedules_runs,
-      blocks: minischedules_blocks
+      runs: minischedule_runs,
+      blocks: minischedule_blocks
     } = Schedule.Minischedule.Load.from_hastus(hastus_activities, hastus_trips)
 
     directions_by_route_id = directions_by_route_id(gtfs_files["directions.txt"])
@@ -257,8 +257,8 @@ defmodule Schedule.Data do
       trips: trips,
       blocks: Block.group_trips_by_block(bus_trips),
       calendar: Calendar.from_files(gtfs_files["calendar.txt"], gtfs_files["calendar_dates.txt"]),
-      minischedule_runs: minischedules_runs,
-      minischedule_blocks: minischedules_blocks
+      minischedule_runs: minischedule_runs,
+      minischedule_blocks: minischedule_blocks
     }
   end
 

--- a/lib/schedule/hastus/activity.ex
+++ b/lib/schedule/hastus/activity.ex
@@ -70,4 +70,9 @@ defmodule Schedule.Hastus.Activity do
       format: :hastus
     )
   end
+
+  @spec run_key(t()) :: Run.key()
+  def run_key(activity) do
+    {activity.schedule_id, activity.run_id}
+  end
 end

--- a/lib/schedule/hastus/activity.ex
+++ b/lib/schedule/hastus/activity.ex
@@ -11,7 +11,7 @@ defmodule Schedule.Hastus.Activity do
           start_place: Place.id(),
           end_place: Place.id(),
           activity_type: String.t(),
-          # present only if
+          # present only for activity_type "Operator"
           # block ids elsewhere have a letter indicating the garage
           # the block id from the activity name is missing it
           # e.g. "57-11" instead of "A57-11"

--- a/lib/schedule/hastus/run.ex
+++ b/lib/schedule/hastus/run.ex
@@ -1,5 +1,9 @@
 defmodule Schedule.Hastus.Run do
+  alias Schedule.Hastus.Schedule
+
   @type id :: String.t()
+
+  @type key :: {Schedule.id, id()}
 
   @doc """
       iex> Schedule.Hastus.Run.from_parts("123", "4567")

--- a/lib/schedule/hastus/run.ex
+++ b/lib/schedule/hastus/run.ex
@@ -3,7 +3,7 @@ defmodule Schedule.Hastus.Run do
 
   @type id :: String.t()
 
-  @type key :: {Schedule.id, id()}
+  @type key :: {Schedule.id(), id()}
 
   @doc """
       iex> Schedule.Hastus.Run.from_parts("123", "4567")

--- a/lib/schedule/hastus/trip.ex
+++ b/lib/schedule/hastus/trip.ex
@@ -75,4 +75,9 @@ defmodule Schedule.Hastus.Trip do
       format: :hastus
     )
   end
+
+  @spec run_key(t()) :: Run.key()
+  def run_key(trip) do
+    {trip.schedule_id, trip.run_id}
+  end
 end

--- a/lib/schedule/helpers.ex
+++ b/lib/schedule/helpers.ex
@@ -2,17 +2,17 @@ defmodule Schedule.Helpers do
   @doc """
   Returns a single list that attempts to keep items in order
 
-  iex> Schedule.Helpers.merge_lists([[:b, :c], [:a, :b]])
-  [:a, :b, :c]
+      iex> Schedule.Helpers.merge_lists([[:b, :c], [:a, :b]])
+      [:a, :b, :c]
 
-  iex> Schedule.Helpers.merge_lists([[:c, :a], [:a, :b], [:b, :c]])
-  [:c, :a, :b]
+      iex> Schedule.Helpers.merge_lists([[:c, :a], [:a, :b], [:b, :c]])
+      [:c, :a, :b]
 
-  iex> Schedule.Helpers.merge_lists([[:a, :b]])
-  [:a, :b]
+      iex> Schedule.Helpers.merge_lists([[:a, :b]])
+      [:a, :b]
 
-  iex> Schedule.Helpers.merge_lists([])
-  []
+      iex> Schedule.Helpers.merge_lists([])
+      []
   """
   @spec merge_lists([[any()]]) :: [any()]
   def merge_lists(lists) do
@@ -28,5 +28,34 @@ defmodule Schedule.Helpers do
     edits
     |> Enum.flat_map(fn {_action, elements} -> elements end)
     |> Enum.uniq()
+  end
+
+  @doc """
+  Like group_by, but preserves the order that the groups appear.
+  Only groups consecutive elements together.
+
+      iex> Schedule.Helpers.split_by(
+      ...>   ["a1", "a2", "b3", "b4", "a5"],
+      ...>   &String.first/1
+      ...> )
+      [
+        {"a", ["a1", "a2"]},
+        {"b", ["b3", "b4"]},
+        {"a", ["a5"]}
+      ]
+  """
+  @spec split_by([element], (element -> key)) :: [{key, [element]}]
+        when element: term(), key: term()
+  def split_by([], _key_fn) do
+    []
+  end
+
+  def split_by(elements, key_fn) do
+    first_key = key_fn.(List.first(elements))
+
+    {first_group, rest} =
+      Enum.split_while(elements, fn element -> key_fn.(element) == first_key end)
+
+    [{first_key, first_group} | split_by(rest, key_fn)]
   end
 end

--- a/lib/schedule/helpers.ex
+++ b/lib/schedule/helpers.ex
@@ -31,31 +31,19 @@ defmodule Schedule.Helpers do
   end
 
   @doc """
-  Like group_by, but preserves the order that the groups appear.
-  Only groups consecutive elements together.
+  Pairs up the values that appear on the same key in the two maps.
+  Leaves nil if a value is not present in one map.
 
-      iex> Schedule.Helpers.split_by(
-      ...>   ["a1", "a2", "b3", "b4", "a5"],
-      ...>   &String.first/1
-      ...> )
-      [
-        {"a", ["a1", "a2"]},
-        {"b", ["b3", "b4"]},
-        {"a", ["a5"]}
-      ]
+      iex> Schedule.Helpers.pair_maps(%{a: "a1", b: "b1"}, %{b: "b2", c: "c2"})
+      %{a: {"a1", nil}, b: {"b1", "b2"}, c: {nil, "c2"}}
   """
-  @spec split_by([element], (element -> key)) :: [{key, [element]}]
-        when element: term(), key: term()
-  def split_by([], _key_fn) do
-    []
-  end
+  @spec pair_maps(%{k => v1}, %{k => v2}) :: %{k => {v1 | nil, v2 | nil}}
+        when k: any(), v1: any(), v2: any()
+  def pair_maps(m1, m2) do
+    keys = Enum.uniq(Map.keys(m1) ++ Map.keys(m2))
 
-  def split_by(elements, key_fn) do
-    first_key = key_fn.(List.first(elements))
-
-    {first_group, rest} =
-      Enum.split_while(elements, fn element -> key_fn.(element) == first_key end)
-
-    [{first_key, first_group} | split_by(rest, key_fn)]
+    Map.new(keys, fn k ->
+      {k, {Map.get(m1, k), Map.get(m2, k)}}
+    end)
   end
 end

--- a/lib/schedule/minischedule/block.ex
+++ b/lib/schedule/minischedule/block.ex
@@ -1,0 +1,27 @@
+defmodule Schedule.Minischedule.Block do
+  alias Schedule.Block
+  alias Schedule.Minischedule.Piece
+  alias Schedule.Hastus.Schedule
+
+  @type key :: {Schedule.id(), Block.id()}
+
+  @type by_id :: %{key() => t()}
+
+  @type t :: %__MODULE__{
+          schedule_id: Schedule.id(),
+          id: Block.id(),
+          pieces: [Piece.t()]
+        }
+
+  @enforce_keys [
+    :schedule_id,
+    :id,
+    :pieces
+  ]
+
+  defstruct [
+    :schedule_id,
+    :id,
+    :pieces
+  ]
+end

--- a/lib/schedule/minischedule/break.ex
+++ b/lib/schedule/minischedule/break.ex
@@ -1,4 +1,5 @@
 defmodule Schedule.Minischedule.Break do
+  alias Schedule.Hastus.Activity
   alias Schedule.Hastus.Place
 
   @type break_type :: String.t()
@@ -26,4 +27,16 @@ defmodule Schedule.Minischedule.Break do
     :start_place,
     :end_place
   ]
+
+  @spec from_activity(Activity.t()) :: t()
+  def from_activity(activity) do
+    %__MODULE__{
+      break_type: activity.activity_type,
+      start_time: activity.start_time,
+      end_time: activity.end_time,
+      start_place: activity.start_place,
+      end_place: activity.end_place
+    }
+  end
+
 end

--- a/lib/schedule/minischedule/break.ex
+++ b/lib/schedule/minischedule/break.ex
@@ -38,5 +38,4 @@ defmodule Schedule.Minischedule.Break do
       end_place: activity.end_place
     }
   end
-
 end

--- a/lib/schedule/minischedule/break.ex
+++ b/lib/schedule/minischedule/break.ex
@@ -1,0 +1,29 @@
+defmodule Schedule.Minischedule.Break do
+  alias Schedule.Hastus.Place
+
+  @type break_type :: String.t()
+
+  @type t :: %__MODULE__{
+          break_type: break_type(),
+          start_time: String.t(),
+          end_time: String.t(),
+          start_place: Place.id(),
+          end_place: Place.id()
+        }
+
+  @enforce_keys [
+    :break_type,
+    :start_time,
+    :end_time,
+    :start_place,
+    :end_place
+  ]
+
+  defstruct [
+    :break_type,
+    :start_time,
+    :end_time,
+    :start_place,
+    :end_place
+  ]
+end

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -6,10 +6,7 @@ defmodule Schedule.Minischedule.Load do
   alias Schedule.Helpers
   alias Schedule.Hastus.Activity
   alias Schedule.Hastus.Trip
-  alias Schedule.Minischedule.Block
-  alias Schedule.Minischedule.Break
-  alias Schedule.Minischedule.Piece
-  alias Schedule.Minischedule.Run
+  alias Schedule.Minischedule.{Block, Break, Piece, Run}
 
   @spec from_hastus([Activity.t()], [Trip.t()]) ::
           %{runs: Run.by_id(), blocks: Block.by_id()}

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -80,7 +80,7 @@ defmodule Schedule.Minischedule.Load do
   defp blocks_from_pieces(pieces) do
     pieces
     |> Enum.group_by(&block_key_for_piece/1)
-    |> Enum.map(fn {{schedule_id, block_id} = block_key, pieces} ->
+    |> Map.new(fn {{schedule_id, block_id} = block_key, pieces} ->
       {block_key,
        %Block{
          schedule_id: schedule_id,
@@ -88,7 +88,6 @@ defmodule Schedule.Minischedule.Load do
          pieces: Enum.sort_by(pieces, fn piece -> piece.start.time end)
        }}
     end)
-    |> Map.new()
   end
 
   @spec block_key_for_piece(Piece.t()) :: Block.key()

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -11,8 +11,8 @@ defmodule Schedule.Minischedule.Load do
   @spec from_hastus([Activity.t()], [Trip.t()]) ::
           %{runs: Run.by_id(), blocks: Block.by_id()}
   def from_hastus(activities, trips) do
-    activities_by_run = Enum.group_by(activities, fn a -> {a.schedule_id, a.run_id} end)
-    trips_by_run = Enum.group_by(trips, fn t -> {t.schedule_id, t.run_id} end)
+    activities_by_run = Enum.group_by(activities, &Activity.run_key/1)
+    trips_by_run = Enum.group_by(trips, &Trip.run_key/1)
     activities_and_trips_by_run = Helpers.pair_maps(activities_by_run, trips_by_run)
 
     runs =

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -1,0 +1,157 @@
+defmodule Schedule.Minischedule.Load do
+  @moduledoc """
+  Load the HASTUS data into minischedules data
+  """
+
+  alias Schedule.Helpers
+  alias Schedule.Hastus.Activity
+  alias Schedule.Hastus.Trip
+  alias Schedule.Minischedule.Block
+  alias Schedule.Minischedule.Break
+  alias Schedule.Minischedule.Piece
+  alias Schedule.Minischedule.Run
+
+  @spec from_hastus([Activity.t()], [Trip.t()]) ::
+          %{runs: Run.by_id(), blocks: Block.by_id()}
+  def from_hastus(activities, trips) do
+    activities_by_run = group_activities_by_run(activities)
+    trips_by_run = group_trips_by_run(trips)
+    run_groups = pair_activities_and_trips(activities_by_run, trips_by_run)
+    runs_and_pieces = Enum.map(run_groups, &run_and_pieces_from_run_group/1)
+    runs_by_id = Map.new(runs_and_pieces, fn {run_key, run, _pieces} -> {run_key, run} end)
+    pieces = Enum.flat_map(runs_and_pieces, fn {_run_key, _run, pieces} -> pieces end)
+    blocks_by_id = blocks_from_pieces(pieces)
+
+    %{
+      runs: runs_by_id,
+      blocks: blocks_by_id
+    }
+  end
+
+  # All the activities on a run
+  @typep activity_group :: {Run.key(), [Activity.t()]}
+
+  @spec group_activities_by_run([Activity.t()]) :: [activity_group()]
+  defp group_activities_by_run(activities) do
+    Helpers.split_by(activities, &run_key_for_activity/1)
+  end
+
+  @spec run_key_for_activity(Activity.t()) :: Run.key()
+  defp run_key_for_activity(activity) do
+    {activity.schedule_id, activity.run_id}
+  end
+
+  # The trips that form a piece together
+  @typep trip_group :: {Run.key(), [Trip.t()]}
+
+  @spec group_trips_by_run([Trip.t()]) :: [trip_group()]
+  defp group_trips_by_run(trips) do
+    Helpers.split_by(trips, &run_key_for_trip/1)
+  end
+
+  @spec run_key_for_trip(Trip.t()) :: Run.key()
+  defp run_key_for_trip(trip) do
+    {trip.schedule_id, trip.run_id}
+  end
+
+  @typep run_group :: {Run.key(), [Activity.t()], [Trip.t()]}
+
+  # Assumes inputs are both sorted by run_key.
+  # Assumes no runs are in trips.csv but not in activities.csv
+  @spec pair_activities_and_trips([activity_group()], [trip_group()]) :: [run_group()]
+  defp pair_activities_and_trips([], _trip_groups) do
+    []
+  end
+
+  defp pair_activities_and_trips([activity_group | other_activity_groups], trip_groups) do
+    {run_key, activities} = activity_group
+
+    case trip_groups do
+      [{^run_key, trips} | other_trip_groups] ->
+        [
+          {run_key, activities, trips}
+          | pair_activities_and_trips(other_activity_groups, other_trip_groups)
+        ]
+
+      _ ->
+        [
+          {run_key, activities, []}
+          | pair_activities_and_trips(other_activity_groups, trip_groups)
+        ]
+    end
+  end
+
+  @spec run_and_pieces_from_run_group(run_group) :: {Run.key(), Run.t(), [Piece.t()]}
+  def run_and_pieces_from_run_group({run_key, activities, trips}) do
+    # TODO real implementation.
+    # Currently, turns the trips directly into pieces, and makes every activity a break.
+    # The real way to do it would be to integrate Sign-on and Operator activities into pieces.
+    {schedule_id, run_id} = run_key
+
+    breaks = Enum.map(activities, &break_from_activity/1)
+
+    pieces =
+      trips
+      |> Helpers.split_by(fn trip -> trip.block_id end)
+      |> Enum.map(fn {block_id, trips} ->
+        first_trip = List.first(trips)
+        last_trip = List.last(trips)
+
+        %Piece{
+          schedule_id: schedule_id,
+          run_id: run_id,
+          block_id: block_id,
+          start: %{
+            time: first_trip.start_time,
+            place: first_trip.start_place,
+            mid_route?: false
+          },
+          trip_ids: Enum.map(trips, fn trip -> trip.trip_id end),
+          end: %{
+            time: last_trip.end_time,
+            place: last_trip.end_place,
+            mid_route?: false
+          }
+        }
+      end)
+
+    run = %Run{
+      schedule_id: schedule_id,
+      id: run_id,
+      activities: breaks ++ pieces
+    }
+
+    {run_key, run, pieces}
+  end
+
+  @spec break_from_activity(Activity.t()) :: Break.t()
+  defp break_from_activity(activity) do
+    %Break{
+      break_type: activity.activity_type,
+      start_time: activity.start_time,
+      end_time: activity.end_time,
+      start_place: activity.start_place,
+      end_place: activity.end_place
+    }
+  end
+
+  @spec blocks_from_pieces([Piece.t()]) :: Block.by_id()
+  defp blocks_from_pieces(pieces) do
+    pieces
+    |> Enum.group_by(&block_key_for_piece/1)
+    |> Enum.map(fn {{schedule_id, block_id} = block_key, pieces} ->
+      {block_key,
+       %Block{
+         schedule_id: schedule_id,
+         id: block_id,
+         pieces: Enum.sort_by(pieces, fn piece -> piece.start.time end)
+       }}
+    end)
+    |> Map.new()
+  end
+
+  @spec block_key_for_piece(Piece.t()) :: Block.key()
+  defp block_key_for_piece(piece) do
+    {piece.schedule_id, piece.block_id}
+  end
+end

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -42,7 +42,7 @@ defmodule Schedule.Minischedule.Load do
     # The real way to do it would be to integrate Sign-on and Operator activities into pieces.
     {schedule_id, run_id} = run_key
 
-    breaks = Enum.map(activities, &break_from_activity/1)
+    breaks = Enum.map(activities, &Break.from_activity/1)
 
     pieces =
       trips
@@ -73,17 +73,6 @@ defmodule Schedule.Minischedule.Load do
       schedule_id: schedule_id,
       id: run_id,
       activities: breaks ++ pieces
-    }
-  end
-
-  @spec break_from_activity(Activity.t()) :: Break.t()
-  defp break_from_activity(activity) do
-    %Break{
-      break_type: activity.activity_type,
-      start_time: activity.start_time,
-      end_time: activity.end_time,
-      start_place: activity.start_place,
-      end_place: activity.end_place
     }
   end
 

--- a/lib/schedule/minischedule/piece.ex
+++ b/lib/schedule/minischedule/piece.ex
@@ -1,0 +1,42 @@
+defmodule Schedule.Minischedule.Piece do
+  alias Schedule.Block
+  alias Schedule.Trip
+  alias Schedule.Hastus.Place
+  alias Schedule.Hastus.Run
+  alias Schedule.Hastus.Schedule
+
+  @type key :: {Schedule.id(), Run.id(), Block.id()}
+
+  @type sign_on_off :: %{
+          time: String.t(),
+          place: Place.id(),
+          mid_route?: boolean()
+        }
+
+  @type t :: %__MODULE__{
+          schedule_id: Schedule.id(),
+          run_id: Run.id(),
+          block_id: Block.id(),
+          start: sign_on_off(),
+          trip_ids: [Trip.id()],
+          end: sign_on_off()
+        }
+
+  @enforce_keys [
+    :schedule_id,
+    :run_id,
+    :block_id,
+    :start,
+    :trip_ids,
+    :end
+  ]
+
+  defstruct [
+    :schedule_id,
+    :run_id,
+    :block_id,
+    :start,
+    :trip_ids,
+    :end
+  ]
+end

--- a/lib/schedule/minischedule/run.ex
+++ b/lib/schedule/minischedule/run.ex
@@ -1,0 +1,28 @@
+defmodule Schedule.Minischedule.Run do
+  alias Schedule.Minischedule.Break
+  alias Schedule.Minischedule.Piece
+  alias Schedule.Hastus.Run
+  alias Schedule.Hastus.Schedule
+
+  @type key :: {Schedule.id(), Run.id()}
+
+  @type by_id :: %{key() => t()}
+
+  @type t :: %__MODULE__{
+          schedule_id: Schedule.id(),
+          id: Run.id(),
+          activities: [Piece.t() | Break.t()]
+        }
+
+  @enforce_keys [
+    :schedule_id,
+    :id,
+    :activities
+  ]
+
+  defstruct [
+    :schedule_id,
+    :id,
+    :activities
+  ]
+end

--- a/lib/schedule/minischedule/run.ex
+++ b/lib/schedule/minischedule/run.ex
@@ -25,4 +25,14 @@ defmodule Schedule.Minischedule.Run do
     :id,
     :activities
   ]
+
+  @spec key(t()) :: key()
+  def key(run) do
+    {run.schedule_id, run.id}
+  end
+
+  @spec pieces(t()) :: [Piece.t()]
+  def pieces(run) do
+    Enum.filter(run.activities, fn activity -> match?(%Piece{}, activity) end)
+  end
 end

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -1,0 +1,273 @@
+defmodule Schedule.Minischedule.LoadTest do
+  use ExUnit.Case, async: true
+
+  alias Schedule.Hastus.Activity
+  alias Schedule.Hastus.Trip
+  alias Schedule.Minischedule.Block
+  alias Schedule.Minischedule.Break
+  alias Schedule.Minischedule.Load
+  alias Schedule.Minischedule.Piece
+  alias Schedule.Minischedule.Run
+
+  describe "from_hastus" do
+    test "trips become pieces in run and block" do
+      activities = [
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run",
+          start_time: 1,
+          end_time: 2,
+          start_place: "start_place",
+          end_place: "end_place",
+          activity_type: "Operator",
+          partial_block_id: "block"
+        }
+      ]
+
+      trips = [
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run",
+          block_id: "block",
+          start_time: 1,
+          end_time: 2,
+          start_place: "start_place",
+          end_place: "end_place",
+          route_id: nil,
+          trip_id: "trip"
+        }
+      ]
+
+      expected_piece = %Piece{
+        schedule_id: "schedule",
+        run_id: "run",
+        block_id: "block",
+        start: %{
+          time: 1,
+          place: "start_place",
+          mid_route?: false
+        },
+        trip_ids: ["trip"],
+        end: %{
+          time: 2,
+          place: "end_place",
+          mid_route?: false
+        }
+      }
+
+      # TODO remove this once the placeholder piece implementation handles Operator activities correctly.
+      placeholder_break = %Break{
+        break_type: "Operator",
+        start_time: 1,
+        end_time: 2,
+        start_place: "start_place",
+        end_place: "end_place"
+      }
+
+      assert Load.from_hastus(activities, trips) == %{
+               runs: %{
+                 {"schedule", "run"} => %Run{
+                   schedule_id: "schedule",
+                   id: "run",
+                   activities: [placeholder_break, expected_piece]
+                 }
+               },
+               blocks: %{
+                 {"schedule", "block"} => %Block{
+                   schedule_id: "schedule",
+                   id: "block",
+                   pieces: [expected_piece]
+                 }
+               }
+             }
+    end
+
+    test "can have multiple pieces in run and block" do
+      activities = [
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run_1",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block_1"
+        },
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run_1",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block_2"
+        },
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run_2",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block_1"
+        }
+      ]
+
+      trips = [
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run_1",
+          block_id: "block_1",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          route_id: nil,
+          trip_id: "trip_11"
+        },
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run_1",
+          block_id: "block_2",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          route_id: nil,
+          trip_id: "trip_12"
+        },
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run_2",
+          block_id: "block_1",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          route_id: nil,
+          trip_id: "trip_21"
+        }
+      ]
+
+      assert %{
+               runs: %{
+                 # TODO remove breaks from runs. They're from the placeholder piece implementation.
+                 {"schedule", "run_1"} => %Run{
+                   activities: [
+                     _break_11,
+                     _break_12,
+                     %Piece{trip_ids: ["trip_11"]},
+                     %Piece{trip_ids: ["trip_12"]}
+                   ]
+                 },
+                 {"schedule", "run_2"} => %Run{
+                   activities: [
+                     _break_21,
+                     %Piece{trip_ids: ["trip_21"]}
+                   ]
+                 }
+               },
+               blocks: %{
+                 {"schedule", "block_1"} => %Block{
+                   pieces: [
+                     %Piece{trip_ids: ["trip_11"]},
+                     %Piece{trip_ids: ["trip_21"]}
+                   ]
+                 },
+                 {"schedule", "block_2"} => %Block{
+                   pieces: [
+                     %Piece{trip_ids: ["trip_12"]}
+                   ]
+                 }
+               }
+             } = Load.from_hastus(activities, trips)
+    end
+
+    test "a different schedule_id means a different run or block" do
+      activities = [
+        %Activity{
+          schedule_id: "schedule_1",
+          run_id: "run",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block"
+        },
+        %Activity{
+          schedule_id: "schedule_2",
+          run_id: "run",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block"
+        }
+      ]
+
+      trips = [
+        %Trip{
+          schedule_id: "schedule_1",
+          run_id: "run",
+          block_id: "block",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          route_id: nil,
+          trip_id: "trip_1"
+        },
+        %Trip{
+          schedule_id: "schedule_2",
+          run_id: "run",
+          block_id: "block",
+          start_time: 0,
+          end_time: 0,
+          start_place: "",
+          end_place: "",
+          route_id: nil,
+          trip_id: "trip_2"
+        }
+      ]
+
+      assert %{
+               runs: %{
+                 # TODO remove breaks from runs. They're from the placeholder piece implementation.
+                 {"schedule_1", "run"} => %Run{
+                   activities: [_break_1, %Piece{trip_ids: ["trip_1"]}]
+                 },
+                 {"schedule_2", "run"} => %Run{
+                   activities: [_break_2, %Piece{trip_ids: ["trip_2"]}]
+                 }
+               },
+               blocks: %{
+                 {"schedule_1", "block"} => %Block{pieces: [%Piece{trip_ids: ["trip_1"]}]},
+                 {"schedule_2", "block"} => %Block{pieces: [%Piece{trip_ids: ["trip_2"]}]}
+               }
+             } = Load.from_hastus(activities, trips)
+    end
+  end
+
+  # TODO when there's a real implementation for making pieces
+  describe "run_and_pieces_from_run_group" do
+    test "multiple trips are grouped into the same piece" do
+    end
+
+    test "trips become multiple pieces if there are multiple Operator activities" do
+    end
+
+    test "piece start time is based on sign_on activity" do
+    end
+
+    test "makes breaks" do
+    end
+
+    test "matches break_id in trips with partial_break_id in activities" do
+    end
+  end
+end

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -254,7 +254,7 @@ defmodule Schedule.Minischedule.LoadTest do
   end
 
   # TODO when there's a real implementation for making pieces
-  describe "run_and_pieces_from_run_group" do
+  describe "run_and_pieces" do
     test "multiple trips are grouped into the same piece" do
     end
 

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -254,7 +254,7 @@ defmodule Schedule.Minischedule.LoadTest do
   end
 
   # TODO when there's a real implementation for making pieces
-  describe "run_and_pieces" do
+  describe "run" do
     test "multiple trips are grouped into the same piece" do
     end
 


### PR DESCRIPTION
Asana Task: [Import the new mini-schedule-related HASTUS data into Skate](https://app.asana.com/0/1148853526253426/1166438708199679)

Preprocesses hastus data into the format we'll need for minischedules, and stores it in Schedule.Data

This does not include a way to get it out of Data yet.

Has a placeholder implementation for the details of turning trips into pieces and understanding Operator and Sign-on activities.

The big picture of separating trips and activities into their blocks and runs is done, and will let us start working on fetching this data into the frontend, though the placeholder means the data won't be quite right.