### PR TITLE
allow missing fields in Schedule.Trip

### DIFF
--- a/lib/concentrate/consumer/stop_time_updates.ex
+++ b/lib/concentrate/consumer/stop_time_updates.ex
@@ -54,7 +54,7 @@ defmodule Concentrate.Consumer.StopTimeUpdates do
       trip_fn = Application.get_env(:realtime, :trip_fn, &Schedule.trip/1)
       trip = trip_fn.(trip_id)
 
-      if trip != nil do
+      if trip != nil and trip.service_id != nil do
         MapSet.put(acc, {trip.block_id, trip.service_id})
       else
         acc

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -379,6 +379,7 @@ defmodule Schedule.Data do
     trips
     |> Enum.map(fn trip -> trip.shape_id end)
     |> Enum.uniq()
+    |> Enum.filter(fn shape_id -> shape_id != nil end)
   end
 
   @spec get_shapes_by_ids([Shape.id()], Shape.shapes_by_id()) :: [Shape.t()]

--- a/lib/schedule/trip.ex
+++ b/lib/schedule/trip.ex
@@ -9,13 +9,13 @@ defmodule Schedule.Trip do
   @type t :: %__MODULE__{
           id: id(),
           route_id: Route.id(),
-          service_id: Service.id(),
-          headsign: String.t(),
-          direction_id: Direction.id(),
           block_id: Block.id(),
+          service_id: Service.id() | nil,
+          headsign: String.t() | nil,
+          direction_id: Direction.id() | nil,
           # Shuttles do not have route_pattern_ids
           route_pattern_id: RoutePattern.id() | nil,
-          shape_id: Shape.id(),
+          shape_id: Shape.id() | nil,
           run_id: Run.id() | nil,
           stop_times: [StopTime.t()]
         }
@@ -23,11 +23,7 @@ defmodule Schedule.Trip do
   @enforce_keys [
     :id,
     :route_id,
-    :service_id,
-    :headsign,
-    :direction_id,
     :block_id,
-    :shape_id
   ]
 
   @derive Jason.Encoder
@@ -35,14 +31,14 @@ defmodule Schedule.Trip do
   defstruct [
     :id,
     :route_id,
-    :service_id,
-    :headsign,
-    :direction_id,
     :block_id,
-    :route_pattern_id,
-    :shape_id,
-    run_id: nil,
-    stop_times: []
+    service_id: nil,
+    headsign: nil,
+    direction_id: nil,
+    route_pattern_id: nil,
+    shape_id: nil,
+    stop_times: [],
+    run_id: nil
   ]
 
   @spec merge(Gtfs.Trip.t(), [StopTime.t()], Run.id() | nil) :: t()
