### PR TITLE
Allow settings page to shrink more responsively

### DIFF
--- a/assets/css/_page.scss
+++ b/assets/css/_page.scss
@@ -29,39 +29,3 @@
   @include font-emph;
   font-weight: bold;
 }
-
-.c-page__section-row {
-  display: flex;
-  align-items: baseline;
-}
-
-.c-page__section-row-icon {
-  align-self: normal;
-  margin: 0.2rem 0.5rem 0 0;
-}
-
-.c-page__section-row-icon-path {
-  display: block;
-  fill: $color-primary;
-  width: 24px;
-}
-
-.c-page__section-row-label {
-  @include font-body;
-  flex: 1 0 auto;
-  margin-right: 2rem;
-}
-
-.c-page__link {
-  @include button-primary;
-  display: block;
-  text-align: center;
-}
-
-.c-page__select {
-  background-color: $color-bg-base;
-  height: 2rem;
-  margin-bottom: 0.7rem;
-  min-width: 9.5rem;
-  padding-left: 0.4rem;
-}

--- a/assets/css/_settings_page.scss
+++ b/assets/css/_settings_page.scss
@@ -1,0 +1,29 @@
+.m-settings-page__row {
+  align-items: baseline;
+  display: flex;
+}
+
+.m-settings-page__icon {
+  align-self: normal;
+  margin: 0.2rem 0.5rem 0 0;
+}
+
+.m-settings-page__icon-path {
+  display: block;
+  fill: $color-primary;
+  width: 24px;
+}
+
+.m-settings-page__label {
+  @include font-body;
+  flex: 1 0 auto;
+  margin-right: 2rem;
+}
+
+.m-settings-page__select {
+  background-color: $color-bg-base;
+  height: 2rem;
+  margin-bottom: 0.7rem;
+  min-width: 9.5rem;
+  padding-left: 0.4rem;
+}

--- a/assets/css/_settings_page.scss
+++ b/assets/css/_settings_page.scss
@@ -1,10 +1,12 @@
 .m-settings-page__row {
   align-items: baseline;
   display: flex;
+  justify-content: space-between;
 }
 
 .m-settings-page__icon {
   align-self: normal;
+  flex: 0 1 auto;
   margin: 0.2rem 0.5rem 0 0;
 }
 
