### PR TITLE
filter out block waivers for bad TM units

### DIFF
--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -55,10 +55,19 @@ defmodule Realtime.BlockWaiver do
          stop_time_updates,
          fn stu ->
            StopTimeUpdate.stop_id(stu) == stop_time.stop_id &&
-             StopTimeUpdate.cause_id(stu) != nil
+             is_block_waiver?(stu)
          end
        )}
     end)
+  end
+
+  @spec is_block_waiver?(StopTimeUpdate.t()) :: boolean()
+  def is_block_waiver?(stop_time_update) do
+    # cause_id 33 is bad TransitMaster units.
+    # Since we can fall back to swiftly data,
+    # these block waivers don't matter to people using skate.
+    StopTimeUpdate.cause_id(stop_time_update) != nil and
+      StopTimeUpdate.cause_id(stop_time_update) != 33
   end
 
   @spec group_consecutive_sequences([trip_stop_time_waiver()], [[trip_stop_time_waiver()]], [

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -154,7 +154,7 @@ defmodule Realtime.BlockWaiverTest do
         @trip1stop1Update
         | cause_id: 33,
           cause_description: "T - Inactive TM",
-          remark: "T - Inactive TM:",
+          remark: "T - Inactive TM:"
       }
 
       stop_time_updates_by_trip = %{

--- a/test/realtime/block_waiver_test.exs
+++ b/test/realtime/block_waiver_test.exs
@@ -149,6 +149,27 @@ defmodule Realtime.BlockWaiverTest do
       assert BlockWaiver.trip_stop_time_waivers(@trip1, stop_time_updates_by_trip) == expected
     end
 
+    test "does not include stop time updates for bad transitmaster units" do
+      trip1stop1UpdateBadTm = %{
+        @trip1stop1Update
+        | cause_id: 33,
+          cause_description: "T - Inactive TM",
+          remark: "T - Inactive TM:",
+      }
+
+      stop_time_updates_by_trip = %{
+        @trip1.id => [trip1stop1UpdateBadTm]
+      }
+
+      expected = [
+        {1, nil},
+        {2, nil},
+        {3, nil}
+      ]
+
+      assert BlockWaiver.trip_stop_time_waivers(@trip1, stop_time_updates_by_trip) == expected
+    end
+
     test "includes stop time updates with causes but no remark" do
       trip1stop1UpdateNilRemark = %{
         @trip1stop1Update


### PR DESCRIPTION
Asana Task: [Don't show/highlight block waivers for invalid Transitmasters in Skate](https://app.asana.com/0/1148853526253426/1166921367572633)