### PR TITLE
fullstory event for delivering a notification

### DIFF
--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -6,7 +6,7 @@ import { Notification, NotificationReason } from "../realtime.d"
 import { formattedTimeDiff, now } from "../util/dateTime"
 import PropertiesList from "./propertiesList"
 
-const fullstoryEvent = (): void => {
+const deliveryFullstoryEvent = (): void => {
   if (window.FS && window.username) {
     window.FS.event("Notification delivered")
   }
@@ -16,7 +16,7 @@ export const Notifications = () => {
   const [notifications, setNotifications] = useState<Notification[]>([])
   const addNotification = (notification: Notification): void => {
     if (featureIsEnabled("notifications")) {
-      fullstoryEvent()
+      deliveryFullstoryEvent()
       setNotifications((previous) => [...previous, notification])
     }
   }

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -6,10 +6,17 @@ import { Notification, NotificationReason } from "../realtime.d"
 import { formattedTimeDiff, now } from "../util/dateTime"
 import PropertiesList from "./propertiesList"
 
+const fullstoryEvent = (): void => {
+  if (window.FS && window.username) {
+    window.FS.event("Notification delivered")
+  }
+}
+
 export const Notifications = () => {
   const [notifications, setNotifications] = useState<Notification[]>([])
   const addNotification = (notification: Notification): void => {
     if (featureIsEnabled("notifications")) {
+      fullstoryEvent()
       setNotifications((previous) => [...previous, notification])
     }
   }

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -17,6 +17,7 @@ declare global {
           email?: string
         }
       ): void
+      event(event: string): void
     }
     ResizeObserver: typeof ResizeObserver
     drift: {

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -59,6 +59,24 @@ describe("Notification", () => {
     expect(wrapper.find(".m-notifications__card")).toHaveLength(1)
   })
 
+  test("makes a fullstory event when a notification arrives", () => {
+    let handler: (notification: Notification) => void
+    ;(useNotifications as jest.Mock).mockImplementationOnce((h) => {
+      handler = h
+    })
+    mount(<Notifications />)
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+    act(() => {
+      handler!(notification)
+    })
+    expect(window.FS!.event).toHaveBeenCalledWith("Notification delivered")
+    window.FS = originalFS
+    window.username = originalUsername
+  })
+
   test("can close notification", () => {
     mockUseStateOnce([notification])
     const wrapper = mount(<Notifications />)


### PR DESCRIPTION
Asana Task:
[Test Fullstory custom event tracking using dummy cards](https://app.asana.com/0/1148853526253426/1191912668336954)
part of [Notifications tracking?](https://app.asana.com/0/1148853526253426/1191223285175310)

This sends "Notification delivered" on every notification (but doesn't do the "Notification stacked" or "Notification VPP unavailable" that the second task asks for.)

I verified with https://github.com/mbta/skate/commit/fc0bcaccf604534511d410d50ed759929c8e799f (which is currently deployed to dev) that `FS.event()` is getting called, and I think that it's getting sent to fullstory, but it's a little opaque how fullstory does its stuff, so @ahakuta , can you check that the event made it to the fullstory dashboard? (It'd be from me on firefox this afternoon)