### PR TITLE
Add hack to keep iPhones from zooming in on inputs

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -72,3 +72,12 @@ body {
   flex: 1 1 0;
   min-height: 0;
 }
+
+// Hack to prevent iPhones from automatically zooming in when an input is
+// selected. A font size of 16px is supposed to do the job, but for some
+// reason this doesn't work at less than 24 px.
+@media screen and (max-width: 767px) {
+  input {
+    font-size: 24px !important;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -72,12 +72,3 @@ body {
   flex: 1 1 0;
   min-height: 0;
 }
-
-// Hack to prevent iPhones from automatically zooming in when an input is
-// selected. A font size of 16px is supposed to do the job, but for some
-// reason this doesn't work at less than 24 px.
-@media screen and (max-width: 767px) {
-  input {
-    font-size: 24px !important;
-  }
-}

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -36,16 +36,6 @@ if (!("ResizeObserver" in global)) {
   window.ResizeObserver = ResizeObserver
 }
 
-// Show more content on small screens by changing the meta viewport scale.
-if (screen.width < 1000 && screen.height < 1000) {
-  document
-    .getElementsByName("viewport")[0]
-    .setAttribute(
-      "content",
-      "width=device-width, initial-scale=.8, minimum-scale=.8"
-    )
-}
-
 // Import local files
 //
 // Local files can be imported directly using relative paths, for example:


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1152520728603475

By setting the `font-size` for `input`s to 24px (rather than the 16px that's theoretically supposed to work), the e.g. search input no longer zooms in when selected.