### PR TITLE
Show breaks in minischedule

### DIFF
--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -7,7 +7,7 @@ import { Block, Break, Piece, Run, Trip } from "../../minischedule"
 import { TripId } from "../../schedule"
 import Loading from "../loading"
 import { questionMarkIcon } from "../../helpers/icon"
-import { formattedScheduledTime, formattedTimeDiff } from "../../util/dateTime"
+import { formattedScheduledTime, formattedDuration } from "../../util/dateTime"
 
 export interface Props {
   activeTripId: TripId
@@ -60,9 +60,8 @@ const Header = ({ label, value }: { label: string; value: string }) => (
 )
 
 const Break = ({ break: breakk }: { break: Break }) => {
-  const formattedBreakTime = formattedTimeDiff(
-    new Date(breakk.endTime * 1000),
-    new Date(breakk.startTime * 1000)
+  const formattedBreakTime = formattedDuration(
+    breakk.endTime - breakk.startTime
   )
   return (
     <Row text={`Break (${breakk.breakType})`} rightText={formattedBreakTime} />

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -61,11 +61,12 @@ const Header = ({ label, value }: { label: string; value: string }) => (
 
 const Break = ({ break: breakk }: { break: Break }) => {
   const formattedBreakTime = formattedTimeDiff(
-    new Date(breakk.endTime * 1000), new Date(breakk.startTime * 1000)
-  );
-  return(
+    new Date(breakk.endTime * 1000),
+    new Date(breakk.startTime * 1000)
+  )
+  return (
     <Row text={`Break (${breakk.breakType})`} rightText={formattedBreakTime} />
-  );
+  )
 }
 
 const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -7,7 +7,7 @@ import { Block, Break, Piece, Run, Trip } from "../../minischedule"
 import { TripId } from "../../schedule"
 import Loading from "../loading"
 import { questionMarkIcon } from "../../helpers/icon"
-import { formattedScheduledTime } from "../../util/dateTime"
+import { formattedScheduledTime, formattedTimeDiff } from "../../util/dateTime"
 
 export interface Props {
   activeTripId: TripId
@@ -59,9 +59,14 @@ const Header = ({ label, value }: { label: string; value: string }) => (
   </div>
 )
 
-const Break = ({ break: breakk }: { break: Break }) => (
-  <Row text={JSON.stringify(breakk)} />
-)
+const Break = ({ break: breakk }: { break: Break }) => {
+  const formattedBreakTime = formattedTimeDiff(
+    new Date(breakk.endTime * 1000), new Date(breakk.startTime * 1000)
+  );
+  return(
+    <Row text={`Break (${breakk.breakType})`} rightText={formattedBreakTime} />
+  );
+}
 
 const Piece = ({ piece, view }: { piece: Piece; view: "run" | "block" }) => (
   <>

--- a/assets/src/minischedule.d.ts
+++ b/assets/src/minischedule.d.ts
@@ -12,7 +12,7 @@ export interface Block {
 }
 
 export interface Break {
-  breakType: String
+  breakType: string
   startTime: Time
   endTime: Time
 }

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -8,15 +8,17 @@ export const formattedTime = (date: Date): string => {
   return `${hours12(hours24)}:${zeroPad(date.getMinutes())}${ampm(hours24)}`
 }
 
-export const formattedTimeDiff = (a: Date, b: Date): string => {
-  const diffMs: number = a.valueOf() - b.valueOf()
-  const diffHours = Math.floor(diffMs / 3_600_000)
-  const diffMinutes = Math.floor((diffMs % 3_600_000) / 60_000)
+export const formattedDuration = (duration: number): string => {
+  const diffHours = Math.floor(duration / 3_600)
+  const diffMinutes = Math.floor((duration % 3_600) / 60)
 
   const diffMinutesStr = `${diffMinutes}m`
 
   return diffHours >= 1 ? `${diffHours}h ${diffMinutesStr}` : diffMinutesStr
 }
+
+export const formattedTimeDiff = (a: Date, b: Date): string =>
+  formattedDuration(a.valueOf() / 1000 - b.valueOf() / 1000)
 
 /** Takes a time of day in seconds since midnight
  */

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -43,7 +43,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
     <div
@@ -101,7 +101,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
   </div>,
@@ -153,7 +153,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
     <div
@@ -257,7 +257,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
   </div>,
@@ -289,7 +289,12 @@ Array [
     <div
       className="m-minischedule__left-text"
     >
-      {"breakType":"Break","startTime":10,"endTime":11}
+      Break (Paid meal before)
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      30m
     </div>
   </div>,
   <div
@@ -318,7 +323,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
     <div
@@ -376,7 +381,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:30am
       </div>
     </div>
   </div>,

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -17,9 +17,9 @@ jest.mock("../../../src/hooks/useMinischedule", () => ({
 }))
 
 const breakk: Break = {
-  breakType: "Break",
+  breakType: "Paid meal before",
   startTime: 10,
-  endTime: 11,
+  endTime: 1810,
 }
 
 const nonrevenueTrip: Trip = {
@@ -50,13 +50,13 @@ const piece: Piece = {
   runId: "run",
   blockId: "block",
   start: {
-    time: 20,
+    time: 1820,
     place: "start",
     midRoute: false,
   },
   trips: [revenueTrip],
   end: {
-    time: 21,
+    time: 1821,
     place: "end",
     midRoute: false,
   },


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1170698291365291

Breaks are now shown in the minischedule in a formatted fashion, rather than a blob of JSON.