### PR TITLE
make VPP fullscreen on small screen

### DIFF
--- a/assets/css/_properties_panel.scss
+++ b/assets/css/_properties_panel.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  max-width: 100%;
   overflow-x: hidden;
   overflow-y: scroll;
   position: absolute;
@@ -11,6 +10,10 @@
   top: 0;
   width: 23.5rem;
   z-index: 1001;
+
+  @media screen and (max-width: $mobile-max-width) {
+    width: 100vw;
+  }
 }
 
 .m-properties-panel .m-properties-panel__header-wrapper {
@@ -27,6 +30,5 @@
 
 .m-properties-panel__modal-overlay {
   @include modal-overlay;
-  position: absolute;
   z-index: 1000;
 }


### PR DESCRIPTION
Asana Task: [VPP should be full-width on mobile devices](https://app.asana.com/0/1148853526253426/1176894565066953)

minimum width before it fills the screen:
<img width="793" alt="Screen Shot 2020-07-20 at 14 33 56" src="https://user-images.githubusercontent.com/23065557/87973395-72506d00-ca96-11ea-9b1b-822d506d1e38.png">

maximum width where it fills the screen:
<img width="785" alt="Screen Shot 2020-07-20 at 14 34 06" src="https://user-images.githubusercontent.com/23065557/87973399-74b2c700-ca96-11ea-8ce0-ec4994b3f043.png">

iphone size:
<img width="458" alt="Screen Shot 2020-07-20 at 14 34 16" src="https://user-images.githubusercontent.com/23065557/87973410-77adb780-ca96-11ea-9893-39e9a1dac42d.png">
<img width="691" alt="Screen Shot 2020-07-20 at 14 34 40" src="https://user-images.githubusercontent.com/23065557/87973417-7aa8a800-ca96-11ea-9be0-c49d388d7221.png">
