### PR TITLE
Bugfix: Autocentering loses focus

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -238,7 +238,11 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
         appState.pickerContainerIsVisible
       )
     }
-  }, [shouldAutoCenter, latLngs, appState.pickerContainerIsVisible])
+  }, [
+    shouldAutoCenter,
+    JSON.stringify(latLngs),
+    appState.pickerContainerIsVisible,
+  ])
 
   const autoCenteringClass = shouldAutoCenter
     ? "m-vehicle-map-state--auto-centering"

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -24,7 +24,7 @@ import { drawnStatus, statusClass } from "../models/vehicleStatus"
 import { TrainVehicle, Vehicle, VehicleId } from "../realtime.d"
 import { Shape } from "../schedule"
 import { Settings } from "../settings"
-import { selectVehicle, State as AppState } from "../state"
+import { selectVehicle } from "../state"
 
 interface Props {
   vehicles: Vehicle[]
@@ -164,13 +164,10 @@ const Shape = ({ shape }: { shape: Shape }) => {
 
 export const autoCenter = (
   map: LeafletMap,
-  vehicles: Vehicle[],
+  latLngs: LatLngExpression[],
   isAutoCentering: MutableRefObject<boolean>,
-  appState: AppState
+  pickerContainerIsVisible: boolean
 ): void => {
-  const latLngs: LatLngExpression[] = vehicles.map((vehicle) =>
-    Leaflet.latLng(vehicle.latitude, vehicle.longitude)
-  )
   isAutoCentering.current = true
   if (latLngs.length === 0) {
     map.setView(defaultCenter, 13)
@@ -179,7 +176,7 @@ export const autoCenter = (
   } else if (latLngs.length > 1) {
     map.fitBounds(Leaflet.latLngBounds(latLngs), {
       paddingBottomRight: [20, 50],
-      paddingTopLeft: [appState.pickerContainerIsVisible ? 220 : 20, 20],
+      paddingTopLeft: [pickerContainerIsVisible ? 220 : 20, 20],
     })
   }
 }
@@ -227,13 +224,21 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const [shouldAutoCenter, setShouldAutoCenter] = useState<boolean>(true)
   const isAutoCentering: MutableRefObject<boolean> = useRef(false)
 
+  const latLngs: LatLngExpression[] = props.vehicles.map(
+    ({ latitude, longitude }) => Leaflet.latLng(latitude, longitude)
+  )
   useEffect(() => {
     const reactLeafletMap: ReactLeafletMap | null = mapRef.current
     if (reactLeafletMap !== null && shouldAutoCenter) {
       const leafletMap: LeafletMap = reactLeafletMap.leafletElement
-      autoCenter(leafletMap, props.vehicles, isAutoCentering, appState)
+      autoCenter(
+        leafletMap,
+        latLngs,
+        isAutoCentering,
+        appState.pickerContainerIsVisible
+      )
     }
-  }, [shouldAutoCenter, props.vehicles, appState])
+  }, [shouldAutoCenter, latLngs, appState.pickerContainerIsVisible])
 
   const autoCenteringClass = shouldAutoCenter
     ? "m-vehicle-map-state--auto-centering"

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -240,6 +240,8 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
     }
   }, [
     shouldAutoCenter,
+    // useEffect uses ===, which doesn't work on arrays.
+    // convert the array to a string so useEffect can tell if it doesn't change.
     JSON.stringify(latLngs),
     appState.pickerContainerIsVisible,
   ])

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -11,7 +11,6 @@ import Map, {
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { TrainVehicle, Vehicle } from "../../src/realtime"
 import { Shape } from "../../src/schedule"
-import { State as AppState } from "../../src/state"
 
 jest.unmock("leaflet")
 jest.unmock("react-leaflet-control")
@@ -114,28 +113,34 @@ describe("map", () => {
 describe("autoCenter", () => {
   const Leaflet = jest.requireActual("leaflet")
   const isAutoCentering = { current: false }
-  const appState: AppState = { pickerContainerIsVisible: false } as AppState
+  const pickerContainerIsVisible: boolean = false
 
   test("centers the map on a single vehicle", () => {
     document.body.innerHTML = "<div id='map'></div>"
     const map = Leaflet.map("map")
-    autoCenter(map, [vehicle], isAutoCentering, appState)
+    autoCenter(map, [[42, -71]], isAutoCentering, pickerContainerIsVisible)
     expect(map.getCenter()).toEqual({ lat: 42, lng: -71 })
   })
 
   test("fits around multiple vehicles", () => {
-    const vehicle1 = { ...vehicle, latitude: 42.0 }
-    const vehicle2 = { ...vehicle, latitude: 42.5 }
     document.body.innerHTML = "<div id='map'></div>"
     const map = Leaflet.map("map")
-    autoCenter(map, [vehicle1, vehicle2], isAutoCentering, appState)
+    autoCenter(
+      map,
+      [
+        [42.0, -71],
+        [42.5, -71],
+      ],
+      isAutoCentering,
+      pickerContainerIsVisible
+    )
     expect(map.getCenter().lat).toBeCloseTo(42.25, 3)
   })
 
   test("does not center the map if there are no vehicles", () => {
     document.body.innerHTML = "<div id='map'></div>"
     const map = Leaflet.map("map")
-    autoCenter(map, [], isAutoCentering, appState)
+    autoCenter(map, [], isAutoCentering, pickerContainerIsVisible)
     expect(map.getCenter()).toEqual(defaultCenter)
   })
 })


### PR DESCRIPTION
Asana Task: [🐞 Vehicle doesn't stay centered in the properties panel map](https://app.asana.com/0/1148853526253426/1171784929698249)

Built on top of #632 

This was the result of two overlapping problems:

1. `useEffect` dependencies use a shallow `===` comparison, and `[] !== []`, so it thought that the list of vehicles was moving every render, and it called `autoCenter()` every render.

That should be fine, autoCentering should be idempotent, but

2. If `autoCenter()` is called twice in quick succession, there's a chance that events will happen in this order:
- 1st `autoCenter` starts, setting `isAutoCentering` to `true`
- 1st `movestart` triggers. `isAutoCentering` is `true`.
- 2nd `autoCenter` call happens. `isAutoCentering` is set to `true` again.
- 1st `moveend` triggers. `isAutoCentering` is set to `false`.
- 2nd `movestart` triggers. `isAutoCentering` is `false`, so it thinks it's a manual move, and turns `shouldAutoCenter` off.

This PR fixes the 1st problem by changing the list of vehicles to a form that `useEffect` can compare, so `autoCenter` is only called if the vehicles move. (Once every few seconds, instead of several times per second.)

Fixing the 2nd bug would require bigger changes to how we tell the difference between autocentering and manual moves. I guess it's possible that if there were two real moves in quick succession it could still happen, but in practice, updates are far enough apart that one move can finish before the next starts. I left the VPP open for 15 minutes and it kept focus on the vehicle the whole time.