### PR TITLE
allow nonrevenue trips with nil route_id in trip type

### DIFF
--- a/lib/schedule/trip.ex
+++ b/lib/schedule/trip.ex
@@ -9,8 +9,8 @@ defmodule Schedule.Trip do
 
   @type t :: %__MODULE__{
           id: id(),
-          route_id: Route.id(),
           block_id: Block.id(),
+          route_id: Route.id() | nil,
           service_id: Service.id() | nil,
           headsign: String.t() | nil,
           direction_id: Direction.id() | nil,
@@ -23,7 +23,6 @@ defmodule Schedule.Trip do
 
   @enforce_keys [
     :id,
-    :route_id,
     :block_id
   ]
 
@@ -31,8 +30,8 @@ defmodule Schedule.Trip do
 
   defstruct [
     :id,
-    :route_id,
     :block_id,
+    route_id: nil,
     service_id: nil,
     headsign: nil,
     direction_id: nil,
@@ -64,8 +63,8 @@ defmodule Schedule.Trip do
   def merge(gtfs_trip, hastus_trip, stop_times) when gtfs_trip != nil or hastus_trip != nil do
     %__MODULE__{
       id: (gtfs_trip && gtfs_trip.id) || (hastus_trip && hastus_trip.trip_id),
-      route_id: (gtfs_trip && gtfs_trip.route_id) || (hastus_trip && hastus_trip.route_id),
       block_id: (gtfs_trip && gtfs_trip.block_id) || (hastus_trip && hastus_trip.block_id),
+      route_id: (gtfs_trip && gtfs_trip.route_id) || (hastus_trip && hastus_trip.route_id),
       service_id: gtfs_trip && gtfs_trip.service_id,
       headsign: gtfs_trip && gtfs_trip.headsign,
       direction_id: gtfs_trip && gtfs_trip.direction_id,

--- a/test/concentrate/consumer/stop_time_updates_test.exs
+++ b/test/concentrate/consumer/stop_time_updates_test.exs
@@ -8,7 +8,6 @@ defmodule Concentrate.Consumer.StopTimeUpdatesTest do
 
   @trip %Trip{
     id: "t1",
-    route_id: "28",
     block_id: "S28-2",
     service_id: "service"
   }

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -9,7 +9,6 @@ defmodule Realtime.BlockWaiverTest do
 
   @trip1 %Trip{
     id: "trip1",
-    route_id: "route",
     block_id: "block",
     service_id: "service",
     stop_times: [
@@ -21,7 +20,6 @@ defmodule Realtime.BlockWaiverTest do
 
   @trip2 %Trip{
     id: "trip2",
-    route_id: "route",
     block_id: "block",
     service_id: "service",
     stop_times: [

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -22,8 +22,8 @@ defmodule Realtime.GhostTest do
     test "makes a ghost bus for a block that doesn't have a vehicle" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -84,8 +84,8 @@ defmodule Realtime.GhostTest do
     test "does not make a ghost for a block if there's a vehicle on that block" do
       trip = %Trip{
         id: "trip1",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -123,8 +123,8 @@ defmodule Realtime.GhostTest do
     test "makes a ghost for a block that should be pulling out" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -172,8 +172,8 @@ defmodule Realtime.GhostTest do
       block = [
         %Trip{
           id: "trip1",
-          route_id: "route",
           block_id: "block",
+          route_id: "route",
           service_id: "service",
           headsign: "headsign1",
           direction_id: 0,
@@ -188,8 +188,8 @@ defmodule Realtime.GhostTest do
         },
         %Trip{
           id: "trip2",
-          route_id: "route",
           block_id: "block",
+          route_id: "route",
           service_id: "service",
           headsign: "headsign2",
           direction_id: 1,
@@ -235,8 +235,8 @@ defmodule Realtime.GhostTest do
     test "no ghost for a trip without timepoints" do
       trip = %Trip{
         id: "trip1",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -272,8 +272,8 @@ defmodule Realtime.GhostTest do
     setup do
       trip1 = %Trip{
         id: "1",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign1",
         direction_id: 0,
@@ -295,8 +295,8 @@ defmodule Realtime.GhostTest do
 
       trip2 = %Trip{
         id: "2",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign2",
         direction_id: 1,

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -230,8 +230,8 @@ defmodule Realtime.TimepointStatusTest do
       block = [
         %Trip{
           id: "1",
-          route_id: "28",
           block_id: "S28-2",
+          route_id: "28",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
@@ -274,8 +274,8 @@ defmodule Realtime.TimepointStatusTest do
       block = [
         %Trip{
           id: "1",
-          route_id: "28",
           block_id: "S28-2",
+          route_id: "28",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
@@ -318,8 +318,8 @@ defmodule Realtime.TimepointStatusTest do
       block = [
         %Trip{
           id: "0",
-          route_id: "28",
           block_id: "S28-2",
+          route_id: "28",
           service_id: "service",
           headsign: "headsign",
           direction_id: 0,
@@ -340,8 +340,8 @@ defmodule Realtime.TimepointStatusTest do
         },
         %Trip{
           id: "1",
-          route_id: "28",
           block_id: "S28-2",
+          route_id: "28",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,
@@ -379,8 +379,8 @@ defmodule Realtime.TimepointStatusTest do
       block = [
         %Trip{
           id: "1",
-          route_id: "28",
           block_id: "S28-2",
+          route_id: "28",
           service_id: "service",
           headsign: "headsign",
           direction_id: 1,

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -54,8 +54,8 @@ defmodule Realtime.VehicleTest do
     setup do
       trip = %Trip{
         id: "39984755",
-        route_id: "28",
         block_id: "S28-2",
+        route_id: "28",
         service_id: "service",
         headsign: "headsign",
         direction_id: 1,
@@ -194,7 +194,6 @@ defmodule Realtime.VehicleTest do
       reassign_env(:realtime, :trip_fn, fn _ ->
         %Trip{
           id: "39984755",
-          route_id: "28",
           block_id: "S28-2"
         }
       end)
@@ -307,7 +306,6 @@ defmodule Realtime.VehicleTest do
       block = [
         %Trip{
           id: "1",
-          route_id: "28",
           block_id: "S28-2",
           stop_times: [
             %StopTime{
@@ -372,7 +370,6 @@ defmodule Realtime.VehicleTest do
     setup do
       trip1 = %Trip{
         id: "t1",
-        route_id: "r1",
         block_id: "b",
         stop_times: [
           %StopTime{
@@ -390,7 +387,6 @@ defmodule Realtime.VehicleTest do
 
       trip2 = %Trip{
         id: "t2",
-        route_id: "r1",
         block_id: "b",
         stop_times: [
           %StopTime{
@@ -444,7 +440,6 @@ defmodule Realtime.VehicleTest do
     setup do
       first_trip = %Trip{
         id: "t1",
-        route_id: "r1",
         block_id: "b",
         run_id: "run1",
         stop_times: [
@@ -465,7 +460,6 @@ defmodule Realtime.VehicleTest do
 
       last_trip_of_run = %Trip{
         id: "t2",
-        route_id: "r1",
         block_id: "b",
         run_id: "run1",
         stop_times: [
@@ -486,7 +480,6 @@ defmodule Realtime.VehicleTest do
 
       last_trip_of_block = %Trip{
         id: "t3",
-        route_id: "r1",
         block_id: "b",
         run_id: "run2",
         stop_times: [

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -187,8 +187,8 @@ defmodule Realtime.VehiclesTest do
     test "includes trip without a vehicle as a ghost" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -267,8 +267,8 @@ defmodule Realtime.VehiclesTest do
 
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -302,8 +302,8 @@ defmodule Realtime.VehiclesTest do
 
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         service_id: "service",
         headsign: "headsign",
         direction_id: 0,
@@ -365,8 +365,8 @@ defmodule Realtime.VehiclesTest do
 
       trip1 = %Trip{
         id: "trip1",
-        route_id: "route1",
         block_id: "block",
+        route_id: "route1",
         service_id: "service",
         headsign: "headsign1",
         direction_id: 0,
@@ -386,8 +386,8 @@ defmodule Realtime.VehiclesTest do
 
       trip2 = %Trip{
         id: "trip2",
-        route_id: "route2",
         block_id: "block",
+        route_id: "route2",
         service_id: "service",
         headsign: "headsign2",
         direction_id: 0,
@@ -442,13 +442,13 @@ defmodule Realtime.VehiclesTest do
       incoming_trips = [
         %Trip{
           id: "first",
-          route_id: "first",
-          block_id: "block"
+          block_id: "block",
+          route_id: "first"
         },
         %Trip{
           id: "second",
-          route_id: "second",
-          block_id: "block"
+          block_id: "block",
+          route_id: "second"
         }
       ]
 
@@ -462,13 +462,13 @@ defmodule Realtime.VehiclesTest do
       incoming_trips = [
         %Trip{
           id: "first",
-          route_id: "route",
-          block_id: "block"
+          block_id: "block",
+          route_id: "route"
         },
         %Trip{
           id: "second",
-          route_id: "route",
-          block_id: "block"
+          block_id: "block",
+          route_id: "route"
         }
       ]
 

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -7,7 +7,6 @@ defmodule Schedule.BlockTest do
 
   @trip1 %Trip{
     id: "t1",
-    route_id: "r",
     block_id: "b",
     service_id: "service",
     stop_times: [
@@ -18,7 +17,6 @@ defmodule Schedule.BlockTest do
 
   @trip2 %Trip{
     id: "t2",
-    route_id: "r",
     block_id: "b",
     service_id: "service",
     stop_times: [

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -163,7 +163,6 @@ defmodule Schedule.DataTest do
         trips: %{
           "t1" => %Trip{
             id: "t1",
-            route_id: "r1",
             block_id: "b"
           }
         },
@@ -194,7 +193,6 @@ defmodule Schedule.DataTest do
     test "block returns the trips on the block" do
       trip = %Trip{
         id: "t1",
-        route_id: "r1",
         block_id: "b",
         service_id: "service",
         stop_times: [
@@ -219,7 +217,6 @@ defmodule Schedule.DataTest do
     test "block doesn't return trips on the same block but a different date" do
       trip = %Trip{
         id: "t1",
-        route_id: "r1",
         block_id: "b",
         service_id: "service",
         stop_times: [
@@ -289,7 +286,6 @@ defmodule Schedule.DataTest do
     test "returns an active trip" do
       trip = %Trip{
         id: "active",
-        route_id: "route",
         block_id: "active",
         service_id: "today",
         stop_times: [
@@ -325,7 +321,6 @@ defmodule Schedule.DataTest do
     test "doesn't return a trip active at a different time today" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
         service_id: "today",
         stop_times: [
@@ -359,7 +354,6 @@ defmodule Schedule.DataTest do
     test "doesn't return a trip active at this time on a different day" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
         service_id: "tomorrow",
         stop_times: [
@@ -393,7 +387,6 @@ defmodule Schedule.DataTest do
     test "returns late-night trips that are still active from yesterday" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
         service_id: "yesterday",
         stop_times: [
@@ -431,7 +424,6 @@ defmodule Schedule.DataTest do
       block = [
         %Trip{
           id: "trip",
-          route_id: "route",
           block_id: "block",
           service_id: "today",
           stop_times: [
@@ -480,7 +472,6 @@ defmodule Schedule.DataTest do
           "block" => [
             %Trip{
               id: "trip",
-              route_id: "route",
               block_id: "block",
               service_id: "today",
               stop_times: [
@@ -507,11 +498,10 @@ defmodule Schedule.DataTest do
       assert Data.active_blocks(data, time0 + 5, time0 + 5) == %{}
     end
 
-    test "returns a block only once per route if it has multiple active trips" do
+    test "returns a block only once if it has multiple active trips" do
       block = [
         %Trip{
           id: "first",
-          route_id: "route",
           block_id: "block",
           service_id: "today",
           stop_times: [
@@ -523,7 +513,6 @@ defmodule Schedule.DataTest do
         },
         %Trip{
           id: "second",
-          route_id: "route",
           block_id: "block",
           service_id: "today",
           stop_times: [
@@ -559,7 +548,6 @@ defmodule Schedule.DataTest do
       block1 = [
         %Trip{
           id: "first",
-          route_id: "route",
           block_id: "block",
           service_id: "today",
           stop_times: [
@@ -574,7 +562,6 @@ defmodule Schedule.DataTest do
       block2 = [
         %Trip{
           id: "second",
-          route_id: "route",
           block_id: "block",
           service_id: "tomorrow",
           stop_times: [
@@ -690,8 +677,8 @@ defmodule Schedule.DataTest do
     test "returns the shape for the given trip_id" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         shape_id: "shape"
       }
 
@@ -724,8 +711,8 @@ defmodule Schedule.DataTest do
     test "returns nil if there is no shape" do
       trip = %Trip{
         id: "trip",
-        route_id: "route",
         block_id: "block",
+        route_id: "route",
         shape_id: "shape"
       }
 

--- a/test/schedule/trip_test.exs
+++ b/test/schedule/trip_test.exs
@@ -99,6 +99,10 @@ defmodule Schedule.TripTest do
     test "combines gtfs trip, hastus_trip, and stop_times" do
       assert Trip.merge(@gtfs_trip, @hastus_trip, @stop_times) == @trip
     end
+
+    test "works for nonrevenue trips" do
+      assert %Trip{route_id: nil} = Trip.merge(nil, %{@hastus_trip | route_id: nil}, nil)
+    end
   end
 
   describe "start_time/1" do

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -299,8 +299,8 @@ defmodule ScheduleTest do
       assert Schedule.trip("t1", pid) ==
                %Trip{
                  id: "t1",
-                 route_id: "route",
                  block_id: "b",
+                 route_id: "route",
                  service_id: "service",
                  headsign: "h1",
                  direction_id: 1,
@@ -389,8 +389,8 @@ defmodule ScheduleTest do
       assert Schedule.block("b", "service", pid) == [
                %Trip{
                  id: "t1",
-                 route_id: "route",
                  block_id: "b",
+                 route_id: "route",
                  service_id: "service",
                  # Shuttles do not have route_pattern_ids
                  headsign: "h1",


### PR DESCRIPTION
No asana ticket. I realized I missed this as part of #597 because route_id is in both gtfs and hastus. But it might be nil in hastus.