### PR TITLE
send number of stacked notifications to fullstory

### DIFF
--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -6,9 +6,11 @@ import { Notification, NotificationReason } from "../realtime.d"
 import { formattedTimeDiff, now } from "../util/dateTime"
 import PropertiesList from "./propertiesList"
 
-const deliveryFullstoryEvent = (): void => {
+const deliveryFullstoryEvent = (numStacked: number): void => {
   if (window.FS && window.username) {
-    window.FS.event("Notification delivered")
+    window.FS.event("Notification delivered", {
+      num_stacked_int: numStacked,
+    })
   }
 }
 
@@ -16,8 +18,11 @@ export const Notifications = () => {
   const [notifications, setNotifications] = useState<Notification[]>([])
   const addNotification = (notification: Notification): void => {
     if (featureIsEnabled("notifications")) {
-      deliveryFullstoryEvent()
-      setNotifications((previous) => [...previous, notification])
+      setNotifications((previous) => {
+        const newNotifications = [...previous, notification]
+        deliveryFullstoryEvent(newNotifications.length)
+        return newNotifications
+      })
     }
   }
   const removeNotification = (id: number): void => {

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -17,7 +17,7 @@ declare global {
           email?: string
         }
       ): void
-      event(event: string): void
+      event(event: string, properties?: object): void
     }
     ResizeObserver: typeof ResizeObserver
     drift: {

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -72,7 +72,9 @@ describe("Notification", () => {
     act(() => {
       handler!(notification)
     })
-    expect(window.FS!.event).toHaveBeenCalledWith("Notification delivered")
+    expect(window.FS!.event).toHaveBeenCalledWith("Notification delivered", {
+      num_stacked_int: 1,
+    })
     window.FS = originalFS
     window.username = originalUsername
   })


### PR DESCRIPTION
Asana Task: [Notifications tracking](https://app.asana.com/0/1148853526253426/1191223285175310)

That task lists 5 notifications, only 1 of which needed to be done by this PR.
* Notification delivered: handled by #835 
* Notification stacked: this PR
* Notification VPP unavailable: not possible yet
* Jumps to VPP: covered by CSS selector `.m-notifications__card-info`
* Closes notification: covered by CSS selector `.m-notifications__close`

Instead of making a new event for it, I added a property `num_stacked_int` to the existing event. I assume you can access those properties on fullstory and filter to where the number stacked ≥2. Is that okay @ahakuta ?