### PR TITLE
Turn block waivers into notifications

### DIFF
--- a/lib/concentrate/consumer/stop_time_updates.ex
+++ b/lib/concentrate/consumer/stop_time_updates.ex
@@ -65,7 +65,7 @@ defmodule Concentrate.Consumer.StopTimeUpdates do
   @spec block_waivers_by_block_key(
           block_keys_set(),
           StopTimeUpdatesByTrip.t()
-        ) :: BlockWaiverStore.block_waivers_by_block_key()
+        ) :: BlockWaiver.block_waivers_by_block_key()
   defp block_waivers_by_block_key(
          block_keys_set,
          stop_time_updates_by_trip

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -12,11 +12,11 @@ defmodule Notifications.Notification do
           trip_ids: [Trip.id()]
         }
 
-  defstruct ~w[
-    created_at
-    reason
-    route_ids
-    run_ids
-    trip_ids
-  ]a
+  defstruct [
+    :created_at,
+    :reason,
+    :route_ids,
+    :run_ids,
+    :trip_ids
+  ]
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -1,0 +1,22 @@
+defmodule Notifications.Notification do
+  alias Schedule.Route
+  alias Schedule.Trip
+
+  @type notification_reason :: :manpower | :disabled | :diverted | :accident
+
+  @type t() :: %__MODULE__{
+          created_at: Util.Time.timestamp(),
+          reason: notification_reason(),
+          route_ids: [Route.id()],
+          run_ids: [String.t()],
+          trip_ids: [Trip.id()]
+        }
+
+  defstruct ~w[
+    created_at
+    reason
+    route_ids
+    run_ids
+    trip_ids
+  ]a
+end

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -72,11 +72,15 @@ defmodule Notifications.NotificationServer do
 
       block = block_fn.(block_id, service_id)
 
+      block_date = Block.date_for_block(block)
+
       waiver_range = Range.new(block_waiver.start_time, block_waiver.end_time)
 
       trips =
         Enum.reject(block.trips, fn trip ->
-          trip_range = Range.new(trip.start_time, trip.end_time)
+          trip_start_timestamp = Util.Time.timestamp_for_time_of_day(trip.start_time, block_date)
+          trip_end_timestamp = Util.Time.timestamp_for_time_of_day(trip.end_time, block_date)
+          trip_range = Range.new(trip_start_timestamp, trip_end_timestamp)
           Range.disjoint?(trip_range, waiver_range)
         end)
 

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -1,0 +1,116 @@
+defmodule Notifications.NotificationServer do
+  use GenServer
+
+  alias Notifications.Notification
+  alias Realtime.BlockWaiver
+  alias Schedule.Block
+
+  require Logger
+
+  @type __MODULE__ :: {schedule_data_mod :: module()}
+
+  defstruct [:schedule_data_mod]
+
+  # Client
+
+  @spec default_name() :: GenServer.name()
+  def default_name(), do: Notifications.NotificationServer
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    schedule_data_mod = Keyword.get(opts, :schedule_data_mod, Schedule)
+    GenServer.start_link(__MODULE__, %{schedule_data_mod: schedule_data_mod}, name: name)
+  end
+
+  @spec new_block_waivers(BlockWaiver.block_waivers_by_block_key(), GenServer.server()) :: :ok
+  def new_block_waivers(new_waivers_by_block_key, server \\ default_name()) do
+    GenServer.cast(server, {:new_block_waivers, new_waivers_by_block_key})
+  end
+
+  # Server
+
+  @impl GenServer
+  def init(initial_state) do
+    schedule_data_mod = Map.fetch!(initial_state, :schedule_data_mod)
+    {:ok, %__MODULE__{schedule_data_mod: schedule_data_mod}}
+  end
+
+  @impl true
+  def handle_cast({:new_block_waivers, new_block_waivers_by_block_key}, state) do
+    new_notifications =
+      new_block_waivers_by_block_key
+      |> convert_new_block_waivers_to_notifications(state.schedule_data_mod)
+
+    if !Enum.empty?(new_notifications) do
+      Logger.warn(
+        "NotificationServer created new notifications new_notifications=#{
+          inspect(new_notifications)
+        }"
+      )
+    end
+
+    {:noreply, state}
+  end
+
+  @spec convert_new_block_waivers_to_notifications([BlockWaiver.t()], module()) :: [
+          Notification.t()
+        ]
+  defp convert_new_block_waivers_to_notifications(new_block_waivers, schedule_data_mod) do
+    new_block_waivers
+    |> Enum.flat_map(fn {block_key, block_waivers} ->
+      Enum.map(
+        block_waivers,
+        &convert_block_waiver_to_notification(block_key, &1, schedule_data_mod)
+      )
+    end)
+    |> Enum.filter(& &1)
+  end
+
+  @spec convert_block_waiver_to_notification(Block.key(), BlockWaiver.t(), module()) ::
+          Notification.t() | nil
+  defp convert_block_waiver_to_notification(
+         {block_id, service_id},
+         block_waiver,
+         schedule_data_mod
+       ) do
+    if reason = get_notification_reason(block_waiver) do
+      block = apply(schedule_data_mod, :block, [block_id, service_id])
+
+      waiver_range = Range.new(block_waiver.start_time, block_waiver.end_time)
+
+      trips =
+        Enum.reject(block.trips, fn trip ->
+          trip_range = Range.new(trip.start_time, trip.end_time)
+          Range.disjoint?(trip_range, waiver_range)
+        end)
+
+      created_at = Util.Time.now()
+      route_ids = trips |> Enum.map(& &1.route_id) |> Enum.uniq()
+      run_ids = trips |> Enum.map(& &1.run_id) |> Enum.uniq()
+      trip_ids = trips |> Enum.map(& &1.id)
+
+      %Notification{
+        reason: reason,
+        created_at: created_at,
+        route_ids: route_ids,
+        run_ids: run_ids,
+        trip_ids: trip_ids
+      }
+    end
+  end
+
+  @spec get_notification_reason(BlockWaiver.t()) :: Notification.notification_reason() | nil
+  defp get_notification_reason(block_waiver) do
+    # TODO: Once a list of possible values of BlockWaiver.cause_id is
+    # available, match on that rather than the text description.
+    #
+    case block_waiver.cause_description do
+      "B - Manpower" -> :manpower
+      "D - Disabled" -> :disabled
+      "E - Diverted" -> :diverted
+      "G - Accident" -> :accident
+      _ -> nil
+    end
+  end
+end

