### PR TITLE
Style minischedule trips

### DIFF
--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -19,12 +19,19 @@
 }
 
 .m-minischedule__icon {
+  border-radius: 50%;
   flex: 0 0 auto;
-  width: 2rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+  padding: 0.25rem;
+  width: 1rem;
+
+  &:not(:empty) {
+    background-color: $color-primary;
+  }
 
   svg {
     fill: $color-secondary-medium;
-    height: 1rem;
   }
 }
 
@@ -38,4 +45,37 @@
 
 .m-minischedule__right-text {
   flex: 0 0 auto;
+}
+
+.m-minischedule__piece-rows {
+  // this is all about drawing the line through the icons on the left
+  .m-minischedule__row {
+    position: relative;
+
+    &::before,
+    &::after {
+      background-color: $color-primary;
+      position: absolute;
+      width: 0.5rem;
+      left: 1rem;
+      // force the line to draw below the icons
+      z-index: -1;
+    }
+  }
+
+  .m-minischedule__row:not(:first-child) {
+    &::before {
+      bottom: 50%;
+      content: "";
+      top: 0;
+    }
+  }
+
+  .m-minischedule__row:not(:last-child) {
+    &::after {
+      bottom: 0;
+      content: "";
+      top: 50%;
+    }
+  }
 }

--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -14,5 +14,24 @@
 
 .m-minischedule__row {
   border-top: 1px solid $color-component-light;
+  display: flex;
   padding: 0.5rem;
+}
+
+.m-minischedule__icon {
+  flex: 0 0 auto;
+  width: 2rem;
+
+  svg {
+    fill: $color-secondary-medium;
+    height: 1rem;
+  }
+}
+
+.m-minischedule__left-text {
+  flex: 1 1 auto;
+}
+
+.m-minischedule__right-text {
+  flex: 0 0 auto;
 }

--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -32,6 +32,10 @@
   flex: 1 1 auto;
 }
 