@@ -16,14 +18,13 @@
 
 .m-settings-page__label {
   @include font-body;
-  flex: 1 0 auto;
-  margin-right: 2rem;
+  flex: 1 1 6rem;
 }
 
 .m-settings-page__select {
   background-color: $color-bg-base;
+  flex: 1 0 6.5rem;
   height: 2rem;
   margin-bottom: 0.7rem;
-  min-width: 9.5rem;
   padding-left: 0.4rem;
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -36,6 +36,7 @@ $picker-width-wide: $picker-width-narrow + 3.1;
 @import "search_form";
 @import "search_page";
 @import "search_results";
+@import "settings_page";
 @import "shuttle_map";
 @import "tab_bar";
 @import "vehicle_icon";

--- a/assets/src/components/settingsPage.tsx
+++ b/assets/src/components/settingsPage.tsx
@@ -3,24 +3,9 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { ladderIcon, mapIcon } from "../helpers/icon"
 import { VehicleLabelSetting } from "../settings"
 import {
-  Dispatch,
   setLadderVehicleLabelSetting,
   setShuttleVehicleLabelSetting,
 } from "../state"
-
-const setLadderVehicleLabel = (dispatch: Dispatch) => (
-  event: React.FormEvent<HTMLSelectElement>
-) =>
-  dispatch(
-    setLadderVehicleLabelSetting(parseInt(event.currentTarget.value, 10))
-  )
-
-const setShuttleVehicleLabel = (dispatch: Dispatch) => (
-  event: React.FormEvent<HTMLSelectElement>
-) =>
-  dispatch(
-    setShuttleVehicleLabelSetting(parseInt(event.currentTarget.value, 10))
-  )
 
 const SettingsPage = (): ReactElement<HTMLDivElement> => {
   const [{ settings }, dispatch] = useContext(StateDispatchContext)
@@ -33,45 +18,71 @@ const SettingsPage = (): ReactElement<HTMLDivElement> => {
         <div className="c-page__section">
           <h2 className="c-page__header">Vehicle Label</h2>
 
-          <div className="m-settings-page__row">
-            <div className="m-settings-page__icon">
-              {ladderIcon("m-settings-page__icon-path")}
-            </div>
-            <div className="m-settings-page__label">Route Ladders</div>
-            <select
-              id="ladder-vehicle-label-setting"
-              className="m-settings-page__select"
-              value={settings.ladderVehicleLabel}
-              onChange={setLadderVehicleLabel(dispatch)}
-            >
-              <option value={VehicleLabelSetting.RunNumber}>Run #</option>
-              <option value={VehicleLabelSetting.VehicleNumber}>
-                Vehicle #
-              </option>
-            </select>
-          </div>
-
-          <div className="m-settings-page__row">
-            <div className="m-settings-page__icon">
-              {mapIcon("m-settings-page__icon-path")}
-            </div>
-            <div className="m-settings-page__label">Map</div>
-            <select
-              id="map-vehicle-label-setting"
-              className="m-settings-page__select"
-              value={settings.shuttleVehicleLabel}
-              onChange={setShuttleVehicleLabel(dispatch)}
-            >
-              <option value={VehicleLabelSetting.RunNumber}>Run #</option>
-              <option value={VehicleLabelSetting.VehicleNumber}>
-                Vehicle #
-              </option>
-            </select>
-          </div>
+          <DropdownSetting
+            icon={ladderIcon}
+            label="Route Ladders"
+            selectId="ladder-vehicle-label-setting"
+            value={settings.ladderVehicleLabel}
+            onChange={(value) => {
+              dispatch(setLadderVehicleLabelSetting(parseInt(value, 10)))
+            }}
+            options={[
+              { label: "Run #", value: VehicleLabelSetting.RunNumber },
+              { label: "Vehicle #", value: VehicleLabelSetting.VehicleNumber },
+            ]}
+          />
+          <DropdownSetting
+            icon={mapIcon}
+            label="Map"
+            selectId="map-vehicle-label-setting"
+            value={settings.shuttleVehicleLabel}
+            onChange={(value) => {
+              dispatch(setShuttleVehicleLabelSetting(parseInt(value, 10)))
+            }}
+            options={[
+              { label: "Run #", value: VehicleLabelSetting.RunNumber },
+              { label: "Vehicle #", value: VehicleLabelSetting.VehicleNumber },
+            ]}
+          />
         </div>
       </div>
     </div>
   )
 }
+
+const DropdownSetting = ({
+  icon,
+  label,
+  selectId,
+  value,
+  onChange,
+  options,
+}: {
+  icon: (className: string) => ReactElement
+  label: string
+  selectId: string
+  value: string | number
+  onChange: (value: string) => void
+  options: { label: string; value: string | number }[]
+}) => (
+  <div className="m-settings-page__row">
+    <div className="m-settings-page__icon">
+      {icon("m-settings-page__icon-path")}
+    </div>
+    <div className="m-settings-page__label">{label}</div>
+    <select
+      id={selectId}
+      className="m-settings-page__select"
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  </div>
+)
 
 export default SettingsPage

--- a/assets/src/components/settingsPage.tsx
+++ b/assets/src/components/settingsPage.tsx
@@ -33,14 +33,14 @@ const SettingsPage = (): ReactElement<HTMLDivElement> => {
         <div className="c-page__section">
           <h2 className="c-page__header">Vehicle Label</h2>
 
-          <div className="c-page__section-row">
-            <div className="c-page__section-row-icon">
-              {ladderIcon("c-page__section-row-icon-path")}
+          <div className="m-settings-page__row">
+            <div className="m-settings-page__icon">
+              {ladderIcon("m-settings-page__icon-path")}
             </div>
-            <div className="c-page__section-row-label">Route Ladders</div>
+            <div className="m-settings-page__label">Route Ladders</div>
             <select
               id="ladder-vehicle-label-setting"
-              className="c-page__select"
+              className="m-settings-page__select"
               value={settings.ladderVehicleLabel}
               onChange={setLadderVehicleLabel(dispatch)}
             >
@@ -51,14 +51,14 @@ const SettingsPage = (): ReactElement<HTMLDivElement> => {
             </select>
           </div>
 
-          <div className="c-page__section-row">
-            <div className="c-page__section-row-icon">
-              {mapIcon("c-page__section-row-icon-path")}
+          <div className="m-settings-page__row">
+            <div className="m-settings-page__icon">
+              {mapIcon("m-settings-page__icon-path")}
             </div>
-            <div className="c-page__section-row-label">Map</div>
+            <div className="m-settings-page__label">Map</div>
             <select
               id="map-vehicle-label-setting"
-              className="c-page__select"
+              className="m-settings-page__select"
               value={settings.shuttleVehicleLabel}
               onChange={setShuttleVehicleLabel(dispatch)}
             >

--- a/assets/tests/components/__snapshots__/settingsPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/settingsPage.test.tsx.snap
@@ -21,13 +21,13 @@ exports[`SettingsPage renders 1`] = `
         Vehicle Label
       </h2>
       <div
-        className="c-page__section-row"
+        className="m-settings-page__row"
       >
         <div
-          className="c-page__section-row-icon"
+          className="m-settings-page__icon"
         >
           <span
-            className="c-page__section-row-icon-path"
+            className="m-settings-page__icon-path"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -36,12 +36,12 @@ exports[`SettingsPage renders 1`] = `
           />
         </div>
         <div
-          className="c-page__section-row-label"
+          className="m-settings-page__label"
         >
           Route Ladders
         </div>
         <select
-          className="c-page__select"
+          className="m-settings-page__select"
           id="ladder-vehicle-label-setting"
           onChange={[Function]}
           value={1}
@@ -59,13 +59,13 @@ exports[`SettingsPage renders 1`] = `
         </select>
       </div>
       <div
-        className="c-page__section-row"
+        className="m-settings-page__row"
       >
         <div
-          className="c-page__section-row-icon"
+          className="m-settings-page__icon"
         >
           <span
-            className="c-page__section-row-icon-path"
+            className="m-settings-page__icon-path"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
@@ -74,12 +74,12 @@ exports[`SettingsPage renders 1`] = `
           />
         </div>
         <div
-          className="c-page__section-row-label"
+          className="m-settings-page__label"
         >
           Map
         </div>
         <select
-          className="c-page__select"
+          className="m-settings-page__select"
           id="map-vehicle-label-setting"
           onChange={[Function]}
           value={2}


### PR DESCRIPTION
Asana Task: [Settings Inputs could be more responsive](https://app.asana.com/0/1148853526253426/1187547356580673)

Before:
<img width="349" alt="Screen Shot 2020-08-06 at 16 40 50" src="https://user-images.githubusercontent.com/23065557/89580604-a13f4080-d803-11ea-8e7c-f505f492518c.png">

After:
![Kapture 2020-08-06 at 16 39 52](https://user-images.githubusercontent.com/23065557/89580627-a7352180-d803-11ea-8758-ca8950d85492.gif)


To completely prevent the problem at those very small screen sizes would require a design for how to put the dropdown below the label, which isn't worth it. It's at least readable and usable at these small sizes now.

Only the last commit has the change. The other two commits are cleanups from while I figured out how the settings page works.