### PR TITLE
highlight pullout and deadhead minischedule rows

### DIFF
--- a/assets/css/_minischedule.scss
+++ b/assets/css/_minischedule.scss
@@ -190,7 +190,7 @@
     width: 1.5rem;
   }
 
-  svg {
+  .m-minischedule__svg--revenue svg {
     stroke: white;
     stroke-width: 0.25rem;
   }

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -511,7 +511,7 @@ const Trip = ({
           />
         )
       ) : (
-        <AsDirected asDirected={trip} timeBasedStyle={tripTimeBasedStyle} />
+        <AsDirected asDirected={trip} timeBasedStyle={onRouteTimeBasedStyle} />
       )}
     </>
   )

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -467,20 +467,23 @@ const Trip = ({
         ? "current"
         : "past"
       : tripTimeBasedStyle
-  tripTimeBasedStyle =
+  const onRouteTimeBasedStyle =
     tripTimeBasedStyle === "current"
       ? vehicleOrGhost.routeStatus === "laying_over"
         ? "future"
         : "current"
       : tripTimeBasedStyle
+  const deadheadTimeBasedStyle = tripTimeBasedStyle
   const layoverActiveStatus: DrawnStatus | null =
     layoverTimeBasedStyle === "current" ? drawnStatus(vehicleOrGhost) : null
-  const tripActiveStatus: DrawnStatus | null =
-    tripTimeBasedStyle === "current" ? drawnStatus(vehicleOrGhost) : null
+  const onRouteActiveStatus: DrawnStatus | null =
+    onRouteTimeBasedStyle === "current" ? drawnStatus(vehicleOrGhost) : null
+  const deadheadActiveStatus: DrawnStatus | null =
+    deadheadTimeBasedStyle === "current" ? drawnStatus(vehicleOrGhost) : null
 
   return (
     <>
-      {view === "run" && previousEndTime !== undefined ? (
+      {view === "run" && previousEndTime !== undefined && !isDeadhead(trip) ? (
         <Layover
           nextTrip={trip}
           previousEndTime={previousEndTime}
@@ -493,14 +496,14 @@ const Trip = ({
           <DeadheadTrip
             trip={trip}
             sequence={sequence}
-            timeBasedStyle={tripTimeBasedStyle}
-            activeStatus={tripActiveStatus}
+            timeBasedStyle={deadheadTimeBasedStyle}
+            activeStatus={deadheadActiveStatus}
           />
         ) : (
           <RevenueTrip
             trip={trip}
-            timeBasedStyle={tripTimeBasedStyle}
-            activeStatus={tripActiveStatus}
+            timeBasedStyle={onRouteTimeBasedStyle}
+            activeStatus={onRouteActiveStatus}
             routes={routes}
           />
         )
@@ -695,7 +698,7 @@ const getActiveIndex = (
       for (let tripIndex = 0; tripIndex < activity.trips.length; tripIndex++) {
         const trip = activity.trips[tripIndex]
         if (
-          isPullingOut(
+          isDeadheading(
             trip,
             activity.trips[tripIndex + 1],
             activeTripId,
@@ -713,13 +716,13 @@ const getActiveIndex = (
   return null
 }
 
-const isPullingOut = (
+const isDeadheading = (
   scheduledTrip: Trip | AsDirected,
   nextScheduledTrip: Trip | AsDirected | undefined,
   activeTripId: TripId | null,
   routeStatus: RouteStatus
 ): boolean =>
-  routeStatus === "pulling_out" &&
+  routeStatus !== "on_route" &&
   isDeadhead(scheduledTrip) &&
   nextScheduledTrip !== undefined &&
   isTrip(nextScheduledTrip) &&

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -266,13 +266,10 @@ const Layover = ({
   activeStatus,
 }: {
   nextTrip: Trip | AsDirected
-  previousEndTime: Time | undefined
+  previousEndTime: Time
   timeBasedStyle: TimeBasedStyle
   activeStatus: DrawnStatus | null
 }) => {
-  if (!previousEndTime) {
-    return null
-  }
   const layoverDuration = nextTrip.startTime - previousEndTime
   if (layoverDuration === 0) {
     return null
@@ -483,7 +480,7 @@ const Trip = ({
 
   return (
     <>
-      {view === "run" ? (
+      {view === "run" && previousEndTime !== undefined ? (
         <Layover
           nextTrip={trip}
           previousEndTime={previousEndTime}

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -570,17 +570,18 @@ const iconForDirectionOnLadder: (
   ladderDirections: LadderDirections,
   routeId: RouteId
 ) => ReactElement = (directionId, ladderDirections, routeId) => {
+  const className = "m-minischedule__svg--revenue"
   if (directionId === null) {
-    return questionMarkIcon("m-minischedule__svg--revenue")
+    return questionMarkIcon(className)
   }
 
   const ladderDirection = getLadderDirectionForRoute(ladderDirections, routeId)
   if (
     directionOnLadder(directionId, ladderDirection) === VehicleDirection.Down
   ) {
-    return triangleDownIcon("m-minischedule__svg--revenue")
+    return triangleDownIcon(className)
   }
-  return triangleUpIcon("m-minischedule__svg--revenue")
+  return triangleUpIcon(className)
 }
 
 const RevenueTrip = ({

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -361,12 +361,15 @@ const Piece = ({
             pieceTimeBasedStyle === "current"
               ? getTimeBasedStyle(tripIndex, activeIndex && activeIndex[1])
               : pieceTimeBasedStyle
+          const previousTrip: Trip | AsDirected | null =
+            piece.trips[tripIndex - 1] || piece.startMidRoute?.trip
           return (
             <Trip
               trip={trip}
               previousEndTime={
-                piece.trips[tripIndex - 1]?.endTime ||
-                piece.startMidRoute?.trip.endTime
+                previousTrip && !isDeadhead(previousTrip)
+                  ? previousTrip.endTime
+                  : null
               }
               sequence={getSequence(tripIndex, piece.trips)}
               tripTimeBasedStyle={tripTimeBasedStyle}
@@ -454,7 +457,7 @@ const Trip = ({
   routes,
 }: {
   trip: Trip | AsDirected
-  previousEndTime: Time | undefined
+  previousEndTime: Time | null
   sequence: "first" | "middle" | "last"
   tripTimeBasedStyle: TimeBasedStyle
   vehicleOrGhost: VehicleOrGhost
@@ -483,7 +486,7 @@ const Trip = ({
 
   return (
     <>
-      {view === "run" && previousEndTime !== undefined && !isDeadhead(trip) ? (
+      {view === "run" && previousEndTime !== null && !isDeadhead(trip) ? (
         <Layover
           nextTrip={trip}
           previousEndTime={previousEndTime}

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -571,16 +571,16 @@ const iconForDirectionOnLadder: (
   routeId: RouteId
 ) => ReactElement = (directionId, ladderDirections, routeId) => {
   if (directionId === null) {
-    return questionMarkIcon()
+    return questionMarkIcon("m-minischedule__svg--revenue")
   }
 
   const ladderDirection = getLadderDirectionForRoute(ladderDirections, routeId)
   if (
     directionOnLadder(directionId, ladderDirection) === VehicleDirection.Down
   ) {
-    return triangleDownIcon()
+    return triangleDownIcon("m-minischedule__svg--revenue")
   }
-  return triangleUpIcon()
+  return triangleUpIcon("m-minischedule__svg--revenue")
 }
 
 const RevenueTrip = ({

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -570,18 +570,18 @@ const iconForDirectionOnLadder: (
   ladderDirections: LadderDirections,
   routeId: RouteId
 ) => ReactElement = (directionId, ladderDirections, routeId) => {
-  const className = "m-minischedule__svg--revenue"
+  const iconClassName = "m-minischedule__svg--revenue"
   if (directionId === null) {
-    return questionMarkIcon(className)
+    return questionMarkIcon(iconClassName)
   }
 
   const ladderDirection = getLadderDirectionForRoute(ladderDirections, routeId)
   if (
     directionOnLadder(directionId, ladderDirection) === VehicleDirection.Down
   ) {
-    return triangleDownIcon(className)
+    return triangleDownIcon(iconClassName)
   }
-  return triangleUpIcon(className)
+  return triangleUpIcon(iconClassName)
 }
 
 const RevenueTrip = ({

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -1,5 +1,245 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Minischedule highlights deadheads if they're active 1`] = `
+<div
+  className="m-minischedule m-minischedule--hide-past"
+>
+  <button
+    className="m-minischedule__show-past"
+    onClick={[Function]}
+  >
+    <span
+      className="m-minischedule__show-past-icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "SVG",
+        }
+      }
+    />
+    Show past trips
+  </button>
+  <div
+    className="m-minischedule__header"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Run
+    </span>
+    run
+  </div>
+  <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Total hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      -10 min
+    </span>
+  </div>
+  <div
+    className="m-minischedule__piece--current"
+  >
+    <div
+      className="m-minischedule__piece-rows"
+    >
+      <div
+        className="m-minischedule__row m-minischedule__row--past"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          Swing on
+          <br />
+          <span
+            className="m-minischedule__below-text"
+          >
+            start
+          </span>
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:30 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--past"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          R_X Revenue
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:00 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--current on-time"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          Deadhead
+          <br />
+          <span
+            className="m-minischedule__below-text"
+          >
+            999th Street and ZZZ Ave
+          </span>
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:00 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future m-minischedule__layover-row"
+      >
+        <div
+          className="m-minischedule__icon"
+        />
+        <div
+          className="m-minischedule__left-text"
+        >
+          Layover
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          -1 min
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          R_X Revenue
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:00 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          Swing off
+          <br />
+          <span
+            className="m-minischedule__below-text"
+          >
+            end
+          </span>
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:30 AM
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Minischedule highlights pullouts if they're active 1`] = `
 <div
   className="m-minischedule m-minischedule--hide-past"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -1,5 +1,210 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Minischedule highlights pullouts if they're active 1`] = `
+<div
+  className="m-minischedule m-minischedule--hide-past"
+>
+  <button
+    className="m-minischedule__show-past"
+    onClick={[Function]}
+  >
+    <span
+      className="m-minischedule__show-past-icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "SVG",
+        }
+      }
+    />
+    Show past trips
+  </button>
+  <div
+    className="m-minischedule__header"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Run
+    </span>
+    run
+  </div>
+  <div
+    className="m-minischedule__duty-details"
+  >
+    <span
+      className="m-minischedule__header-label"
+    >
+      Paid break
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Working hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      0 min
+    </span>
+    <br />
+    <span
+      className="m-minischedule__header-label"
+    >
+      Total hours
+    </span>
+    <span
+      className="m-minischedule__duty-details-data"
+    >
+      -10 min
+    </span>
+  </div>
+  <div
+    className="m-minischedule__piece--current"
+  >
+    <div
+      className="m-minischedule__row m-minischedule__row--past"
+    >
+      <div
+        className="m-minischedule__icon"
+      />
+      <div
+        className="m-minischedule__left-text"
+      >
+        Start time
+        <br />
+        <span
+          className="m-minischedule__below-text"
+        >
+          start
+        </span>
+      </div>
+      <div
+        className="m-minischedule__right-text"
+      >
+        12:30 AM
+      </div>
+    </div>
+    <div
+      className="m-minischedule__piece-rows"
+    >
+      <div
+        className="m-minischedule__row m-minischedule__row--current on-time"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          Pull out
+          <br />
+          <span
+            className="m-minischedule__below-text"
+          >
+            1st Street and A Ave
+          </span>
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:00 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future m-minischedule__layover-row"
+      >
+        <div
+          className="m-minischedule__icon"
+        />
+        <div
+          className="m-minischedule__left-text"
+        >
+          Layover
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          -1 min
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          R_X Revenue
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:00 AM
+        </div>
+      </div>
+      <div
+        className="m-minischedule__row m-minischedule__row--future"
+      >
+        <div
+          className="m-minischedule__icon"
+        >
+          <span
+            className=""
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "SVG",
+              }
+            }
+          />
+        </div>
+        <div
+          className="m-minischedule__left-text"
+        >
+          Swing off
+          <br />
+          <span
+            className="m-minischedule__below-text"
+          >
+            end
+          </span>
+        </div>
+        <div
+          className="m-minischedule__right-text"
+        >
+          12:30 AM
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Minischedule renders a Hide past trips button 1`] = `
 <div
   className="m-minischedule m-minischedule--show-past"

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Minischedule highlights deadheads if they're active 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -167,7 +167,7 @@ exports[`Minischedule highlights deadheads if they're active 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -355,7 +355,7 @@ exports[`Minischedule highlights pullouts if they're active 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -551,7 +551,7 @@ exports[`MinischeduleBlock renders a block 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -685,7 +685,7 @@ exports[`MinischeduleBlock renders a mid route swing 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -788,7 +788,7 @@ exports[`MinischeduleBlock renders a mid route swing 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -814,7 +814,7 @@ exports[`MinischeduleBlock renders a mid route swing 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1138,7 +1138,7 @@ exports[`MinischeduleBlock renders trips in both directions, or missing directio
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1164,7 +1164,7 @@ exports[`MinischeduleBlock renders trips in both directions, or missing directio
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1190,7 +1190,7 @@ exports[`MinischeduleBlock renders trips in both directions, or missing directio
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1355,7 +1355,7 @@ exports[`MinischeduleRun on a run with multiple layovers, marks the correct one 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1398,7 +1398,7 @@ exports[`MinischeduleRun on a run with multiple layovers, marks the correct one 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1441,7 +1441,7 @@ exports[`MinischeduleRun on a run with multiple layovers, marks the correct one 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1606,7 +1606,7 @@ exports[`MinischeduleRun renders a mid route swing off 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1736,7 +1736,7 @@ exports[`MinischeduleRun renders a mid route swing on 1`] = `
         className="m-minischedule__icon"
       >
         <span
-          className=""
+          className="m-minischedule__svg--revenue"
           dangerouslySetInnerHTML={
             Object {
               "__html": "SVG",
@@ -1803,7 +1803,7 @@ exports[`MinischeduleRun renders a mid route swing on 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -1846,7 +1846,7 @@ exports[`MinischeduleRun renders a mid route swing on 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2036,7 +2036,7 @@ exports[`MinischeduleRun renders a run 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2079,7 +2079,7 @@ exports[`MinischeduleRun renders a run 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2244,7 +2244,7 @@ exports[`MinischeduleRun renders a run with a current layover between trips 1`] 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2287,7 +2287,7 @@ exports[`MinischeduleRun renders a run with a current layover between trips 1`] 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2452,7 +2452,7 @@ exports[`MinischeduleRun renders a run with a layover before an as-directed 1`] 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2651,7 +2651,7 @@ exports[`MinischeduleRun renders a run with a non-current layover between trips 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2694,7 +2694,7 @@ exports[`MinischeduleRun renders a run with a non-current layover between trips 
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2859,7 +2859,7 @@ exports[`MinischeduleRun renders a run with no layovers between trips 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -2885,7 +2885,7 @@ exports[`MinischeduleRun renders a run with no layovers between trips 1`] = `
           className="m-minischedule__icon"
         >
           <span
-            className=""
+            className="m-minischedule__svg--revenue"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",

--- a/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/minischedule.test.tsx.snap
@@ -161,23 +161,6 @@ exports[`Minischedule highlights deadheads if they're active 1`] = `
         </div>
       </div>
       <div
-        className="m-minischedule__row m-minischedule__row--future m-minischedule__layover-row"
-      >
-        <div
-          className="m-minischedule__icon"
-        />
-        <div
-          className="m-minischedule__left-text"
-        >
-          Layover
-        </div>
-        <div
-          className="m-minischedule__right-text"
-        >
-          -1 min
-        </div>
-      </div>
-      <div
         className="m-minischedule__row m-minischedule__row--future"
       >
         <div
@@ -363,23 +346,6 @@ exports[`Minischedule highlights pullouts if they're active 1`] = `
           className="m-minischedule__right-text"
         >
           12:00 AM
-        </div>
-      </div>
-      <div
-        className="m-minischedule__row m-minischedule__row--future m-minischedule__layover-row"
-      >
-        <div
-          className="m-minischedule__icon"
-        />
-        <div
-          className="m-minischedule__left-text"
-        >
-          Layover
-        </div>
-        <div
-          className="m-minischedule__right-text"
-        >
-          -1 min
         </div>
       </div>
       <div

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -641,6 +641,27 @@ describe("Minischedule", () => {
     wrapper.find(".m-minischedule__show-past").simulate("click")
     expect(wrapper.html()).toContain("m-minischedule--hide-past")
   })
+
+  test("highlights pullouts if they're active", () => {
+    const run = {
+      id: "run",
+      activities: [{ ...piece, trips: [nonrevenueTrip, revenueTrip] }],
+    }
+    const tree = renderer
+      .create(
+        <Minischedule
+          runOrBlock={run}
+          vehicleOrGhost={{
+            ...vehicle,
+            tripId: revenueTrip.id,
+            routeStatus: "pulling_out",
+          }}
+          view="run"
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })
 
 describe("BreakRow", () => {

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -645,7 +645,15 @@ describe("Minischedule", () => {
   test("highlights pullouts if they're active", () => {
     const run = {
       id: "run",
-      activities: [{ ...piece, trips: [nonrevenueTrip, revenueTrip] }],
+      activities: [
+        {
+          ...piece,
+          trips: [
+            { ...nonrevenueTrip, startTime: 0 },
+            { ...revenueTrip, startTime: 1 },
+          ],
+        },
+      ],
     }
     const tree = renderer
       .create(
@@ -670,9 +678,9 @@ describe("Minischedule", () => {
         {
           ...piece,
           trips: [
-            { ...revenueTrip, id: "before" },
-            { ...nonrevenueTrip, id: "deadhead" },
-            { ...revenueTrip, id: "after" },
+            { ...revenueTrip, id: "before", startTime: 0 },
+            { ...nonrevenueTrip, id: "deadhead", startTime: 1 },
+            { ...revenueTrip, id: "after", startTime: 2 },
           ],
         },
       ],

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -662,6 +662,36 @@ describe("Minischedule", () => {
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test("highlights deadheads if they're active", () => {
+    const run = {
+      id: "run",
+      activities: [
+        {
+          ...piece,
+          trips: [
+            { ...revenueTrip, id: "before" },
+            { ...nonrevenueTrip, id: "deadhead" },
+            { ...revenueTrip, id: "after" },
+          ],
+        },
+      ],
+    }
+    const tree = renderer
+      .create(
+        <Minischedule
+          runOrBlock={run}
+          vehicleOrGhost={{
+            ...vehicle,
+            tripId: "after",
+            routeStatus: "laying_over",
+          }}
+          view="run"
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })
 
 describe("BreakRow", () => {


### PR DESCRIPTION
Asana Task: [Minischedules | Show active status on more than just revenue trips](https://app.asana.com/0/1148853526253426/1180597825747907)

One problem: The 🚍 icon doesn't play as nicely with highlighting the stroke as the simple triangles do. Any ideas what to do about that?

<img width="586" alt="Screen Shot 2020-07-02 at 15 04 10" src="https://user-images.githubusercontent.com/23065557/86401332-0a1d2100-bc78-11ea-9b26-30c1996a2de8.png">
<img width="586" alt="Screen Shot 2020-07-02 at 15 20 55" src="https://user-images.githubusercontent.com/23065557/86401337-0ab5b780-bc78-11ea-8fef-6f9999913cf0.png">