--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -16,6 +16,8 @@ defmodule Realtime.BlockWaiver do
           remark: String.t() | nil
         }
 
+  @type block_waivers_by_block_key :: %{Block.key() => [t()]}
+
   @enforce_keys [
     :start_time,
     :end_time,

--- a/lib/realtime/block_waiver.ex
+++ b/lib/realtime/block_waiver.ex
@@ -9,8 +9,8 @@ defmodule Realtime.BlockWaiver do
   alias Realtime.StopTimeUpdatesByTrip
 
   @type t :: %__MODULE__{
-          start_time: Util.Time.time_of_day(),
-          end_time: Util.Time.time_of_day(),
+          start_time: Util.Time.timestamp(),
+          end_time: Util.Time.timestamp(),
           cause_id: integer(),
           cause_description: String.t(),
           remark: String.t() | nil
@@ -42,7 +42,7 @@ defmodule Realtime.BlockWaiver do
     block.trips
     |> Enum.flat_map(&trip_stop_time_waivers(&1, stop_time_updates_by_trip))
     |> group_consecutive_sequences()
-    |> Enum.map(&from_trip_stop_time_waivers(&1, date_for_block(block)))
+    |> Enum.map(&from_trip_stop_time_waivers(&1, Block.date_for_block(block)))
   end
 
   @type trip_stop_time_waiver :: {Util.Time.time_of_day(), StopTimeUpdate.t() | nil}
@@ -133,25 +133,5 @@ defmodule Realtime.BlockWaiver do
       cause_description: StopTimeUpdate.cause_description(stu),
       remark: StopTimeUpdate.remark(stu)
     }
-  end
-
-  @spec date_for_block(Block.t()) :: Date.t()
-  defp date_for_block(block) do
-    active_blocks_fn =
-      Application.get_env(:realtime, :active_blocks_fn, &Schedule.active_blocks/2)
-
-    now = Util.Time.now()
-    one_hour_ago = now - 60 * 60
-    in_ten_minutes = now + 10 * 60
-
-    {date, _blocks} =
-      one_hour_ago
-      |> active_blocks_fn.(in_ten_minutes)
-      |> Enum.find(
-        {Util.Time.today(), []},
-        fn {_date, blocks} -> Enum.member?(blocks, block) end
-      )
-
-    date
   end
 end

--- a/lib/realtime/block_waiver_store.ex
+++ b/lib/realtime/block_waiver_store.ex
@@ -107,6 +107,10 @@ defmodule Realtime.BlockWaiverStore do
      }}
   end
 
