### PR TITLE
Disable map recenter button when auto centering is on

### DIFF
--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -2,3 +2,8 @@
   width: 100%;
   height: 100%;
 }
+
+.leaflet-bar.leaflet-control-zoom .leaflet-disabled {
+  background-color: $color-button-disabled;
+  color: $color-font-grey;
+}

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -55,6 +55,7 @@
   .m-vehicle-map-state--auto-centering + .m-vehicle-map & a {
     background-color: $color-button-disabled;
     color: $color-font-grey;
+    cursor: default;
 
     path {
       stroke: $color-font-grey;

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -48,7 +48,7 @@
 .m-vehicle-map__recenter-button {
   path {
     fill: none;
-    stroke: $black;
+    stroke: $color-button-secondary;
     stroke-width: 2;
   }
 

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -52,7 +52,7 @@
     stroke-width: 1.8;
   }
 
-  .m-vehicle-map--auto-centering & a {
+  .m-vehicle-map-state--auto-centering + .m-vehicle-map & a {
     background-color: $color-button-disabled;
     color: $color-font-grey;
 

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -51,4 +51,13 @@
     stroke: $black;
     stroke-width: 1.8;
   }
+
+  .m-vehicle-map--auto-centering & a {
+    background-color: $color-button-disabled;
+    color: $color-font-grey;
+
+    path {
+      stroke: $color-font-grey;
+    }
+  }
 }

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -49,7 +49,7 @@
   path {
     fill: none;
     stroke: $black;
-    stroke-width: 1.8;
+    stroke-width: 2;
   }
 
   .m-vehicle-map-state--auto-centering + .m-vehicle-map & a {

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -278,7 +278,7 @@ const recenterControl = (
       ) as HTMLLinkElement
       link.innerHTML = `<svg
         height="30"
-        viewBox="-7 -5 36 36"
+        viewBox="-5 -2 36 36"
         width="30"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -387,10 +387,14 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
     setMapState({ map, markers, shapes })
   }, [shouldAutoCenter, props, containerRef, appState])
 
+  const autoCenteringClass = shouldAutoCenter
+    ? "m-vehicle-map--auto-centering"
+    : ""
+
   return (
     <div
       id="id-vehicle-map"
-      className="m-vehicle-map"
+      className={`m-vehicle-map ${autoCenteringClass}`}
       ref={(container) => (containerRef.current = container)}
     />
   )

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -388,15 +388,18 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
   }, [shouldAutoCenter, props, containerRef, appState])
 
   const autoCenteringClass = shouldAutoCenter
-    ? "m-vehicle-map--auto-centering"
+    ? "m-vehicle-map-state--auto-centering"
     : ""
 
   return (
-    <div
-      id="id-vehicle-map"
-      className={`m-vehicle-map ${autoCenteringClass}`}
-      ref={(container) => (containerRef.current = container)}
-    />
+    <>
+      <div className={`m-vehicle-map-state ${autoCenteringClass}`} />
+      <div
+        id="id-vehicle-map"
+        className="m-vehicle-map"
+        ref={(container) => (containerRef.current = container)}
+      />
+    </>
   )
 }
 

--- a/assets/tests/components/__snapshots__/map.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/map.test.tsx.snap
@@ -1,8 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`map renders 1`] = `
-<div
-  className="m-vehicle-map m-vehicle-map--auto-centering"
-  id="id-vehicle-map"
-/>
+Array [
+  <div
+    className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+  />,
+  <div
+    className="m-vehicle-map"
+    id="id-vehicle-map"
+  />,
+]
 `;

--- a/assets/tests/components/__snapshots__/map.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/map.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`map renders 1`] = `
 <div
-  className="m-vehicle-map"
+  className="m-vehicle-map m-vehicle-map--auto-centering"
   id="id-vehicle-map"
 />
 `;

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -415,7 +415,10 @@ Array [
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map m-vehicle-map--auto-centering"
+            className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          />
+          <div
+            className="m-vehicle-map"
             id="id-vehicle-map"
           />
         </div>

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -415,7 +415,7 @@ Array [
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map"
+            className="m-vehicle-map m-vehicle-map--auto-centering"
             id="id-vehicle-map"
           />
         </div>

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>
@@ -396,7 +396,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map"
+            className="m-vehicle-map m-vehicle-map--auto-centering"
             id="id-vehicle-map"
           />
         </div>
@@ -587,7 +587,7 @@ exports[`SearchPage renders the empty state 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>
@@ -765,7 +765,7 @@ exports[`SearchPage renders vehicle data 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -171,7 +171,10 @@ exports[`SearchPage renders a selected vehicle 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>
@@ -396,7 +399,10 @@ exports[`SearchPage renders a selected vehicle 1`] = `
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map m-vehicle-map--auto-centering"
+            className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          />
+          <div
+            className="m-vehicle-map"
             id="id-vehicle-map"
           />
         </div>
@@ -587,7 +593,10 @@ exports[`SearchPage renders the empty state 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>
@@ -765,7 +774,10 @@ exports[`SearchPage renders vehicle data 1`] = `
     className="m-search-page__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`Shuttle Map Page renders 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>
@@ -413,7 +413,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>
@@ -609,7 +609,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map"
+            className="m-vehicle-map m-vehicle-map--auto-centering"
             id="id-vehicle-map"
           />
         </div>
@@ -832,7 +832,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>
@@ -1042,7 +1042,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map"
+      className="m-vehicle-map m-vehicle-map--auto-centering"
       id="id-vehicle-map"
     />
   </div>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -203,7 +203,10 @@ exports[`Shuttle Map Page renders 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>
@@ -413,7 +416,10 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>
@@ -609,7 +615,10 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
           className="m-vehicle-properties-panel__map"
         >
           <div
-            className="m-vehicle-map m-vehicle-map--auto-centering"
+            className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          />
+          <div
+            className="m-vehicle-map"
             id="id-vehicle-map"
           />
         </div>
@@ -832,7 +841,10 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>
@@ -1042,7 +1054,10 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
     className="m-shuttle-map__map"
   >
     <div
-      className="m-vehicle-map m-vehicle-map--auto-centering"
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
       id="id-vehicle-map"
     />
   </div>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -444,7 +444,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -670,7 +670,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -867,7 +867,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -1202,7 +1202,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -1428,7 +1428,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -1668,7 +1668,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>
@@ -1894,7 +1894,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map"
+        className="m-vehicle-map m-vehicle-map--auto-centering"
         id="id-vehicle-map"
       />
     </div>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -218,7 +218,10 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -444,7 +447,10 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -670,7 +676,10 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -867,7 +876,10 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -1202,7 +1214,10 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -1428,7 +1443,10 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -1668,7 +1686,10 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -1894,7 +1915,10 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
       className="m-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map m-vehicle-map--auto-centering"
+        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        className="m-vehicle-map"
         id="id-vehicle-map"
       />
     </div>


### PR DESCRIPTION
Asana ticket: [Disable map recenter button if autoCenter is on](https://app.asana.com/0/1148853526253426/1145445573523887)

New version of https://github.com/mbta/skate/pull/585 that was reverted by https://github.com/mbta/skate/pull/589. This version fixes the bug where our tab bar would disappear that was discovered here: https://github.com/mbta/skate/pull/587#issuecomment-614684877.

Background: Leaflet doesn't want its div changing, that caused the bug. I moved the class name that represents the current state of things to an adjacent div.