### PR TITLE
Remove async: true from tests that aren't async safe

### DIFF
--- a/test/concentrate/consumer/stop_time_updates_test.exs
+++ b/test/concentrate/consumer/stop_time_updates_test.exs
@@ -1,6 +1,5 @@
-defmodule Concentrate.Supervisor.StopTimeUpdatesTest do
-  @moduledoc false
-  use ExUnit.Case, async: true
+defmodule Concentrate.Consumer.StopTimeUpdatesTest do
+  use ExUnit.Case
   import Test.Support.Helpers
 
   alias Concentrate.{StopTimeUpdate, TripUpdate}

--- a/test/concentrate/consumer/vehicle_positions_test.exs
+++ b/test/concentrate/consumer/vehicle_positions_test.exs
@@ -1,6 +1,5 @@
-defmodule Concentrate.Supervisor.VehiclePositionsTest do
-  @moduledoc false
-  use ExUnit.Case, async: true
+defmodule Concentrate.Consumer.VehiclePositionsTest do
+  use ExUnit.Case
   import Test.Support.Helpers
 
   alias Concentrate.Consumer.VehiclePositions

--- a/test/concentrate/pipeline/stop_time_updates_pipeline_test.exs
+++ b/test/concentrate/pipeline/stop_time_updates_pipeline_test.exs
@@ -1,5 +1,5 @@
 defmodule Concentrate.Pipeline.StopTimeUpdatesPipelineTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Test.Support.Helpers
 
   describe "init/1" do

--- a/test/concentrate/pipeline/vehicle_positions_pipeline_test.exs
+++ b/test/concentrate/pipeline/vehicle_positions_pipeline_test.exs
@@ -1,5 +1,5 @@
 defmodule Concentrate.Pipeline.VehiclePositionsPipelineTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Test.Support.Helpers
 
   describe "init/1" do

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -1,5 +1,5 @@
 defmodule Concentrate.StopTimeUpdateTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Concentrate.{Mergeable, StopTimeUpdate}
   alias Schedule.Gtfs.Stop

--- a/test/realtime/headway_test.exs
+++ b/test/realtime/headway_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.HeadwayTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Realtime.Headway
 
   describe "current_headway_spacing" do

--- a/test/realtime/time_period_test.exs
+++ b/test/realtime/time_period_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.TimePeriodTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Realtime.TimePeriod
 
   @time_periods TimePeriod.data()

--- a/test/realtime/vehicle_or_ghost_test.exs
+++ b/test/realtime/vehicle_or_ghost_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.VehicleOrGhostTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Realtime.{Ghost, Vehicle, VehicleOrGhost}
 

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.VehiclesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Test.Support.Helpers
 
   alias Schedule.Trip

--- a/test/schedule/hastus/activity_test.exs
+++ b/test/schedule/hastus/activity_test.exs
@@ -1,5 +1,5 @@
 defmodule Schedule.Hastus.ActivityTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Schedule.Hastus.Activity
 

--- a/test/schedule/hastus/trip_test.exs
+++ b/test/schedule/hastus/trip_test.exs
@@ -1,5 +1,5 @@
 defmodule Schedule.Hastus.TripTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Schedule.Hastus.Trip
 

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -1,5 +1,5 @@
 defmodule GtfsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   import Test.Support.Helpers
 

--- a/test/skate_web/views/layout_view_test.exs
+++ b/test/skate_web/views/layout_view_test.exs
@@ -1,5 +1,5 @@
 defmodule SkateWeb.LayoutViewTest do
-  use SkateWeb.ConnCase, async: true
+  use SkateWeb.ConnCase
   import Test.Support.Helpers
 
   alias SkateWeb.LayoutView


### PR DESCRIPTION
... and add `async: true` to tests that are async safe.

Asana Task: [Intermittent Test Failure in VehiclePositionsTest](https://app.asana.com/0/1148853526253420/1170653240610633)