### PR TITLE
Show duty details of run in minischedules

### DIFF
--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -12,6 +12,16 @@
   padding: 0.5rem 1rem;
 }
 
+.m-minischedule__duty-details {
+  background-color: $color-secondary-light;
+  padding: 0.5rem 1rem;
+
+  .m-minischedule__header-label {
+    display: inline-block;
+    width: 40%;
+  }
+}
+
 .m-minischedule__row {
   border-top: 1px solid $color-component-light;
   display: flex;

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -116,10 +116,10 @@ const Header = ({ label, value }: { label: string; value: string }) => (
 const DutyDetails = ({ run }: { run: Run }) => {
   const paidBreakTotal = paidBreakTotalDuration(run)
   const workingHours = workingHoursDuration(run)
-  const spread = spreadDuration(run)
+  const totalHours = totalHoursDuration(run)
   const formattedPaidBreakTotal = formattedDuration(paidBreakTotal)
   const formattedWorkingHours = formattedDuration(workingHours)
-  const formattedSpread = formattedDuration(spread)
+  const formattedTotalHours = formattedDuration(totalHours)
 
   return (
     <div className="m-minischedule__duty-details">
@@ -133,9 +133,9 @@ const DutyDetails = ({ run }: { run: Run }) => {
         {formattedWorkingHours}
       </span>
       <br />
-      <span className="m-minischedule__header-label">Spread</span>
+      <span className="m-minischedule__header-label">Total hours</span>
       <span className="m-minischedule__duty-details-data">
-        {formattedSpread}
+        {formattedTotalHours}
       </span>
     </div>
   )
@@ -162,10 +162,18 @@ const workingHoursDuration = (run: Run): number => {
   )
 }
 
-const spreadDuration = (run: Run): number => {
+const runHasPartTimeOperator = (run: Run): boolean =>
+  // Runs driven by part-timers have a run number starting with "9"
+  !!run.id.match(/^\d{3}-9\d{3}$/)
+
+const totalHoursDuration = (run: Run): number => {
   const firstActivity = run.activities[0]
   const lastActivity = run.activities[run.activities.length - 1]
-  return lastActivity.endTime - firstActivity.startTime
+  const realDuration = lastActivity.endTime - firstActivity.startTime
+
+  // Part-timers have their 10-minute report time counted in total hours.
+  // Full-timers do not.
+  return runHasPartTimeOperator(run) ? realDuration : realDuration - 600
 }
 
 export const BreakRow = ({

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -52,6 +52,7 @@ export const MinischeduleRun = ({ vehicleOrGhost }: Props): ReactElement => {
     return (
       <>
         <Header label="Run" value={run.id} />
+        <DutyDetails run={run} />
         {run.activities.map((activity, index) =>
           isPiece(activity) ? (
             <Piece
@@ -111,6 +112,61 @@ const Header = ({ label, value }: { label: string; value: string }) => (
     {value}
   </div>
 )
+
+const DutyDetails = ({ run }: { run: Run }) => {
+  const paidBreakTotal = paidBreakTotalDuration(run)
+  const workingHours = workingHoursDuration(run)
+  const spread = spreadDuration(run)
+  const formattedPaidBreakTotal = formattedDuration(paidBreakTotal)
+  const formattedWorkingHours = formattedDuration(workingHours)
+  const formattedSpread = formattedDuration(spread)
+
+  return (
+    <div className="m-minischedule__duty-details">
+      <span className="m-minischedule__header-label">Paid break</span>
+      <span className="m-minischedule__duty-details-data">
+        {formattedPaidBreakTotal}
+      </span>
+      <br />
+      <span className="m-minischedule__header-label">Working hours</span>
+      <span className="m-minischedule__duty-details-data">
+        {formattedWorkingHours}
+      </span>
+      <br />
+      <span className="m-minischedule__header-label">Spread</span>
+      <span className="m-minischedule__duty-details-data">
+        {formattedSpread}
+      </span>
+    </div>
+  )
+}
+
+const paidBreakTotalDuration = (run: Run): number => {
+  const paidBreaks: Break[] = run.activities.filter(
+    (activity) => isBreak(activity) && breakIsPaid(activity.breakType)
+  ) as Break[]
+  return paidBreaks.reduce(
+    (total, breakk) => total + breakk.endTime - breakk.startTime,
+    0
+  )
+}
+
+const workingHoursDuration = (run: Run): number => {
+  const pieces: Piece[] = run.activities.filter((activity) =>
+    isPiece(activity)
+  ) as Piece[]
+
+  return pieces.reduce(
+    (total, piece) => total + piece.endTime - piece.startTime,
+    0
+  )
+}
+
+const spreadDuration = (run: Run): number => {
+  const firstActivity = run.activities[0]
+  const lastActivity = run.activities[run.activities.length - 1]
+  return lastActivity.endTime - firstActivity.startTime
+}
 
 export const BreakRow = ({
   break: breakk,
@@ -597,6 +653,9 @@ const getTimeBasedStyle = (
 
 const isPiece = (activity: Piece | Break): activity is Piece =>
   activity.hasOwnProperty("trips")
+
+const isBreak = (activity: Piece | Break): activity is Break =>
+  activity.hasOwnProperty("breakType")
 
 const isTrip = (trip: Trip | AsDirected): trip is Trip =>
   trip.hasOwnProperty("id")

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -729,12 +729,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      0 min
+      -10 min
     </span>
   </div>,
   <div
@@ -960,12 +960,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      3 min
+      -7 min
     </span>
   </div>,
   <div
@@ -1105,12 +1105,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      6 min
+      -4 min
     </span>
   </div>,
   <div
@@ -1327,12 +1327,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      30 min
+      20 min
     </span>
   </div>,
   <div
@@ -1538,12 +1538,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      0 min
+      -10 min
     </span>
   </div>,
   <div
@@ -1726,12 +1726,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      10 min
+      0 min
     </span>
   </div>,
   <div
@@ -1905,12 +1905,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      0 min
+      -10 min
     </span>
   </div>,
   <div
@@ -2093,12 +2093,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      0 min
+      -10 min
     </span>
   </div>,
   <div
@@ -2264,12 +2264,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      10 min
+      0 min
     </span>
   </div>,
   <div
@@ -2391,12 +2391,12 @@ Array [
     <span
       className="m-minischedule__header-label"
     >
-      Spread
+      Total hours
     </span>
     <span
       className="m-minischedule__duty-details-data"
     >
-      16 hr 56 min
+      16 hr 46 min
     </span>
   </div>,
   <div

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -702,6 +702,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
@@ -897,6 +933,42 @@ Array [
     run1
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      3 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      3 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
@@ -1004,6 +1076,42 @@ Array [
       Run
     </span>
     run2
+  </div>,
+  <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      6 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      6 min
+    </span>
   </div>,
   <div
     className="m-minischedule__row m-minischedule__row--unknown m-minischedule__row--mid-route-first-half"
@@ -1192,6 +1300,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      30 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      30 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
@@ -1367,6 +1511,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
   >
     <div
@@ -1519,6 +1699,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      10 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      10 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
@@ -1660,6 +1876,42 @@ Array [
       Run
     </span>
     run
+  </div>,
+  <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
   </div>,
   <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--current"
@@ -1814,6 +2066,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
   >
     <div
@@ -1949,6 +2237,42 @@ Array [
     run
   </div>,
   <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      10 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      10 min
+    </span>
+  </div>,
+  <div
     className="m-minischedule__row m-minischedule__row--unknown"
   >
     <div
@@ -2022,6 +2346,345 @@ Array [
       className="m-minischedule__right-text"
     >
       4:30 AM
+    </div>
+  </div>,
+]
+`;
+
+exports[`MinischeduleRun renders duty details of run 1`] = `
+Array [
+  <div
+    className="m-minischedule__header"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Run
+    </span>
+    run
+  </div>,
+  <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      3 hr 24 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      11 hr 18 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Spread
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      16 hr 56 min
+    </span>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Start time
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      6:06 AM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
+  />,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Done
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      10:07 AM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Break (Paid)
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      27 min
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Start time
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      10:34 AM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
+  />,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Done
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      11:19 AM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Break (Unpaid)
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      50 min
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Start time
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      12:09 PM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
+  />,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Done
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      2:36 PM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Technical break (Paid)
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      2 hr 57 min
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Start time
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      5:34 PM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__piece-rows m-minischedule__piece-rows--unknown"
+  />,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Done
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      9:40 PM
+    </div>
+  </div>,
+  <div
+    className="m-minischedule__row m-minischedule__row--unknown"
+  >
+    <div
+      className="m-minischedule__icon"
+    />
+    <div
+      className="m-minischedule__left-text"
+    >
+      Break (Unpaid)
+      <br />
+      <span
+        className="m-minischedule__below-text"
+      >
+        cabot
+      </span>
+    </div>
+    <div
+      className="m-minischedule__right-text"
+    >
+      1 hr 23 min
     </div>
   </div>,
 ]

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -419,6 +419,97 @@ describe("MinischeduleRun", () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  test("renders duty details of run", () => {
+    const piece1: Piece = {
+      runId: "run",
+      blockId: "block",
+      startTime: 22000,
+      startPlace: "cabot",
+      trips: [],
+      endTime: 36450,
+      endPlace: "cabot",
+      startMidRoute: null,
+      endMidRoute: false,
+    }
+    const break1: Break = {
+      breakType: "Paid meal before",
+      startTime: 36450,
+      endTime: 38070,
+      endPlace: "cabot",
+    }
+    const piece2: Piece = {
+      runId: "run",
+      blockId: "block",
+      startTime: 38070,
+      startPlace: "cabot",
+      trips: [],
+      endTime: 40760,
+      endPlace: "cabot",
+      startMidRoute: null,
+      endMidRoute: false,
+    }
+    const break2: Break = {
+      breakType: "Split break",
+      startTime: 40760,
+      endTime: 43760,
+      endPlace: "cabot",
+    }
+    const piece3: Piece = {
+      runId: "run",
+      blockId: "block",
+      startTime: 43760,
+      startPlace: "cabot",
+      trips: [],
+      endTime: 52590,
+      endPlace: "cabot",
+      startMidRoute: null,
+      endMidRoute: false,
+    }
+    const break3: Break = {
+      breakType: "Technical break",
+      startTime: 52590,
+      endTime: 63240,
+      endPlace: "cabot",
+    }
+    const piece4: Piece = {
+      runId: "run",
+      blockId: "block",
+      startTime: 63240,
+      startPlace: "cabot",
+      trips: [],
+      endTime: 78000,
+      endPlace: "cabot",
+      startMidRoute: null,
+      endMidRoute: false,
+    }
+    const break4: Break = {
+      breakType: "Split break",
+      startTime: 78000,
+      endTime: 83000,
+      endPlace: "cabot",
+    }
+
+    const run: Run = {
+      id: "run",
+      activities: [
+        piece1,
+        break1,
+        piece2,
+        break2,
+        piece3,
+        break3,
+        piece4,
+        break4,
+      ],
+    }
+    ;(useMinischeduleRun as jest.Mock).mockImplementationOnce(() => run)
+    const tree = renderer
+      .create(<MinischeduleRun vehicleOrGhost={vehicle} />)
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })
 
 describe("MinischeduleBlock", () => {


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1153848861994002

We show a summary of the "duty details" of the given run in the run view
in the minischedule: the "spread" (total length of the working day),
number of hours actually spent working, and number of hours on paid
break.