### PR TITLE
Add start_time and end_time to minischedules trip

### DIFF
--- a/assets/src/minischedule.d.ts
+++ b/assets/src/minischedule.d.ts
@@ -38,6 +38,8 @@ export interface Trip {
   headsign: string | null
   directionId: DirectionId | null
   runId: RunId | null
+  startTime: Time
+  endTime: Time
 }
 
 export type Time = number

--- a/assets/src/models/minischeduleData.ts
+++ b/assets/src/models/minischeduleData.ts
@@ -47,6 +47,8 @@ interface TripData {
   headsign: string | null
   direction_id: DirectionId | null
   run_id: RunId | null
+  start_time: Time
+  end_time: Time
 }
 
 const isBreakData = (
@@ -94,4 +96,6 @@ const tripFromData = (tripData: TripData): Trip => ({
   headsign: tripData.headsign,
   directionId: tripData.direction_id,
   runId: tripData.run_id,
+  startTime: tripData.start_time,
+  endTime: tripData.end_time,
 })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -381,6 +381,8 @@ describe("minischedulesBlock", () => {
                 headsign: "headsign",
                 direction_id: 0,
                 run_id: "run",
+                start_time: 45,
+                end_time: 567,
               },
             ],
             end: {
@@ -413,6 +415,8 @@ describe("minischedulesBlock", () => {
                 headsign: "headsign",
                 directionId: 0,
                 runId: "run",
+                startTime: 45,
+                endTime: 567,
               },
             ],
             end: {

--- a/lib/realtime/ghost.ex
+++ b/lib/realtime/ghost.ex
@@ -108,7 +108,7 @@ defmodule Realtime.Ghost do
               layover_departure_time:
                 if route_status == :laying_over || route_status == :pulling_out do
                   Util.Time.timestamp_for_time_of_day(
-                    Trip.start_time(trip),
+                    trip.start_time,
                     date
                   )
                 else
@@ -135,14 +135,14 @@ defmodule Realtime.Ghost do
   end
 
   def current_trip([trip | later_trips], now_time_of_day) do
-    if now_time_of_day < Trip.start_time(trip) do
+    if now_time_of_day < trip.start_time do
       {:pulling_out, trip}
     else
       case current_trip(later_trips, now_time_of_day) do
         nil ->
           # the current trip is the last trip
           # has it finished?
-          if now_time_of_day > Trip.end_time(trip) do
+          if now_time_of_day > trip.end_time do
             nil
           else
             {:on_route, trip}
@@ -151,7 +151,7 @@ defmodule Realtime.Ghost do
         {:pulling_out, next_trip} ->
           # the next trip hasn't started yet.
           # are we in between trips or still in the current trip?
-          if now_time_of_day > Trip.end_time(trip) do
+          if now_time_of_day > trip.end_time do
             {:laying_over, next_trip}
           else
             {:on_route, trip}

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -177,7 +177,7 @@ defmodule Realtime.TimepointStatus do
               direction_id: trip.direction_id,
               trip_id: trip.id,
               run_id: trip.run_id,
-              time_since_trip_start_time: now_time_of_day - Trip.start_time(trip),
+              time_since_trip_start_time: now_time_of_day - trip.start_time,
               headsign: trip.headsign,
               via_variant: RoutePattern.via_variant(trip.route_pattern_id),
               timepoint_status: timepoint_status

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -29,9 +29,7 @@ defmodule Schedule.Block do
   """
   @spec start_time(t()) :: Util.Time.time_of_day()
   def start_time(block) do
-    block
-    |> first_trip()
-    |> Trip.start_time()
+    first_trip(block).start_time
   end
 
   @doc """
@@ -39,9 +37,7 @@ defmodule Schedule.Block do
   """
   @spec end_time(t()) :: Util.Time.time_of_day()
   def end_time(block) do
-    block
-    |> last_trip()
-    |> Trip.end_time()
+    last_trip(block).end_time
   end
 
   @doc """
@@ -91,7 +87,7 @@ defmodule Schedule.Block do
 
       true ->
         # Either the current trip or the trip that is about to start
-        Enum.find(block, fn trip -> Trip.end_time(trip) > now end)
+        Enum.find(block, fn trip -> trip.end_time > now end)
     end
   end
 
@@ -105,7 +101,7 @@ defmodule Schedule.Block do
 
   @spec sort_trips_by_time([Trip.t()]) :: [Trip.t()]
   defp sort_trips_by_time(trips) do
-    Enum.sort_by(trips, &Trip.start_time/1)
+    Enum.sort_by(trips, & &1.start_time)
   end
 
   defp overload_id_regex(), do: ~r/-OL.+$/

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -40,7 +40,9 @@ defmodule Realtime.GhostTest do
             time: 3,
             timepoint_id: "t2"
           }
-        ]
+        ],
+        start_time: 1,
+        end_time: 3
       }
 
       block = [trip]
