### PR TITLE
Show pulling out ghosts buses based on scheduled pullout times instead of 10min threshhold

### DIFF
--- a/lib/realtime/vehicles.ex
+++ b/lib/realtime/vehicles.ex
@@ -10,19 +10,18 @@ defmodule Realtime.Vehicles do
   @spec group_by_route([Vehicle.t()]) :: Route.by_id([VehicleOrGhost.t()])
   def group_by_route(ungrouped_vehicles) do
     now = Util.Time.now()
-    in_ten_minutes = now + 10 * 60
     in_fifteen_minutes = now + 15 * 60
 
     # We show vehicles incoming from another route if they'll start the new route within 15 minutes
     incoming_trips = Schedule.active_trips(now, in_fifteen_minutes)
     incoming_blocks_by_route = incoming_blocks_by_route(incoming_trips)
-    # We show pulling out ghosts if they'll start within 10 minutes
-    active_and_incoming_blocks_by_date = Schedule.active_blocks(now, in_ten_minutes)
+    # Includes blocks that are scheduled to be pulling out
+    active_blocks_by_date = Schedule.active_blocks(now, now)
 
     group_by_route_with_blocks(
       ungrouped_vehicles,
       incoming_blocks_by_route,
-      active_and_incoming_blocks_by_date,
+      active_blocks_by_date,
       now
     )
   end
@@ -40,10 +39,10 @@ defmodule Realtime.Vehicles do
   def group_by_route_with_blocks(
         ungrouped_vehicles,
         incoming_blocks_by_route,
-        active_and_incoming_blocks_by_date,
+        active_blocks_by_date,
         now
       ) do
-    ghosts = Ghost.ghosts(active_and_incoming_blocks_by_date, ungrouped_vehicles, now)
+    ghosts = Ghost.ghosts(active_blocks_by_date, ungrouped_vehicles, now)
     vehicles_and_ghosts = ghosts ++ ungrouped_vehicles
 
     incoming_from_another_route =

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -1,5 +1,6 @@
 defmodule Schedule.Block do
   alias Schedule.Gtfs.Service
+  alias Schedule.Hastus
   alias Schedule.Trip
 
   @type id :: String.t()