+  @spec waiver_diff(
+          BlockWaiver.block_waivers_by_block_key(),
+          BlockWaiver.block_waivers_by_block_key()
+        ) :: %{Block.key() => MapSet.t()}
   defp waiver_diff(old_block_waivers_by_block_key, new_block_waivers_by_block_key) do
     Enum.reduce(
       new_block_waivers_by_block_key,

--- a/lib/realtime/block_waiver_store.ex
+++ b/lib/realtime/block_waiver_store.ex
@@ -10,22 +10,38 @@ defmodule Realtime.BlockWaiverStore do
   alias Realtime.BlockWaiver
 
   @type t :: %__MODULE__{
-          block_waivers_by_block_key: block_waivers_by_block_key()
+          block_waivers_by_block_key: BlockWaiver.block_waivers_by_block_key(),
+          notification_server_mod: GenServer.name(),
+          never_set: boolean()
         }
 
-  @type block_waivers_by_block_key :: %{Block.key() => [BlockWaiver.t()]}
-
-  defstruct block_waivers_by_block_key: %{}
+  defstruct [
+    :notification_server_mod,
+    block_waivers_by_block_key: %{},
+    never_set: true
+  ]
 
   # Client
 
   @spec default_name() :: GenServer.name()
   def default_name(), do: Realtime.BlockWaiverStore
 
+  @spec default_notification_server_mod :: module()
+  def default_notification_server_mod(), do: Notifications.NotificationServer
+
   @spec start_link() :: GenServer.on_start()
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, nil, name: Keyword.get(opts, :name, default_name()))
+    name = Keyword.get(opts, :name, default_name())
+
+    notification_server_mod =
+      Keyword.get(opts, :notification_server_mod, default_notification_server_mod())
+
+    initial_state = %__MODULE__{
+      notification_server_mod: notification_server_mod
+    }
+
+    GenServer.start_link(__MODULE__, initial_state, name: name)
   end
 
   @spec block_waivers_for_block_and_service(Block.id(), Service.id()) :: [BlockWaiver.t()]
@@ -36,8 +52,8 @@ defmodule Realtime.BlockWaiverStore do
     GenServer.call(server, {:block_waivers_for_block_and_service, block_id, service_id})
   end
 
-  @spec set(block_waivers_by_block_key()) :: :ok
-  @spec set(block_waivers_by_block_key(), GenServer.server()) :: :ok
+  @spec set(BlockWaiver.block_waivers_by_block_key()) :: :ok
+  @spec set(BlockWaiver.block_waivers_by_block_key(), GenServer.server()) :: :ok
   def set(block_waivers_by_block_key, server \\ default_name()) do
     GenServer.cast(server, {:set, block_waivers_by_block_key})
   end
@@ -45,8 +61,8 @@ defmodule Realtime.BlockWaiverStore do
   # Server
 
   @impl GenServer
-  def init(_) do
-    {:ok, %__MODULE__{}}
+  def init(initial_state) do
+    {:ok, initial_state}
   end
 
   @impl true
@@ -64,14 +80,52 @@ defmodule Realtime.BlockWaiverStore do
 
   @impl true
   def handle_cast(
-        {:set, block_waivers_by_block_key},
+        {:set, new_block_waivers_by_block_key},
         %__MODULE__{} = state
       ) do
