### PR TITLE
Force geonames to use TLS v1.2

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -119,6 +119,8 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :ssl, protocol_version: :"tlsv1.2"
+
 # Fake Cognito authentication
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -30,11 +30,13 @@ defmodule Geonames do
         |> Jason.decode!(strings: :copy)
 
       response ->
-        sanitized_url = if geonames_token do
-          String.replace(url, geonames_token, "SECRET")
-        else
-          url
-        end
+        sanitized_url =
+          if geonames_token do
+            String.replace(url, geonames_token, "SECRET")
+          else
+            url
+          end
+
         Logger.warn(fn -> "Unexpected response from #{sanitized_url} : #{inspect(response)}" end)
         nil
     end

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -29,7 +29,12 @@ defmodule Geonames do
         |> Jason.decode!(strings: :copy)
 
       response ->
-        Logger.warn(fn -> "Unexpected response from #{url} : #{inspect(response)}" end)
+        sanitized_url = if geonames_token do
+          String.replace(url, geonames_token, "SECRET")
+        else
+          url
+        end
+        Logger.warn(fn -> "Unexpected response from #{sanitized_url} : #{inspect(response)}" end)
         nil
     end
   end

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -23,8 +23,7 @@ defmodule Geonames do
         token_param
       }"
 
-    # force TLS v1.2, see https://campezzi.ghost.io/httpoison-ssl-connection-closed/
-    case HTTPoison.get(url, [], ssl: [versions: [:"tlsv1.2"]]) do
+    case HTTPoison.get(url) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         body
         |> Jason.decode!(strings: :copy)

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -23,7 +23,8 @@ defmodule Geonames do
         token_param
       }"
 
-    case HTTPoison.get(url) do
+    # force TLS v1.2, see https://campezzi.ghost.io/httpoison-ssl-connection-closed/
+    case HTTPoison.get(url, [], ssl: [versions: [:"tlsv1.2"]]) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         body
         |> Jason.decode!(strings: :copy)


### PR DESCRIPTION
This is a guess as to what might fix [🐛Investigate Geonames access failures](https://app.asana.com/0/1148853526253426/1193058913335769)

The situation is most succinctly described here: https://campezzi.ghost.io/httpoison-ssl-connection-closed/

~I'll deploy to dev, and if that is the issue, then this should fix it.~
Dev only sees this error every few days, and without a specific way to reproduce it, I think we won't be able to see if this works until it's on prod where we'd be able to notice the errors stopping. We can revert it if it doesn't solve the problem on prod.