### PR TITLE
make blocks a struct instead of a list

### DIFF
--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -37,7 +37,7 @@ defmodule Realtime.BlockWaiver do
   def block_waivers_for_block(nil, _), do: []
 
   def block_waivers_for_block(block, stop_time_updates_by_trip) do
-    block
+    block.trips
     |> Enum.flat_map(&trip_stop_time_waivers(&1, stop_time_updates_by_trip))
     |> group_consecutive_sequences()
     |> Enum.map(&from_trip_stop_time_waivers(&1, date_for_block(block)))

--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -144,16 +144,12 @@ defmodule Realtime.TimepointStatus do
     nil
   end
 
-  def scheduled_location([], _now) do
-    nil
-  end
-
   def scheduled_location(block, now) do
     now_time_of_day =
       Util.Time.next_time_of_day_for_timestamp_after(
         now,
         # Allow a little wiggle room in case a bus appears just before its block starts
-        Util.Time.time_of_day_add_minutes(Block.start_time(block), -60)
+        Util.Time.time_of_day_add_minutes(block.start_time, -60)
       )
 
     trip = Block.trip_at_time(block, now_time_of_day)
@@ -179,7 +175,8 @@ defmodule Realtime.TimepointStatus do
               run_id: trip.run_id,
               time_since_trip_start_time: now_time_of_day - trip.start_time,
               headsign: trip.headsign,
-              via_variant: RoutePattern.via_variant(trip.route_pattern_id),
+              via_variant:
+                trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id),
               timepoint_status: timepoint_status
             }
         end

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -283,7 +283,7 @@ defmodule Realtime.Vehicle do
     one_hour_in_seconds = 1 * 60 * 60
     now_time_of_day = Util.Time.time_of_day_for_timestamp(now, Util.Time.date_of_timestamp(now))
 
-    now_time_of_day - Block.end_time(block) <= one_hour_in_seconds
+    now_time_of_day - block.end_time <= one_hour_in_seconds
   end
 
   @spec stop_name(map() | nil, String.t() | nil) :: String.t() | nil
@@ -316,7 +316,7 @@ defmodule Realtime.Vehicle do
   def route_status(stop_id, trip, block) do
     if stop_id == List.first(trip.stop_times).stop_id do
       # hasn't started trip yet
-      if block != nil && trip.id == List.first(block).id do
+      if block != nil && trip.id == List.first(block.trips).id do
         # starting the block, pulling out from garage
         :pulling_out
       else

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -147,7 +147,7 @@ defmodule Schedule.Data do
     blocks_by_service =
       blocks
       |> Map.values()