@@ -101,7 +103,9 @@ defmodule Realtime.GhostTest do
             time: 3,
             timepoint_id: "t2"
           }
-        ]
+        ],
+        start_time: 1,
+        end_time: 3
       }
 
       block = [trip]
@@ -135,7 +139,9 @@ defmodule Realtime.GhostTest do
             time: 2,
             timepoint_id: "t1"
           }
-        ]
+        ],
+        start_time: 2,
+        end_time: 2
       }
 
       block = [trip]
@@ -184,7 +190,9 @@ defmodule Realtime.GhostTest do
               time: 10,
               timepoint_id: "t1"
             }
-          ]
+          ],
+          start_time: 10,
+          end_time: 10
         },
         %Trip{
           id: "trip2",
@@ -200,7 +208,9 @@ defmodule Realtime.GhostTest do
               time: 20,
               timepoint_id: "t2"
             }
-          ]
+          ],
+          start_time: 20,
+          end_time: 20
         }
       ]
 
@@ -252,7 +262,9 @@ defmodule Realtime.GhostTest do
             time: 3,
             timepoint_id: nil
           }
-        ]
+        ],
+        start_time: 1,
+        end_time: 3
       }
 
       block = [trip]
@@ -290,7 +302,9 @@ defmodule Realtime.GhostTest do
             time: 4,
             timepoint_id: "stop2"
           }
-        ]
+        ],
+        start_time: 2,
+        end_time: 4
       }
 
       trip2 = %Trip{
@@ -313,7 +327,9 @@ defmodule Realtime.GhostTest do
             time: 8,
             timepoint_id: "stop1"
           }
-        ]
+        ],
+        start_time: 6,
+        end_time: 8
       }
 
       %{

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -248,7 +248,9 @@ defmodule Realtime.TimepointStatusTest do
               time: Util.Time.parse_hhmmss("12:02:00"),
               timepoint_id: "tp2"
             }
-          ]
+          ],
+          start_time: Util.Time.parse_hhmmss("12:01:00"),
+          end_time: Util.Time.parse_hhmmss("12:02:00")
         }
       ]
 
@@ -292,7 +294,9 @@ defmodule Realtime.TimepointStatusTest do
               time: Util.Time.parse_hhmmss("11:02:00"),
               timepoint_id: "tp2"
             }
-          ]
+          ],
+          start_time: Util.Time.parse_hhmmss("11:01:00"),
+          end_time: Util.Time.parse_hhmmss("11:02:00")
         }
       ]
 
@@ -353,7 +357,9 @@ defmodule Realtime.TimepointStatusTest do
               time: Util.Time.parse_hhmmss("12:03:00"),
               timepoint_id: "tp3"
             }
-          ]
+          ],
+          start_time: Util.Time.parse_hhmmss("12:03:00"),
+          end_time: Util.Time.parse_hhmmss("12:03:00")
         }
       ]
 
@@ -390,7 +396,9 @@ defmodule Realtime.TimepointStatusTest do
             %StopTime{stop_id: "1", time: Util.Time.parse_hhmmss("12:05:00"), timepoint_id: "1"},
             %StopTime{stop_id: "2", time: Util.Time.parse_hhmmss("12:10:00"), timepoint_id: "2"},
             %StopTime{stop_id: "3", time: Util.Time.parse_hhmmss("12:20:00"), timepoint_id: "3"}
