### PR TITLE
Fix line length with long minischedule rows.

### DIFF
--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -88,7 +88,7 @@
 
   .m-minischedule__row:not(:first-child) {
     &::before {
-      bottom: 50%;
+      bottom: calc(100% - 1rem);
       content: "";
       top: 0;
     }
@@ -98,7 +98,7 @@
     &::after {
       bottom: 0;
       content: "";
-      top: 50%;
+      top: 1rem;
     }
   }
 }


### PR DESCRIPTION
Asana Task: [🐞 minischedules graphical problem with long place names](https://app.asana.com/0/1148853526253426/1180667035759089)

Before:
<img width="331" alt="Screen Shot 2020-06-22 at 15 38 29" src="https://user-images.githubusercontent.com/23065557/85328404-b0aa3a80-b49e-11ea-8d9f-37381648139f.png">

After:
<img width="330" alt="Screen Shot 2020-06-22 at 15 36 14" src="https://user-images.githubusercontent.com/23065557/85328396-ad16b380-b49e-11ea-9d31-fcc8888d5881.png">

(I changed the text to force it to wrap, but the asana card has an example of it happening with real text.)