+    # We have this never_set flag to detect if this is the first time this
+    # particular instance of BlockWaiverStore has had set called on it.
+    # Consider what happens if we don't do this check: the first time
+    # set is called, it calls waiver_diff to compare
+    # new_block_waivers_by_block_key against the existing state. But
+    # since we just initialized that state to an empty map, all block
+    # waivers will appear to be new, and we end up possibly sending
+    # notifications for waivers to users who have already seen them.
+    #
+    if(!state.never_set) do
+      new_block_waivers =
+        waiver_diff(state.block_waivers_by_block_key, new_block_waivers_by_block_key)
+
+      apply(state.notification_server_mod, :new_block_waivers, [new_block_waivers])
+    end
+
     {:noreply,
-     Map.put(
-       state,
-       :block_waivers_by_block_key,
-       block_waivers_by_block_key
-     )}
+     %__MODULE__{
+       state
+       | block_waivers_by_block_key: new_block_waivers_by_block_key,
+         never_set: false
+     }}
+  end
+
+  defp waiver_diff(old_block_waivers_by_block_key, new_block_waivers_by_block_key) do
+    Enum.reduce(
+      new_block_waivers_by_block_key,
+      %{},
+      fn {block_key, new_block_waiver_list}, result ->
+        old_block_waiver_list = Map.get(old_block_waivers_by_block_key, block_key, [])
+        old_block_waiver_set = MapSet.new(old_block_waiver_list)
+
+        newly_appearing_waivers =
+          new_block_waiver_list
+          |> MapSet.new()
+          |> MapSet.difference(old_block_waiver_set)
+
+        if MapSet.size(newly_appearing_waivers) == 0 do
+          result
+        else
+          Map.put(result, block_key, MapSet.to_list(newly_appearing_waivers))
+        end
+      end
+    )
   end
 end

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -155,5 +155,25 @@ defmodule Schedule.Block do
 
   def id_sans_overload(id), do: String.replace(id, overload_id_regex(), "")
 
+  @spec date_for_block(t()) :: Date.t()
+  def date_for_block(block) do
+    active_blocks_fn =
+      Application.get_env(:realtime, :active_blocks_fn, &Schedule.active_blocks/2)
+
+    now = Util.Time.now()
+    one_hour_ago = now - 60 * 60
+    in_ten_minutes = now + 10 * 60
+
+    {date, _blocks} =
+      one_hour_ago
+      |> active_blocks_fn.(in_ten_minutes)
+      |> Enum.find(
+        {Util.Time.today(), []},
+        fn {_date, blocks} -> Enum.member?(blocks, block) end
+      )
+
+    date
+  end
+
   defp overload_id_regex(), do: ~r/-OL.+$/
 end

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -21,6 +21,7 @@ defmodule Skate.Application do
           [
             Schedule.Supervisor,
             TrainVehicles.Supervisor,
+            Notifications.NotificationServer,
             Realtime.Supervisor
           ]
         else

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -56,8 +56,10 @@ defmodule Notifications.NotificationServerTest do
 
   describe "handle_cast/2" do
     setup do
-      reassign_env(:realtime, :block_fn, fn _, _ ->
-        @block
+      reassign_env(:realtime, :block_fn, fn _, _ -> @block end)
+
+      reassign_env(:realtime, :active_blocks_fn, fn _, _ ->
+        %{~D[2020-08-17] => [@block]}
       end)
     end
 
@@ -76,6 +78,9 @@ defmodule Notifications.NotificationServerTest do
         "G - Accident" => :accident
       }
 
