### PR TITLE
Add action that deliberately fails, to test Sentry

### DIFF
--- a/.dialyzer.ignore-warnings
+++ b/.dialyzer.ignore-warnings
@@ -9,3 +9,4 @@ Unknown function 'Elixir.Concentrate.Mergeable.PID':'__impl__'/1
 Unknown function 'Elixir.Concentrate.Mergeable.Port':'__impl__'/1
 Unknown function 'Elixir.Concentrate.Mergeable.Reference':'__impl__'/1
 Unknown function 'Elixir.Concentrate.Mergeable.Tuple':'__impl__'/1
+deliberately_fail

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "lib/skate_web/router.ex"
+  - "lib/skate_web/controllers/deliberately_fail_controller.ex"

--- a/lib/skate_web/controllers/deliberately_fail_controller.ex
+++ b/lib/skate_web/controllers/deliberately_fail_controller.ex
@@ -1,0 +1,13 @@
+defmodule SkateWeb.DeliberatelyFailController do
+  require Logger
+  use SkateWeb, :controller
+
+  def index(conn, _params) do
+    some_operation(1)
+    # We'll never actually get here...
+    conn
+  end
+
+  def some_operation(2) do
+  end
+end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -57,6 +57,7 @@ defmodule SkateWeb.Router do
     get "/shuttle-map", PageController, :index
     get "/search", PageController, :index
     get "/settings", PageController, :index
+    get("/deliberately_fail", DeliberatelyFailController, :index)
   end
 
   scope "/api", SkateWeb do


### PR DESCRIPTION
No card. Added this to deliberately generate a harmless error in production, so that we can make sure that Sentry is working properly in prod.