### PR TITLE
Prevent wrapping of time since last gps ping

### DIFF
--- a/assets/css/properties_panel/_header.scss
+++ b/assets/css/properties_panel/_header.scss
@@ -16,7 +16,9 @@
 .m-properties-panel__variant {
   border-left: 1px solid $color-rule;
   flex: 1 1 auto;
-  padding: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-top: 1rem;
 }
 
 .m-properties-panel__inbound-outbound {
@@ -78,16 +80,20 @@
 .m-properties-panel__close-ping {
   align-items: flex-end;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   justify-content: space-between;
 
   .m-close-button,
   .m-properties-panel__last-gps-ping {
-    padding: 1rem;
+    padding-bottom: 1rem;
+    padding-right: 1rem;
+    padding-top: 1rem;
   }
 }
 
 .m-properties-panel__last-gps-ping {
   @include font-small;
   color: $color-font-grey;
+  min-width: 3rem;
 }


### PR DESCRIPTION
Asana Task: [🐞 Last GPS ping in VPP can cause weird wrapping issues](https://app.asana.com/0/1148853526253426/1180518784070169)

Headsign will wrap without the time wrapping:
<img width="334" alt="Screen Shot 2020-06-25 at 09 49 50" src="https://user-images.githubusercontent.com/23065557/85733532-437aed00-b6ca-11ea-8a1d-04127064418a.png">

Removed the padding between headsign and last gps ping so the headsign can be longer without wrapping:
<img width="335" alt="Screen Shot 2020-06-25 at 09 45 51" src="https://user-images.githubusercontent.com/23065557/85733612-5392cc80-b6ca-11ea-8b86-e6f9316cfc0f.png">

and make headsign less likely to wrap and unwrap by preventing width changes until the data is 100 seconds old
