### PR TITLE
Minischedules Api Endpoints

### DIFF
--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -126,12 +126,16 @@ defmodule Schedule do
     )
   end
 
-  @spec minischedule(Trip.id()) ::
-          {Minischedule.Run.t(), Minischedule.Block.t()} | nil
-  @spec minischedule(Trip.id(), GenServer.server()) ::
-          {Minischedule.Run.t(), Minischedule.Block.t()} | nil
-  def minischedule(trip_id, server \\ __MODULE__) do
-    call_catch_timeout(server, {:minischedule, trip_id}, :minischedule, nil)
+  @spec minischedule_run(Trip.id()) :: Minischedule.Run.t() | nil
+  @spec minischedule_run(Trip.id(), GenServer.server()) :: Minischedule.Run.t() | nil
+  def minischedule_run(trip_id, server \\ __MODULE__) do
+    call_catch_timeout(server, {:minischedule_run, trip_id}, :minischedule_run, nil)
+  end
+
+  @spec minischedule_block(Trip.id()) :: Minischedule.Block.t() | nil
+  @spec minischedule_block(Trip.id(), GenServer.server()) :: Minischedule.Block.t() | nil
+  def minischedule_block(trip_id, server \\ __MODULE__) do
+    call_catch_timeout(server, {:minischedule_block, trip_id}, :minischedule_block, nil)
   end
 
   @doc """
@@ -196,8 +200,12 @@ defmodule Schedule do
      state}
   end
 
-  def handle_call({:minischedule, trip_id}, _from, {:loaded, gtfs_data} = state) do
-    {:reply, Data.minischedule(gtfs_data, trip_id), state}
+  def handle_call({:minischedule_run, trip_id}, _from, {:loaded, gtfs_data} = state) do
+    {:reply, Data.minischedule_run(gtfs_data, trip_id), state}
+  end
+
+  def handle_call({:minischedule_block, trip_id}, _from, {:loaded, gtfs_data} = state) do
+    {:reply, Data.minischedule_block(gtfs_data, trip_id), state}
   end
 
   # Initialization (Client)

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -194,10 +194,9 @@ defmodule Schedule.Data do
     end)
   end
 
-  @spec minischedule(t(), Trip.id()) ::
-          {Minischedule.Run.t(), Minischedule.Block.t()} | nil
-  def minischedule(
-        %__MODULE__{trips: trips, minischedule_runs: runs, minischedule_blocks: blocks},
+  @spec minischedule_run(t(), Trip.id()) :: Minischedule.Run.t() | nil
+  def minischedule_run(
+        %__MODULE__{trips: trips, minischedule_runs: runs},
         trip_id
       ) do
     trip = trips[trip_id]
@@ -205,12 +204,23 @@ defmodule Schedule.Data do
     if trip != nil && trip.schedule_id != nil do
       # we have HASTUS data for this trip
       run = runs[{trip.schedule_id, trip.run_id}]
-      block = blocks[{trip.schedule_id, trip.block_id}]
+      Minischedule.Run.hydrate(run, trips)
+    else
+      nil
+    end
+  end
 
-      {
-        Minischedule.Run.hydrate(run, trips),
-        Minischedule.Block.hydrate(block, trips)
-      }
+  @spec minischedule_block(t(), Trip.id()) :: Minischedule.Block.t() | nil
+  def minischedule_block(
+        %__MODULE__{trips: trips, minischedule_blocks: blocks},
+        trip_id
+      ) do
+    trip = trips[trip_id]
+
+    if trip != nil && trip.schedule_id != nil do
+      # we have HASTUS data for this trip
+      block = blocks[{trip.schedule_id, trip.block_id}]
+      Minischedule.Block.hydrate(block, trips)
     else
       nil
     end

--- a/lib/schedule/minischedule/block.ex
+++ b/lib/schedule/minischedule/block.ex
@@ -20,6 +20,8 @@ defmodule Schedule.Minischedule.Block do
     :pieces
   ]
 
+  @derive Jason.Encoder
+
   defstruct [
     :schedule_id,
     :id,

--- a/lib/schedule/minischedule/break.ex
+++ b/lib/schedule/minischedule/break.ex
@@ -20,6 +20,8 @@ defmodule Schedule.Minischedule.Break do
     :end_place
   ]
 
+  @derive Jason.Encoder
+
   defstruct [
     :break_type,
     :start_time,

--- a/lib/schedule/minischedule/piece.ex
+++ b/lib/schedule/minischedule/piece.ex
@@ -32,6 +32,8 @@ defmodule Schedule.Minischedule.Piece do
     :end
   ]
 
+  @derive Jason.Encoder
+
   defstruct [
     :schedule_id,
     :run_id,

--- a/lib/schedule/minischedule/run.ex
+++ b/lib/schedule/minischedule/run.ex
@@ -21,6 +21,8 @@ defmodule Schedule.Minischedule.Run do
     :activities
   ]
 
+  @derive Jason.Encoder
+
   defstruct [
     :schedule_id,
     :id,

--- a/lib/skate_web/controllers/minischedule_controller.ex
+++ b/lib/skate_web/controllers/minischedule_controller.ex
@@ -1,0 +1,21 @@
+defmodule SkateWeb.MinischeduleController do
+  use SkateWeb, :controller
+
+  @spec run(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def run(conn, %{"trip_id" => trip_id}) do
+    run_fn = Application.get_env(:skate_web, :run_fn, &Schedule.minischedule_run/1)
+
+    run = run_fn.(trip_id)
+
+    json(conn, %{data: run})
+  end
+
+  @spec block(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def block(conn, %{"trip_id" => trip_id}) do
+    block_fn = Application.get_env(:skate_web, :block_fn, &Schedule.minischedule_block/1)
+
+    block = block_fn.(trip_id)
+
+    json(conn, %{data: block})
+  end
+end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -65,6 +65,8 @@ defmodule SkateWeb.Router do
     get "/shapes/route/:route_id", ShapeController, :route
     get "/shapes/trip/:trip_id", ShapeController, :trip
     get "/shuttles", ShuttleController, :index
+    get "/minischedule/run/:trip_id", MinischeduleController, :run
+    get "/minischedule/block/:trip_id", MinischeduleController, :block
   end
 
   scope "/_flags" do

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -747,8 +747,8 @@ defmodule Schedule.DataTest do
     end
   end
 
-  describe "minischedule" do
-    test "returns run and block for trip" do
+  describe "minischedule_run" do
+    test "returns run for the trip" do
       trip = %Trip{
         id: "trip",
         block_id: "block",
@@ -762,6 +762,43 @@ defmodule Schedule.DataTest do
         activities: []
       }
 
+      data = %Data{
+        trips: %{trip.id => trip},
+        minischedule_runs: %{Minischedule.Run.key(run) => run}
+      }
+
+      assert Data.minischedule_run(data, trip.id) == run
+    end
+
+    test "returns nil if the trip isn't known" do
+      data = %Data{}
+
+      assert Data.minischedule_run(data, "trip") == nil
+    end
+
+    test "returns nil if the trip is in gtfs but not hastus" do
+      trip = %Trip{
+        id: "trip",
+        block_id: "block",
+        schedule_id: nil
+      }
+
+      data = %Data{
+        trips: %{trip.id => trip}
+      }
+
+      assert Data.minischedule_run(data, trip.id) == nil
+    end
+  end
+
+  describe "minischedule_block" do
+    test "returns block for trip" do
+      trip = %Trip{
+        id: "trip",
+        block_id: "block",
+        schedule_id: "schedule"
+      }
+
       block = %Minischedule.Block{
         schedule_id: "schedule",
         id: "block",
@@ -770,41 +807,30 @@ defmodule Schedule.DataTest do
 
       data = %Data{
         trips: %{trip.id => trip},
-        minischedule_runs: %{Minischedule.Run.key(run) => run},
         minischedule_blocks: %{Minischedule.Block.key(block) => block}
       }
 
-      assert Data.minischedule(data, trip.id) == {
-               %Minischedule.Run{
-                 schedule_id: "schedule",
-                 id: "run",
-                 activities: []
-               },
-               %Minischedule.Block{
-                 schedule_id: "schedule",
-                 id: "block",
-                 pieces: []
-               }
-             }
+      assert Data.minischedule_block(data, trip.id) == block
     end
 
     test "returns nil if the trip isn't known" do
       data = %Data{}
 
-      assert Data.minischedule(data, "trip") == nil
+      assert Data.minischedule_block(data, "trip") == nil
     end
 
     test "returns nil if the trip is in gtfs but not hastus" do
       trip = %Trip{
         id: "trip",
-        block_id: "block"
+        block_id: "block",
+        schedule_id: nil
       }
 
       data = %Data{
         trips: %{trip.id => trip}
       }
 
-      assert Data.minischedule(data, trip.id) == nil
+      assert Data.minischedule_block(data, trip.id) == nil
     end
   end
 end

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -727,7 +727,7 @@ defmodule ScheduleTest do
   end
 
   describe "minischedule" do
-    test "returns run and block for trip" do
+    setup do
       pid =
         Schedule.start_mocked(%{
           hastus: %{
@@ -767,28 +767,34 @@ defmodule ScheduleTest do
         }
       }
 
-      assert Schedule.minischedule("trip", pid) ==
-               {
-                 %Minischedule.Run{
-                   schedule_id: "schedule",
-                   id: "123-4567",
-                   activities: [
-                     # TODO remove the break once Minischedule.Load.run is finished
-                     %Minischedule.Break{
-                       break_type: "Operator",
-                       start_time: 0,
-                       end_time: 0,
-                       start_place: "start",
-                       end_place: "end"
-                     },
-                     expected_piece
-                   ]
-                 },
-                 %Minischedule.Block{
-                   schedule_id: "schedule",
-                   id: "block",
-                   pieces: [expected_piece]
-                 }
+      %{pid: pid, expected_piece: expected_piece}
+    end
+
+    test "can get run", %{pid: pid, expected_piece: expected_piece} do
+      assert Schedule.minischedule_run("trip", pid) ==
+               %Minischedule.Run{
+                 schedule_id: "schedule",
+                 id: "123-4567",
+                 activities: [
+                   # TODO remove the break once Minischedule.Load.run is finished
+                   %Minischedule.Break{
+                     break_type: "Operator",
+                     start_time: 0,
+                     end_time: 0,
+                     start_place: "start",
+                     end_place: "end"
+                   },
+                   expected_piece
+                 ]
+               }
+    end
+
+    test "can get block", %{pid: pid, expected_piece: expected_piece} do
+      assert Schedule.minischedule_block("trip", pid) ==
+               %Minischedule.Block{
+                 schedule_id: "schedule",
+                 id: "block",
+                 pieces: [expected_piece]
                }
     end
   end

--- a/test/skate_web/controllers/minischedule_controller_test.exs
+++ b/test/skate_web/controllers/minischedule_controller_test.exs
@@ -1,0 +1,117 @@
+defmodule SkateWeb.MinischeduleControllerTest do
+  use SkateWeb.ConnCase
+  import Test.Support.Helpers
+
+  alias SkateWeb.AuthManager
+  alias Schedule.Minischedule
+
+  @run %Minischedule.Run{
+    schedule_id: "schedule",
+    id: "run",
+    activities: []
+  }
+
+  @block %Minischedule.Block{
+    schedule_id: "schedule",
+    id: "block",
+    pieces: []
+  }
+
+  describe "GET /api/minischedule/run/:trip_id" do
+    test "when logged out, redirects you to cognito auth", %{conn: conn} do
+      reassign_env(:skate_web, :run_fn, fn _trip_id -> @run end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> get("/api/minischedule/run/1")
+
+      assert redirected_to(conn) == "/auth/cognito"
+    end
+
+    test "when logged in, returns the run for this trip", %{conn: conn} do
+      reassign_env(:skate_web, :run_fn, fn _trip_id -> @run end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> logged_in()
+        |> get("/api/minischedule/run/1")
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "schedule_id" => "schedule",
+                 "id" => "run",
+                 "activities" => []
+               }
+             }
+    end
+
+    test "returns null if there's no minischedule for this trip", %{conn: conn} do
+      reassign_env(:skate_web, :run_fn, fn _trip_id -> nil end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> logged_in()
+        |> get("/api/minischedule/run/1")
+
+      assert json_response(conn, 200) == %{"data" => nil}
+    end
+  end
+
+  describe "GET /api/minischedule/block/:trip_id" do
+    test "when logged out, redirects you to cognito auth", %{conn: conn} do
+      reassign_env(:skate_web, :block_fn, fn _trip_id -> @block end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> get("/api/minischedule/block/1")
+
+      assert redirected_to(conn) == "/auth/cognito"
+    end
+
+    test "when logged in, returns the block for this trip", %{conn: conn} do
+      reassign_env(:skate_web, :block_fn, fn _trip_id -> @block end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> logged_in()
+        |> get("/api/minischedule/block/1")
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "schedule_id" => "schedule",
+                 "id" => "block",
+                 "pieces" => []
+               }
+             }
+    end
+
+    test "returns null if there's no minischedule for this trip", %{conn: conn} do
+      reassign_env(:skate_web, :block_fn, fn _trip_id -> nil end)
+
+      conn =
+        conn
+        |> api_headers()
+        |> logged_in()
+        |> get("/api/minischedule/block/1")
+
+      assert json_response(conn, 200) == %{"data" => nil}
+    end
+  end
+
+  defp api_headers(conn) do
+    conn
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("content-type", "application/json")
+  end
+
+  defp logged_in(conn) do
+    {:ok, token, _} = AuthManager.encode_and_sign(%{})
+
+    put_req_header(conn, "authorization", "bearer: " <> token)
+  end
+end


### PR DESCRIPTION
Asana Task: [Mini-schedule | Make API endpoints](https://app.asana.com/0/1148853526253426/1170680075334326)

Also splits `Schedule.minischedule` into two functions, a followup from #612 

Example:
http://localhost:4000/api/minischedule/block/43773724
```json
{
  "data": {
    "id": "A502-95",
    "pieces": [
      {
        "block_id": "A502-95",
        "end": {
          "mid_route?": false,
          "place": "albny",
          "time": 70620
        },
        "run_id": "123-9039",
        "schedule_id": "aba20011",
        "start": {
          "mid_route?": false,
          "place": "albny",
          "time": 57300
        },
        "trips": ["...trips..."]
      }
    ],
    "schedule_id": "aba20011"
  }
}
```