### PR TITLE
fix intermittent failure. ts-nocheck in test setup

### DIFF
--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -1,3 +1,4 @@
+// mocking createSVGRect does some stuff that typescript doesn't like.
 // @ts-nocheck
 import { configure } from "enzyme"
 import React from "react"

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -1,4 +1,4 @@
-// setup file
+// @ts-nocheck
 import { configure } from "enzyme"
 import React from "react"
 import Adapter from "enzyme-adapter-react-16"
@@ -15,19 +15,16 @@ jest.mock("react-tooltip", () => ({
 // JSDOM doesn't support part of SVG that's needed for Leaflet to run in tests.
 // https://stackoverflow.com/questions/54382414/fixing-react-leaflet-testing-error-cannot-read-property-layeradd-of-null
 const createElementNSOrig = document.createElementNS
-// @ts-ignore
 // tslint:disable-next-line only-arrow-functions
 document.createElementNS = function (namespaceURI, qualifiedName) {
   if (
     namespaceURI === "http://www.w3.org/2000/svg" &&
     qualifiedName === "svg"
   ) {
-    // @ts-ignore
     const element = createElementNSOrig.apply(this, arguments)
     // tslint:disable-next-line no-empty
     element.createSVGRect = () => {}
     return element
   }
-  // @ts-ignore
   return createElementNSOrig.apply(this, arguments)
 }

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -18,14 +18,13 @@ jest.mock("react-tooltip", () => ({
 const createElementNSOrig = document.createElementNS
 // tslint:disable-next-line only-arrow-functions
 document.createElementNS = function (namespaceURI, qualifiedName) {
+  const element = createElementNSOrig.apply(this, arguments)
   if (
     namespaceURI === "http://www.w3.org/2000/svg" &&
     qualifiedName === "svg"
   ) {
-    const element = createElementNSOrig.apply(this, arguments)
     // tslint:disable-next-line no-empty
     element.createSVGRect = () => {}
-    return element
   }
-  return createElementNSOrig.apply(this, arguments)
+  return element
 }


### PR DESCRIPTION
No Asana Task

I don't know how a typechecker could have intermittent failures, but here we are. There's a function in `tests/setup.tsx` that adds a missing function so that Leaflet can work in tests. (It was introduced in #632 ). But typescript has failed a couple times on it.

Example failure: https://semaphoreci.com/mbta/skate/branches/dependabot-npm_and_yarn-assets-typescript-3-9-2/builds/2

```
> @ check /home/runner/skate/assets
> tsc --noEmit && npm run lint:check && npm run format:check
tests/setup.tsx:28:13 - error TS2339: Property 'createSVGRect' does not exist on type 'Element'.
28     element.createSVGRect = () => {}
               ~~~~~~~~~~~~~
Found 1 error.
```

I know that function doesn't exist, that's why I'm adding it!

Rather than add even more `@ts-ignore` lines, I figured it'd be easier to disable ts for the whole file. (Unfortunately there's not a way to disable it for just the function.)

I think this is relatively safe, because if some type is wrong in this file, the consequence is that tests will fail, not that prod will break.