### PR TITLE
Merge trips and activities into a run.

### DIFF
--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -68,7 +68,12 @@ defmodule Schedule.Minischedule.Load do
           trip.block_id
 
         _ ->
-          Logger.warn("Operator activity with no trips", activity: activity)
+          Logger.warn(fn ->
+            "Operator activity with no trips: #{activity.schedule_id} #{activity.run_id} start_time:#{
+              activity.start_time
+            }"
+          end)
+
           activity.partial_block_id
       end
 

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -360,17 +360,95 @@ defmodule Schedule.Minischedule.LoadTest do
 
       assert %Run{
                activities: [
+                 # %Piece{},
+                 # %Piece{} = _p
                  %Piece{
                    block_id: "block",
                    start: %{time: 101},
                    trips: ["trip1"],
                    end: %{time: 102}
-                 },
+                 } = _,
                  %Piece{
                    block_id: "block",
                    start: %{time: 103},
                    trips: ["trip2"],
                    end: %{time: 104}
+                 } = _
+               ]
+             } = Load.run(run_key, activities, trips)
+    end
+
+    test "Deadhead from becomes part of following piece" do
+      run_key = {"schedule", "run"}
+
+      activities = [
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run",
+          start_time: 101,
+          end_time: 102,
+          start_place: "",
+          end_place: "",
+          activity_type: "Deadhead from"
+        },
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run",
+          start_time: 102,
+          end_time: 103,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block"
+        }
+      ]
+
+      trips = []
+
+      assert %Run{
+               activities: [
+                 %Piece{
+                   start: %{time: 101},
+                   trips: [],
+                   end: %{time: 103}
+                 }
+               ]
+             } = Load.run(run_key, activities, trips)
+    end
+
+    test "Deadhead to becomes part of previous piece" do
+      run_key = {"schedule", "run"}
+
+      activities = [
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run",
+          start_time: 101,
+          end_time: 102,
+          start_place: "",
+          end_place: "",
+          activity_type: "Operator",
+          partial_block_id: "block"
+        },
+        %Activity{
+          schedule_id: "schedule",
+          run_id: "run",
+          start_time: 102,
+          end_time: 103,
+          start_place: "",
+          end_place: "",
+          activity_type: "Deadhead to"
+        }
+      ]
+
+      trips = []
+
+      assert %Run{
+               activities: [
+                 %Piece{
+                   start: %{time: 101},
+                   trips: [],
+                   end: %{time: 103}
                  }
                ]
              } = Load.run(run_key, activities, trips)

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -776,14 +776,6 @@ defmodule ScheduleTest do
                  schedule_id: "schedule",
                  id: "123-4567",
                  activities: [
-                   # TODO remove the break once Minischedule.Load.run is finished
-                   %Minischedule.Break{
-                     break_type: "Operator",
-                     start_time: 0,
-                     end_time: 0,
-                     start_place: "start",
-                     end_place: "end"
-                   },
                    expected_piece
                  ]
                }


### PR DESCRIPTION
Asana Task: [Mini-schedule | Data | Make Pieces Correctly](https://app.asana.com/0/1148853526253426/1170680075334323)

Replaces the existing placeholder implementation.

Matches trips to their `"Operator"` activity, so trips and breaks can be shown in the right order. (Explanation is in the Asana Task.) `"Operator"` activities and their matching `"Sign-on"` activities won't be shown as `Break`s anymore.

Lynn garage also has pulls as separate activities instead of trips. In this PR, the piece's time extends to take those into account. But since they don't have a `Trip`, the pull row won't show in the frontend. [Task to fix that.](https://app.asana.com/0/1148863597048545/1170698291365294)

This doesn't handle wad/rad activities. They still show up as `Break`s for now. [Task to fix that.](https://app.asana.com/0/1148863597048545/1173661402437253). Their `"Sign-on"` activities also will stick around as `Break`s for now.