@@ -50,10 +46,10 @@ defmodule Schedule.Trip do
     %__MODULE__{
       id: gtfs_trip.id,
       route_id: gtfs_trip.route_id,
+      block_id: gtfs_trip.block_id,
       service_id: gtfs_trip.service_id,
       headsign: gtfs_trip.headsign,
       direction_id: gtfs_trip.direction_id,
-      block_id: gtfs_trip.block_id,
       route_pattern_id: gtfs_trip.route_pattern_id,
       shape_id: gtfs_trip.shape_id,
       run_id: run_id,

--- a/lib/schedule/trip.ex
+++ b/lib/schedule/trip.ex
@@ -23,7 +23,7 @@ defmodule Schedule.Trip do
   @enforce_keys [
     :id,
     :route_id,
-    :block_id,
+    :block_id
   ]
 
   @derive Jason.Encoder

--- a/test/concentrate/consumer/stop_time_updates_test.exs
+++ b/test/concentrate/consumer/stop_time_updates_test.exs
@@ -9,14 +9,8 @@ defmodule Concentrate.Consumer.StopTimeUpdatesTest do
   @trip %Trip{
     id: "t1",
     route_id: "28",
-    service_id: "service",
-    headsign: "headsign",
-    direction_id: 1,
     block_id: "S28-2",
-    route_pattern_id: "28-_-0",
-    shape_id: "shape1",
-    run_id: "run1",
-    stop_times: []
+    service_id: "service"
   }
 
   @stop_time_update %StopTimeUpdate{

--- a/test/concentrate/consumer/stop_time_updates_test.exs
+++ b/test/concentrate/consumer/stop_time_updates_test.exs
@@ -69,6 +69,14 @@ defmodule Concentrate.Consumer.StopTimeUpdatesTest do
 
       assert response == {:noreply, [], %{}}
     end
+
+    test "trips with missing data", %{events: events} do
+      reassign_env(:realtime, :trip_fn, fn _trip_id -> %{@trip | service_id: nil} end)
+
+      response = StopTimeUpdates.handle_events(events, nil, %{})
+
+      assert response == {:noreply, [], %{}}
+    end
   end
 
   describe "stop_time_updates_by_trip/1" do

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -11,10 +11,7 @@ defmodule Realtime.BlockWaiverTest do
     id: "trip1",
     route_id: "route",
     service_id: "service",
-    headsign: "headsign",
-    direction_id: 0,
     block_id: "block",
-    shape_id: "shape",
     stop_times: [
       %StopTime{stop_id: "stop1", time: 1},
       %StopTime{stop_id: "stop2", time: 2},
@@ -26,10 +23,7 @@ defmodule Realtime.BlockWaiverTest do
     id: "trip2",
     route_id: "route",
     service_id: "service",
-    headsign: "headsign",
-    direction_id: 1,
     block_id: "block",
-    shape_id: "shape",
     stop_times: [
       %StopTime{stop_id: "stop3", time: 4},
       %StopTime{stop_id: "stop2", time: 5},

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -10,8 +10,8 @@ defmodule Realtime.BlockWaiverTest do
   @trip1 %Trip{
     id: "trip1",
     route_id: "route",
-    service_id: "service",
     block_id: "block",
+    service_id: "service",
     stop_times: [
       %StopTime{stop_id: "stop1", time: 1},
       %StopTime{stop_id: "stop2", time: 2},
@@ -22,8 +22,8 @@ defmodule Realtime.BlockWaiverTest do
   @trip2 %Trip{
     id: "trip2",
     route_id: "route",
-    service_id: "service",
     block_id: "block",
+    service_id: "service",
     stop_times: [
       %StopTime{stop_id: "stop3", time: 4},
       %StopTime{stop_id: "stop2", time: 5},

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -28,7 +28,6 @@ defmodule Realtime.GhostTest do
         direction_id: 0,
         block_id: "block",
         route_pattern_id: "route-X-0",
-        shape_id: "shape1",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -90,7 +89,6 @@ defmodule Realtime.GhostTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -130,7 +128,6 @@ defmodule Realtime.GhostTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -180,7 +177,6 @@ defmodule Realtime.GhostTest do
           headsign: "headsign1",
           direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           run_id: "run",
           stop_times: [
             %StopTime{
@@ -197,7 +193,6 @@ defmodule Realtime.GhostTest do
           headsign: "headsign2",
           direction_id: 1,
           block_id: "block",
-          shape_id: "shape2",
           run_id: "run",
           stop_times: [
             %StopTime{
@@ -245,7 +240,6 @@ defmodule Realtime.GhostTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -284,7 +278,6 @@ defmodule Realtime.GhostTest do
         direction_id: 0,
         block_id: "block",
         route_pattern_id: nil,
-        shape_id: "shape",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -308,7 +301,6 @@ defmodule Realtime.GhostTest do
         direction_id: 1,
         block_id: "block",
         route_pattern_id: nil,
-        shape_id: "shape",
         run_id: "run",
         stop_times: [
           %StopTime{

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -23,10 +23,10 @@ defmodule Realtime.GhostTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         route_pattern_id: "route-X-0",
         run_id: "run",
         stop_times: [
@@ -85,10 +85,10 @@ defmodule Realtime.GhostTest do
       trip = %Trip{
         id: "trip1",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -124,10 +124,10 @@ defmodule Realtime.GhostTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -173,10 +173,10 @@ defmodule Realtime.GhostTest do
         %Trip{
           id: "trip1",
           route_id: "route",
+          block_id: "block",
           service_id: "service",
           headsign: "headsign1",
           direction_id: 0,
-          block_id: "block",
           run_id: "run",
           stop_times: [
             %StopTime{
@@ -189,10 +189,10 @@ defmodule Realtime.GhostTest do
         %Trip{
           id: "trip2",
           route_id: "route",
+          block_id: "block",
           service_id: "service",
           headsign: "headsign2",
           direction_id: 1,
-          block_id: "block",
           run_id: "run",
           stop_times: [
             %StopTime{
@@ -236,10 +236,10 @@ defmodule Realtime.GhostTest do
       trip = %Trip{
         id: "trip1",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         run_id: "run",
         stop_times: [
           %StopTime{
@@ -273,10 +273,10 @@ defmodule Realtime.GhostTest do
       trip1 = %Trip{
         id: "1",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign1",
         direction_id: 0,
-        block_id: "block",
         route_pattern_id: nil,
         run_id: "run",
         stop_times: [
@@ -296,10 +296,10 @@ defmodule Realtime.GhostTest do
       trip2 = %Trip{
         id: "2",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign2",
         direction_id: 1,
-        block_id: "block",
         route_pattern_id: nil,
         run_id: "run",
         stop_times: [

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -231,10 +231,10 @@ defmodule Realtime.TimepointStatusTest do
         %Trip{
           id: "1",
           route_id: "28",
+          block_id: "S28-2",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
-          block_id: "S28-2",
           route_pattern_id: "28-_-1",
           run_id: "run1",
           stop_times: [
@@ -275,10 +275,10 @@ defmodule Realtime.TimepointStatusTest do
         %Trip{
           id: "1",
           route_id: "28",
+          block_id: "S28-2",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
-          block_id: "S28-2",
           route_pattern_id: "28-_-1",
           run_id: "run1",
           stop_times: [
@@ -319,10 +319,10 @@ defmodule Realtime.TimepointStatusTest do
         %Trip{
           id: "0",
           route_id: "28",
+          block_id: "S28-2",
           service_id: "service",
           headsign: "headsign",
           direction_id: 0,
-          block_id: "S28-2",
           route_pattern_id: "28-_-0",
           run_id: "run1",
           stop_times: [
@@ -341,10 +341,10 @@ defmodule Realtime.TimepointStatusTest do
         %Trip{
           id: "1",
           route_id: "28",
+          block_id: "S28-2",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
-          block_id: "S28-2",
           route_pattern_id: "28-_-1",
           run_id: "run1",
           stop_times: [
@@ -380,10 +380,10 @@ defmodule Realtime.TimepointStatusTest do
         %Trip{
           id: "1",
           route_id: "28",
+          block_id: "S28-2",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
-          block_id: "S28-2",
           route_pattern_id: "28-_-1",
           run_id: "run1",
           stop_times: [

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -236,7 +236,6 @@ defmodule Realtime.TimepointStatusTest do
           direction_id: 1,
           block_id: "S28-2",
           route_pattern_id: "28-_-1",
-          shape_id: "shape1",
           run_id: "run1",
           stop_times: [
             %StopTime{
@@ -281,7 +280,6 @@ defmodule Realtime.TimepointStatusTest do
           direction_id: 1,
           block_id: "S28-2",
           route_pattern_id: "28-_-1",
-          shape_id: "shape1",
           run_id: "run1",
           stop_times: [
             %StopTime{
@@ -326,7 +324,6 @@ defmodule Realtime.TimepointStatusTest do
           direction_id: 0,
           block_id: "S28-2",
           route_pattern_id: "28-_-0",
-          shape_id: "shape1",
           run_id: "run1",
           stop_times: [
             %StopTime{
@@ -349,7 +346,6 @@ defmodule Realtime.TimepointStatusTest do
           direction_id: 1,
           block_id: "S28-2",
           route_pattern_id: "28-_-1",
-          shape_id: "shape1",
           run_id: "run1",
           stop_times: [
             %StopTime{
@@ -389,7 +385,6 @@ defmodule Realtime.TimepointStatusTest do
           direction_id: 1,
           block_id: "S28-2",
           route_pattern_id: "28-_-1",
-          shape_id: "shape1",
           run_id: "run1",
           stop_times: [
             %StopTime{stop_id: "1", time: Util.Time.parse_hhmmss("12:05:00"), timepoint_id: "1"},

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -55,10 +55,10 @@ defmodule Realtime.VehicleTest do
       trip = %Trip{
         id: "39984755",
         route_id: "28",
+        block_id: "S28-2",
         service_id: "service",
         headsign: "headsign",
         direction_id: 1,
-        block_id: "S28-2",
         route_pattern_id: "28-_-0",
         run_id: "run1",
         stop_times: [

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -60,7 +60,6 @@ defmodule Realtime.VehicleTest do
         direction_id: 1,
         block_id: "S28-2",
         route_pattern_id: "28-_-0",
-        shape_id: "shape1",
         run_id: "run1",
         stop_times: [
           %StopTime{stop_id: "18511", time: 0, timepoint_id: "tp1"},
@@ -290,12 +289,7 @@ defmodule Realtime.VehicleTest do
         %Trip{
           id: "1",
           route_id: "28",
-          service_id: "service",
-          headsign: "headsign",
-          direction_id: 1,
           block_id: "S28-2",
-          route_pattern_id: "28-_-1",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "6553",
@@ -360,11 +354,7 @@ defmodule Realtime.VehicleTest do
       trip1 = %Trip{
         id: "t1",
         route_id: "r1",
-        service_id: "service",
-        headsign: "Trip 1",
-        direction_id: 1,
         block_id: "b",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "s1",
@@ -382,11 +372,7 @@ defmodule Realtime.VehicleTest do
       trip2 = %Trip{
         id: "t2",
         route_id: "r1",
-        service_id: "service",
-        headsign: "Trip 2",
-        direction_id: 0,
         block_id: "b",
-        shape_id: "shape2",
         stop_times: [
           %StopTime{
             stop_id: "s2",
@@ -440,11 +426,7 @@ defmodule Realtime.VehicleTest do
       first_trip = %Trip{
         id: "t1",
         route_id: "r1",
-        service_id: "service",
-        headsign: "Trip 1",
-        direction_id: 1,
         block_id: "b",
-        shape_id: "shape1",
         run_id: "run1",
         stop_times: [
           %StopTime{
@@ -465,11 +447,7 @@ defmodule Realtime.VehicleTest do
       last_trip_of_run = %Trip{
         id: "t2",
         route_id: "r1",
-        service_id: "service",
-        headsign: "Trip 2",
-        direction_id: 0,
         block_id: "b",
-        shape_id: "shape2",
         run_id: "run1",
         stop_times: [
           %StopTime{
@@ -490,11 +468,7 @@ defmodule Realtime.VehicleTest do
       last_trip_of_block = %Trip{
         id: "t3",
         route_id: "r1",
-        service_id: "service",
-        headsign: "Trip 33",
-        direction_id: 0,
         block_id: "b",
-        shape_id: "shape3",
         run_id: "run2",
         stop_times: [
           %StopTime{

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -183,6 +183,25 @@ defmodule Realtime.VehicleTest do
       assert result.headway_secs == nil
       assert result.headway_spacing == nil
     end
+
+    test "handles unknown trips" do
+      reassign_env(:realtime, :trip_fn, fn _ -> nil end)
+      result = Vehicle.from_vehicle_position(@vehicle_position)
+      assert %Vehicle{} = result
+    end
+
+    test "handles trips with incomplete data" do
+      reassign_env(:realtime, :trip_fn, fn _ ->
+        %Trip{
+          id: "39984755",
+          route_id: "28",
+          block_id: "S28-2"
+        }
+      end)
+
+      result = Vehicle.from_vehicle_position(@vehicle_position)
+      assert %Vehicle{} = result
+    end
   end
 
   describe "off_course?/2" do

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -192,7 +192,6 @@ defmodule Realtime.VehiclesTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -273,7 +272,6 @@ defmodule Realtime.VehiclesTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -309,7 +307,6 @@ defmodule Realtime.VehiclesTest do
         headsign: "headsign",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -373,7 +370,6 @@ defmodule Realtime.VehiclesTest do
         headsign: "headsign1",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -395,7 +391,6 @@ defmodule Realtime.VehiclesTest do
         headsign: "headsign2",
         direction_id: 0,
         block_id: "block",
-        shape_id: "shape2",
         stop_times: [
           %StopTime{
             stop_id: "stop3",
@@ -448,32 +443,12 @@ defmodule Realtime.VehiclesTest do
         %Trip{
           id: "first",
           route_id: "first",
-          service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
-          block_id: "block",
-          shape_id: "shape1",
-          stop_times: [
-            %StopTime{
-              stop_id: "stop",
-              time: 2
-            }
-          ]
+          block_id: "block"
         },
         %Trip{
           id: "second",
           route_id: "second",
-          service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
-          block_id: "block",
-          shape_id: "shape1",
-          stop_times: [
-            %StopTime{
-              stop_id: "stop",
-              time: 3
-            }
-          ]
+          block_id: "block"
         }
       ]
 
@@ -488,32 +463,12 @@ defmodule Realtime.VehiclesTest do
         %Trip{
           id: "first",
           route_id: "route",
-          service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
-          block_id: "block",
-          shape_id: "shape1",
-          stop_times: [
-            %StopTime{
-              stop_id: "stop",
-              time: 2
-            }
-          ]
+          block_id: "block"
         },
         %Trip{
           id: "second",
           route_id: "route",
-          service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
-          block_id: "block",
-          shape_id: "shape1",
-          stop_times: [
-            %StopTime{
-              stop_id: "stop",
-              time: 3
-            }
-          ]
+          block_id: "block"
         }
       ]
 

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -188,10 +188,10 @@ defmodule Realtime.VehiclesTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -268,10 +268,10 @@ defmodule Realtime.VehiclesTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -303,10 +303,10 @@ defmodule Realtime.VehiclesTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
-        block_id: "block",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -366,10 +366,10 @@ defmodule Realtime.VehiclesTest do
       trip1 = %Trip{
         id: "trip1",
         route_id: "route1",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign1",
         direction_id: 0,
-        block_id: "block",
         stop_times: [
           %StopTime{
             stop_id: "stop1",
@@ -387,10 +387,10 @@ defmodule Realtime.VehiclesTest do
       trip2 = %Trip{
         id: "trip2",
         route_id: "route2",
+        block_id: "block",
         service_id: "service",
         headsign: "headsign2",
         direction_id: 0,
-        block_id: "block",
         stop_times: [
           %StopTime{
             stop_id: "stop3",

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -8,8 +8,8 @@ defmodule Schedule.BlockTest do
   @trip1 %Trip{
     id: "t1",
     route_id: "r",
-    service_id: "service",
     block_id: "b",
+    service_id: "service",
     stop_times: [
       %StopTime{stop_id: "s1", time: 3, timepoint_id: "tp1"},
       %StopTime{stop_id: "s7", time: 4, timepoint_id: nil}
@@ -19,8 +19,8 @@ defmodule Schedule.BlockTest do
   @trip2 %Trip{
     id: "t2",
     route_id: "r",
-    service_id: "service",
     block_id: "b",
+    service_id: "service",
     stop_times: [
       %StopTime{stop_id: "s7", time: 6, timepoint_id: nil},
       %StopTime{stop_id: "s1", time: 7, timepoint_id: "tp1"}

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -9,11 +9,7 @@ defmodule Schedule.BlockTest do
     id: "t1",
     route_id: "r",
     service_id: "service",
-    headsign: "h",
-    direction_id: 0,
     block_id: "b",
-    route_pattern_id: "rp",
-    shape_id: "shape1",
     stop_times: [
       %StopTime{stop_id: "s1", time: 3, timepoint_id: "tp1"},
       %StopTime{stop_id: "s7", time: 4, timepoint_id: nil}
@@ -24,11 +20,7 @@ defmodule Schedule.BlockTest do
     id: "t2",
     route_id: "r",
     service_id: "service",
-    headsign: "h",
-    direction_id: 1,
     block_id: "b",
-    route_pattern_id: "rp",
-    shape_id: "shape1",
     stop_times: [
       %StopTime{stop_id: "s7", time: 6, timepoint_id: nil},
       %StopTime{stop_id: "s1", time: 7, timepoint_id: "tp1"}

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -195,8 +195,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "t1",
         route_id: "r1",
-        service_id: "service",
         block_id: "b",
+        service_id: "service",
         stop_times: [
           %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
         ]
@@ -220,8 +220,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "t1",
         route_id: "r1",
-        service_id: "service",
         block_id: "b",
+        service_id: "service",
         stop_times: [
           %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
         ]
@@ -290,8 +290,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "active",
         route_id: "route",
-        service_id: "today",
         block_id: "active",
+        service_id: "today",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -326,8 +326,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
-        service_id: "today",
         block_id: "block",
+        service_id: "today",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -360,8 +360,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
-        service_id: "tomorrow",
         block_id: "block",
+        service_id: "tomorrow",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -394,8 +394,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
-        service_id: "yesterday",
         block_id: "block",
+        service_id: "yesterday",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -432,8 +432,8 @@ defmodule Schedule.DataTest do
         %Trip{
           id: "trip",
           route_id: "route",
-          service_id: "today",
           block_id: "block",
+          service_id: "today",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -481,8 +481,8 @@ defmodule Schedule.DataTest do
             %Trip{
               id: "trip",
               route_id: "route",
-              service_id: "today",
               block_id: "block",
+              service_id: "today",
               stop_times: [
                 %StopTime{
                   stop_id: "stop",
@@ -512,8 +512,8 @@ defmodule Schedule.DataTest do
         %Trip{
           id: "first",
           route_id: "route",
-          service_id: "today",
           block_id: "block",
+          service_id: "today",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -524,8 +524,8 @@ defmodule Schedule.DataTest do
         %Trip{
           id: "second",
           route_id: "route",
-          service_id: "today",
           block_id: "block",
+          service_id: "today",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -560,8 +560,8 @@ defmodule Schedule.DataTest do
         %Trip{
           id: "first",
           route_id: "route",
-          service_id: "today",
           block_id: "block",
+          service_id: "today",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -575,8 +575,8 @@ defmodule Schedule.DataTest do
         %Trip{
           id: "second",
           route_id: "route",
-          service_id: "tomorrow",
           block_id: "block",
+          service_id: "tomorrow",
           stop_times: [
             %StopTime{
               stop_id: "stop",

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -164,15 +164,7 @@ defmodule Schedule.DataTest do
           "t1" => %Trip{
             id: "t1",
             route_id: "r1",
-            service_id: "service",
-            headsign: "h",
-            direction_id: 1,
-            block_id: "b",
-            route_pattern_id: "r1-_-0",
-            shape_id: "shape1",
-            stop_times: [
-              %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
-            ]
+            block_id: "b"
           }
         },
         blocks: %{},
@@ -204,11 +196,7 @@ defmodule Schedule.DataTest do
         id: "t1",
         route_id: "r1",
         service_id: "service",
-        headsign: "h",
-        direction_id: 1,
         block_id: "b",
-        route_pattern_id: "r1-_-0",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
         ]
@@ -233,11 +221,7 @@ defmodule Schedule.DataTest do
         id: "t1",
         route_id: "r1",
         service_id: "service",
-        headsign: "h",
-        direction_id: 1,
         block_id: "b",
-        route_pattern_id: "r1-_-0",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{stop_id: "s1", time: 1, timepoint_id: nil}
         ]
@@ -307,10 +291,7 @@ defmodule Schedule.DataTest do
         id: "active",
         route_id: "route",
         service_id: "today",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "active",
-        shape_id: "shape",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -346,10 +327,7 @@ defmodule Schedule.DataTest do
         id: "trip",
         route_id: "route",
         service_id: "today",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -383,10 +361,7 @@ defmodule Schedule.DataTest do
         id: "trip",
         route_id: "route",
         service_id: "tomorrow",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -420,10 +395,7 @@ defmodule Schedule.DataTest do
         id: "trip",
         route_id: "route",
         service_id: "yesterday",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "block",
-        shape_id: "shape1",
         stop_times: [
           %StopTime{
             stop_id: "stop",
@@ -461,10 +433,7 @@ defmodule Schedule.DataTest do
           id: "trip",
           route_id: "route",
           service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -513,10 +482,7 @@ defmodule Schedule.DataTest do
               id: "trip",
               route_id: "route",
               service_id: "today",
-              headsign: "headsign",
-              direction_id: 0,
               block_id: "block",
-              shape_id: "shape1",
               stop_times: [
                 %StopTime{
                   stop_id: "stop",
@@ -547,10 +513,7 @@ defmodule Schedule.DataTest do
           id: "first",
           route_id: "route",
           service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -562,10 +525,7 @@ defmodule Schedule.DataTest do
           id: "second",
           route_id: "route",
           service_id: "today",
-          headsign: "headsign",
-          direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -601,10 +561,7 @@ defmodule Schedule.DataTest do
           id: "first",
           route_id: "route",
           service_id: "today",
-          headsign: "headsign1",
-          direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -619,10 +576,7 @@ defmodule Schedule.DataTest do
           id: "second",
           route_id: "route",
           service_id: "tomorrow",
-          headsign: "headsign2",
-          direction_id: 0,
           block_id: "block",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{
               stop_id: "stop",
@@ -737,12 +691,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
-        service_id: "today",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "block",
-        shape_id: "shape",
-        stop_times: []
+        shape_id: "shape"
       }
 
       shape = %Shape{
@@ -775,12 +725,8 @@ defmodule Schedule.DataTest do
       trip = %Trip{
         id: "trip",
         route_id: "route",
-        service_id: "today",
-        headsign: "headsign",
-        direction_id: 0,
         block_id: "block",
-        shape_id: "shape",
-        stop_times: []
+        shape_id: "shape"
       }
 
       data = %Data{
@@ -905,12 +851,8 @@ defmodule Schedule.DataTest do
         "t1" => %Trip{
           id: "t1",
           route_id: "r1",
-          service_id: "service",
-          headsign: "h1",
-          direction_id: 0,
           block_id: "b1",
           route_pattern_id: "rp1",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{stop_id: "s1", time: 1, timepoint_id: "tp1"},
             %StopTime{stop_id: "s7", time: 2, timepoint_id: nil}
@@ -919,12 +861,8 @@ defmodule Schedule.DataTest do
         "t2" => %Trip{
           id: "t2",
           route_id: "r2",
-          service_id: "service",
-          headsign: "h2",
-          direction_id: 0,
           block_id: "b2",
           route_pattern_id: "rp2",
-          shape_id: "shape2",
           stop_times: [
             %StopTime{stop_id: "s2", time: 1, timepoint_id: "tp2"},
             %StopTime{stop_id: "s3", time: 2, timepoint_id: "tp3"}
@@ -933,12 +871,8 @@ defmodule Schedule.DataTest do
         "t3" => %Trip{
           id: "t3",
           route_id: "r1",
-          service_id: "service",
-          headsign: "h3",
-          direction_id: 1,
           block_id: "b3",
           route_pattern_id: "rp3",
-          shape_id: "shape3",
           stop_times: [
             %StopTime{stop_id: "s4", time: 1, timepoint_id: "tp4"},
             %StopTime{stop_id: "s5", time: 2, timepoint_id: "tp1"}
@@ -981,12 +915,8 @@ defmodule Schedule.DataTest do
         "t1" => %Trip{
           id: "t1",
           route_id: "r1",
-          service_id: "service",
-          headsign: "h1",
-          direction_id: 1,
           block_id: "b1",
           route_pattern_id: "rp1",
-          shape_id: "shape1",
           stop_times: [
             %StopTime{stop_id: "s1", time: 1, timepoint_id: "tp1"},
             %StopTime{stop_id: "s3b", time: 2, timepoint_id: "tp3"}
@@ -995,12 +925,8 @@ defmodule Schedule.DataTest do
         "t2" => %Trip{
           id: "t2",
           route_id: "r1",
-          service_id: "service",
-          headsign: "h2",
-          direction_id: 1,
           block_id: "b2",
           route_pattern_id: "rp2",
-          shape_id: "shape2",
           stop_times: [
             %StopTime{stop_id: "s1", time: 1, timepoint_id: "tp1"},
             %StopTime{stop_id: "s2", time: 2, timepoint_id: "tp2"},

--- a/test/schedule/health/checkers/trip_stop_times_checker_test.exs
+++ b/test/schedule/health/checkers/trip_stop_times_checker_test.exs
@@ -23,13 +23,7 @@ defmodule Schedule.Health.Checkers.TripStopTimesCheckerTest do
         %Trip{
           id: "39984755",
           route_id: "28",
-          service_id: "service",
-          headsign: "headsign",
-          direction_id: 1,
           block_id: "S28-2",
-          route_pattern_id: "28-_-0",
-          shape_id: "shape1",
-          run_id: "run1",
           stop_times: [
             %StopTime{stop_id: "18511", time: 0, timepoint_id: "tp1"},
             %StopTime{stop_id: "18512", time: 1, timepoint_id: nil},

--- a/test/schedule/trip_test.exs
+++ b/test/schedule/trip_test.exs
@@ -21,10 +21,10 @@ defmodule Schedule.TripTest do
   @trip %Trip{
     id: "trip",
     route_id: "route",
+    block_id: "block",
     service_id: "service",
     headsign: "headsign",
     direction_id: 0,
-    block_id: "block",
     shape_id: "shape",
     run_id: "run",
     stop_times: @stop_times

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -300,10 +300,10 @@ defmodule GtfsTest do
                %Trip{
                  id: "t1",
                  route_id: "route",
+                 block_id: "b",
                  service_id: "service",
                  headsign: "h1",
                  direction_id: 1,
-                 block_id: "b",
                  route_pattern_id: "route-_-0",
                  shape_id: "shape1",
                  stop_times: [
@@ -390,11 +390,11 @@ defmodule GtfsTest do
                %Trip{
                  id: "t1",
                  route_id: "route",
+                 block_id: "b",
                  service_id: "service",
                  # Shuttles do not have route_pattern_ids
                  headsign: "h1",
                  direction_id: 1,
-                 block_id: "b",
                  route_pattern_id: "route-_-0",
                  shape_id: "shape1",
                  stop_times: [


### PR DESCRIPTION
Preparing for [Mini-schedule | Store nonrevenue trips and trip schedule_ids](https://app.asana.com/0/1148853526253426/1171782113097825)

Allowing nonrevenue trips means some trips will exist in our data that don't have GTFS data. This makes that possible and makes sure everywhere that expects GTFS data can handle nonrevenue data gracefully.