### PR TITLE
Open drift from tab bar

### DIFF
--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -151,7 +151,7 @@ const openDrift = (): void => {
   // @ts-ignore
   if (typeof drift !== "undefined") {
     // @ts-ignore
-    drift.api.sidebar.open()
+    drift.api.sidebar.toggle()
   }
 }
 

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -90,6 +90,7 @@ const TabBar = ({
       </ul>
 
       <div className="m-tab-bar__bottom-buttons">
+        <button onClick={openDrift}>{driftIcon}</button>
         <button className="m-tab-bar__help" onClick={displayHelp}>
           {questionMarkIcon("m-tab-bar__icon")}
         </button>
@@ -129,6 +130,30 @@ const settingsIcon = (
     />
   </svg>
 )
+
+const driftIcon = (
+  <svg
+    width="25"
+    height="23"
+    viewBox="0 0 25 23"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      className="m-tab-bar__icon"
+      d="M24.516 9.953C24.516 4.453 19.04 0 12.258 0 5.476 0 0 4.452 0 9.953c0 3.318 1.986 6.24 5.05 8.053-.34 2.552-1.815 4.055-1.844 4.084-.14.14-.17.368-.113.567a.524.524 0 0 0 .482.312c2.95 0 5.335-1.93 6.612-3.206.652.086 1.362.142 2.07.142 6.783 0 12.26-4.452 12.26-9.953z"
+    />
+  </svg>
+)
+
+const openDrift = (): void => {
+  // drift is set by scripts loaded by _drift.html.eex
+  // but we don't have types for it
+  // @ts-ignore
+  if (typeof drift !== "undefined") {
+    // @ts-ignore
+    drift.api.sidebar.open()
+  }
+}
 
 const showAppcue = (appcueId: string): void => {
   if (window.Appcues) {

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -90,7 +90,9 @@ const TabBar = ({
       </ul>
 
       <div className="m-tab-bar__bottom-buttons">
-        <button onClick={openDrift}>{driftIcon}</button>
+        <button className="m-tab-bar__drift" onClick={openDrift}>
+          {driftIcon}
+        </button>
         <button className="m-tab-bar__help" onClick={displayHelp}>
           {questionMarkIcon("m-tab-bar__icon")}
         </button>

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -19,6 +19,13 @@ declare global {
       ): void
     }
     ResizeObserver: typeof ResizeObserver
+    drift: {
+      api: {
+        sidebar: {
+          toggle: () => void
+        }
+      }
+    }
     username: string
   }
 }

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -114,6 +114,21 @@ exports[`App renders 1`] = `
         className="m-tab-bar__bottom-buttons"
       >
         <button
+          onClick={[Function]}
+        >
+          <svg
+            height="23"
+            viewBox="0 0 25 23"
+            width="25"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              className="m-tab-bar__icon"
+              d="M24.516 9.953C24.516 4.453 19.04 0 12.258 0 5.476 0 0 4.452 0 9.953c0 3.318 1.986 6.24 5.05 8.053-.34 2.552-1.815 4.055-1.844 4.084-.14.14-.17.368-.113.567a.524.524 0 0 0 .482.312c2.95 0 5.335-1.93 6.612-3.206.652.086 1.362.142 2.07.142 6.783 0 12.26-4.452 12.26-9.953z"
+            />
+          </svg>
+        </button>
+        <button
           className="m-tab-bar__help"
           onClick={[Function]}
         >
@@ -348,6 +363,21 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
       <div
         className="m-tab-bar__bottom-buttons"
       >
+        <button
+          onClick={[Function]}
+        >
+          <svg
+            height="23"
+            viewBox="0 0 25 23"
+            width="25"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              className="m-tab-bar__icon"
+              d="M24.516 9.953C24.516 4.453 19.04 0 12.258 0 5.476 0 0 4.452 0 9.953c0 3.318 1.986 6.24 5.05 8.053-.34 2.552-1.815 4.055-1.844 4.084-.14.14-.17.368-.113.567a.524.524 0 0 0 .482.312c2.95 0 5.335-1.93 6.612-3.206.652.086 1.362.142 2.07.142 6.783 0 12.26-4.452 12.26-9.953z"
+            />
+          </svg>
+        </button>
         <button
           className="m-tab-bar__help"
           onClick={[Function]}

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`App renders 1`] = `
         className="m-tab-bar__bottom-buttons"
       >
         <button
+          className="m-tab-bar__drift"
           onClick={[Function]}
         >
           <svg
@@ -364,6 +365,7 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
         className="m-tab-bar__bottom-buttons"
       >
         <button
+          className="m-tab-bar__drift"
           onClick={[Function]}
         >
           <svg

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`renders 1`] = `
         className="m-tab-bar__bottom-buttons"
       >
         <button
+          className="m-tab-bar__drift"
           onClick={[Function]}
         >
           <svg

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -114,6 +114,21 @@ exports[`renders 1`] = `
         className="m-tab-bar__bottom-buttons"
       >
         <button
+          onClick={[Function]}
+        >
+          <svg
+            height="23"
+            viewBox="0 0 25 23"
+            width="25"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              className="m-tab-bar__icon"
+              d="M24.516 9.953C24.516 4.453 19.04 0 12.258 0 5.476 0 0 4.452 0 9.953c0 3.318 1.986 6.24 5.05 8.053-.34 2.552-1.815 4.055-1.844 4.084-.14.14-.17.368-.113.567a.524.524 0 0 0 .482.312c2.95 0 5.335-1.93 6.612-3.206.652.086 1.362.142 2.07.142 6.783 0 12.26-4.452 12.26-9.953z"
+            />
+          </svg>
+        </button>
+        <button
           className="m-tab-bar__help"
           onClick={[Function]}
         >

--- a/assets/tests/components/__snapshots__/tabBar.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/tabBar.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`tabBar renders 1`] = `
     className="m-tab-bar__bottom-buttons"
   >
     <button
+      className="m-tab-bar__drift"
       onClick={[Function]}
     >
       <svg

--- a/assets/tests/components/__snapshots__/tabBar.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/tabBar.test.tsx.snap
@@ -105,6 +105,21 @@ exports[`tabBar renders 1`] = `
     className="m-tab-bar__bottom-buttons"
   >
     <button
+      onClick={[Function]}
+    >
+      <svg
+        height="23"
+        viewBox="0 0 25 23"
+        width="25"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          className="m-tab-bar__icon"
+          d="M24.516 9.953C24.516 4.453 19.04 0 12.258 0 5.476 0 0 4.452 0 9.953c0 3.318 1.986 6.24 5.05 8.053-.34 2.552-1.815 4.055-1.844 4.084-.14.14-.17.368-.113.567a.524.524 0 0 0 .482.312c2.95 0 5.335-1.93 6.612-3.206.652.086 1.362.142 2.07.142 6.783 0 12.26-4.452 12.26-9.953z"
+        />
+      </svg>
+    </button>
+    <button
       className="m-tab-bar__help"
       onClick={[Function]}
     >

--- a/assets/tests/components/tabBar.test.tsx
+++ b/assets/tests/components/tabBar.test.tsx
@@ -11,6 +11,14 @@ window.Appcues = {
   show: jest.fn(),
 }
 
+window.drift = {
+  api: {
+    sidebar: {
+      toggle: jest.fn(),
+    },
+  },
+}
+
 describe("tabBar", () => {
   it("renders", () => {
     const tree = renderer
@@ -58,6 +66,18 @@ describe("tabBar", () => {
     wrapper.find(".m-tab-bar__logo").first().simulate("click")
 
     expect(reloadSpy).toHaveBeenCalled()
+  })
+
+  it("opens drift when you click on the chat icon", () => {
+    const wrapper = mount(
+      <BrowserRouter>
+        <TabBar pickerContainerIsVisible={false} />
+      </BrowserRouter>
+    )
+
+    wrapper.find(".m-tab-bar__drift").first().simulate("click")
+
+    expect(window.drift.api.sidebar.toggle).toHaveBeenCalled()
   })
 
   it("displays an appcue for the current page when you click on the help button", () => {

--- a/lib/skate_web/templates/layout/_drift.html.eex
+++ b/lib/skate_web/templates/layout/_drift.html.eex
@@ -23,4 +23,8 @@
 }();
 drift.SNIPPET_VERSION = '0.3.1';
 drift.load('xhxx5rayxher');
+
+drift.on('ready', function(api) {
+  api.widget.hide();
+})
 </script>


### PR DESCRIPTION
Asana Task: [Test moving the Drift entrypoint to the nav bar (above the ? icon) to simplify the Skate UI](https://app.asana.com/0/1148853526253426/1173065850148382)

Default state:
<img width="717" alt="Screen Shot 2020-05-20 at 12 02 14" src="https://user-images.githubusercontent.com/23065557/82469347-df915300-9a91-11ea-89af-b8dfc5d1e189.png">

The button opens the bigger sidebar:
<img width="716" alt="Screen Shot 2020-05-20 at 12 02 21" src="https://user-images.githubusercontent.com/23065557/82469350-e029e980-9a91-11ea-847f-86f207a2bfd7.png">

Instead of the former smaller popup:
<img width="783" alt="Screen Shot 2020-05-20 at 12 04 23" src="https://user-images.githubusercontent.com/23065557/82469480-149da580-9a92-11ea-957b-97a21e77f787.png">

If the window is narrow, it fills the whole screen instead:
<img width="434" alt="Screen Shot 2020-05-20 at 12 02 45" src="https://user-images.githubusercontent.com/23065557/82469351-e029e980-9a91-11ea-9ad2-59e41e24d69f.png">

To close the chat window, there's a ❌ in the new bigger sidebar, or you can click the tab bar 💬 again.