+      # Midnight Eastern time, 8/17/2020
+      midnight = 1_597_636_800
+
       for {reason_string, reason_atom} <- reasons_map do
         log =
           capture_log(fn ->
@@ -84,15 +89,15 @@ defmodule Notifications.NotificationServerTest do
                %{
                  {"block1", "service1"} => [
                    %BlockWaiver{
-                     start_time: 100,
-                     end_time: 500,
+                     start_time: midnight + 100,
+                     end_time: midnight + 500,
                      cause_id: 666,
                      cause_description: reason_string,
                      remark: "some_remark"
                    },
                    %BlockWaiver{
-                     start_time: 0,
-                     end_time: 86400,
+                     start_time: midnight,
+                     end_time: midnight + 86400,
                      cause_id: 999,
                      cause_description: "W - Whatever",
                      remark: "Ignored due to unrecognized cause_description"

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -1,0 +1,116 @@
+defmodule Notifications.NotificationServerTest do
+  use ExUnit.Case, async: true
+
+  alias Notifications.NotificationServer
+  alias Realtime.BlockWaiver
+  alias Schedule.Block
+  alias Schedule.Trip
+
+  import ExUnit.CaptureLog, only: [capture_log: 1]
+
+  require Logger
+
+  defmodule MockSchedule do
+    def block(block_id, service_id) do
+      map = %{
+        {"block1", "service1"} => %Block{
+          id: "block1",
+          service_id: "service1",
+          start_time: 1,
+          end_time: 1000,
+          trips: [
+            %Trip{
+              id: "trip1",
+              block_id: "block1",
+              run_id: "run1",
+              route_id: "1",
+              start_time: 50,
+              end_time: 200
+            },
+            %Trip{
+              id: "trip2",
+              block_id: "block1",
+              run_id: "run2",
+              route_id: "2",
+              start_time: 400,
+              end_time: 800
+            },
+            %Trip{
+              id: "not_covered_by_waiver",
+              block_id: "block1",
+              run_id: "run3",
+              route_id: "3",
+              start_time: 501,
+              end_time: 800
+            }
+          ]
+        }
+      }
+
+      Map.get(map, {block_id, service_id})
+    end
+  end
+
+  describe "start_link/1" do
+    test "starts up and lives" do
+      {:ok, server} = NotificationServer.start_link(name: :start_link)
+
+      Process.sleep(10)
+
+      assert Process.alive?(server)
+    end
+  end
+
+  describe "handle_cast/2" do
+    test "creates new notifications for waivers with recognized reason" do
+      log =
+        capture_log(fn ->
+          NotificationServer.handle_cast({:new_block_waivers, %{}}, %{
+            schedule_data_mod: MockSchedule
+          })
+        end)
+
+      assert log == ""
+
+      reasons_map = %{
+        "B - Manpower" => :manpower,
+        "D - Disabled" => :disabled,
+        "E - Diverted" => :diverted,
+        "G - Accident" => :accident
+      }
+
+      for {reason_string, reason_atom} <- reasons_map do
+        log =
+          capture_log(fn ->
+            NotificationServer.handle_cast(
+              {:new_block_waivers,
+               %{
+                 {"block1", "service1"} => [
+                   %BlockWaiver{
+                     start_time: 100,
+                     end_time: 500,
+                     cause_id: 666,
+                     cause_description: reason_string,
+                     remark: "some_remark"
+                   },
+                   %BlockWaiver{
+                     start_time: 0,
+                     end_time: 86400,
+                     cause_id: 999,
+                     cause_description: "W - Whatever",
+                     remark: "Ignored due to unrecognized cause_description"
+                   }
+                 ]
+               }},
+              %{schedule_data_mod: MockSchedule}
+            )
+          end)
+
+        assert String.contains?(log, "reason: :#{reason_atom}")
+        assert String.contains?(log, "route_ids: [\"1\", \"2\"]")
+        assert String.contains?(log, "run_ids: [\"run1\", \"run2\"]")
+        assert String.contains?(log, "trip_ids: [\"trip1\", \"trip2\"]")
+      end
+    end
+  end
+end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -54,6 +54,13 @@ defmodule Notifications.NotificationServerTest do
     end
   end
 
+  describe "new_block_waivers/2" do
+    test "sends appropriate cast" do
+      NotificationServer.new_block_waivers("dummy list of new waivers", self())
+      assert_received({:"$gen_cast", {:new_block_waivers, "dummy list of new waivers"}})
+    end
+  end
+
   describe "handle_cast/2" do
     setup do
       reassign_env(:realtime, :block_fn, fn _, _ -> @block end)

--- a/test/realtime/block_waiver_store_test.exs
+++ b/test/realtime/block_waiver_store_test.exs
@@ -16,6 +16,37 @@ defmodule Realtime.BlockWaiverStoreTest do
     {"block1", "service1"} => @block_waivers
   }
 
+  defmodule MockNotificationServer do
+    use GenServer
+
+    def start_link() do
+      GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+    end
+
+    def new_block_waivers(new_waivers) do
+      GenServer.cast(__MODULE__, new_waivers)
+    end
+
+    def last_received_cast() do
+      GenServer.call(__MODULE__, :last_received_cast)
+    end
+
+    @impl GenServer
+    def init(_) do
+      {:ok, []}
+    end
+
+    @impl true
+    def handle_cast(message, state) do
+      {:noreply, [message | state]}
+    end
+
+    @impl true
+    def handle_call(:last_received_cast, _from, state) do
+      {:reply, List.first(state), state}
+    end
+  end
+
   describe "start_link/1" do
     test "starts up and lives" do
       {:ok, server} = BlockWaiverStore.start_link(name: :start_link)
@@ -77,6 +108,81 @@ defmodule Realtime.BlockWaiverStoreTest do
       assert BlockWaiverStore.set(@block_waivers_by_block_key, server) == :ok
 
       assert %{block_waivers_by_block_key: @block_waivers_by_block_key} = :sys.get_state(server)
+    end
+
+    test "sends new BlockWaivers to the notification server" do
+      {:ok, _} = MockNotificationServer.start_link()
+
+      {:ok, server} =
+        BlockWaiverStore.start_link(
+          name: :send_test,
+          notification_server_mod: MockNotificationServer
+        )
+
+      # This is the first time we're storing waivers, so no notification.
+      block_waivers_by_block_key = @block_waivers_by_block_key
+      BlockWaiverStore.set(block_waivers_by_block_key, server)
+      refute_received {:new_block_waivers, _}
+
+      # Called again, but with the same arguments, so the difference
+      # between iterations is empty.
+      BlockWaiverStore.set(block_waivers_by_block_key, server)
+      Process.sleep(10)
+      assert MockNotificationServer.last_received_cast() == %{}
+
+      # Called with a waiver added; existing waiver for block ignored.
+      new_waiver_1 = %BlockWaiver{
+        start_time: 15,
+        end_time: 25,
+        cause_id: 22,
+        cause_description: "Q - Fake",
+        remark: "Q:1234"
+      }
+
+      block_waivers_by_block_key = %{
+        {"block1", "service1"} => [new_waiver_1 | @block_waivers]
+      }
+
+      BlockWaiverStore.set(block_waivers_by_block_key, server)
+      Process.sleep(10)
+
+      assert MockNotificationServer.last_received_cast() == %{
+               {"block1", "service1"} => [new_waiver_1]
+             }
+
+      # Two existing waivers continue on, and are not passed to the
+      # notification server. Two notifications on two other blocks
+      # enter however.
+
+      new_waiver_2 = %BlockWaiver{
+        start_time: 35,
+        end_time: 45,
+        cause_id: 42,
+        cause_description: "R - Faker",
+        remark: "R:2345"
+      }
+
+      new_waiver_3 = %BlockWaiver{
+        start_time: 55,
+        end_time: 65,
+        cause_id: 62,
+        cause_description: "S - Fakest",
+        remark: "S:3456"
+      }
+
+      block_waivers_by_block_key = %{
+        {"block1", "service1"} => [new_waiver_1 | @block_waivers],
+        {"block2", "service2"} => [new_waiver_2],
+        {"block3", "service3"} => [new_waiver_3]
+      }
+
+      BlockWaiverStore.set(block_waivers_by_block_key, server)
+      Process.sleep(10)
+
+      assert MockNotificationServer.last_received_cast() == %{
+               {"block2", "service2"} => [new_waiver_2],
+               {"block3", "service3"} => [new_waiver_3]
+             }
     end
   end
 end

--- a/test/realtime/block_waiver_store_test.exs
+++ b/test/realtime/block_waiver_store_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.BlockWaiverStoreTest do
 
   alias Realtime.{BlockWaiver, BlockWaiverStore}
 
+  import Test.Support.Helpers
+
   @block_waivers [
     %BlockWaiver{
       start_time: 10,
@@ -113,11 +115,13 @@ defmodule Realtime.BlockWaiverStoreTest do
     test "sends new BlockWaivers to the notification server" do
       {:ok, _} = MockNotificationServer.start_link()
 
-      {:ok, server} =
-        BlockWaiverStore.start_link(
-          name: :send_test,
-          notification_server_mod: MockNotificationServer
-        )
+      reassign_env(
+        :notifications,
+        :notifications_server_new_block_waivers_fn,
+        &MockNotificationServer.new_block_waivers/1
+      )
+
+      {:ok, server} = BlockWaiverStore.start_link(name: :send_test)
 
       # This is the first time we're storing waivers, so no notification.
       block_waivers_by_block_key = @block_waivers_by_block_key


### PR DESCRIPTION
Block waivers are now forwarded to a new NotificationsServer, which
creates appropriate notifications for each. For the moment, we're not
doing anything with said notifications except logging them.