### PR TITLE
in hastus export, sort 0-duration trips correctly

### DIFF
--- a/hastus_oig/skate.id
+++ b/hastus_oig/skate.id
@@ -25,6 +25,7 @@ file trips
          criteria csc_name { value 'Get(crew_schedule).csc_name' }
          criteria dty_number { value 'Get(duty).dty_number' }
          criteria trp_time_start { value 'trp_time_start' }
+         criteria trp_time_end { value 'trp_time_end' }
          }
 
       line trip


### PR DESCRIPTION
they can share a start_time with the following trip,
so you need to check the end_time to sort them correctly

Example:
before:
```
abc40011;123;    9077;Crad-338;06:00;09:00;cabot;cabot;  rad;   45682341
abc40011;123;    9077;Crad-338;06:00;06:00;cabot;cabot;;   45684791
```
after:
```
abc40011;123;    9077;Crad-338;06:00;06:00;cabot;cabot;;   45684791
abc40011;123;    9077;Crad-338;06:00;09:00;cabot;cabot;  rad;   45682341
```