### PR TITLE
Require token for nearest intersection service calls

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :skate,
   hastus_url: "https://cdn.mbta.com/hastus_export/skate/hastus_skate_dev.zip",
+  geonames_url_base: "http://api.geonames.org",
   log_duration_timing: false
 
 config :skate, Schedule.CacheFile, cache_filename: "dev_cache.terms"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,16 +1,16 @@
 use Mix.Config
 
 config :skate,
-  api_key: {:secret, "API_KEY"},
+  api_key: {:secret, "ENV-api-key"},
   geonames_url_base: "https://ba-secure.geonames.net",
-  geonames_token: {:secret, "GEONAMES_TOKEN"},
+  geonames_token: {:secret, "geonames-token"},
   redirect_http?: true,
   record_fullstory: true,
   record_appcues: true,
   record_sentry: true,
-  secret_key_base: {:secret, "SECRET_KEY_BASE"},
+  secret_key_base: {:secret, "ENV-secret-key-base"},
   static_href: {SkateWeb.Router.Helpers, :static_url},
-  swiftly_authorization_key: {:secret, "SWIFTLY_AUTHORIZATION_KEY"}
+  swiftly_authorization_key: {:secret, "ENV-swiftly-authorization-key"}
 
 # For production, don't forget to configure the url host
 # to something meaningful, Phoenix uses this information

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,8 @@ use Mix.Config
 
 config :skate,
   api_key: {:secret, "API_KEY"},
+  geonames_url_base: "https://ba-secure.geonames.net",
+  geonames_token: {:secret, "GEONAMES_TOKEN"},
   redirect_http?: true,
   record_fullstory: true,
   record_appcues: true,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -8,9 +8,9 @@ Application.ensure_all_started(:ex_aws)
 Application.ensure_all_started(:ex_aws_secretsmanager)
 
 config :skate,
-  secret_key_base: SecretsManager.fetch!("SECRET_KEY_BASE")
+  secret_key_base: SecretsManager.fetch!("ENV-secret-key-base")
 
 config :ueberauth, Ueberauth.Strategy.Cognito,
-  client_secret: SecretsManager.fetch!("COGNITO_CLIENT_SECRET")
+  client_secret: SecretsManager.fetch!("ENV-cognito-client-secret")
 
-config :skate, SkateWeb.AuthManager, secret_key: SecretsManager.fetch!("GUARDIAN_SECRET_KEY")
+config :skate, SkateWeb.AuthManager, secret_key: SecretsManager.fetch!("ENV-guardian-secret-key")

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -14,10 +14,14 @@ defmodule Geonames do
 
   @spec get(String.t(), String.t()) :: map() | nil
   defp get(latitude, longitude) do
-    geonames_url_base = Application.get_env(:skate, :geonames_url_base, "http://api.geonames.org")
+    geonames_url_base = Application.get_env(:skate, :geonames_url_base)
+    geonames_token = Application.get_env(:skate, :geonames_token)
+    token_param = if geonames_token, do: "&token=#{geonames_token}", else: ""
 
     url =
-      "#{geonames_url_base}/findNearestIntersectionOSMJSON?lat=#{latitude}&lng=#{longitude}&username=mbta_busloc"
+      "#{geonames_url_base}/findNearestIntersectionOSMJSON?lat=#{latitude}&lng=#{longitude}&username=mbta_busloc#{
+        token_param
+      }"
 
     case HTTPoison.get(url) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -59,6 +59,8 @@ defmodule Skate.Application do
       :swiftly_authorization_key,
       :swiftly_realtime_vehicles_url,
       :trip_updates_url,
+      :geonames_url_base,
+      :geonames_token,
       :sentry_frontend_dsn,
       SkateWeb.Endpoint
     ]

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -45,7 +45,7 @@ defmodule Skate.Application do
   Will recursively check the keys below in the application config for any {:system, "ENVIRONMENT_VARIABLE"},
   and replace them with the value in the given environment variable.
 