-      |> Enum.group_by(fn block -> List.first(block).service_id end)
+      |> Enum.group_by(fn block -> block.service_id end)
 
     active_services
     |> Map.new(fn {date, service_ids} ->
@@ -281,7 +281,7 @@ defmodule Schedule.Data do
       shapes: shapes_by_route_id(gtfs_files["shapes.txt"], gtfs_trips),
       stops: all_stops_by_id(gtfs_files["stops.txt"]),
       trips: trips_by_id,
-      blocks: Block.group_trips_by_block(Map.values(trips_by_id)),
+      blocks: Block.blocks_from_trips(Map.values(trips_by_id)),
       calendar: Calendar.from_files(gtfs_files["calendar.txt"], gtfs_files["calendar_dates.txt"]),
       minischedule_runs: minischedule_runs,
       minischedule_blocks: minischedule_blocks

--- a/test/concentrate/consumer/stop_time_updates_test.exs
+++ b/test/concentrate/consumer/stop_time_updates_test.exs
@@ -4,12 +4,20 @@ defmodule Concentrate.Consumer.StopTimeUpdatesTest do
 
   alias Concentrate.{StopTimeUpdate, TripUpdate}
   alias Concentrate.Consumer.StopTimeUpdates
-  alias Schedule.Trip
+  alias Schedule.{Block, Trip}
 
   @trip %Trip{
     id: "t1",
     block_id: "S28-2",
     service_id: "service"
+  }
+
+  @block %Block{
+    id: "S28-2",
+    service_id: "service",
+    start_time: 0,
+    end_time: 0,
+    trips: [@trip]
   }
 
   @stop_time_update %StopTimeUpdate{
@@ -49,7 +57,7 @@ defmodule Concentrate.Consumer.StopTimeUpdatesTest do
   describe "handle_events/3" do
     setup do
       reassign_env(:realtime, :trip_fn, fn _trip_id -> @trip end)
-      reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> [@trip] end)
+      reassign_env(:realtime, :block_fn, fn _block_id, _service_id -> @block end)
 
       events = [@all_updates]
 

--- a/test/realtime/ghost_test.exs
+++ b/test/realtime/ghost_test.exs
@@ -2,7 +2,7 @@ defmodule Realtime.GhostTest do
   use ExUnit.Case
   import Test.Support.Helpers
 
-  alias Schedule.Trip
+  alias Schedule.{Block, Trip}
   alias Schedule.Gtfs.StopTime
   alias Realtime.{BlockWaiver, Ghost}
 
@@ -47,7 +47,7 @@ defmodule Realtime.GhostTest do
         end_time: 3
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       # 2019-01-01 00:00:00 EST
       time0 = 1_546_318_800
@@ -112,7 +112,7 @@ defmodule Realtime.GhostTest do
         end_time: 3
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       vehicles = [%{block_id: "block"}]
 
@@ -148,7 +148,7 @@ defmodule Realtime.GhostTest do
         end_time: 2
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       assert %Ghost{
                id: "ghost-trip",
@@ -179,7 +179,7 @@ defmodule Realtime.GhostTest do
     end
 
     test "makes a ghost for a block that should be laying over" do
-      block = [
+      trips = [
         %Trip{
           id: "trip1",
           block_id: "block",
@@ -217,6 +217,8 @@ defmodule Realtime.GhostTest do
           end_time: 20
         }
       ]
+
+      block = Block.block_from_trips(trips)
 
       # 2019-01-01 00:00:00 EST
       time0 = 1_546_318_800
@@ -277,7 +279,7 @@ defmodule Realtime.GhostTest do
         end_time: 3
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       # 2019-01-01 00:00:00 EST
       time0 = 1_546_318_800
@@ -345,32 +347,32 @@ defmodule Realtime.GhostTest do
       %{
         trip1: trip1,
         trip2: trip2,
-        block: [trip1, trip2]
+        trips: [trip1, trip2]
       }
     end
 
-    test "returns pulling out for a block that hasn't started yet", %{block: block, trip1: trip1} do
-      assert Ghost.current_trip(block, 1) == {:pulling_out, trip1}
+    test "returns pulling out for a block that hasn't started yet", %{trips: trips, trip1: trip1} do
+      assert Ghost.current_trip(trips, 1) == {:pulling_out, trip1}
     end
 
     test "returns on_route if a trip is scheduled to be in progress", %{
-      block: block,
+      trips: trips,
       trip1: trip1,
       trip2: trip2
     } do
-      assert Ghost.current_trip(block, 3) == {:on_route, trip1}
-      assert Ghost.current_trip(block, 7) == {:on_route, trip2}
+      assert Ghost.current_trip(trips, 3) == {:on_route, trip1}
+      assert Ghost.current_trip(trips, 7) == {:on_route, trip2}
     end
 
     test "returns laying_over if the block is scheduled to be between trips", %{
-      block: block,
+      trips: trips,
       trip2: trip2
     } do
-      assert Ghost.current_trip(block, 5) == {:laying_over, trip2}
+      assert Ghost.current_trip(trips, 5) == {:laying_over, trip2}
     end
 
-    test "returns nil if the block is scheduled to have finished", %{block: block} do
-      assert Ghost.current_trip(block, 9) == nil
+    test "returns nil if the block is scheduled to have finished", %{trips: trips} do
+      assert Ghost.current_trip(trips, 9) == nil
     end
   end
 end

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -2,7 +2,7 @@ defmodule Realtime.VehiclesTest do
   use ExUnit.Case
   import Test.Support.Helpers
 
-  alias Schedule.Trip
+  alias Schedule.{Block, Trip}
   alias Schedule.Gtfs.StopTime
   alias Realtime.{BlockWaiver, Ghost, Vehicle, Vehicles}
 
@@ -69,7 +69,7 @@ defmodule Realtime.VehiclesTest do
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
                pulling_out_blocks_by_route,
-               [],
+               %{},
                0
              ) == %{
                "route" => [on_route_vehicle, laying_over_vehicle, pulling_out_vehicle]
@@ -137,7 +137,7 @@ defmodule Realtime.VehiclesTest do
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
                incoming_blocks_by_route,
-               [],
+               %{},
                0
              ) == %{
                "route1" => [vehicle],
@@ -179,7 +179,7 @@ defmodule Realtime.VehiclesTest do
       assert Vehicles.group_by_route_with_blocks(
                ungrouped_vehicles,
                incoming_blocks_by_route,
-               [],
+               %{},
                0
              ) == %{
                "route2" => [vehicle]
@@ -205,7 +205,7 @@ defmodule Realtime.VehiclesTest do
         end_time: 0
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       # 2019-12-20 00:00:00
       time0 = 1_576_818_000
@@ -287,7 +287,7 @@ defmodule Realtime.VehiclesTest do
         end_time: 0
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
 
       # 2019-12-20 00:00:00
       time0 = 1_576_818_000
@@ -324,7 +324,7 @@ defmodule Realtime.VehiclesTest do
         end_time: 1
       }
 
-      block = [trip]
+      block = Block.block_from_trips([trip])
       # 2019-12-20 00:00:00
       time0 = 1_576_818_000
 
@@ -412,7 +412,7 @@ defmodule Realtime.VehiclesTest do
         end_time: 4
       }
 
-      block = [trip1, trip2]
+      block = Block.block_from_trips([trip1, trip2])
 
       # 2019-12-20 00:00:00
       time0 = 1_576_818_000

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -3,7 +3,7 @@ defmodule ScheduleTest do
 
   import Test.Support.Helpers
 
-  alias Schedule.Trip
+  alias Schedule.{Block, Trip}
   alias Schedule.Gtfs.{Route, RoutePattern, Shape, Stop, StopTime, Timepoint}
   alias Schedule.Gtfs.Shape.Point
   alias Schedule.Minischedule
@@ -373,38 +373,44 @@ defmodule ScheduleTest do
           }
         })
 
