### PR TITLE
Convert leading/following deadhead activities

### DIFF
--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -218,9 +218,12 @@ defmodule Schedule.Minischedule.Load do
          %Piece{} = piece
          | rest
        ]) do
+    dummy_trip = Schedule.Minischedule.Trip.from_leading_deadhead(deadhead, piece)
+
     new_piece = %{
       piece
-      | start: %{
+      | trips: [dummy_trip | piece.trips],
+        start: %{
           time: deadhead.start_time,
           place: deadhead.start_place,
           mid_route?: false
@@ -235,9 +238,12 @@ defmodule Schedule.Minischedule.Load do
          %Activity{activity_type: "Deadhead to"} = deadhead
          | rest
        ]) do
+    dummy_trip = Schedule.Minischedule.Trip.from_following_deadhead(deadhead, piece)
+
     new_piece = %{
       piece
-      | end: %{
+      | trips: piece.trips ++ [dummy_trip],
+        end: %{
           time: deadhead.end_time,
           place: deadhead.end_place,
           mid_route?: false

--- a/lib/schedule/minischedule/load.ex
+++ b/lib/schedule/minischedule/load.ex
@@ -218,7 +218,7 @@ defmodule Schedule.Minischedule.Load do
          %Piece{} = piece
          | rest
        ]) do
-    dummy_trip = Schedule.Minischedule.Trip.from_leading_deadhead(deadhead, piece)
+    dummy_trip = Schedule.Minischedule.Trip.from_leading_deadhead(deadhead, piece.block_id)
 
     new_piece = %{
       piece
@@ -238,7 +238,7 @@ defmodule Schedule.Minischedule.Load do
          %Activity{activity_type: "Deadhead to"} = deadhead
          | rest
        ]) do
-    dummy_trip = Schedule.Minischedule.Trip.from_following_deadhead(deadhead, piece)
+    dummy_trip = Schedule.Minischedule.Trip.from_following_deadhead(deadhead, piece.block_id)
 
     new_piece = %{
       piece

--- a/lib/schedule/minischedule/trip.ex
+++ b/lib/schedule/minischedule/trip.ex
@@ -2,7 +2,6 @@ defmodule Schedule.Minischedule.Trip do
   alias Schedule.Block
   alias Schedule.Gtfs.{Direction, Route, RoutePattern}
   alias Schedule.Hastus.{Activity, Run}
-  alias Schedule.Minischedule.Piece
 
   @type id :: Schedule.Trip.id()
 
@@ -52,25 +51,25 @@ defmodule Schedule.Minischedule.Trip do
     }
   end
 
-  @spec from_following_deadhead(Activity.t(), Piece.t()) :: t()
-  def from_following_deadhead(deadhead, piece) do
+  @spec from_following_deadhead(Activity.t(), Block.id()) :: t()
+  def from_following_deadhead(deadhead, block_id) do
     %__MODULE__{
-      id: "following_deadhead_#{piece.block_id}_#{deadhead.start_time}",
-      block_id: piece.block_id,
+      id: "following_deadhead_#{deadhead.run_id}_#{deadhead.start_time}",
+      block_id: block_id,
       route_id: nil,
-      run_id: piece.run_id,
+      run_id: deadhead.run_id,
       start_time: deadhead.start_time,
       end_time: deadhead.end_time
     }
   end
 
-  @spec from_leading_deadhead(Activity.t(), Piece.t()) :: t()
-  def from_leading_deadhead(deadhead, piece) do
+  @spec from_leading_deadhead(Activity.t(), Block.id()) :: t()
+  def from_leading_deadhead(deadhead, block_id) do
     %__MODULE__{
-      id: "leading_deadhead_#{piece.block_id}_#{deadhead.start_time}",
-      block_id: piece.block_id,
+      id: "leading_deadhead_#{deadhead.run_id}_#{deadhead.start_time}",
+      block_id: block_id,
       route_id: nil,
-      run_id: piece.run_id,
+      run_id: deadhead.run_id,
       start_time: deadhead.start_time,
       end_time: deadhead.end_time
     }

--- a/lib/schedule/minischedule/trip.ex
+++ b/lib/schedule/minischedule/trip.ex
@@ -1,7 +1,8 @@
 defmodule Schedule.Minischedule.Trip do
   alias Schedule.Block
   alias Schedule.Gtfs.{Direction, Route, RoutePattern}
-  alias Schedule.Hastus.Run
+  alias Schedule.Hastus.{Activity, Run}
+  alias Schedule.Minischedule.Piece
 
   @type id :: Schedule.Trip.id()
 
@@ -48,6 +49,30 @@ defmodule Schedule.Minischedule.Trip do
       run_id: trip.run_id,
       start_time: trip.start_time,
       end_time: trip.end_time
+    }
+  end
+
+  @spec from_following_deadhead(Activity.t(), Piece.t()) :: t()
+  def from_following_deadhead(deadhead, piece) do
+    %__MODULE__{
+      id: "following_deadhead_#{piece.block_id}_#{deadhead.start_time}",
+      block_id: piece.block_id,
+      route_id: nil,
+      run_id: piece.run_id,
+      start_time: deadhead.start_time,
+      end_time: deadhead.end_time
+    }
+  end
+
+  @spec from_leading_deadhead(Activity.t(), Piece.t()) :: t()
+  def from_leading_deadhead(deadhead, piece) do
+    %__MODULE__{
+      id: "leading_deadhead_#{piece.block_id}_#{deadhead.start_time}",
+      block_id: piece.block_id,
+      route_id: nil,
+      run_id: piece.run_id,
+      start_time: deadhead.start_time,
+      end_time: deadhead.end_time
     }
   end
 end

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -426,7 +426,7 @@ defmodule Schedule.Minischedule.LoadTest do
                        direction_id: nil,
                        end_time: 102,
                        headsign: nil,