-          ]
+          ],
+          start_time: Util.Time.parse_hhmmss("12:05:00"),
+          end_time: Util.Time.parse_hhmmss("12:20:00")
         }
       ]
 

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -65,7 +65,9 @@ defmodule Realtime.VehicleTest do
           %StopTime{stop_id: "18511", time: 0, timepoint_id: "tp1"},
           %StopTime{stop_id: "18512", time: 1, timepoint_id: nil},
           %StopTime{stop_id: "18513", time: 2, timepoint_id: "tp2"}
-        ]
+        ],
+        start_time: 0,
+        end_time: 2
       }
 
       reassign_env(:realtime, :trip_fn, fn trip_id ->
@@ -318,7 +320,9 @@ defmodule Realtime.VehicleTest do
               time: Util.Time.parse_hhmmss("11:59:00"),
               timepoint_id: "tp2"
             }
-          ]
+          ],
+          start_time: Util.Time.parse_hhmmss("11:59:00"),
+          end_time: Util.Time.parse_hhmmss("11:59:00")
         }
       ]
 

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -198,7 +198,9 @@ defmodule Realtime.VehiclesTest do
             time: 0,
             timepoint_id: "timepoint"
           }
-        ]
+        ],
+        start_time: 0,
+        end_time: 0
       }
 
       block = [trip]
@@ -278,7 +280,9 @@ defmodule Realtime.VehiclesTest do
             time: 0,
             timepoint_id: "timepoint"
           }
-        ]
+        ],
+        start_time: 0,
+        end_time: 0
       }
 
       block = [trip]
@@ -313,7 +317,9 @@ defmodule Realtime.VehiclesTest do
             time: 1,
             timepoint_id: "timepoint"
           }
-        ]
+        ],
+        start_time: 1,
+        end_time: 1
       }
 
       block = [trip]
@@ -381,7 +387,9 @@ defmodule Realtime.VehiclesTest do
             time: 3,
             timepoint_id: "t2"
           }
-        ]
+        ],
+        start_time: 1,
+        end_time: 3
       }
 
       trip2 = %Trip{
@@ -397,7 +405,9 @@ defmodule Realtime.VehiclesTest do
             time: 4,
             timepoint_id: "t3"
           }
-        ]
+        ],
+        start_time: 4,
+        end_time: 4
       }
 
       block = [trip1, trip2]

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -12,7 +12,9 @@ defmodule Schedule.BlockTest do
     stop_times: [
       %StopTime{stop_id: "s1", time: 3, timepoint_id: "tp1"},
       %StopTime{stop_id: "s7", time: 4, timepoint_id: nil}
-    ]
+    ],
+    start_time: 3,
+    end_time: 4
   }
 
   @trip2 %Trip{
@@ -22,7 +24,9 @@ defmodule Schedule.BlockTest do
     stop_times: [
       %StopTime{stop_id: "s7", time: 6, timepoint_id: nil},
       %StopTime{stop_id: "s1", time: 7, timepoint_id: "tp1"}
-    ]
+    ],
+    start_time: 6,
+    end_time: 7
   }
 
   @block [@trip1, @trip2]
@@ -42,14 +46,18 @@ defmodule Schedule.BlockTest do
           | id: "t2",
             stop_times: [
               %StopTime{stop_id: "s", time: 2}
-            ]
+            ],
+            start_time: 2,
+            end_time: 2
         },
         %{
           @trip1
           | id: "t1",
             stop_times: [
               %StopTime{stop_id: "s", time: 1}
-            ]
+            ],
+            start_time: 1,
+            end_time: 1
         }
       ]
 

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -224,7 +224,9 @@ defmodule Schedule.DataTest do
             stop_id: "stop",
             time: 4
           }
-        ]
+        ],
+        start_time: 3,
+        end_time: 4
       }
 
       data = %Data{
@@ -304,7 +306,9 @@ defmodule Schedule.DataTest do
             # 24:00:02
             time: 86402
           }
-        ]
+        ],
+        start_time: 86402,
+        end_time: 86402
       }
 
       data = %Data{
@@ -338,7 +342,9 @@ defmodule Schedule.DataTest do
               stop_id: "stop",
               time: 4
             }
-          ]
+          ],
+          start_time: 3,
+          end_time: 4
         }
       ]
 
@@ -400,7 +406,9 @@ defmodule Schedule.DataTest do
               stop_id: "stop",
               time: 2
             }
