### PR TITLE
bugfix don't close vpp when swiping map

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -297,6 +297,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
       <div className={`m-vehicle-map-state ${autoCenteringClass}`} />
       <ReactLeafletMap
         className="m-vehicle-map"
+        id="id-vehicle-map"
         ref={mapRef}
         maxBounds={[
           [41.2, -72],

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -596,6 +596,7 @@ Array [
             />
             <div
               className="m-vehicle-map"
+              id="id-vehicle-map"
             />
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
   <div
@@ -497,6 +498,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
             />
             <div
               className="m-vehicle-map"
+              id="id-vehicle-map"
             />
           </div>
         </div>
@@ -685,6 +687,7 @@ exports[`SearchPage renders the empty state 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>
@@ -865,6 +868,7 @@ exports[`SearchPage renders vehicle data 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -207,6 +207,7 @@ exports[`Shuttle Map Page renders 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>
@@ -419,6 +420,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
   <div
@@ -709,6 +711,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
           />
           <div
             className="m-vehicle-map"
+            id="id-vehicle-map"
           />
         </div>
       </div>
@@ -928,6 +931,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>
@@ -1140,6 +1144,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>
@@ -1183,6 +1188,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>
@@ -1395,6 +1401,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
     />
     <div
       className="m-vehicle-map"
+      id="id-vehicle-map"
     />
   </div>
 </div>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -317,6 +317,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -641,6 +642,7 @@ exports[`VehiclePropertiesPanel renders for a headway-based vehicle 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -965,6 +967,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -1257,6 +1260,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       />
       <div
         className="m-vehicle-map"
+        id="id-vehicle-map"
       />
     </div>
   </div>
@@ -1675,6 +1679,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -1999,6 +2004,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -2337,6 +2343,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>
@@ -2661,6 +2668,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         />
         <div
           className="m-vehicle-map"
+          id="id-vehicle-map"
         />
       </div>
     </div>


### PR DESCRIPTION
Asana Task: [🐞 VPP map appears to automatically close on mobile](https://app.asana.com/0/1148853526253426/1185530236239773)

We were preventing closing the VPP when swiping on the map by [checking here](https://github.com/mbta/skate/blob/bd06e91dbd470fe1f678f99ee6f7bd7fb9e8d39e/assets/src/components/propertiesPanel.tsx#L20), but I guess we accidentally removed the id.