### PR TITLE
add missing api mocks. fix intermittent test failures

### DIFF
--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -1063,6 +1063,49 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
 </div>
 `;
 
+exports[`Shuttle Map Page renders with shapes selected 1`] = `
+<div
+  className="m-shuttle-map"
+>
+  <div
+    className="m-picker-container m-picker-container--wide visible"
+  >
+    <div
+      className="m-picker-container__tab"
+    >
+      <button
+        className="m-picker-container__tab-button"
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-route-picker"
+    >
+      loading...
+    </div>
+  </div>
+  <div
+    className="m-shuttle-map__map"
+  >
+    <div
+      className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+    />
+    <div
+      className="m-vehicle-map"
+    />
+  </div>
+</div>
+`;
+
 exports[`Shuttle Map Page renders with train vehicles 1`] = `
 <div
   className="m-shuttle-map"

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -10,6 +10,10 @@ jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
   default: jest.fn(() => "good"),
 }))
+jest.mock("../../src/hooks/useRoutes", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
 
 describe("App", () => {
   test("renders", () => {

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -6,6 +6,7 @@ import LadderPage, {
 } from "../../src/components/ladderPage"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import useRoutes from "../../src/hooks/useRoutes"
+import useTimepoints from "../../src/hooks/useTimepoints"
 import useVehicles from "../../src/hooks/useVehicles"
 import { Ghost, Vehicle, VehicleOrGhost } from "../../src/realtime"
 import { ByRouteId, Route, TimepointsByRouteId } from "../../src/schedule.d"
@@ -14,6 +15,10 @@ import { initialState } from "../../src/state"
 jest.mock("../../src/hooks/useRoutes", () => ({
   __esModule: true,
   default: jest.fn(() => routes),
+}))
+jest.mock("../../src/hooks/useTimepoints", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({})),
 }))
 jest.mock("../../src/hooks/useVehicles", () => ({
   __esModule: true,
@@ -54,17 +59,10 @@ describe("LadderPage", () => {
   })
 
   test("renders with timepoints", () => {
-    const mockState = {
-      ...initialState,
-      timepointsByRouteId,
-    }
-    const tree = renderer
-      .create(
-        <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
-          <LadderPage />
-        </StateDispatchProvider>
-      )
-      .toJSON()
+    ;(useTimepoints as jest.Mock).mockImplementationOnce(
+      () => timepointsByRouteId
+    )
+    const tree = renderer.create(<LadderPage />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -4,11 +4,12 @@ import ShuttleMapPage, {
   allTrainVehicles,
 } from "../../src/components/shuttleMapPage"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import { useRouteShapes, useTripShape } from "../../src/hooks/useShapes"
 import useShuttleVehicles from "../../src/hooks/useShuttleVehicles"
 import useTrainVehicles from "../../src/hooks/useTrainVehicles"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import { TrainVehicle, Vehicle } from "../../src/realtime"
-import { ByRouteId } from "../../src/schedule"
+import { ByRouteId, Shape } from "../../src/schedule"
 import { initialState } from "../../src/state"
 import * as dateTime from "../../src/util/dateTime"
 
@@ -17,13 +18,22 @@ jest
   .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
 
 jest.spyOn(Date, "now").mockImplementation(() => 234000)
+jest.mock("../../src/hooks/useShuttleRoutes", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
+jest.mock("../../src/hooks/useShapes", () => ({
+  __esModule: true,
+  useRouteShapes: jest.fn(() => []),
+  useTripShape: jest.fn(() => []),
+}))
 jest.mock("../../src/hooks/useShuttleVehicles", () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => null),
 }))
 jest.mock("../../src/hooks/useTrainVehicles", () => ({
   __esModule: true,
-  default: jest.fn(),
+  default: jest.fn(() => ({})),
 }))
 
 const shuttle: Vehicle = {
@@ -67,10 +77,21 @@ const shuttle: Vehicle = {
   blockWaivers: [],
 }
 
+const shape: Shape = {
+  id: "shape",
+  points: [],
+}
+
 describe("Shuttle Map Page", () => {
   test("renders", () => {
     ;(useShuttleVehicles as jest.Mock).mockImplementationOnce(() => [shuttle])
-    ;(useTrainVehicles as jest.Mock).mockImplementationOnce(() => ({}))
+    const tree = renderer.create(<ShuttleMapPage />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders with shapes selected", () => {
+    ;(useRouteShapes as jest.Mock).mockImplementationOnce(() => [shape])
+    ;(useTripShape as jest.Mock).mockImplementationOnce(() => [shape])
     const tree = renderer.create(<ShuttleMapPage />).toJSON()
     expect(tree).toMatchSnapshot()
   })
@@ -94,7 +115,6 @@ describe("Shuttle Map Page", () => {
   test("renders selected shuttle routes", () => {
     const dispatch = jest.fn()
     ;(useShuttleVehicles as jest.Mock).mockImplementationOnce(() => [shuttle])
-    ;(useTrainVehicles as jest.Mock).mockImplementationOnce(() => ({}))
     const tree = renderer
       .create(
         <StateDispatchProvider
@@ -111,7 +131,6 @@ describe("Shuttle Map Page", () => {
   test("renders with all shuttles selected", () => {
     const dispatch = jest.fn()
     ;(useShuttleVehicles as jest.Mock).mockImplementationOnce(() => [shuttle])
-    ;(useTrainVehicles as jest.Mock).mockImplementationOnce(() => ({}))
     const tree = renderer
       .create(
         <StateDispatchProvider
@@ -133,7 +152,6 @@ describe("Shuttle Map Page", () => {
       selectedVehicleId: shuttle.id,
     }
     ;(useShuttleVehicles as jest.Mock).mockImplementationOnce(() => [shuttle])
-    ;(useTrainVehicles as jest.Mock).mockImplementationOnce(() => ({}))
     const tree = renderer
       .create(
         <StateDispatchProvider state={state} dispatch={dispatch}>


### PR DESCRIPTION
Asana Task: [Intermittent test failure](https://app.asana.com/0/1152340551558956/1173051855704249)

This was continuing to get in my way, but it turned out to be a pretty quick fix. The intermittent test failures+warnings were because a couple of tests were making real api calls.

Also adds a test because we weren't testing that one of the api calls was used.