### PR TITLE
change time formatting

### DIFF
--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -4,17 +4,16 @@ export const dateFromEpochSeconds = (time: number): Date =>
   new Date(time * 1_000)
 
 export const formattedTime = (date: Date): string => {
-  const hours24 = date.getHours()
-  return `${hours12(hours24)}:${zeroPad(date.getMinutes())}${ampm(hours24)}`
+  return formattedHoursMinutes(date.getHours(), date.getMinutes())
 }
 
 export const formattedDuration = (duration: number): string => {
   const diffHours = Math.floor(duration / 3_600)
   const diffMinutes = Math.floor((duration % 3_600) / 60)
 
-  const diffMinutesStr = `${diffMinutes}m`
+  const diffMinutesStr = `${diffMinutes} min`
 
-  return diffHours >= 1 ? `${diffHours}h ${diffMinutesStr}` : diffMinutesStr
+  return diffHours >= 1 ? `${diffHours} hr ${diffMinutesStr}` : diffMinutesStr
 }
 
 export const formattedTimeDiff = (a: Date, b: Date): string =>
@@ -26,12 +25,15 @@ export const formattedScheduledTime = (time: number): string => {
   const minutes = Math.floor(time / 60)
   const hours25 = Math.floor(minutes / 60)
   const minutes60 = minutes - hours25 * 60
-  return `${hours12(hours25)}:${zeroPad(minutes60)}${ampm(hours25)}`
+  return formattedHoursMinutes(hours25, minutes60)
 }
 
-export const hours12 = (hours25: number): number => hours25 % 12 || 12
-
-export const ampm = (hours24: number): string =>
-  hours24 >= 12 && hours24 < 24 ? "pm" : "am"
-
-const zeroPad = (time: number): string => (time < 10 ? `0${time}` : `${time}`)
+export const formattedHoursMinutes = (
+  hours25: number,
+  minutes60: number
+): string => {
+  const hours12 = hours25 % 12 || 12
+  const zeroPaddedMinutes = minutes60 < 10 ? `0${minutes60}` : `${minutes60}`
+  const ampm = hours25 >= 12 && hours25 < 24 ? "PM" : "AM"
+  return `${hours12}:${zeroPaddedMinutes} ${ampm}`
+}

--- a/assets/tests/components/STABLE/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/STABLE/__snapshots__/propertiesPanel.test.tsx.snap
@@ -383,7 +383,7 @@ Array [
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>

--- a/assets/tests/components/STABLE/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/STABLE/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          3:53pm
+          3:53 PM
         </td>
       </tr>
       <tr>
@@ -86,7 +86,7 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          4:26pm
+          4:26 PM
         </td>
       </tr>
     </tbody>
@@ -168,7 +168,7 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          4:26pm
+          4:26 PM
         </td>
       </tr>
       <tr>
@@ -180,7 +180,7 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          4:43pm
+          4:43 PM
         </td>
       </tr>
     </tbody>
@@ -262,7 +262,7 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          3:36pm
+          3:36 PM
         </td>
       </tr>
       <tr>
@@ -274,7 +274,7 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          3:53pm
+          3:53 PM
         </td>
       </tr>
     </tbody>

--- a/assets/tests/components/STABLE/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/STABLE/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`BlockWaiverList renders 1`] = `
           <td
             className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
           >
-            5:05am
+            5:05 AM
           </td>
         </tr>
         <tr>
@@ -89,7 +89,7 @@ exports[`BlockWaiverList renders 1`] = `
           <td
             className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
           >
-            12:38pm
+            12:38 PM
           </td>
         </tr>
       </tbody>

--- a/assets/tests/components/STABLE/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/STABLE/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -358,7 +358,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
             >
-              5:05am
+              5:05 AM
             </td>
           </tr>
           <tr>
@@ -370,7 +370,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
             >
-              12:38pm
+              12:38 PM
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/STABLE/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/STABLE/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -414,7 +414,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -646,7 +646,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -845,7 +845,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -1097,7 +1097,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
             >
-              5:05am
+              5:05 AM
             </td>
           </tr>
           <tr>
@@ -1109,7 +1109,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
             >
-              12:38pm
+              12:38 PM
             </td>
           </tr>
         </tbody>
@@ -1176,7 +1176,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -1408,7 +1408,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -1650,7 +1650,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -1886,7 +1886,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>

