### PR TITLE
Minischedule label pull and deadhead rows

### DIFF
--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -74,9 +74,15 @@ const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
         icon={questionMarkIcon()}
         text={JSON.stringify(piece.start)}
       />
-      {piece.trips.map((trip) => (
-        <Trip trip={trip} key={trip.id} />
-      ))}
+      {piece.trips.map((trip, index) => {
+        const sequence: "first" | "middle" | "last" =
+          index === 0
+            ? "first"
+            : index === piece.trips.length - 1
+            ? "last"
+            : "middle"
+        return <Trip trip={trip} sequence={sequence} key={trip.id} />
+      })}
       <Row
         key="sign-off"
         icon={questionMarkIcon()}
@@ -86,23 +92,57 @@ const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
   </>
 )
 
-const Trip = ({ trip }: { trip: Trip }) => {
-  const formattedVariant: string =
-    trip.viaVariant !== null && trip.viaVariant !== "_" ? trip.viaVariant : ""
-  const formattedRouteAndVariant: string =
-    trip.routeId !== null ? `${trip.routeId}_${formattedVariant}` : ""
-  return (
-    <Row
-      icon={questionMarkIcon()}
-      text={
-        <>
-          {formattedRouteAndVariant}{" "}
-          <span className="m-minischedule__headsign">{trip.headsign}</span>
-        </>
-      }
-      rightText={formattedScheduledTime(trip.startTime)}
-    />
-  )
+const Trip = ({
+  trip,
+  sequence,
+}: {
+  trip: Trip
+  sequence: "first" | "middle" | "last"
+}) => {
+  const startTime: string = formattedScheduledTime(trip.startTime)
+  if (isDeadhead(trip)) {
+    if (sequence === "first") {
+      return (
+        <Row
+          icon={questionMarkIcon()}
+          text={"Pull Out"}
+          rightText={startTime}
+        />
+      )
+    } else if (sequence === "last") {
+      return (
+        <Row
+          icon={questionMarkIcon()}
+          text={"Pull Back"}
+          rightText={startTime}
+        />
+      )
+    } else {
+      return (
+        <Row
+          icon={questionMarkIcon()}
+          text={"Deadhead"}
+          rightText={startTime}
+        />
+      )
+    }
+  } else {
+    const formattedVariant: string =
+      trip.viaVariant !== null && trip.viaVariant !== "_" ? trip.viaVariant : ""
+    const formattedRouteAndVariant: string = `${trip.routeId}_${formattedVariant}`
+    return (
+      <Row
+        icon={questionMarkIcon()}
+        text={
+          <>
+            {formattedRouteAndVariant}{" "}
+            <span className="m-minischedule__headsign">{trip.headsign}</span>
+          </>
+        }
+        rightText={startTime}
+      />
+    )
+  }
 }
 
 const Row = ({
@@ -123,3 +163,5 @@ const Row = ({
 
 const isPiece = (activity: Piece | Break): activity is Piece =>
   activity.hasOwnProperty("trips")
+
+const isDeadhead = (trip: Trip): boolean => trip.routeId == null

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -99,50 +99,53 @@ const Trip = ({
   trip: Trip
   sequence: "first" | "middle" | "last"
 }) => {
-  const startTime: string = formattedScheduledTime(trip.startTime)
   if (isDeadhead(trip)) {
-    if (sequence === "first") {
-      return (
-        <Row
-          icon={questionMarkIcon()}
-          text={"Pull Out"}
-          rightText={startTime}
-        />
-      )
-    } else if (sequence === "last") {
-      return (
-        <Row
-          icon={questionMarkIcon()}
-          text={"Pull Back"}
-          rightText={startTime}
-        />
-      )
-    } else {
-      return (
-        <Row
-          icon={questionMarkIcon()}
-          text={"Deadhead"}
-          rightText={startTime}
-        />
-      )
-    }
+    return <DeadheadTrip trip={trip} sequence={sequence} />
   } else {
-    const formattedVariant: string =
-      trip.viaVariant !== null && trip.viaVariant !== "_" ? trip.viaVariant : ""
-    const formattedRouteAndVariant: string = `${trip.routeId}_${formattedVariant}`
+    return <RevenueTrip trip={trip} />
+  }
+}
+
+const DeadheadTrip = ({
+  trip,
+  sequence,
+}: {
+  trip: Trip
+  sequence: "first" | "middle" | "last"
+}) => {
+  const startTime: string = formattedScheduledTime(trip.startTime)
+  if (sequence === "first") {
     return (
-      <Row
-        icon={questionMarkIcon()}
-        text={
-          <>
-            {formattedRouteAndVariant}{" "}
-            <span className="m-minischedule__headsign">{trip.headsign}</span>
-          </>
-        }
-        rightText={startTime}
-      />
+      <Row icon={questionMarkIcon()} text={"Pull Out"} rightText={startTime} />
+    )
+  } else if (sequence === "last") {
+    return (
+      <Row icon={questionMarkIcon()} text={"Pull Back"} rightText={startTime} />
+    )
+  } else {
+    return (
+      <Row icon={questionMarkIcon()} text={"Deadhead"} rightText={startTime} />
     )
   }
+}
+
+const RevenueTrip = ({ trip }: { trip: Trip }) => {
+  const startTime: string = formattedScheduledTime(trip.startTime)
+  const formattedVariant: string =
+    trip.viaVariant !== null && trip.viaVariant !== "_" ? trip.viaVariant : ""
+  const formattedRouteAndVariant: string = `${trip.routeId}_${formattedVariant}`
+  return (
+    <Row
+      icon={questionMarkIcon()}
+      text={
+        <>
+          {formattedRouteAndVariant}{" "}
+          <span className="m-minischedule__headsign">{trip.headsign}</span>
+        </>
+      }
+      rightText={startTime}
+    />
+  )
 }
 
 const Row = ({

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -59,11 +59,7 @@ Array [
       <div
         className="m-minischedule__left-text"
       >
-        
-         
-        <span
-          className="m-minischedule__headsign"
-        />
+        Pull Out
       </div>
       <div
         className="m-minischedule__right-text"
@@ -200,11 +196,7 @@ Array [
       <div
         className="m-minischedule__left-text"
       >
-        
-         
-        <span
-          className="m-minischedule__headsign"
-        />
+        Pull Out
       </div>
       <div
         className="m-minischedule__right-text"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -59,32 +59,6 @@ Array [
       <div
         className="m-minischedule__left-text"
       >
-        Pull Out
-      </div>
-      <div
-        className="m-minischedule__right-text"
-      >
-        12:00am
-      </div>
-    </div>
-    <div
-      className="m-minischedule__row"
-    >
-      <div
-        className="m-minischedule__icon"
-      >
-        <span
-          className=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
-      </div>
-      <div
-        className="m-minischedule__left-text"
-      >
         R_X
          
         <span
@@ -125,6 +99,150 @@ Array [
 `;
 
 exports[`MinischeduleBlock renders a not found state 1`] = `"No block found"`;
+
+exports[`MinischeduleBlock renders pulls and deadheads 1`] = `
+Array [
+  <div
+    className="m-minischedule__header"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Block
+    </span>
+    block
+  </div>,
+  <div
+    className="m-minischedule__run-header"
+  >
+    run
+  </div>,
+  <div
+    className="m-minischedule__piece-rows"
+  >
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":20,"place":"start","midRoute":false}
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Pull Out
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Deadhead
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Pull Back
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:00am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        {"time":21,"place":"end","midRoute":false}
+      </div>
+    </div>
+  </div>,
+]
+`;
 
 exports[`MinischeduleBlock renders the loading state 1`] = `"loading..."`;
 
@@ -176,32 +294,6 @@ Array [
         className="m-minischedule__left-text"
       >
         {"time":20,"place":"start","midRoute":false}
-      </div>
-    </div>
-    <div
-      className="m-minischedule__row"
-    >
-      <div
-        className="m-minischedule__icon"
-      >
-        <span
-          className=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
-      </div>
-      <div
-        className="m-minischedule__left-text"
-      >
-        Pull Out
-      </div>
-      <div
-        className="m-minischedule__right-text"
-      >
-        12:00am
       </div>
     </div>
     <div

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -54,7 +54,7 @@ const piece: Piece = {
     place: "start",
     midRoute: false,
   },
-  trips: [nonrevenueTrip, revenueTrip],
+  trips: [revenueTrip],
   end: {
     time: 21,
     place: "end",
@@ -117,6 +117,26 @@ describe("MinischeduleBlock", () => {
     ;(useMinischeduleBlock as jest.Mock).mockImplementationOnce(() => ({
       id: "block",
       pieces: [piece],
+    }))
+    const tree = renderer
+      .create(<MinischeduleBlock activeTripId={"trip"} />)
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders pulls and deadheads", () => {
+    const deadheadPiece: Piece = {
+      ...piece,
+      trips: [
+        { ...nonrevenueTrip, id: "pullout" },
+        { ...nonrevenueTrip, id: "deadhead" },
+        { ...nonrevenueTrip, id: "pullback" },
+      ],
+    }
+    ;(useMinischeduleBlock as jest.Mock).mockImplementationOnce(() => ({
+      id: "block",
+      pieces: [deadheadPiece],
     }))
     const tree = renderer
       .create(<MinischeduleBlock activeTripId={"trip"} />)

--- a/lib/schedule/hastus/trip.ex
+++ b/lib/schedule/hastus/trip.ex
@@ -49,14 +49,15 @@ defmodule Schedule.Hastus.Trip do
       end_time: Util.Time.parse_hhmm(row["end_time"]),
       start_place: row["start_place"],
       end_place: row["end_place"],
-      route_id: nonempty_string(row["route_id"]),
+      route_id: route_id(row["route_id"]),
       trip_id: row["trip_id"]
     }
   end
 
-  @spec nonempty_string(String.t()) :: String.t() | nil
-  defp nonempty_string(""), do: nil
-  defp nonempty_string(s), do: s
+  @spec route_id(String.t()) :: Route.id() | nil
+  defp route_id(""), do: nil
+  defp route_id("pull"), do: nil
+  defp route_id(s), do: s
 
   @doc """
   Some rows in trips.csv are missing a lot of data. Drop them.

--- a/test/schedule/hastus/trip_test.exs
+++ b/test/schedule/hastus/trip_test.exs
@@ -8,23 +8,11 @@ defmodule Schedule.Hastus.TripTest do
       binary =
         [
           "schedule_id;area;run_id;block_id;start_time;end_time;start_place;end_place;route_id;trip_id",
-          "aba20021;123;    1501; 57 - 11;04:15;04:30;albny;wtryd;;   43858890",
           "aba20021;123;    1501; 57 - 11;04:30;05:05;wtryd;hayms;  193;   43857919"
         ]
         |> Enum.join("\n")
 
       assert Trip.parse(binary) == [
-               %Trip{
-                 schedule_id: "aba20021",
-                 run_id: "123-1501",
-                 block_id: "57-11",
-                 start_time: 15300,
-                 end_time: 16200,
-                 start_place: "albny",
-                 end_place: "wtryd",
-                 route_id: nil,
-                 trip_id: "43858890"
-               },
                %Trip{
                  schedule_id: "aba20021",
                  run_id: "123-1501",
@@ -48,6 +36,25 @@ defmodule Schedule.Hastus.TripTest do
         |> Enum.join("\n")
 
       assert Trip.parse(binary) == []
+    end
+
+    test "parses deadheads with null route" do
+      binary =
+        [
+          "schedule_id;area;run_id;block_id;start_time;end_time;start_place;end_place;route_id;trip_id",
+          "aba20021;123;    1501; pull;04:15;04:30;albny;wtryd;;   43858890",
+          "aba20021;123;    1501; pull;04:15;04:30;albny;wtryd; pull;   43858890"
+        ]
+        |> Enum.join("\n")
+
+      assert [
+               %Trip{
+                 route_id: nil
+               },
+               %Trip{
+                 route_id: nil
+               }
+             ] = Trip.parse(binary)
     end
   end
 end


### PR DESCRIPTION
Asana Task: [Mini-schedule | Trip List Component | Pulls+Deadheads](https://app.asana.com/0/1148853526253426/1170698291365287)

<img width="329" alt="Screen Shot 2020-05-13 at 12 44 00" src="https://user-images.githubusercontent.com/23065557/81840939-a9932280-9517-11ea-864f-6340e184e321.png">

Depends on #656 . Wait til that merges to review this.

A couple rows in HASTUS's trips.csv have route_id `pull`. Since we detect deadheads by them not having a route_id, this PR also had to detect and fix those rows.

[Later task to add the icons](https://app.asana.com/0/1148863597048545/1175607249486042)
[Later task to add the details about which garage/place the deadhead is to/from](https://app.asana.com/0/1148863597048545/1172768650171943)