-      assert Schedule.block("b", "service", pid) == [
-               %Trip{
-                 id: "t1",
-                 block_id: "b",
-                 route_id: "route",
-                 service_id: "service",
-                 # Shuttles do not have route_pattern_ids
-                 headsign: "h1",
-                 direction_id: 1,
-                 route_pattern_id: "route-_-0",
-                 shape_id: "shape1",
-                 schedule_id: "schedule",
-                 run_id: "123-1501",
-                 start_time: 1,
-                 end_time: 3,
-                 start_place: "wtryd",
-                 end_place: "hayms",
-                 stop_times: [
-                   %StopTime{
-                     stop_id: "s4",
-                     time: 1,
-                     timepoint_id: "exurb"
-                   },
-                   %StopTime{stop_id: "s5", time: 2, timepoint_id: nil},
-                   %StopTime{
-                     stop_id: "s3",
-                     time: 3,
-                     timepoint_id: "suburb"
-                   }
-                 ]
-               }
-             ]
+      assert Schedule.block("b", "service", pid) == %Block{
+               id: "b",
+               service_id: "service",
+               start_time: 1,
+               end_time: 3,
+               trips: [
+                 %Trip{
+                   id: "t1",
+                   block_id: "b",
+                   route_id: "route",
+                   service_id: "service",
+                   # Shuttles do not have route_pattern_ids
+                   headsign: "h1",
+                   direction_id: 1,
+                   route_pattern_id: "route-_-0",
+                   shape_id: "shape1",
+                   schedule_id: "schedule",
+                   run_id: "123-1501",
+                   start_time: 1,
+                   end_time: 3,
+                   start_place: "wtryd",
+                   end_place: "hayms",
+                   stop_times: [
+                     %StopTime{
+                       stop_id: "s4",
+                       time: 1,
+                       timepoint_id: "exurb"
+                     },
+                     %StopTime{stop_id: "s5", time: 2, timepoint_id: nil},
+                     %StopTime{
+                       stop_id: "s3",
+                       time: 3,
+                       timepoint_id: "suburb"
+                     }
+                   ]
+                 }
+               ]
+             }
     end
 
     test "returns nil if the block doesn't exist" do
@@ -481,7 +487,7 @@ defmodule ScheduleTest do
       # 2019-01-01 00:00:00 EST
       time0 = 1_546_318_800
 
-      assert %{~D[2019-01-01] => [[%Trip{id: "now", block_id: "now"}]]} =
+      assert %{~D[2019-01-01] => [%Block{id: "now"}]} =
                Schedule.active_blocks(time0 + 1, time0 + 3, pid)
     end
   end


### PR DESCRIPTION
Refactor in preparation for [Detect pullouts dynamically based on the duration of the pullout, instead of a fixed threshold before the trip](https://app.asana.com/0/1148853526253426/1182075650453425)
To do that task, I'm planning on setting `block.start_time` to include the nonrevenue time, but that means that block needs to be a struct with a `start_time` field instead of calculating it from revenue trips.

This PR should have no user-facing changes. The `start_time` is still calculated as the start of the first revenue trip. I'll mix in the nonrevenue trips later.