### PR TITLE
 style past and future trips and pieces 

### DIFF
--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -40,14 +40,6 @@
   padding: 0.25rem;
   width: 1rem;
   z-index: 2;
-
-  &:not(:empty) {
-    background-color: $color-primary;
-  }
-
-  svg {
-    fill: $color-secondary-medium;
-  }
 }
 
 .m-minischedule__left-text {
@@ -70,7 +62,6 @@
 
     &::before,
     &::after {
-      background-color: $color-primary;
       left: 1.75rem;
       position: absolute;
       transform: translateX(-50%);
@@ -100,6 +91,50 @@
       top: 50%;
     }
   }
+}
+
+.m-minischedule__piece-rows--past,
+.m-minischedule__piece-rows--future {
+  .m-minischedule__icon {
+    &:not(:empty) {
+      background-color: $color-component-light;
+    }
+
+    svg {
+      fill: $color-component-medium;
+    }
+  }
+
+  .m-minischedule__row {
+    &::before,
+    &::after {
+      background-color: $color-component-light;
+    }
+  }
+}
+
+.m-minischedule__piece-rows--current,
+.m-minischedule__piece-rows--unknown {
+  .m-minischedule__icon {
+    &:not(:empty) {
+      background-color: $color-primary;
+    }
+
+    svg {
+      fill: $color-secondary-light;
+    }
+  }
+
+  .m-minischedule__row {
+    &::before,
+    &::after {
+      background-color: $color-primary;
+    }
+  }
+}
+
+.m-minischedule__row--past {
+  color: $color-font-grey;
 }
 
 .m-minischedule__row--current {

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -55,7 +55,12 @@ export const MinischeduleRun = ({ vehicleOrGhost }: Props): ReactElement => {
               key={activity.start.time}
             />
           ) : (
-            <BreakRow break={activity} key={activity.startTime} />
+            <BreakRow
+              key={activity.startTime}
+              break={activity}
+              index={index}
+              activeIndex={activeIndex}
+            />
           )
         )}
       </>
@@ -99,7 +104,15 @@ const Header = ({ label, value }: { label: string; value: string }) => (
   </div>
 )
 