-          ]
+          ],
+          start_time: 2,
+          end_time: 2
         },
         %Trip{
           id: "second",
@@ -411,7 +419,9 @@ defmodule Schedule.DataTest do
               stop_id: "stop",
               time: 3
             }
-          ]
+          ],
+          start_time: 3,
+          end_time: 3
         }
       ]
 
@@ -430,6 +440,8 @@ defmodule Schedule.DataTest do
     end
 
     test "blocks can be active on two different dates" do
+      just_before_midnight = 24 * 60 * 60 - 1
+
       block1 = [
         %Trip{
           id: "first",
@@ -438,9 +450,11 @@ defmodule Schedule.DataTest do
           stop_times: [
             %StopTime{
               stop_id: "stop",
-              time: 24 * 60 * 60 - 1
+              time: just_before_midnight
             }
-          ]
+          ],
+          start_time: just_before_midnight,
+          end_time: just_before_midnight
         }
       ]
 
@@ -454,7 +468,9 @@ defmodule Schedule.DataTest do
               stop_id: "stop",
               time: 1
             }
-          ]
+          ],
+          start_time: 1,
+          end_time: 1
         }
       ]
 

--- a/test/schedule/trip_test.exs
+++ b/test/schedule/trip_test.exs
@@ -20,8 +20,8 @@ defmodule Schedule.TripTest do
     schedule_id: "schedule",
     run_id: "run",
     block_id: "block",
-    start_time: 0,
-    end_time: 0,
+    start_time: 12,
+    end_time: 34,
     start_place: "start",
     end_place: "end",
     # nil means nonrevenue
@@ -53,7 +53,9 @@ defmodule Schedule.TripTest do
     shape_id: "shape",
     schedule_id: "schedule",
     run_id: "run",
-    stop_times: @stop_times
+    stop_times: @stop_times,
+    start_time: 3,
+    end_time: 9
   }
 
   describe "merge_trips" do
@@ -75,7 +77,9 @@ defmodule Schedule.TripTest do
                  shape_id: "shape",
                  schedule_id: nil,
                  run_id: nil,
-                 stop_times: @stop_times
+                 stop_times: @stop_times,
+                 start_time: 3,
+                 end_time: 9
                }
              }
     end
@@ -92,7 +96,9 @@ defmodule Schedule.TripTest do
                  shape_id: nil,
                  schedule_id: "schedule",
                  run_id: "run",
-                 stop_times: []
+                 stop_times: [],
+                 start_time: 12,
+                 end_time: 34
                }
              }
     end
@@ -105,18 +111,6 @@ defmodule Schedule.TripTest do
 
     test "works for nonrevenue trips" do
       assert %Trip{route_id: nil} = Trip.merge(nil, %{@hastus_trip | route_id: nil}, nil)
-    end
-  end
-
-  describe "start_time/1" do
-    test "returns the time of the trip's first stop" do
-      assert Trip.start_time(@trip) == 3
-    end
-  end
-
-  describe "end_time/1" do
-    test "returns the time of the trip's last stop" do
-      assert Trip.end_time(@trip) == 9
     end
   end
 

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -315,6 +315,8 @@ defmodule ScheduleTest do
                  shape_id: "shape1",
                  schedule_id: "schedule",
                  run_id: "123-1501",
+                 start_time: 1,
+                 end_time: 3,
                  stop_times: [
                    %StopTime{
                      stop_id: "s4",
@@ -382,6 +384,8 @@ defmodule ScheduleTest do
                  shape_id: "shape1",
                  schedule_id: "schedule",
                  run_id: "123-1501",
+                 start_time: 1,
+                 end_time: 3,
                  stop_times: [
                    %StopTime{
                      stop_id: "s4",
@@ -755,9 +759,11 @@ defmodule ScheduleTest do
           %Trip{
             id: "trip",
             block_id: "block",
+            end_time: 0,
             route_id: "route",
             run_id: "123-4567",
-            schedule_id: "schedule"
+            schedule_id: "schedule",
+            start_time: 0
           }
         ],
         end: %{


### PR DESCRIPTION
Minischedules trips now contain a start_time and an end_time. If a GTFS
trip is present the minischedule uses the times of the first and last
stops. Otherwise the start_time and end_time from the HASTUS trip are
used.