+.m-minischedule__headsign {
+  font-weight: bold;
+}
+
 .m-minischedule__right-text {
   flex: 0 0 auto;
 }

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -6,6 +6,7 @@ import {
 import { Block, Break, Piece, Run, Trip } from "../../minischedule"
 import { TripId } from "../../schedule"
 import Loading from "../loading"
+import { questionMarkIcon } from "../../helpers/icon"
 
 export interface Props {
   activeTripId: TripId
@@ -66,18 +67,40 @@ const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
     {view === "block" ? (
       <div className="m-minischedule__run-header">{piece.runId}</div>
     ) : null}
-    <Row key="sign-on" text={JSON.stringify(piece.start)} />
+    <Row
+      key="sign-on"
+      icon={questionMarkIcon()}
+      text={JSON.stringify(piece.start)}
+    />
     {piece.trips.map((trip) => (
       <Trip trip={trip} key={trip.id} />
     ))}
-    <Row key="sign-off" text={JSON.stringify(piece.end)} />
+    <Row
+      key="sign-off"
+      icon={questionMarkIcon()}
+      text={JSON.stringify(piece.end)}
+    />
   </div>
 )
 
-const Trip = ({ trip }: { trip: Trip }) => <Row text={JSON.stringify(trip)} />
+const Trip = ({ trip }: { trip: Trip }) => (
+  <Row icon={questionMarkIcon()} text={JSON.stringify(trip)} />
+)
 
-const Row = ({ text }: { text: string }) => (
-  <div className="m-minischedule__row">{text}</div>
+const Row = ({
+  icon,
+  text,
+  rightText,
+}: {
+  icon?: ReactElement
+  text: string
+  rightText?: string
+}) => (
+  <div className="m-minischedule__row">
+    <div className="m-minischedule__icon">{icon}</div>
+    <div className="m-minischedule__left-text">{text}</div>
+    {rightText && <div className="m-minischedule__right-text">{rightText}</div>}
+  </div>
 )
 
 const isPiece = (activity: Piece | Break): activity is Piece =>

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -22,7 +22,7 @@ export const MinischeduleRun = ({ activeTripId }: Props): ReactElement => {
         <Header label="Run" value={run.id} />
         {run.activities.map((activity) =>
           isPiece(activity) ? (
-            <Piece piece={activity} key={activity.start.time} />
+            <Piece piece={activity} view="run" key={activity.start.time} />
           ) : (
             <Break break={activity} key={activity.startTime} />
           )
@@ -43,10 +43,7 @@ export const MinischeduleBlock = ({ activeTripId }: Props): ReactElement => {
       <>
         <Header label="Block" value={block.id} />
         {block.pieces.map((piece) => (
-          <React.Fragment key={piece.start.time}>
-            <div className="m-minischedule__run-header">{piece.runId}</div>
-            <Piece piece={piece} />
-          </React.Fragment>
+          <Piece piece={piece} view="block" key={piece.start.time} />
         ))}
       </>
     )
@@ -64,14 +61,17 @@ const Break = ({ break: breakk }: { break: Break }) => (
   <Row text={JSON.stringify(breakk)} />
 )
 
-const Piece = ({ piece }: { piece: Piece }) => (
-  <>
+const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
+  <div>
+    {view === "block" ? (
+      <div className="m-minischedule__run-header">{piece.runId}</div>
+    ) : null}
     <Row key="sign-on" text={JSON.stringify(piece.start)} />
     {piece.trips.map((trip) => (
       <Trip trip={trip} key={trip.id} />
     ))}
     <Row key="sign-off" text={JSON.stringify(piece.end)} />
-  </>
+  </div>
 )
 
 const Trip = ({ trip }: { trip: Trip }) => <Row text={JSON.stringify(trip)} />

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -7,6 +7,7 @@ import { Block, Break, Piece, Run, Trip } from "../../minischedule"
 import { TripId } from "../../schedule"
 import Loading from "../loading"
 import { questionMarkIcon } from "../../helpers/icon"
+import { formattedScheduledTime } from "../../util/dateTime"
 
 export interface Props {
   activeTripId: TripId
@@ -83,9 +84,24 @@ const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
   </div>
 )
 
-const Trip = ({ trip }: { trip: Trip }) => (
-  <Row icon={questionMarkIcon()} text={JSON.stringify(trip)} />
-)
+const Trip = ({ trip }: { trip: Trip }) => {
+  const formattedVariant: string =
+    trip.viaVariant !== null && trip.viaVariant !== "_" ? trip.viaVariant : ""
+  const formattedRouteAndVariant: string =
+    trip.routeId !== null ? `${trip.routeId}_${formattedVariant}` : ""
+  return (
+    <Row
+      icon={questionMarkIcon()}
+      text={
+        <>
+          {formattedRouteAndVariant}{" "}
+          <span className="m-minischedule__headsign">{trip.headsign}</span>
+        </>
+      }
+      rightText={formattedScheduledTime(trip.startTime)}
+    />
+  )
+}
 
 const Row = ({
   icon,
@@ -93,7 +109,7 @@ const Row = ({
   rightText,
 }: {
   icon?: ReactElement
-  text: string
+  text: string | ReactElement
   rightText?: string
 }) => (
   <div className="m-minischedule__row">

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -64,24 +64,26 @@ const Break = ({ break: breakk }: { break: Break }) => (
 )
 
 const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
-  <div>
+  <>
     {view === "block" ? (
       <div className="m-minischedule__run-header">{piece.runId}</div>
     ) : null}
-    <Row
-      key="sign-on"
-      icon={questionMarkIcon()}
-      text={JSON.stringify(piece.start)}
-    />
-    {piece.trips.map((trip) => (
-      <Trip trip={trip} key={trip.id} />
-    ))}
-    <Row
-      key="sign-off"
-      icon={questionMarkIcon()}
-      text={JSON.stringify(piece.end)}
-    />
-  </div>
+    <div className="m-minischedule__piece-rows">
+      <Row
+        key="sign-on"
+        icon={questionMarkIcon()}
+        text={JSON.stringify(piece.start)}
+      />
+      {piece.trips.map((trip) => (
+        <Trip trip={trip} key={trip.id} />
+      ))}
+      <Row
+        key="sign-off"
+        icon={questionMarkIcon()}
+        text={JSON.stringify(piece.end)}
+      />
+    </div>
+  </>
 )
 
 const Trip = ({ trip }: { trip: Trip }) => {

--- a/assets/src/minischedule.d.ts
+++ b/assets/src/minischedule.d.ts
@@ -34,7 +34,7 @@ export interface SignOnOff {
 export interface Trip {
   id: TripId
   blockId: BlockId
-  routeId: RouteId
+  routeId: RouteId | null
   headsign: string | null
   directionId: DirectionId | null
   viaVariant: ViaVariant | null

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -18,15 +18,16 @@ export const formattedTimeDiff = (a: Date, b: Date): string => {
   return diffHours >= 1 ? `${diffHours}h ${diffMinutesStr}` : diffMinutesStr
 }
 
-export const hours12 = (hours24: number): number => {
-  if (hours24 === 0) {
-    return 12
-  }
-  if (hours24 > 12) {
-    return hours24 - 12
-  }
-  return hours24
+/** Takes a time of day in seconds since midnight
+ */
+export const formattedScheduledTime = (time: number): string => {
+  const minutes = Math.floor(time / 60)
+  const hours25 = Math.floor(minutes / 60)
+  const minutes60 = minutes - hours25 * 60
+  return `${hours12(hours25)}:${zeroPad(minutes60)}${ampm(hours25)}`
 }
+
+export const hours12 = (hours25: number): number => hours25 % 12 || 12
 
 export const ampm = (hours24: number): string =>
   hours24 >= 12 && hours24 < 24 ? "pm" : "am"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -18,19 +18,112 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__piece-rows"
   >
-    {"time":20,"place":"start","midRoute":false}
-  </div>,
-  <div
-    className="m-minischedule__row"
-  >
-    {"id":"trip"}
-  </div>,
-  <div
-    className="m-minischedule__row"
-  >
-    {"time":21,"place":"end","midRoute":false}
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":20,"place":"start","midRoute":false}
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        
+         
+        <span
+          className="m-minischedule__headsign"
+        />
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        R_X
+         
+        <span
+          className="m-minischedule__headsign"
+        >
+          Revenue
+        </span>
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":21,"place":"end","midRoute":false}
+      </div>
+    </div>
   </div>,
 ]
 `;
@@ -56,22 +149,122 @@ Array [
   <div
     className="m-minischedule__row"
   >
-    {"breakType":"Break","startTime":10,"endTime":11}
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      {"breakType":"Break","startTime":10,"endTime":11}
+    </div>
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__piece-rows"
   >
-    {"time":20,"place":"start","midRoute":false}
-  </div>,
-  <div
-    className="m-minischedule__row"
-  >
-    {"id":"trip"}
-  </div>,
-  <div
-    className="m-minischedule__row"
-  >
-    {"time":21,"place":"end","midRoute":false}
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":20,"place":"start","midRoute":false}
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        
+         
+        <span
+          className="m-minischedule__headsign"
+        />
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        R_X
+         
+        <span
+          className="m-minischedule__headsign"
+        >
+          Revenue
+        </span>
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":21,"place":"end","midRoute":false}
+      </div>
+    </div>
   </div>,
 ]
 `;

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -22,6 +22,30 @@ const breakk: Break = {
   endTime: 11,
 }
 
+const nonrevenueTrip: Trip = {
+  id: "nonrevenue",
+  blockId: "block",
+  routeId: null,
+  headsign: null,
+  directionId: null,
+  viaVariant: null,
+  runId: null,
+  startTime: 0,
+  endTime: 1,
+}
+
+const revenueTrip: Trip = {
+  id: "trip",
+  blockId: "block",
+  routeId: "R",
+  headsign: "Revenue",
+  directionId: 1,
+  viaVariant: "X",
+  runId: "run",
+  startTime: 0,
+  endTime: 1,
+}
+
 const piece: Piece = {
   runId: "run",
   blockId: "block",
@@ -30,7 +54,7 @@ const piece: Piece = {
     place: "start",
     midRoute: false,
   },
-  trips: [{ id: "trip" } as Trip],
+  trips: [nonrevenueTrip, revenueTrip],
   end: {
     time: 21,
     place: "end",

--- a/assets/tests/util/dateTime.test.ts
+++ b/assets/tests/util/dateTime.test.ts
@@ -5,6 +5,7 @@ import {
   formattedTimeDiff,
   hours12,
   now,
+  formattedScheduledTime,
 } from "../../src/util/dateTime"
 
 describe("now", () => {
@@ -57,12 +58,25 @@ describe("formattedTimeDiff", () => {
   })
 })
 
+describe("formattedScheduledTime", () => {
+  test("formats time", () => {
+    expect(formattedScheduledTime(0)).toEqual("12:00am")
+    expect(formattedScheduledTime(34100)).toEqual("9:28am")
+    expect(formattedScheduledTime(43200)).toEqual("12:00pm")
+    expect(formattedScheduledTime(47100)).toEqual("1:05pm")
+    expect(formattedScheduledTime(86400)).toEqual("12:00am")
+    expect(formattedScheduledTime(90900)).toEqual("1:15am")
+  })
+})
+
 describe("hours12", () => {
   test("returns the 12-hour version of the 24-hour-plus hour", () => {
     expect(hours12(0)).toEqual(12)
     expect(hours12(5)).toEqual(5)
     expect(hours12(12)).toEqual(12)
     expect(hours12(13)).toEqual(1)
+    expect(hours12(24)).toEqual(12)
+    expect(hours12(25)).toEqual(1)
   })
 })
 
@@ -72,5 +86,7 @@ describe("ampm", () => {
     expect(ampm(9)).toEqual("am")
     expect(ampm(12)).toEqual("pm")
     expect(ampm(21)).toEqual("pm")
+    expect(ampm(24)).toEqual("am")
+    expect(ampm(25)).toEqual("am")
   })
 })


### PR DESCRIPTION
Asana Task: [Mini-schedule | Style Revenue Trips](https://app.asana.com/0/1148853526253426/1170698291365302)

<img width="329" alt="Screen Shot 2020-05-12 at 14 59 57" src="https://user-images.githubusercontent.com/23065557/81822040-9d4f9b00-9500-11ea-9a56-96111e958355.png">
<img width="331" alt="Screen Shot 2020-05-12 at 15 07 31" src="https://user-images.githubusercontent.com/23065557/81822043-9de83180-9500-11ea-92d0-6a8292ce6572.png">

And with long multi-line headsigns:
<img width="330" alt="Screen Shot 2020-05-12 at 15 17 45" src="https://user-images.githubusercontent.com/23065557/81822077-a9d3f380-9500-11ea-895a-6cb514b4214f.png">

I don't have svg icons yet, so I'm using the ❓ as a placeholder for now. I'll replace them later.

Depends on #653 . Wait until that merges to review this.