-export const BreakRow = ({ break: breakk }: { break: Break }) => {
+export const BreakRow = ({
+  break: breakk,
+  index,
+  activeIndex,
+}: {
+  break: Break
+  index: number
+  activeIndex: [number, number] | null
+}) => {
   const formattedBreakTime = formattedDuration(
     breakk.endTime - breakk.startTime
   )
@@ -108,14 +121,26 @@ export const BreakRow = ({ break: breakk }: { break: Break }) => {
     isPaid === null ? "" : isPaid ? " (Paid)" : " (Unpaid)"
   const text: string = breakDisplayText(breakk) + isPaidText
 
+  const timeBasedStyle: TimeBasedStyle = getTimeBasedStyle(
+    index,
+    activeIndex && activeIndex[0]
+  )
+
   if (breakk.breakType === "Travel from" || breakk.breakType === "Travel to") {
-    return <Row text={text} rightText={formattedBreakTime} />
+    return (
+      <Row
+        text={text}
+        rightText={formattedBreakTime}
+        timeBasedStyle={timeBasedStyle}
+      />
+    )
   } else {
     return (
       <Row
         text={text}
         rightText={formattedBreakTime}
         belowText={breakk.endPlace}
+        timeBasedStyle={timeBasedStyle}
       />
     )
   }
@@ -185,6 +210,10 @@ const Piece = ({
     pieceIndex,
     activeIndex && activeIndex[0]
   )
+  const startTimeBasedStyle: TimeBasedStyle =
+    pieceTimeBasedStyle === "current" ? "past" : pieceTimeBasedStyle
+  const doneTimeBasedStyle: TimeBasedStyle =
+    pieceTimeBasedStyle === "current" ? "future" : pieceTimeBasedStyle
 
   return (
     <>
@@ -196,6 +225,7 @@ const Piece = ({
           text="Start time"
           rightText={formattedScheduledTime(piece.start.time)}
           belowText={startPlace}
+          timeBasedStyle={startTimeBasedStyle}
         />
       )}
       <div
@@ -211,6 +241,7 @@ const Piece = ({
             text="Swing on"
             rightText={formattedScheduledTime(piece.start.time)}
             belowText={startPlace}
+            timeBasedStyle={startTimeBasedStyle}
           />
         ) : null}
         {piece.trips.map((trip, tripIndex) => {
@@ -237,6 +268,7 @@ const Piece = ({
             text="Swing off"
             rightText={formattedScheduledTime(piece.end.time)}
             belowText={startPlace}
+            timeBasedStyle={doneTimeBasedStyle}
           />
         ) : null}
       </div>
@@ -245,6 +277,7 @@ const Piece = ({
           text="Done"
           rightText={formattedScheduledTime(piece.end.time)}
           belowText={endPlace}
+          timeBasedStyle={doneTimeBasedStyle}
         />
       )}
     </>

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -116,18 +116,18 @@ export const BreakRow = ({ break: breakk }: { break: Break }) => {
 }
 
 const Layover = ({
-  currentTrip,
   nextTrip,
+  previousTrip,
   vehicleOrGhost,
 }: {
-  currentTrip: Trip | AsDirected
-  nextTrip?: Trip | AsDirected
+  nextTrip: Trip | AsDirected
+  previousTrip?: Trip | AsDirected
   vehicleOrGhost: VehicleOrGhost
 }) => {
-  if (!nextTrip) {
+  if (!previousTrip) {
     return null
   }
-  const layoverDuration = nextTrip.startTime - currentTrip.endTime
+  const layoverDuration = nextTrip.startTime - previousTrip.endTime
   if (layoverDuration === 0) {
     return null
   }
@@ -222,6 +222,13 @@ const Piece = ({
               : "middle"
           return (
             <React.Fragment key={trip.startTime}>
+              {view === "run" ? (
+                <Layover
+                  nextTrip={trip}
+                  previousTrip={piece.trips[index - 1]}
+                  vehicleOrGhost={vehicleOrGhost}
+                />
+              ) : null}
               {isTrip(trip) ? (
                 <Trip
                   trip={trip}
@@ -231,13 +238,6 @@ const Piece = ({
               ) : (
                 <AsDirected asDirected={trip} />
               )}
-              {view === "run" ? (
-                <Layover
-                  currentTrip={trip}
-                  nextTrip={piece.trips[index + 1]}
-                  vehicleOrGhost={vehicleOrGhost}
-                />
-              ) : null}
             </React.Fragment>
           )
         })}

--- a/assets/src/helpers/dom.ts
+++ b/assets/src/helpers/dom.ts
@@ -1,6 +1,2 @@
-// ts-lint doesn't like either Array<string | undefined> or
-// (string | undefined)[], so we create this type as a workaround.
-export type MaybeString = string | undefined
-
-export const className = (classes: MaybeString[]): string =>
+export const className = (classes: (string | null | undefined)[]): string =>
   classes.filter((c) => c && c !== "").join(" ")

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -524,7 +524,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--past"
+      className="m-minischedule__row m-minischedule__row--past m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"
@@ -567,7 +567,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--current on-time"
+      className="m-minischedule__row m-minischedule__row--current on-time m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"
@@ -744,7 +744,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--unknown"
+      className="m-minischedule__row m-minischedule__row--unknown m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"
@@ -896,7 +896,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--current on-time"
+      className="m-minischedule__row m-minischedule__row--current on-time m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"
@@ -1048,7 +1048,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--unknown"
+      className="m-minischedule__row m-minischedule__row--unknown m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"
@@ -1186,7 +1186,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--past"
+      className="m-minischedule__row m-minischedule__row--past m-minischedule__layover-row"
     >
       <div
         className="m-minischedule__icon"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -21,7 +21,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -79,7 +79,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -134,7 +134,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"
@@ -257,7 +257,7 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"
@@ -305,7 +305,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -415,7 +415,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -466,7 +466,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -610,7 +610,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--future"
     >
       <div
         className="m-minischedule__icon"
@@ -660,7 +660,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"
@@ -686,7 +686,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -787,7 +787,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -838,7 +838,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -939,7 +939,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--future"
     >
       <div
         className="m-minischedule__icon"
@@ -990,7 +990,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1092,7 +1092,7 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"
@@ -1128,7 +1128,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -1229,7 +1229,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--future"
     >
       <div
         className="m-minischedule__icon"
@@ -1280,7 +1280,7 @@ Array [
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1364,7 +1364,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1412,7 +1412,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"
@@ -1460,7 +1460,7 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__row"
+    className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
       className="m-minischedule__icon"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -18,7 +18,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
       className="m-minischedule__row"
@@ -53,7 +53,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -157,10 +157,10 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -192,7 +192,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -224,7 +224,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -302,7 +302,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
       className="m-minischedule__row"
@@ -337,7 +337,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -363,7 +363,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -389,7 +389,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -463,7 +463,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
       className="m-minischedule__row"
@@ -498,7 +498,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -524,7 +524,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row"
+      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -541,7 +541,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -584,7 +584,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--future"
     >
       <div
         className="m-minischedule__icon"
@@ -683,7 +683,7 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
       className="m-minischedule__row"
@@ -718,7 +718,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -744,7 +744,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row"
+      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -761,7 +761,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -835,7 +835,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
       className="m-minischedule__row"
@@ -870,7 +870,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -913,7 +913,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--future"
     >
       <div
         className="m-minischedule__icon"
@@ -987,7 +987,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
       className="m-minischedule__row"
@@ -1022,7 +1022,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1048,7 +1048,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row"
+      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1065,7 +1065,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1125,7 +1125,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
       className="m-minischedule__row"
@@ -1160,7 +1160,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -1186,7 +1186,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row m-minischedule__layover-row"
+      className="m-minischedule__row m-minischedule__layover-row m-minischedule__row--past"
     >
       <div
         className="m-minischedule__icon"
@@ -1277,7 +1277,7 @@ Array [
     run
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
       className="m-minischedule__row"
@@ -1312,7 +1312,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1338,7 +1338,7 @@ Array [
       </div>
     </div>
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"
@@ -1430,10 +1430,10 @@ Array [
     </div>
   </div>,
   <div
-    className="m-minischedule__piece-rows"
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
-      className="m-minischedule__row"
+      className="m-minischedule__row m-minischedule__row--unknown"
     >
       <div
         className="m-minischedule__icon"

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -426,7 +426,9 @@ describe("BlockRow", () => {
       endPlace: "Charlie Circle",
     }
 
-    const wrapper = mount(<BreakRow break={breakk} />)
+    const wrapper = mount(
+      <BreakRow break={breakk} index={0} activeIndex={null} />
+    )
     expect(wrapper.html()).toContain("Break (Unpaid)")
     expect(wrapper.html()).toContain("Charlie Circle")
   })
@@ -439,7 +441,9 @@ describe("BlockRow", () => {
       endPlace: "Delta Drive",
     }
 
-    const wrapper = mount(<BreakRow break={breakk} />)
+    const wrapper = mount(
+      <BreakRow break={breakk} index={0} activeIndex={null} />
+    )
     expect(wrapper.html()).toContain("Break (Paid)")
     expect(wrapper.html()).toContain("Delta Drive")
   })
@@ -452,7 +456,9 @@ describe("BlockRow", () => {
       endPlace: "Echo Avenue",
     }
 
-    const wrapper = mount(<BreakRow break={breakk} />)
+    const wrapper = mount(
+      <BreakRow break={breakk} index={0} activeIndex={null} />
+    )
     expect(wrapper.html()).toContain("Travel to Echo Avenue (Paid)")
   })
 
@@ -464,7 +470,9 @@ describe("BlockRow", () => {
       endPlace: "Foxtrot Village",
     }
 
-    const wrapper = mount(<BreakRow break={breakk} />)
+    const wrapper = mount(
+      <BreakRow break={breakk} index={0} activeIndex={null} />
+    )
     expect(wrapper.html()).toContain("Unrecognized break type")
     expect(wrapper.html()).toContain("Foxtrot Village")
     expect(wrapper.html()).not.toContain("(Paid)")


### PR DESCRIPTION
Asana Task: [Mini-schedule | Trip List Component | Past Trip or Event row styling](https://app.asana.com/0/1148853526253426/1153870789408625)

<img width="333" alt="Screen Shot 2020-06-02 at 14 41 38" src="https://user-images.githubusercontent.com/23065557/83662798-01acca00-a596-11ea-86a6-5ec1b53b81dc.png">
<img width="331" alt="Screen Shot 2020-06-02 at 14 42 03" src="https://user-images.githubusercontent.com/23065557/83662802-02456080-a596-11ea-8409-5ef8c454c054.png">
<img width="330" alt="Screen Shot 2020-06-02 at 14 42 10" src="https://user-images.githubusercontent.com/23065557/83662803-02456080-a596-11ea-9169-67c6c64ebeeb.png">