-  Will recursively check the keys below in the application config for any {:secret, "SECRET_VARIABLE"},
+  Will recursively check the keys below in the application config for any {:secret, "secret-variable"},
   and replace them with the value in the given value from SecretsManager.
   """
   @spec load_runtime_config() :: :ok
@@ -93,8 +93,8 @@ defmodule Skate.Application do
     System.get_env(environment_variable)
   end
 
-  defp runtime_config({:secret, environment_variable}) do
-    SecretsManager.fetch!(environment_variable)
+  defp runtime_config({:secret, secret_variable}) do
+    SecretsManager.fetch!(secret_variable)
   end
 
   defp runtime_config(value) do

--- a/lib/skate/secrets_manager.ex
+++ b/lib/skate/secrets_manager.ex
@@ -7,26 +7,14 @@ defmodule Skate.SecretsManager do
     aws_request_fn = Application.get_env(:skate, :aws_request_fn, &ExAws.request!/1)
 
     key_name
-    |> env_specific_key_name()
+    |> replace_env_in_key_name()
     |> get_secret_value_fn.()
     |> aws_request_fn.()
     |> Map.fetch!("SecretString")
   end
 
-  @spec env_specific_key_name(String.t()) :: String.t()
-  def env_specific_key_name(key_name) do
-    env() <> "-" <> secret_key_name(key_name)
-  end
-
-  @spec env() :: String.t()
-  def env do
-    System.get_env("ENVIRONMENT_NAME")
-  end
-
-  @spec secret_key_name(String.t()) :: String.t()
-  def secret_key_name(env_name) do
-    env_name
-    |> String.downcase()
-    |> String.replace("_", "-")
+  @spec replace_env_in_key_name(String.t()) :: String.t()
+  def replace_env_in_key_name(key_name) do
+    String.replace(key_name, "ENV", System.get_env("ENVIRONMENT_NAME"))
   end
 end

--- a/test/geonames_test.exs
+++ b/test/geonames_test.exs
@@ -12,6 +12,23 @@ defmodule GeonamesTest do
       assert Geonames.nearest_intersection("0.0", "0.0") == nil
     end
 
+    test "passes all query params" do
+      bypass = Bypass.open()
+      reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
+      reassign_env(:skate, :geonames_token, "TOKEN")
+
+      Bypass.expect(bypass, fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.params["lat"] == "40.0"
+        assert conn.params["lng"] == "-70.0"
+        assert conn.params["username"] == "mbta_busloc"
+        assert conn.params["token"] == "TOKEN"
+        Plug.Conn.resp(conn, 200, "{}")
+      end)
+
+      assert Geonames.nearest_intersection("40.0", "-70.0") == nil
+    end
+
     test "parses the street names out" do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")

--- a/test/skate/application_test.exs
+++ b/test/skate/application_test.exs
@@ -14,9 +14,13 @@ defmodule Skate.ApplicationTest do
 
     test "replaces {:secret, var_name} with secret from AWS SecretsManager" do
       System.put_env("ENVIRONMENT_NAME", "TEST")
-      reassign_env(:skate, :get_secret_value_fn, fn _ -> "mock response" end)
+
+      reassign_env(:skate, :get_secret_value_fn, fn "TEST-test-variable" ->
+        "mock aws operation"
+      end)
+
       reassign_env(:skate, :aws_request_fn, fn _ -> %{"SecretString" => "TEST VALUE"} end)
-      Application.put_env(:skate, :swiftly_authorization_key, {:secret, "TEST_VARIABLE"})
+      Application.put_env(:skate, :swiftly_authorization_key, {:secret, "ENV-test-variable"})
 
       Skate.Application.load_runtime_config()
 

--- a/test/skate/secrets_manager_test.exs
+++ b/test/skate/secrets_manager_test.exs
@@ -6,7 +6,7 @@ defmodule Skate.SecretsManagerTest do
 
   setup do
     System.put_env("ENVIRONMENT_NAME", "TEST")
-    reassign_env(:skate, :get_secret_value_fn, fn _ -> "mock response" end)
+    reassign_env(:skate, :get_secret_value_fn, fn _ -> "mock aws operation" end)
     reassign_env(:skate, :aws_request_fn, fn _ -> %{"SecretString" => "mock secret value"} end)
   end
 
@@ -16,21 +16,13 @@ defmodule Skate.SecretsManagerTest do
     end
   end
 
-  describe "env_specific_key_name/1" do
+  describe "replace_env_in_key_name/1" do
     test "returns the SecretsManager version of the key name specific to the current environment" do
-      assert SecretsManager.env_specific_key_name("TEST_KEY") == "TEST-test-key"
+      assert SecretsManager.replace_env_in_key_name("ENV-test-key") == "TEST-test-key"
     end
-  end
 
-  describe "env/0" do
-    test "returns the system environment name" do
-      assert SecretsManager.env() == "TEST"
-    end
-  end
-
-  describe "secret_key_name/1" do
-    test "converts the key name from env format to SecretsManager format" do
-      assert SecretsManager.secret_key_name("COGNITO_CLIENT_SECRET") == "cognito-client-secret"
+    test "allows key names to not include the env" do
+      assert SecretsManager.replace_env_in_key_name("test-key") == "test-key"
     end
   end
 end


### PR DESCRIPTION
Don't merge until [the token is added to aws secrets manager](https://app.asana.com/0/1113179098808463/1185267665560161) and we have a chance to test this in dev. (I couldn't check the secret managing part locally.)

Asana Task: [Require token for nearest intersection service calls](https://app.asana.com/0/1148853526253426/1185064914992633)

The dev config still uses the free url, so you won't need to set the token locally.