### PR TITLE
Show alert icons on route ladders for current block waivers only

### DIFF
--- a/assets/css/_icon_alert_circle.scss
+++ b/assets/css/_icon_alert_circle.scss
@@ -9,17 +9,6 @@
   }
 }
 
-.c-icon-alert-circle--grey {
-  .c-icon-alert-circle__outline,
-  .c-icon-alert-circle__exclamation-point {
-    fill: $color-bg-base;
-  }
-
-  .c-icon-alert-circle__fill {
-    fill: $color-component-medium;
-  }
-}
-
 .c-icon-alert-circle--grey-on-grey {
   .c-icon-alert-circle__outline,
   .c-icon-alert-circle__exclamation-point {

--- a/assets/src/components/iconAlertCircle.tsx
+++ b/assets/src/components/iconAlertCircle.tsx
@@ -2,7 +2,6 @@ import React from "react"
 
 export enum AlertIconStyle {
   Black = 1,
-  Grey,
   GreyOnGrey,
   Highlighted,
 }
@@ -11,8 +10,6 @@ const styleClass = (style: AlertIconStyle): string => {
   switch (style) {
     case AlertIconStyle.Black:
       return "--black"
-    case AlertIconStyle.Grey:
-      return "--grey"
     case AlertIconStyle.GreyOnGrey:
       return "--grey-on-grey"
     case AlertIconStyle.Highlighted:

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -9,13 +9,16 @@ export enum CurrentFuturePastType {
   Past,
 }
 
-export const currentFuturePastType = ({
-  startTime,
-  endTime,
-}: BlockWaiver): CurrentFuturePastType => {
+export const currentFuturePastType = (
+  { startTime, endTime }: BlockWaiver,
+  startThresholdInMinutes: number = 0
+): CurrentFuturePastType => {
   const nowDate: Date = now()
+  const startThresholdInMilliseconds = startThresholdInMinutes * 60_000
+  const maxStartTimeForCurrent =
+    nowDate.valueOf() + startThresholdInMilliseconds
 
-  if (startTime > nowDate) {
+  if (startTime.valueOf() > maxStartTimeForCurrent) {
     return CurrentFuturePastType.Future
   } else if (endTime < nowDate) {
     return CurrentFuturePastType.Past
@@ -32,7 +35,7 @@ export const hasCurrentBlockWaiver = ({
 }: VehicleOrGhost): boolean =>
   blockWaivers.some(
     (blockWaiver) =>
-      currentFuturePastType(blockWaiver) === CurrentFuturePastType.Current
+      currentFuturePastType(blockWaiver, 240) === CurrentFuturePastType.Current
   )
 
 /**

--- a/assets/src/models/blockWaiver.ts
+++ b/assets/src/models/blockWaiver.ts
@@ -36,11 +36,11 @@ export const hasCurrentBlockWaiver = ({
   )
 
 /**
- * has waiver?      | ghost       | vehicle and late indicator ghosts
- * ---------------- | ----------- | ---------------------------------
- * yes, current     | black       | black
- * yes, not current | highlighted | grey
- * none             | highlighted | none
+ * has waiver?              | ghost       | late ghost | vehicle
+ * ------------------------ | ----------- | ---------- | -------
+ * yes, current or soon     | black       | black      | black
+ * yes, not current         | highlighted | none       | none
+ * none                     | highlighted | none       | none
  */
 export const blockWaiverAlertStyle = (
   vehicleOrGhost: VehicleOrGhost
@@ -48,9 +48,10 @@ export const blockWaiverAlertStyle = (
   if (hasCurrentBlockWaiver(vehicleOrGhost)) {
     return AlertIconStyle.Black
   }
+
   if (isGhost(vehicleOrGhost) && !isLateVehicleIndicator(vehicleOrGhost)) {
     return AlertIconStyle.Highlighted
-  } else {
-    return hasBlockWaiver(vehicleOrGhost) ? AlertIconStyle.Grey : undefined
   }
+
+  return undefined
 }

--- a/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/iconAlertCircle.test.tsx.snap
@@ -65,40 +65,6 @@ exports[`renders black 1`] = `
 </svg>
 `;
 
-exports[`renders grey 1`] = `
-<svg
-  className="c-icon-alert-circle"
-  viewBox="-3 -3 54 54"
->
-  <g
-    className="c-icon-alert-circle--grey"
-  >
-    <circle
-      className="c-icon-alert-circle__outline"
-      cx="24"
-      cy="24"
-      r="27"
-    />
-    <circle
-      className="c-icon-alert-circle__fill"
-      cx="24"
-      cy="24"
-      r="22.59"
-    />
-    <g
-      className="c-icon-alert-circle__exclamation-point"
-    >
-      <path
-        d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
-      />
-      <path
-        d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
-      />
-    </g>
-  </g>
-</svg>
-`;
-
 exports[`renders greyOnGrey 1`] = `
 <svg
   className="c-icon-alert-circle"

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -1502,21 +1502,28 @@ exports[`ladder shows schedule line in the other direction 1`] = `
 </div>
 `;
 
-exports[`ladder shows vehicles with block waivers 1`] = `
+exports[`ladder shows vehicles with current block waivers 1`] = `
 <div
   className="m-ladder"
   style={
     Object {
-      "width": 184,
+      "width": 232,
     }
   }
 >
   <svg
     className="m-ladder__svg"
     height={0}
-    viewBox="-92 -55 184 0"
-    width={184}
+    viewBox="-116 -55 232 0"
+    width={232}
   >
+    <line
+      className="m-ladder__scheduled-line on-time"
+      x1={-87}
+      x2={40}
+      y1={-68.75}
+      y2={-151.25}
+    />
     <line
       className="m-ladder__scheduled-line on-time"
       x1={-63}
@@ -1608,7 +1615,7 @@ exports[`ladder shows vehicles with block waivers 1`] = `
     <g
       className="m-ladder__vehicle  "
       onClick={[Function]}
-      transform="translate(-63,-68.75)"
+      transform="translate(-87,-68.75)"
     >
       <g
         className="m-vehicle-icon m-vehicle-icon--medium on-time"
@@ -1640,7 +1647,7 @@ exports[`ladder shows vehicles with block waivers 1`] = `
           transform="translate(-8.75, -1.875) scale(0.2) translate(-24, -24)"
         >
           <g
-            className="c-icon-alert-circle--grey"
+            className="c-icon-alert-circle--black"
           >
             <circle
               className="c-icon-alert-circle__outline"
@@ -1666,6 +1673,39 @@ exports[`ladder shows vehicles with block waivers 1`] = `
             </g>
           </g>
         </g>
+      </g>
+    </g>
+    <g
+      className="m-ladder__vehicle  "
+      onClick={[Function]}
+      transform="translate(-63,-68.75)"
+    >
+      <g
+        className="m-vehicle-icon m-vehicle-icon--medium on-time"
+      >
+        <rect
+          className="m-vehicle-icon__label-background"
+          height={11}
+          rx={5.5}
+          ry={5.5}
+          width={26}
+          x={-13}
+          y={-22.5}
+        />
+        <text
+          className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+          dominantBaseline="central"
+          textAnchor="middle"
+          x="0"
+          y={-17}
+        >
+          run
+        </text>
+        <path
+          className="m-vehicle-icon__triangle"
+          d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+          transform="scale(0.625) rotate(180) translate(-24,-22)"
+        />
       </g>
     </g>
     <line

--- a/assets/tests/components/iconAlertCircle.test.tsx
+++ b/assets/tests/components/iconAlertCircle.test.tsx
@@ -1,20 +1,13 @@
 import React from "react"
 import renderer from "react-test-renderer"
 import IconAlertCircle, {
-  IconAlertCircleSvgNode,
   AlertIconStyle,
+  IconAlertCircleSvgNode,
 } from "../../src/components/iconAlertCircle"
 
 test("renders black", () => {
   const tree = renderer
     .create(<IconAlertCircle style={AlertIconStyle.Black} />)
-    .toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-test("renders grey", () => {
-  const tree = renderer
-    .create(<IconAlertCircle style={AlertIconStyle.Grey} />)
     .toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -4,6 +4,7 @@ import renderer from "react-test-renderer"
 import Ladder from "../../src/components/ladder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { LadderDirection } from "../../src/models/ladderDirection"
+import { emptyVehiclesByPosition } from "../../src/models/vehiclesByPosition"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
 import {
   BlockWaiver,
@@ -14,7 +15,6 @@ import {
 import { Timepoint } from "../../src/schedule.d"
 import { initialState, selectVehicle } from "../../src/state"
 import * as dateTime from "../../src/util/dateTime"
-import { emptyVehiclesByPosition } from "../../src/models/vehiclesByPosition"
 
 jest.mock("../../src/hooks/useVehicles", () => ({
   __esModule: true,
@@ -407,7 +407,7 @@ describe("ladder", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("shows vehicles with block waivers", () => {
+  test("shows vehicles with current block waivers", () => {
     jest
       .spyOn(dateTime, "now")
       .mockImplementation(() => new Date("2020-01-01T01:00:00.000Z"))
@@ -501,9 +501,25 @@ describe("ladder", () => {
         },
       ],
     }
+
+    const vehicleWithCurrentBlockWaiver: Vehicle = {
+      ...vehicleWithOldBlockWaiver,
+      id: "otherVehicle",
+      blockWaivers: [
+        {
+          startTime: new Date("2019-12-31T00:00:00.000Z"),
+          endTime: new Date("2020-01-01T02:00:00.000Z"),
+          causeId: 0,
+          causeDescription: "Block Waiver",
+          remark: null,
+        },
+      ],
+    }
+
     const vehiclesAndGhosts: VehicleOrGhost[] = [
       ghostWithBlockWaiver,
       vehicleWithOldBlockWaiver,
+      vehicleWithCurrentBlockWaiver,
     ]
     const ladderDirection = LadderDirection.ZeroToOne
 

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -22,8 +22,8 @@ const currentBlockWaiver: BlockWaiver = {
 }
 
 const futureBlockWaiver: BlockWaiver = {
-  startTime: new Date("2020-02-25T16:26:40.000Z"),
-  endTime: new Date("2020-02-25T16:43:20.000Z"),
+  startTime: new Date("2020-02-25T20:26:40.000Z"),
+  endTime: new Date("2020-02-25T20:43:20.000Z"),
   causeId: 0,
   causeDescription: "Block Waiver",
   remark: null,
@@ -81,6 +81,29 @@ describe("hasCurrentBlockWaiver", () => {
     } as Vehicle
 
     expect(hasCurrentBlockWaiver(vehicleWithBlockWaivers)).toBeTruthy()
+  })
+
+  test("considers a block waiver starting within the next 240 minutes to be current", () => {
+    const vehicleWithWaiverBeforeCutoff: Vehicle = {
+      blockWaivers: [
+        {
+          ...currentBlockWaiver,
+          startTime: new Date("2020-02-25T20:10:00.000Z"),
+        },
+      ],
+    } as Vehicle
+
+    const vehicleWithWaiverAfterCutoff: Vehicle = {
+      blockWaivers: [
+        {
+          ...currentBlockWaiver,
+          startTime: new Date("2020-02-25T20:10:00.001Z"),
+        },
+      ],
+    } as Vehicle
+
+    expect(hasCurrentBlockWaiver(vehicleWithWaiverBeforeCutoff)).toBeTruthy()
+    expect(hasCurrentBlockWaiver(vehicleWithWaiverAfterCutoff)).toBeFalsy()
   })
 
   test("returns false if the vehicle or ghost has only non-current block waivers", () => {

--- a/assets/tests/models/blockWaiver.test.ts
+++ b/assets/tests/models/blockWaiver.test.ts
@@ -115,12 +115,12 @@ describe("blockWaiverAlertStyle", () => {
     expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Black)
   })
 
-  test("vehicle with a non-current waiver gets a grey icon", () => {
+  test("vehicle with a non-current waiver gets no icon", () => {
     const vehicle = {
       id: "id",
-      blockWaivers: [pastBlockWaiver],
+      blockWaivers: [pastBlockWaiver, futureBlockWaiver],
     } as Vehicle
-    expect(blockWaiverAlertStyle(vehicle)).toEqual(AlertIconStyle.Grey)
+    expect(blockWaiverAlertStyle(vehicle)).toEqual(undefined)
   })
 
   test("ghost with no waiver gets a highlighted icon", () => {
@@ -155,13 +155,21 @@ describe("blockWaiverAlertStyle", () => {
     expect(blockWaiverAlertStyle(lateIndicatorGhost)).toEqual(undefined)
   })
 
-  test("late indicator ghost whose vehicle has a waiver gets an alert", () => {
+  test("late indicator ghost whose vehicle has a current waiver gets an alert", () => {
     const lateIndicatorGhost = {
       id: "ghost-incoming-id",
-      blockWaivers: [pastBlockWaiver],
+      blockWaivers: [currentBlockWaiver],
     } as Vehicle
     expect(blockWaiverAlertStyle(lateIndicatorGhost)).toEqual(
-      AlertIconStyle.Grey
+      AlertIconStyle.Black
     )
+  })
+
+  test("late indicator ghost whose vehicle has a no waiver gets no alert", () => {
+    const lateIndicatorGhost = {
+      id: "ghost-incoming-id",
+      blockWaivers: [pastBlockWaiver, futureBlockWaiver],
+    } as Vehicle
+    expect(blockWaiverAlertStyle(lateIndicatorGhost)).toEqual(undefined)
   })
 })


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1176421268419395

For vehicles, we now only show the alert icon on the route ladder if there's a current block waiver, as opposed to a past or future one. We also extend the definition of "current" in this case to cover future block waivers that start no more than 240 minutes in the future.