@@ -13,6 +14,7 @@ defmodule Schedule.Block do
   @type t :: %__MODULE__{
           id: id(),
           service_id: Service.id(),
+          schedule_id: Hastus.Schedule.id() | nil,
           start_time: Util.Time.time_of_day(),
           end_time: Util.Time.time_of_day(),
           # only revenue trips. always nonempty
@@ -30,6 +32,7 @@ defmodule Schedule.Block do
   defstruct [
     :id,
     :service_id,
+    :schedule_id,
     :start_time,
     :end_time,
     :trips
@@ -55,6 +58,7 @@ defmodule Schedule.Block do
     %__MODULE__{
       id: first_trip.block_id,
       service_id: first_trip.service_id,
+      schedule_id: first_trip.schedule_id,
       start_time: first_trip.start_time,
       end_time: List.last(trips).end_time,
       trips: trips

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -52,7 +52,7 @@ defmodule Schedule.Block do
     |> Helpers.map_values(fn trips ->
       block_id = List.first(trips).block_id
       schedule_id = List.first(trips).schedule_id
-      deadheads = nonrevenue_trips[{block_id, schedule_id}] || []
+      deadheads = Map.get(nonrevenue_trips, {block_id, schedule_id}, [])
       block_from_trips(trips, deadheads)
     end)
   end
@@ -61,7 +61,7 @@ defmodule Schedule.Block do
   def block_from_trips(revenue_trips, nonrevenue_trips \\ []) do
     revenue_trips = Enum.sort_by(revenue_trips, & &1.start_time)
     nonrevenue_trips = Enum.sort_by(nonrevenue_trips, & &1.start_time)
-    [first_trip | _] = revenue_trips
+    first_trip = List.first(revenue_trips)
 
     start_time =
       if nonrevenue_trips == [] do

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -40,28 +40,56 @@ defmodule Schedule.Block do
 
   @spec blocks_from_trips([Trip.t()]) :: by_id()
   def blocks_from_trips(trips) do
-    trips
-    |> group_trips_by_block()
-    |> Helpers.map_values(&block_from_trips/1)
-  end
+    {revenue_trips, nonrevenue_trips} =
+      Enum.split_with(trips, fn trip -> trip.route_id != nil end)
 
-  @spec group_trips_by_block([Trip.t()]) :: %{key() => [Trip.t()]}
-  defp group_trips_by_block(trips) do
-    trips
+    nonrevenue_trips =
+      Enum.group_by(nonrevenue_trips, fn trip -> {trip.block_id, trip.schedule_id} end)
+
+    revenue_trips
     |> Enum.filter(fn trip -> trip.stop_times != [] end)
     |> Enum.group_by(fn trip -> {trip.block_id, trip.service_id} end)
-    |> Helpers.map_values(&sort_trips_by_time/1)
+    |> Helpers.map_values(fn trips ->
+      block_id = List.first(trips).block_id
+      schedule_id = List.first(trips).schedule_id
+      deadheads = nonrevenue_trips[{block_id, schedule_id}] || []
+      block_from_trips(trips, deadheads)
+    end)
   end
 
-  @spec block_from_trips([Trip.t()]) :: t()
-  def block_from_trips([first_trip | _] = trips) do
+  @spec block_from_trips([Trip.t()], [Trip.t()]) :: t()
+  def block_from_trips(revenue_trips, nonrevenue_trips \\ []) do
+    revenue_trips = Enum.sort_by(revenue_trips, & &1.start_time)
+    nonrevenue_trips = Enum.sort_by(nonrevenue_trips, & &1.start_time)
+    [first_trip | _] = revenue_trips
+
+    start_time =
+      if nonrevenue_trips == [] do
+        first_trip.start_time
+      else
+        min(
+          first_trip.start_time,
+          List.first(nonrevenue_trips).start_time
+        )
+      end
+
+    end_time =
+      if nonrevenue_trips == [] do
+        List.last(revenue_trips).end_time
+      else
+        max(
+          List.last(revenue_trips).end_time,
+          List.last(nonrevenue_trips).end_time
+        )
+      end
+
     %__MODULE__{
       id: first_trip.block_id,
       service_id: first_trip.service_id,
       schedule_id: first_trip.schedule_id,
-      start_time: first_trip.start_time,
-      end_time: List.last(trips).end_time,
-      trips: trips
+      start_time: start_time,
+      end_time: end_time,
+      trips: revenue_trips
     }
   end
 
@@ -126,11 +154,6 @@ defmodule Schedule.Block do
   def id_sans_overload(nil), do: nil
 
   def id_sans_overload(id), do: String.replace(id, overload_id_regex(), "")
-
-  @spec sort_trips_by_time([Trip.t()]) :: [Trip.t()]
-  defp sort_trips_by_time(trips) do
-    Enum.sort_by(trips, & &1.start_time)
-  end
 
   defp overload_id_regex(), do: ~r/-OL.+$/
 end

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -9,6 +9,7 @@ defmodule Schedule.BlockTest do
     id: "t1",
     block_id: "b",
     service_id: "service",
+    schedule_id: "schedule",
     stop_times: [
       %StopTime{stop_id: "s1", time: 3, timepoint_id: "tp1"},
       %StopTime{stop_id: "s7", time: 4, timepoint_id: nil}
@@ -21,6 +22,7 @@ defmodule Schedule.BlockTest do
     id: "t2",
     block_id: "b",
     service_id: "service",
+    schedule_id: "schedule",
     stop_times: [
       %StopTime{stop_id: "s7", time: 6, timepoint_id: nil},
       %StopTime{stop_id: "s1", time: 7, timepoint_id: "tp1"}
@@ -32,6 +34,7 @@ defmodule Schedule.BlockTest do
   @block %Block{
     id: "b",
     service_id: "service",
+    schedule_id: "schedule",
     start_time: 3,
     end_time: 7,
     trips: [@trip1, @trip2]
@@ -44,6 +47,7 @@ defmodule Schedule.BlockTest do
       assert Block.get(by_id, @trip1.block_id, @trip1.service_id) == %Block{
                id: @trip1.block_id,
                service_id: @trip1.service_id,
+               schedule_id: @trip1.schedule_id,
                start_time: 3,
                end_time: 4,
                trips: [@trip1]

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -376,6 +376,7 @@ defmodule ScheduleTest do
       assert Schedule.block("b", "service", pid) == %Block{
                id: "b",
                service_id: "service",
+               schedule_id: "schedule",
                start_time: 1,
                end_time: 3,
                trips: [


### PR DESCRIPTION
Asana Task: [Detect pullouts dynamically based on the duration of the pullout, instead of a fixed threshold before the trip](https://app.asana.com/0/1148853526253426/1182075650453425)

~Builds on top of #779. Wait until that merges to review this.~

### Preventing false negatives:
<img width="470" alt="Screen Shot 2020-08-03 at 16 36 38" src="https://user-images.githubusercontent.com/23065557/89225814-d8fe7c00-d5a8-11ea-8e3c-3688e8db260b.png">
This screenshot was taken at 16:36:38.
The route 23 pullout is scheduled from 16:35 to 16:48. The route 77 pullout is scheduled from 16:36 to 16:54. In both cases, revenue service was more than 10m away, so prod showed nothing in either incoming box.


### Preventing false positives:
run 123-1150 is scheduled to pull out from 17:01 to 17:05
At 16:55, prod showed a ghost bus for it:
<img width="201" alt="Screen Shot 2020-08-03 at 16 55 10" src="https://user-images.githubusercontent.com/23065557/89226649-4e1e8100-d5aa-11ea-9a9a-d30bb5577407.png">
This PR didn't show a ghost bus:
<img width="193" alt="Screen Shot 2020-08-03 at 16 55 18" src="https://user-images.githubusercontent.com/23065557/89226651-4eb71780-d5aa-11ea-9593-9e03d7624f97.png">

