### PR TITLE
turn layover box into svg

### DIFF
--- a/assets/css/layover_box.scss
+++ b/assets/css/layover_box.scss
@@ -1,6 +1,5 @@
 .m-layover-box {
-  display: flex;
-  justify-content: center;
+  margin: auto;
 }
 
 .m-layover-box--bottom {

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { ReactElement } from "react"
 import { className } from "../helpers/dom"
 import { DrawnStatus, statusClass } from "../models/vehicleStatus"
 import { IconAlertCircleSvgNode, AlertIconStyle } from "./iconAlertCircle"
@@ -34,7 +34,7 @@ const Y_CENTER_TO_POINT = 20
 const Y_CENTER_TO_BASE = 20
 const ALERT_ICON_RADIUS = 27
 
-export const VehicleIcon = (props: Props) => {
+export const VehicleIcon = (props: Props): ReactElement<HTMLElement> => {
   if (
     props.status === "ghost" &&
     (props.orientation === Orientation.Left ||
@@ -124,7 +124,7 @@ export const VehicleIconSvgNode = ({
   variant,
   status,
   alertIconStyle,
-}: Props) => {
+}: Props): ReactElement<SVGElement> => {
   status = status || "plain"
   variant = variant && variant !== "_" ? variant : undefined
   // ghosts can't be drawn sideways

--- a/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/layoverBox.test.tsx.snap
@@ -1,194 +1,170 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LayoverBox renders 1`] = `
-<div
+<svg
   className="m-layover-box m-layover-box--top"
+  height={32}
+  viewBox="-30 -10 60 32"
+  width={60}
 >
-  <div
-    className="m-layover-box__vehicle"
+  <g
     onClick={[Function]}
+    transform="translate(-15,0)"
   >
-    <svg
-      style={
-        Object {
-          "height": 27.72,
-          "width": 40,
-        }
-      }
-      viewBox="-20 -8.36 40 27.72"
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small on-time"
     >
-      <g
-        className="m-vehicle-icon m-vehicle-icon--small on-time"
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={40}
+        x={-20}
+        y={7.359999999999999}
+      />
+      <text
+        className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.86}
       >
-        <rect
-          className="m-vehicle-icon__label-background"
-          height={11}
-          rx={5.5}
-          ry={5.5}
-          width={40}
-          x={-20}
-          y={7.359999999999999}
-        />
-        <text
-          className="m-vehicle-icon__label m-vehicle-icon__label--extended"
-          dominantBaseline="central"
-          textAnchor="middle"
-          x="0"
-          y={12.86}
-        >
-          sooner
-        </text>
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          transform="scale(0.38) rotate(270) translate(-24,-22)"
-        />
-      </g>
-    </svg>
-  </div>
-  <div
-    className="m-layover-box__vehicle"
+        sooner
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(270) translate(-24,-22)"
+      />
+    </g>
+  </g>
+  <g
     onClick={[Function]}
+    transform="translate(15,0)"
   >
-    <svg
-      style={
-        Object {
-          "height": 27.72,
-          "width": 40,
-        }
-      }
-      viewBox="-20 -8.36 40 27.72"
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small on-time"
     >
-      <g
-        className="m-vehicle-icon m-vehicle-icon--small on-time"
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={40}
+        x={-20}
+        y={7.359999999999999}
+      />
+      <text
+        className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.86}
       >
-        <rect
-          className="m-vehicle-icon__label-background"
-          height={11}
-          rx={5.5}
-          ry={5.5}
-          width={40}
-          x={-20}
-          y={7.359999999999999}
-        />
-        <text
-          className="m-vehicle-icon__label m-vehicle-icon__label--extended"
-          dominantBaseline="central"
-          textAnchor="middle"
-          x="0"
-          y={12.86}
-        >
-          later
-        </text>
-        <path
-          className="m-vehicle-icon__triangle"
-          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-          transform="scale(0.38) rotate(270) translate(-24,-22)"
-        />
-      </g>
-    </svg>
-  </div>
-</div>
+        later
+      </text>
+      <path
+        className="m-vehicle-icon__triangle"
+        d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+        transform="scale(0.38) rotate(270) translate(-24,-22)"
+      />
+    </g>
+  </g>
+</svg>
 `;
 
 exports[`LayoverBox renders ghost 1`] = `
-<div
+<svg
   className="m-layover-box m-layover-box--top"
+  height={32}
+  viewBox="-15 -10 30 32"
+  width={30}
 >
-  <div
-    className="m-layover-box__vehicle"
+  <g
     onClick={[Function]}
+    transform="translate(0,0)"
   >
-    <svg
-      style={
-        Object {
-          "height": 26.720000000000002,
-          "width": 40,
-        }
-      }
-      viewBox="-20 -8.120000000000001 40 26.720000000000002"
+    <g
+      className="m-vehicle-icon m-vehicle-icon--small ghost m-vehicle-icon--highlighted"
     >
-      <g
-        className="m-vehicle-icon m-vehicle-icon--small ghost m-vehicle-icon--highlighted"
+      <rect
+        className="m-vehicle-icon__label-background"
+        height={11}
+        rx={5.5}
+        ry={5.5}
+        width={40}
+        x={-20}
+        y={6.6}
+      />
+      <text
+        className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="0"
+        y={12.1}
       >
-        <rect
-          className="m-vehicle-icon__label-background"
-          height={11}
-          rx={5.5}
-          ry={5.5}
-          width={40}
-          x={-20}
-          y={6.6}
+        ghost_soonest
+      </text>
+      <g
+        transform="scale(0.26599999999999996) translate(-24,-23)"
+      >
+        <path
+          className="m-vehicle-icon__ghost-highlight"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
         />
-        <text
-          className="m-vehicle-icon__label m-vehicle-icon__label--extended"
-          dominantBaseline="central"
-          textAnchor="middle"
-          x="0"
-          y={12.1}
-        >
-          ghost_soonest
-        </text>
+        <path
+          className="m-vehicle-icon__ghost-body"
+          d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+          stroke-join="round"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="19.73"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+        <ellipse
+          className="m-vehicle-icon__ghost-eye"
+          cx="35.29"
+          cy="22.8"
+          rx="3.11"
+          ry="3.03"
+        />
+      </g>
+      <g
+        transform="translate(5.7, -3.8) scale(0.16) translate(-24, -24)"
+      >
         <g
-          transform="scale(0.26599999999999996) translate(-24,-23)"
+          className="c-icon-alert-circle--highlighted"
         >
-          <path
-            className="m-vehicle-icon__ghost-highlight"
-            d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-            stroke-join="round"
+          <circle
+            className="c-icon-alert-circle__outline"
+            cx="24"
+            cy="24"
+            r="27"
           />
-          <path
-            className="m-vehicle-icon__ghost-body"
-            d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-            stroke-join="round"
+          <circle
+            className="c-icon-alert-circle__fill"
+            cx="24"
+            cy="24"
+            r="22.59"
           />
-          <ellipse
-            className="m-vehicle-icon__ghost-eye"
-            cx="19.73"
-            cy="22.8"
-            rx="3.11"
-            ry="3.03"
-          />
-          <ellipse
-            className="m-vehicle-icon__ghost-eye"
-            cx="35.29"
-            cy="22.8"
-            rx="3.11"
-            ry="3.03"
-          />
-        </g>
-        <g
-          transform="translate(5.7, -3.8) scale(0.16) translate(-24, -24)"
-        >
           <g
-            className="c-icon-alert-circle--highlighted"
+            className="c-icon-alert-circle__exclamation-point"
           >
-            <circle
-              className="c-icon-alert-circle__outline"
-              cx="24"
-              cy="24"
-              r="27"
+            <path
+              d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
             />
-            <circle
-              className="c-icon-alert-circle__fill"
-              cx="24"
-              cy="24"
-              r="22.59"
+            <path
+              d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
             />
-            <g
-              className="c-icon-alert-circle__exclamation-point"
-            >
-              <path
-                d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
-              />
-              <path
-                d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
-              />
-            </g>
           </g>
         </g>
       </g>
-    </svg>
-  </div>
-</div>
+    </g>
+  </g>
+</svg>
 `;

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -88,8 +88,11 @@ Array [
       Reverse
     </button>
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-ladder"
@@ -193,8 +196,11 @@ Array [
       className="mock-react-tooltip"
     />
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-incoming-box"
@@ -244,52 +250,45 @@ Array [
       Reverse
     </button>
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="-15 -10 30 32"
+    width={30}
   >
-    <div
-      className="m-layover-box__vehicle"
+    <g
       onClick={[Function]}
+      transform="translate(0,0)"
     >
-      <svg
-        style={
-          Object {
-            "height": 27.72,
-            "width": 26,
-          }
-        }
-        viewBox="-13 -8.36 26 27.72"
+      <g
+        className="m-vehicle-icon m-vehicle-icon--small on-time"
       >
-        <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time"
+        <rect
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={7.359999999999999}
+        />
+        <text
+          className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={12.86}
         >
-          <rect
-            className="m-vehicle-icon__label-background"
-            height={11}
-            rx={5.5}
-            ry={5.5}
-            width={26}
-            x={-13}
-            y={7.359999999999999}
-          />
-          <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-            dominantBaseline="central"
-            textAnchor="middle"
-            x="0"
-            y={12.86}
-          >
-            2
-          </text>
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-            transform="scale(0.38) rotate(270) translate(-24,-22)"
-          />
-        </g>
-      </svg>
-    </div>
-  </div>,
+          2
+        </text>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.38) rotate(270) translate(-24,-22)"
+        />
+      </g>
+    </g>
+  </svg>,
   <div
     className="m-ladder"
     style={
@@ -392,61 +391,54 @@ Array [
       className="mock-react-tooltip"
     />
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="-15 -10 30 32"
+    width={30}
   >
-    <div
-      className="m-layover-box__vehicle"
+    <g
       onClick={[Function]}
+      transform="translate(0,0)"
     >
-      <svg
-        style={
-          Object {
-            "height": 27.72,
-            "width": 26,
-          }
-        }
-        viewBox="-13 -8.36 26 27.72"
+      <g
+        className="m-vehicle-icon m-vehicle-icon--small on-time"
       >
-        <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time"
+        <rect
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={7.359999999999999}
+        />
+        <text
+          className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={12.86}
         >
-          <rect
-            className="m-vehicle-icon__label-background"
-            height={11}
-            rx={5.5}
-            ry={5.5}
-            width={26}
-            x={-13}
-            y={7.359999999999999}
-          />
-          <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-            dominantBaseline="central"
-            textAnchor="middle"
-            x="0"
-            y={12.86}
-          >
-            1
-          </text>
-          <path
-            className="m-vehicle-icon__triangle"
-            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-            transform="scale(0.38) rotate(90) translate(-24,-22)"
-          />
-          <text
-            className="m-vehicle-icon__variant"
-            dominantBaseline="central"
-            textAnchor="start"
-            x={-5.6}
-            y={0}
-          >
-            4
-          </text>
-        </g>
-      </svg>
-    </div>
-  </div>,
+          1
+        </text>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.38) rotate(90) translate(-24,-22)"
+        />
+        <text
+          className="m-vehicle-icon__variant"
+          dominantBaseline="central"
+          textAnchor="start"
+          x={-5.6}
+          y={0}
+        >
+          4
+        </text>
+      </g>
+    </g>
+  </svg>,
   <div
     className="m-incoming-box"
   />,
@@ -495,8 +487,11 @@ Array [
       Reverse
     </button>
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-ladder"
@@ -774,8 +769,11 @@ Array [
       className="mock-react-tooltip"
     />
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-incoming-box"
@@ -825,8 +823,11 @@ Array [
       Reverse
     </button>
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-ladder"
@@ -930,8 +931,11 @@ Array [
       className="mock-react-tooltip"
     />
   </div>,
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />,
   <div
     className="m-incoming-box"

--- a/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
@@ -44,8 +44,11 @@ exports[`renders a route ladder 1`] = `
       Reverse
     </button>
   </div>
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />
   <div
     className="m-ladder"
@@ -149,8 +152,11 @@ exports[`renders a route ladder 1`] = `
       className="mock-react-tooltip"
     />
   </div>
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />
   <div
     className="m-incoming-box"
@@ -195,8 +201,11 @@ exports[`renders a route ladder 1`] = `
       Reverse
     </button>
   </div>
-  <div
+  <svg
     className="m-layover-box m-layover-box--top"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />
   <div
     className="m-ladder"
@@ -300,8 +309,11 @@ exports[`renders a route ladder 1`] = `
       className="mock-react-tooltip"
     />
   </div>
-  <div
+  <svg
     className="m-layover-box m-layover-box--bottom"
+    height={32}
+    viewBox="0 -10 0 32"
+    width={0}
   />
   <div
     className="m-incoming-box"

--- a/assets/tests/components/layoverBox.test.tsx
+++ b/assets/tests/components/layoverBox.test.tsx
@@ -163,7 +163,7 @@ describe("LayoverBox", () => {
       </StateDispatchProvider>
     )
 
-    wrapper.find(".m-layover-box__vehicle").first().simulate("click")
+    wrapper.find(".m-vehicle-icon").first().simulate("click")
 
     expect(dispatch).toHaveBeenCalledWith(selectVehicle(vehicles[0].id))
   })
@@ -188,11 +188,11 @@ describe("LayoverBox", () => {
     )
 
     expect(
-      topWrapper.find(".m-layover-box__vehicle").map((icon) => icon.text())
+      topWrapper.find(".m-vehicle-icon").map((icon) => icon.text())
     ).toEqual(["ghost_soonest", "sooner", "later"])
 
     expect(
-      bottomWrapper.find(".m-layover-box__vehicle").map((icon) => icon.text())
+      bottomWrapper.find(".m-vehicle-icon").map((icon) => icon.text())
     ).toEqual(["later", "sooner", "ghost_soonest"])
   })
 })


### PR DESCRIPTION
Asana Task: [Move laying over areas into the route ladder SVG - (1) Turn each laying over sections into a single SVG](https://app.asana.com/0/1148853526253426/1166474874729001)

The space above/below the layover box might have changed by a couple pixels, but otherwise no user facing changes.

<img width="615" alt="Screen Shot 2020-04-09 at 15 35 11" src="https://user-images.githubusercontent.com/23065557/78934139-6822d980-7a78-11ea-89af-453000e5bdcb.png">


It'll be a lot easier to see how the snapshot changes if you turn off whitespace changes.