--- a/assets/tests/components/__snapshots__/propertiesList.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesList.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`PropertiesList highlights requested text 1`] = `
         <td
           className="m-properties-list__property-value"
         >
-          4h 3m; 1:38pm
+          4 hr 3 min; 1:38 PM
         </td>
       </tr>
     </tbody>
@@ -163,7 +163,7 @@ exports[`PropertiesList renders a properties list for a vehicle 1`] = `
         <td
           className="m-properties-list__property-value"
         >
-          4h 3m; 1:38pm
+          4 hr 3 min; 1:38 PM
         </td>
       </tr>
     </tbody>
@@ -232,7 +232,7 @@ exports[`PropertiesList renders a properties list for an overloaded vehicle 1`] 
         <td
           className="m-properties-list__property-value"
         >
-          4h 3m; 1:38pm
+          4 hr 3 min; 1:38 PM
         </td>
       </tr>
     </tbody>

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -610,7 +610,7 @@ Array [
                   <td
                     className="m-properties-list__property-value"
                   >
-                    4h 3m; 1:38pm
+                    4 hr 3 min; 1:38 PM
                   </td>
                 </tr>
               </tbody>

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -362,7 +362,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -230,7 +230,7 @@ exports[`SearchResults renders a selected result card 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -386,7 +386,7 @@ exports[`SearchResults shows the new badge for vehicle that have logged in withi
               <td
                 className="m-properties-list__property-value"
               >
-                1m; 5:40pm
+                1 min; 5:40 PM
               </td>
             </tr>
           </tbody>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -573,7 +573,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -198,7 +198,7 @@ describe("Highlighted", () => {
 describe("formattedLogonTime", () => {
   test("formats the logon time relative to now, and with the actual time", () => {
     const logonTime = new Date("2018-08-15T13:38:21.000Z")
-    const expected = "4h 3m; 1:38pm"
+    const expected = "4 hr 3 min; 1:38 PM"
 
     expect(formattedLogonTime(logonTime)).toEqual(expected)
   })

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverBanner.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          3:53pm
+          3:53 PM
         </td>
       </tr>
       <tr>
@@ -86,7 +86,7 @@ exports[`BlockWaiverBanner renders a current time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          4:26pm
+          4:26 PM
         </td>
       </tr>
     </tbody>
@@ -168,7 +168,7 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          4:26pm
+          4:26 PM
         </td>
       </tr>
       <tr>
@@ -180,7 +180,7 @@ exports[`BlockWaiverBanner renders a future time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          4:43pm
+          4:43 PM
         </td>
       </tr>
     </tbody>
@@ -262,7 +262,7 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
         >
-          3:36pm
+          3:36 PM
         </td>
       </tr>
       <tr>
@@ -274,7 +274,7 @@ exports[`BlockWaiverBanner renders a past time waiver 1`] = `
         <td
           className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
         >
-          3:53pm
+          3:53 PM
         </td>
       </tr>
     </tbody>

--- a/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/blockWaiverList.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`BlockWaiverList renders 1`] = `
           <td
             className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
           >
-            5:05am
+            5:05 AM
           </td>
         </tr>
         <tr>
@@ -89,7 +89,7 @@ exports[`BlockWaiverList renders 1`] = `
           <td
             className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
           >
-            12:38pm
+            12:38 PM
           </td>
         </tr>
       </tbody>

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -476,7 +476,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
             >
-              5:05am
+              5:05 AM
             </td>
           </tr>
           <tr>
@@ -488,7 +488,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
             >
-              12:38pm
+              12:38 PM
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -43,7 +43,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -75,7 +75,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -101,7 +101,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -153,7 +153,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -179,7 +179,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -205,7 +205,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:03am
+        12:03 AM
       </div>
     </div>
     <div
@@ -231,7 +231,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:14am
+        12:14 AM
       </div>
     </div>
     <div
@@ -257,7 +257,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -309,7 +309,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -341,7 +341,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -373,7 +373,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:05am
+        12:05 AM
       </div>
     </div>
     <div
@@ -405,7 +405,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:10am
+        12:10 AM
       </div>
     </div>
     <div
@@ -431,7 +431,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -667,7 +667,7 @@ Array [
     <div
       className="m-minischedule__right-text"
     >
-      30m
+      30 min
     </div>
   </div>,
   <div
@@ -696,7 +696,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -728,7 +728,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -745,7 +745,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        5m
+        5 min
       </div>
     </div>
     <div
@@ -777,7 +777,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:05am
+        12:05 AM
       </div>
     </div>
     <div
@@ -803,7 +803,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -1298,7 +1298,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -1330,7 +1330,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -1362,7 +1362,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -1388,7 +1388,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -1433,7 +1433,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:20am
+        4:20 AM
       </div>
     </div>
     <div
@@ -1459,7 +1459,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:30am
+        4:30 AM
       </div>
     </div>
     <div
@@ -1485,7 +1485,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:30am
+        4:30 AM
       </div>
     </div>
   </div>,

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -476,7 +476,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -508,7 +508,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -525,7 +525,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        5m
+        5 min
       </div>
     </div>
     <div
@@ -557,7 +557,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:05am
+        12:05 AM
       </div>
     </div>
     <div
@@ -574,7 +574,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4m
+        4 min
       </div>
     </div>
     <div
@@ -606,7 +606,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:10am
+        12:10 AM
       </div>
     </div>
     <div
@@ -632,7 +632,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -848,7 +848,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -880,7 +880,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -897,7 +897,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        5m
+        5 min
       </div>
     </div>
     <div
@@ -929,7 +929,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:05am
+        12:05 AM
       </div>
     </div>
     <div
@@ -955,7 +955,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,
@@ -1000,7 +1000,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:20am
+        4:20 AM
       </div>
     </div>
     <div
@@ -1032,7 +1032,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -1049,7 +1049,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4h 29m
+        4 hr 29 min
       </div>
     </div>
     <div
@@ -1075,7 +1075,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:30am
+        4:30 AM
       </div>
     </div>
     <div
@@ -1101,7 +1101,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        4:30am
+        4:30 AM
       </div>
     </div>
   </div>,
@@ -1146,7 +1146,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
     <div
@@ -1178,7 +1178,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:00am
+        12:00 AM
       </div>
     </div>
     <div
@@ -1195,7 +1195,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        5m
+        5 min
       </div>
     </div>
     <div
@@ -1227,7 +1227,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:05am
+        12:05 AM
       </div>
     </div>
     <div
@@ -1253,7 +1253,7 @@ Array [
       <div
         className="m-minischedule__right-text"
       >
-        12:30am
+        12:30 AM
       </div>
     </div>
   </div>,

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -636,7 +636,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -981,7 +981,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -1189,7 +1189,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
           <td
             className="m-properties-list__property-value"
           >
-            4h 3m; 1:38pm
+            4 hr 3 min; 1:38 PM
           </td>
         </tr>
       </tbody>
@@ -1436,7 +1436,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--start-time"
             >
-              5:05am
+              5:05 AM
             </td>
           </tr>
           <tr>
@@ -1448,7 +1448,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             <td
               className="m-block-waiver-banner__detail-value m-block-waiver-banner__detail-value--end-time"
             >
-              12:38pm
+              12:38 PM
             </td>
           </tr>
         </tbody>
@@ -1619,7 +1619,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -1964,7 +1964,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -2319,7 +2319,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>
@@ -2668,7 +2668,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
               <td
                 className="m-properties-list__property-value"
               >
-                4h 3m; 1:38pm
+                4 hr 3 min; 1:38 PM
               </td>
             </tr>
           </tbody>

--- a/assets/tests/util/dateTime.test.ts
+++ b/assets/tests/util/dateTime.test.ts
@@ -1,9 +1,8 @@
 import {
-  ampm,
   dateFromEpochSeconds,
+  formattedHoursMinutes,
   formattedTime,
   formattedTimeDiff,
-  hours12,
   now,
   formattedScheduledTime,
 } from "../../src/util/dateTime"
@@ -26,14 +25,16 @@ describe("dateFromEpochSeconds", () => {
 describe("formattedTime", () => {
   test("returns a formatted string version of the time", () => {
     expect(formattedTime(new Date("Februrary 18, 2020 0:38"))).toEqual(
-      "12:38am"
+      "12:38 AM"
     )
-    expect(formattedTime(new Date("Februrary 18, 2020 9:38"))).toEqual("9:38am")
+    expect(formattedTime(new Date("Februrary 18, 2020 9:38"))).toEqual(
+      "9:38 AM"
+    )
     expect(formattedTime(new Date("Februrary 18, 2020 12:38"))).toEqual(
-      "12:38pm"
+      "12:38 PM"
     )
     expect(formattedTime(new Date("Februrary 18, 2020 21:08"))).toEqual(
-      "9:08pm"
+      "9:08 PM"
     )
   })
 })
@@ -43,7 +44,7 @@ describe("formattedTimeDiff", () => {
     const a: Date = new Date("Februrary 18, 2020 14:42")
     const b: Date = new Date("Februrary 18, 2020 9:38")
 
-    const expected: string = "5h 4m"
+    const expected: string = "5 hr 4 min"
 
     expect(formattedTimeDiff(a, b)).toEqual(expected)
   })
@@ -52,7 +53,7 @@ describe("formattedTimeDiff", () => {
     const a: Date = new Date("Februrary 18, 2020 2:00")
     const b: Date = new Date("Februrary 18, 2020 1:01")
 
-    const expected: string = "59m"
+    const expected: string = "59 min"
 
     expect(formattedTimeDiff(a, b)).toEqual(expected)
   })
@@ -60,33 +61,41 @@ describe("formattedTimeDiff", () => {
 
 describe("formattedScheduledTime", () => {
   test("formats time", () => {
-    expect(formattedScheduledTime(0)).toEqual("12:00am")
-    expect(formattedScheduledTime(34100)).toEqual("9:28am")
-    expect(formattedScheduledTime(43200)).toEqual("12:00pm")
-    expect(formattedScheduledTime(47100)).toEqual("1:05pm")
-    expect(formattedScheduledTime(86400)).toEqual("12:00am")
-    expect(formattedScheduledTime(90900)).toEqual("1:15am")
+    expect(formattedScheduledTime(0)).toEqual("12:00 AM")
+    expect(formattedScheduledTime(34100)).toEqual("9:28 AM")
+    expect(formattedScheduledTime(43200)).toEqual("12:00 PM")
+    expect(formattedScheduledTime(47100)).toEqual("1:05 PM")
+    expect(formattedScheduledTime(86400)).toEqual("12:00 AM")
+    expect(formattedScheduledTime(90900)).toEqual("1:15 AM")
   })
 })
 
-describe("hours12", () => {
-  test("returns the 12-hour version of the 24-hour-plus hour", () => {
-    expect(hours12(0)).toEqual(12)
-    expect(hours12(5)).toEqual(5)
-    expect(hours12(12)).toEqual(12)
-    expect(hours12(13)).toEqual(1)
-    expect(hours12(24)).toEqual(12)
-    expect(hours12(25)).toEqual(1)
+describe("formattedHoursMinutes", () => {
+  test("works at midnight 00:00", () => {
+    expect(formattedHoursMinutes(0, 0)).toEqual("12:00 AM")
   })
-})
 
-describe("ampm", () => {
-  test("returns whether a 24-hour-plus hours number represents 'am' or 'pm'", () => {
-    expect(ampm(0)).toEqual("am")
-    expect(ampm(9)).toEqual("am")
-    expect(ampm(12)).toEqual("pm")
-    expect(ampm(21)).toEqual("pm")
-    expect(ampm(24)).toEqual("am")
-    expect(ampm(25)).toEqual("am")
+  test("works in am", () => {
+    expect(formattedHoursMinutes(10, 55)).toEqual("10:55 AM")
+  })
+
+  test("works at noon", () => {
+    expect(formattedHoursMinutes(12, 0)).toEqual("12:00 PM")
+  })
+
+  test("works in pm", () => {
+    expect(formattedHoursMinutes(22, 55)).toEqual("10:55 PM")
+  })
+
+  test("works at midnight 24:00", () => {
+    expect(formattedHoursMinutes(24, 0)).toEqual("12:00 AM")
+  })
+
+  test("works after midnight", () => {
+    expect(formattedHoursMinutes(25, 55)).toEqual("1:55 AM")
+  })
+
+  test("zero pads short minutes, but not hours", () => {
+    expect(formattedHoursMinutes(5, 5)).toEqual("5:05 AM")
   })
 })


### PR DESCRIPTION
Asana Task: [Mini-schedule | Format times](https://app.asana.com/0/1148853526253426/1176968901192792)

<img width="336" alt="Screen Shot 2020-05-26 at 16 07 38" src="https://user-images.githubusercontent.com/23065557/82949245-3fe03300-9f71-11ea-884c-537a859c5c00.png">

Also affects the time formatting for logon times and block waivers.
<img width="281" alt="Screen Shot 2020-05-26 at 16 07 16" src="https://user-images.githubusercontent.com/23065557/82949275-4ff81280-9f71-11ea-9630-556f8ce4caa8.png">
