### PR TITLE
rad/wad in minischedules

### DIFF
--- a/assets/src/minischedule.d.ts
+++ b/assets/src/minischedule.d.ts
@@ -19,7 +19,7 @@ export interface Break {
 
 export interface Piece {
   runId: RunId
-  blockId: BlockId
+  blockId: BlockId | null
   start: SignOnOff
   trips: Trip[]
   end: SignOnOff

--- a/assets/src/minischedule.d.ts
+++ b/assets/src/minischedule.d.ts
@@ -17,11 +17,17 @@ export interface Break {
   endTime: Time
 }
 
+export interface AsDirected {
+  kind: "wad" | "rad"
+  startTime: Time
+  endTime: Time
+}
+
 export interface Piece {
   runId: RunId
   blockId: BlockId | null
   start: SignOnOff
-  trips: Trip[]
+  trips: (Trip | AsDirected)[]
   end: SignOnOff
 }
 

--- a/assets/src/models/minischeduleData.ts
+++ b/assets/src/models/minischeduleData.ts
@@ -1,4 +1,5 @@
 import {
+  AsDirected,
   Block,
   Break,
   Piece,
@@ -18,6 +19,12 @@ interface RunData {
 interface BlockData {
   id: BlockId
   pieces: PieceData[]
+}
+
+interface AsDirectedData {
+  kind: "wad" | "rad"
+  start_time: Time
+  end_time: Time
 }
 
 interface BreakData {
@@ -80,7 +87,9 @@ const pieceFromData = (pieceData: PieceData): Piece => ({
   runId: pieceData.run_id,
   blockId: pieceData.block_id,
   start: signOnOffFromData(pieceData.start),
-  trips: pieceData.trips.map(tripFromData),
+  trips: pieceData.trips.map((data) =>
+    isTripData(data) ? tripFromData(data) : asDirectedFromData(data)
+  ),
   end: signOnOffFromData(pieceData.end),
 })
 
@@ -101,3 +110,12 @@ const tripFromData = (tripData: TripData): Trip => ({
   startTime: tripData.start_time,
   endTime: tripData.end_time,
 })
+
+const asDirectedFromData = (asDirectedData: AsDirectedData): AsDirected => ({
+  kind: asDirectedData.kind,
+  startTime: asDirectedData.start_time,
+  endTime: asDirectedData.end_time,
+})
+
+const isTripData = (data: TripData | AsDirectedData): data is TripData =>
+  data.hasOwnProperty("id")

--- a/assets/src/models/minischeduleData.ts
+++ b/assets/src/models/minischeduleData.ts
@@ -28,7 +28,7 @@ interface BreakData {
 
 interface PieceData {
   run_id: RunId
-  block_id: BlockId
+  block_id: BlockId | null
   start: SignOnOffData
   trips: TripData[]
   end: SignOnOffData

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -385,6 +385,11 @@ describe("minischedulesBlock", () => {
                 start_time: 45,
                 end_time: 567,
               },
+              {
+                kind: "rad",
+                start_time: 567,
+                end_time: 1000,
+              },
             ],
             end: {
               time: 1,
@@ -419,6 +424,11 @@ describe("minischedulesBlock", () => {
                 runId: "run",
                 startTime: 45,
                 endTime: 567,
+              },
+              {
+                kind: "rad",
+                startTime: 567,
+                endTime: 1000,
               },
             ],
             end: {

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -744,4 +744,101 @@ Array [
 ]
 `;
 
+exports[`MinischeduleRun renders as directed pieces 1`] = `
+Array [
+  <div
+    className="m-minischedule__header"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Run
+    </span>
+    run
+  </div>,
+  <div
+    className="m-minischedule__piece-rows"
+  >
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Start Time
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        4:20am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Run as directed
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        4:30am
+      </div>
+    </div>
+    <div
+      className="m-minischedule__row"
+    >
+      <div
+        className="m-minischedule__icon"
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+      <div
+        className="m-minischedule__left-text"
+      >
+        Done
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        4:30am
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`MinischeduleRun renders the loading state 1`] = `"loading..."`;

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -8,7 +8,7 @@ import {
   useMinischeduleBlock,
   useMinischeduleRun,
 } from "../../../src/hooks/useMinischedule"
-import { Break, Piece, Trip } from "../../../src/minischedule"
+import { Break, Piece, Trip, Run } from "../../../src/minischedule"
 
 jest.mock("../../../src/hooks/useMinischedule", () => ({
   __esModule: true,
@@ -137,6 +137,42 @@ describe("MinischeduleRun", () => {
       id: "run",
       activities: [multiTripPiece],
     }))
+    const tree = renderer
+      .create(<MinischeduleRun activeTripId={"trip"} />)
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders as directed pieces", () => {
+    const asDirectedPiece: Piece = {
+      runId: "run",
+      blockId: null,
+      start: {
+        time: 15600,
+        place: "place",
+        midRoute: false,
+      },
+      trips: [
+        {
+          kind: "rad",
+          startTime: 16200,
+          endTime: 44400,
+        },
+      ],
+      end: {
+        time: 16200,
+        place: "place",
+        midRoute: false,
+      },
+    }
+
+    const run: Run = {
+      id: "run",
+      activities: [asDirectedPiece],
+    }
+
+    ;(useMinischeduleRun as jest.Mock).mockImplementationOnce(() => run)
     const tree = renderer
       .create(<MinischeduleRun activeTripId={"trip"} />)
       .toJSON()

--- a/lib/schedule/minischedule/as_directed.ex
+++ b/lib/schedule/minischedule/as_directed.ex
@@ -1,0 +1,29 @@
+defmodule Schedule.Minischedule.AsDirected do
+  alias Schedule.Hastus.Place
+
+  @type t :: %__MODULE__{
+          kind: :wad | :rad,
+          start_time: Util.Time.time_of_day(),
+          end_time: Util.Time.time_of_day(),
+          start_place: Place.id(),
+          end_place: Place.id()
+        }
+
+  @enforce_keys [
+    :kind,
+    :start_time,
+    :end_time,
+    :start_place,
+    :end_place
+  ]
+
+  @derive Jason.Encoder
+
+  defstruct [
+    :kind,
+    :start_time,
+    :end_time,
+    :start_place,
+    :end_place
+  ]
+end

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -74,7 +74,7 @@ defmodule Schedule.Minischedule.Load do
             }"
           end)
 
-          activity.partial_block_id
+          nil
       end
 
     %Piece{
@@ -186,6 +186,7 @@ defmodule Schedule.Minischedule.Load do
   @spec blocks_from_pieces([Piece.t()]) :: Block.by_id()
   defp blocks_from_pieces(pieces) do
     pieces
+    |> Enum.filter(fn piece -> piece.block_id != nil end)
     |> Enum.group_by(&block_key_for_piece/1)
     |> Map.new(fn {{schedule_id, block_id} = block_key, pieces} ->
       {block_key,

--- a/lib/schedule/minischedule/piece.ex
+++ b/lib/schedule/minischedule/piece.ex
@@ -16,7 +16,7 @@ defmodule Schedule.Minischedule.Piece do
   @type t :: %__MODULE__{
           schedule_id: Hastus.Schedule.id(),
           run_id: Run.id(),
-          block_id: Block.id(),
+          block_id: Block.id() | nil,
           start: sign_on_off(),
           # stored with trip ids, but sent to the frontend as full objects
           trips: [Trip.id()] | [Trip.t()],
@@ -26,7 +26,6 @@ defmodule Schedule.Minischedule.Piece do
   @enforce_keys [
     :schedule_id,
     :run_id,
-    :block_id,
     :start,
     :trips,
     :end

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -360,8 +360,6 @@ defmodule Schedule.Minischedule.LoadTest do
 
       assert %Run{
                activities: [
-                 # %Piece{},
-                 # %Piece{} = _p
                  %Piece{
                    block_id: "block",
                    start: %{time: 101},

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -3,6 +3,7 @@ defmodule Schedule.Minischedule.LoadTest do
 
   alias Schedule.Hastus.Activity
   alias Schedule.Hastus.Trip
+  alias Schedule.Minischedule.AsDirected
   alias Schedule.Minischedule.Block
   alias Schedule.Minischedule.Break
   alias Schedule.Minischedule.Load
@@ -484,6 +485,129 @@ defmodule Schedule.Minischedule.LoadTest do
                  %Piece{
                    start: %{time: 101},
                    end: %{time: 103}
+                 }
+               ]
+             } = Load.run(run_key, activities, trips)
+    end
+
+    test "makes as directed pieces when given rad/wad activities" do
+      run_key = {"aba20l31", "123-1502"}
+
+      activities = [
+        %Activity{
+          schedule_id: "aba20l31",
+          run_id: "123-1502",
+          start_time: 15600,
+          end_time: 16200,
+          start_place: "alban",
+          end_place: "alban",
+          activity_type: "Sign-on"
+        },
+        %Activity{
+          schedule_id: "aba20l31",
+          run_id: "123-1502",
+          start_time: 16200,
+          end_time: 44400,
+          start_place: "alban",
+          end_place: "alban",
+          activity_type: "wad"
+        }
+      ]
+
+      trips = []
+
+      assert %Run{
+               activities: [
+                 %Piece{
+                   block_id: nil,
+                   start: %{time: 15600},
+                   trips: [
+                     %AsDirected{
+                       kind: :wad,
+                       start_time: 16200,
+                       end_time: 44400
+                     }
+                   ],
+                   end: %{time: 44400}
+                 }
+               ]
+             } = Load.run(run_key, activities, trips)
+    end
+
+    test "makes as directed pieces when given rad/wad trips" do
+      run_key = {"abc20011", "123-9073"}
+
+      activities = [
+        %Activity{
+          schedule_id: "abc20011",
+          run_id: "123-9073",
+          start_time: 21000,
+          end_time: 21600,
+          start_place: "cabot",
+          end_place: "cabot",
+          activity_type: "Sign-on"
+        },
+        %Activity{
+          schedule_id: "abc20011",
+          run_id: "123-9073",
+          start_time: 21600,
+          end_time: 32400,
+          start_place: "cabot",
+          end_place: "cabot",
+          activity_type: "Operator",
+          partial_block_id: "rad-340"
+        }
+      ]
+
+      trips = [
+        %Trip{
+          schedule_id: "abc20011",
+          run_id: "123-9073",
+          block_id: "Crad-340",
+          start_time: 21600,
+          end_time: 21600,
+          start_place: "cabot",
+          end_place: "cabot",
+          route_id: nil,
+          trip_id: "43756185"
+        },
+        %Trip{
+          schedule_id: "abc20011",
+          run_id: "123-9073",
+          block_id: "Crad-340",
+          start_time: 21600,
+          end_time: 32400,
+          start_place: "cabot",
+          end_place: "cabot",
+          route_id: "rad",
+          trip_id: "43753838"
+        },
+        %Trip{
+          schedule_id: "abc20011",
+          run_id: "123-9073",
+          block_id: "Crad-340",
+          start_time: 32400,
+          end_time: 32400,
+          start_place: "cabot",
+          end_place: "cabot",
+          route_id: nil,
+          trip_id: "43756526"
+        }
+      ]
+
+      assert %Run{
+               activities: [
+                 %Piece{
+                   block_id: "Crad-340",
+                   start: %{time: 21000},
+                   trips: [
+                     %AsDirected{
+                       kind: :rad,
+                       start_time: 21600,
+                       end_time: 32400
+                     }
+                   ],
+                   end: %{time: 32400}
                  }
                ]
              } = Load.run(run_key, activities, trips)

--- a/test/schedule/minischedule/piece_test.exs
+++ b/test/schedule/minischedule/piece_test.exs
@@ -3,6 +3,7 @@ defmodule Schedule.Minischedule.PieceTest do
 
   alias Schedule.Gtfs.StopTime
   alias Schedule.Minischedule
+  alias Schedule.Minischedule.AsDirected
   alias Schedule.Minischedule.Piece
 
   describe "hydrate" do
@@ -56,6 +57,44 @@ defmodule Schedule.Minischedule.PieceTest do
       }
 
       assert Piece.hydrate(stored_piece, %{trip_id => stored_trip}) == expected_piece
+    end
+
+    test "doesn't replace non-ids" do
+      trip = %Minischedule.Trip{
+        id: "trip",
+        block_id: "block"
+      }
+
+      as_directed = %AsDirected{
+        kind: :wad,
+        start_time: 0,
+        end_time: 1,
+        start_place: "start",
+        end_place: "end"
+      }
+
+      sign_on = %{
+        time: "0",
+        place: "on",
+        mid_route?: false
+      }
+
+      sign_off = %{
+        time: "1",
+        place: "off",
+        mid_route?: false
+      }
+
+      piece = %Piece{
+        schedule_id: "schedule",
+        run_id: "run",
+        block_id: "block",
+        start: sign_on,
+        trips: [trip, as_directed],
+        end: sign_off
+      }
+
+      assert Piece.hydrate(piece, %{}) == piece
     end
   end
 end


### PR DESCRIPTION
Asana Task: [Mini-schedule | RADs/WADs](https://app.asana.com/0/1148853526253426/1173661402437253)

<img width="329" alt="Screen Shot 2020-05-21 at 17 17 48" src="https://user-images.githubusercontent.com/23065557/82609768-2a42c600-9b8b-11ea-95d2-f251a392ea08.png">

It shows as "Work as directed" if the data has "wad".

Will require running `mix cache.clean` locally to see it, but they're pretty rare.

Examples of what rads/wads appear like in the HASTUS data are in the asana tasks. Looking at that will help understand the parsing step.