-                       id: "leading_deadhead_block_101"
+                       id: "leading_deadhead_run_101"
                      },
                      "trip"
                    ],
@@ -484,7 +484,7 @@ defmodule Schedule.Minischedule.LoadTest do
                    trips: [
                      "trip",
                      %Schedule.Minischedule.Trip{
-                       id: "following_deadhead_block_102",
+                       id: "following_deadhead_run_102",
                        block_id: "block",
                        direction_id: nil,
                        start_time: 102,

--- a/test/schedule/minischedule/load_test.exs
+++ b/test/schedule/minischedule/load_test.exs
@@ -377,7 +377,7 @@ defmodule Schedule.Minischedule.LoadTest do
              } = Load.run(run_key, activities, trips)
     end
 
-    test "Deadhead from becomes part of following piece" do
+    test "Deadhead from becomes part of following piece as a trip" do
       run_key = {"schedule", "run"}
 
       activities = [
@@ -402,14 +402,37 @@ defmodule Schedule.Minischedule.LoadTest do
         }
       ]
 
-      trips = []
+      trips = [
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run",
+          block_id: "block",
+          start_time: 102,
+          end_time: 103,
+          start_place: "start_place",
+          end_place: "end_place",
+          route_id: nil,
+          trip_id: "trip"
+        }
+      ]
 
       assert %Run{
                activities: [
                  %Piece{
                    start: %{time: 101},
-                   trips: [],
-                   end: %{time: 103}
+                   trips: [
+                     %Schedule.Minischedule.Trip{
+                       block_id: "block",
+                       direction_id: nil,
+                       end_time: 102,
+                       headsign: nil,
+                       id: "leading_deadhead_block_101"
+                     },
+                     "trip"
+                   ],
+                   end: %{time: 103},
+                   schedule_id: "schedule",
+                   run_id: "run"
                  }
                ]
              } = Load.run(run_key, activities, trips)
@@ -440,14 +463,38 @@ defmodule Schedule.Minischedule.LoadTest do
         }
       ]
 
-      trips = []
+      trips = [
+        %Trip{
+          schedule_id: "schedule",
+          run_id: "run",
+          block_id: "block",
+          start_time: 101,
+          end_time: 102,
+          start_place: "start_place",
+          end_place: "end_place",
+          route_id: nil,
+          trip_id: "trip"
+        }
+      ]
 
       assert %Run{
                activities: [
                  %Piece{
                    start: %{time: 101},
-                   trips: [],
-                   end: %{time: 103}
+                   trips: [
+                     "trip",
+                     %Schedule.Minischedule.Trip{
+                       id: "following_deadhead_block_102",
+                       block_id: "block",
+                       direction_id: nil,
+                       start_time: 102,
+                       end_time: 103
+                     }
+                   ],
+                   end: %{time: 103},
+                   run_id: "run",
+                   block_id: "block",
+                   schedule_id: "schedule"
                  }
                ]
              } = Load.run(run_key, activities, trips)


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1170698291365294

Lynn has some "Deadhead to" (pull back) and "Deadhead from" (pull out)
activities. Everywhere else, deadheads are represented as a trip with no
route_id. Here we convert those deadheads into dummy trips that get
tacked onto the correct end of the adjacent piece.