### PR TITLE
Realtime server tracks vehicles by trip ID

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -9,7 +9,10 @@ defmodule Notifications.Notification do
           reason: notification_reason(),
           route_ids: [Route.id()],
           run_ids: [String.t()],
-          trip_ids: [Trip.id()]
+          trip_ids: [Trip.id()],
+          operator_id: String.t() | nil,
+          operator_name: String.t() | nil,
+          current_route_id: Route.id() | nil
         }
 
   @derive Jason.Encoder
@@ -19,6 +22,9 @@ defmodule Notifications.Notification do
     :reason,
     :route_ids,
     :run_ids,
-    :trip_ids
+    :trip_ids,
+    :operator_id,
+    :operator_name,
+    :current_route_id
   ]
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -12,7 +12,7 @@ defmodule Notifications.Notification do
           trip_ids: [Trip.id()],
           operator_id: String.t() | nil,
           operator_name: String.t() | nil,
-          current_route_id: Route.id() | nil
+          route_id_at_creation: Route.id() | nil
         }
 
   @derive Jason.Encoder
@@ -25,6 +25,6 @@ defmodule Notifications.Notification do
     :trip_ids,
     :operator_id,
     :operator_name,
-    :current_route_id
+    :route_id_at_creation
   ]
 end

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -121,7 +121,7 @@ defmodule Notifications.NotificationServer do
         trip_ids: trip_ids,
         operator_id: operator_id,
         operator_name: operator_name,
-        current_route_id: route_id
+        route_id_at_creation: route_id
       }
     end
   end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -167,7 +167,10 @@ defmodule Notifications.NotificationServerTest do
                reason: ^cause_atom,
                route_ids: ["1", "2"],
                run_ids: ["run1", "run2"],
-               trip_ids: ["trip1", "trip2"]
+               trip_ids: ["trip1", "trip2"],
+               operator_name: "CHARLIE",
+               operator_id: "56785678",
+               route_id_at_creation: "SL9001"
              }
            ]}
         )

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -3,6 +3,7 @@ defmodule Notifications.NotificationServerTest do
 
   alias Notifications.NotificationServer
   alias Realtime.BlockWaiver
+  alias Realtime.Ghost
   alias Realtime.Vehicle
   alias Schedule.Block
   alias Schedule.Trip
@@ -44,6 +45,24 @@ defmodule Notifications.NotificationServerTest do
       }
     ]
   }
+
+  @ghost %Ghost{
+    id: "ghost1",
+    direction_id: 0,
+    route_id: "SL9001",
+    trip_id: "ghost-trip-1",
+    headsign: "headsign",
+    block_id: "block",
+    run_id: "ghost-run-1",
+    via_variant: "X",
+    layover_departure_time: nil,
+    scheduled_timepoint_status: %{
+      timepoint_id: "t2",
+      fraction_until_timepoint: 0.5
+    },
+    route_status: :on_route
+  }
+
   @vehicle %Vehicle{
     id: "y0507",
     label: "0507",
@@ -80,6 +99,87 @@ defmodule Notifications.NotificationServerTest do
     end_of_trip_type: :another_trip
   }
 
+  # Midnight Eastern time, 8/17/2020
+  @midnight 1_597_636_800
+
+  # See Realtime.BlockWaiver for the full mapping
+  @reasons_map %{
+    1 => {"J - Other", :other},
+    23 => {"B - Manpower", :manpower},
+    25 => {"D - Disabled", :disabled},
+    26 => {"E - Diverted", :diverted},
+    27 => {"F - Traffic", :traffic},
+    28 => {"G - Accident", :accident},
+    30 => {"I - Operator Error", :operator_error},
+    31 => {"K - Adjusted", :adjusted}
+  }
+
+  def assert_notification(cause_atom, cause_description, cause_id, server, opts \\ []) do
+    log =
+      capture_log(fn ->
+        waiver_map(cause_id, cause_description)
+        |> NotificationServer.new_block_waivers(server)
+
+        Process.sleep(50)
+      end)
+
+    operator_name = Keyword.get(opts, :operator_name)
+    operator_id = Keyword.get(opts, :operator_id)
+    route_id_at_creation = Keyword.get(opts, :route_id_at_creation)
+
+    assert_received(
+      {:notifications,
+       [
+         %Notifications.Notification{
+           created_at: _,
+           reason: ^cause_atom,
+           route_ids: ["1", "2"],
+           run_ids: ["run1", "run2"],
+           trip_ids: ["trip1", "trip2"],
+           operator_name: ^operator_name,
+           operator_id: ^operator_id,
+           route_id_at_creation: ^route_id_at_creation
+         }
+       ]}
+    )
+
+    assert String.contains?(log, "reason: :#{cause_atom}")
+    assert String.contains?(log, "route_ids: [\"1\", \"2\"]")
+    assert String.contains?(log, "run_ids: [\"run1\", \"run2\"]")
+    assert String.contains?(log, "trip_ids: [\"trip1\", \"trip2\"]")
+  end
+
+  def setup_server do
+    registry_name = :new_notifications_registry
+    start_supervised({Registry, keys: :duplicate, name: registry_name})
+    reassign_env(:notifications, :registry, registry_name)
+
+    {:ok, server} = NotificationServer.start_link(name: :new_notifications)
+    NotificationServer.subscribe(server)
+    {:ok, server}
+  end
+
+  def waiver_map(cause_id, cause_description) do
+    %{
+      {"block1", "service1"} => [
+        %BlockWaiver{
+          start_time: @midnight + 100,
+          end_time: @midnight + 500,
+          cause_id: cause_id,
+          cause_description: cause_description,
+          remark: "some_remark"
+        },
+        %BlockWaiver{
+          start_time: @midnight,
+          end_time: @midnight + 86400,
+          cause_id: 999,
+          cause_description: "W - Whatever",
+          remark: "Ignored due to unrecognized cause_description"
+        }
+      ]
+    }
+  end
+
   describe "start_link/1" do
     test "starts up and lives" do
       {:ok, server} = NotificationServer.start_link(name: :start_link)
@@ -99,17 +199,8 @@ defmodule Notifications.NotificationServerTest do
       end)
     end
 
-    test "broadcasts and logs new notifications for waivers with recognized reason" do
-      reassign_env(:realtime, :peek_at_vehicles_fn, fn _ ->
-        [@vehicle]
-      end)
-
-      registry_name = :new_notifications_registry
-      start_supervised({Registry, keys: :duplicate, name: registry_name})
-      reassign_env(:notifications, :registry, registry_name)
-
-      {:ok, server} = NotificationServer.start_link(name: :new_notifications)
-      NotificationServer.subscribe(server)
+    test "broadcasts and logs nothing if no new block waivers are received" do
+      {:ok, _server} = setup_server()
 
       log =
         capture_log(fn ->
@@ -117,68 +208,47 @@ defmodule Notifications.NotificationServerTest do
         end)
 
       assert log == ""
+    end
 
-      # See Realtime.BlockWaiver for the full mapping
-      reasons_map = %{
-        1 => {"J - Other", :other},
-        23 => {"B - Manpower", :manpower},
-        25 => {"D - Disabled", :disabled},
-        26 => {"E - Diverted", :diverted},
-        27 => {"F - Traffic", :traffic},
-        28 => {"G - Accident", :accident},
-        30 => {"I - Operator Error", :operator_error},
-        31 => {"K - Adjusted", :adjusted}
-      }
+    test "broadcasts and logs new notifications for waivers with recognized reason for vehicles" do
+      reassign_env(:realtime, :peek_at_vehicles_fn, fn _ ->
+        [@vehicle]
+      end)
 
-      # Midnight Eastern time, 8/17/2020
-      midnight = 1_597_636_800
+      {:ok, server} = setup_server()
 
-      for {cause_id, {cause_description, cause_atom}} <- reasons_map do
-        waiver_map = %{
-          {"block1", "service1"} => [
-            %BlockWaiver{
-              start_time: midnight + 100,
-              end_time: midnight + 500,
-              cause_id: cause_id,
-              cause_description: cause_description,
-              remark: "some_remark"
-            },
-            %BlockWaiver{
-              start_time: midnight,
-              end_time: midnight + 86400,
-              cause_id: 999,
-              cause_description: "W - Whatever",
-              remark: "Ignored due to unrecognized cause_description"
-            }
-          ]
-        }
-
-        log =
-          capture_log(fn ->
-            NotificationServer.new_block_waivers(waiver_map, server)
-            Process.sleep(50)
-          end)
-
-        assert_received(
-          {:notifications,
-           [
-             %Notifications.Notification{
-               created_at: _,
-               reason: ^cause_atom,
-               route_ids: ["1", "2"],
-               run_ids: ["run1", "run2"],
-               trip_ids: ["trip1", "trip2"],
-               operator_name: "CHARLIE",
-               operator_id: "56785678",
-               route_id_at_creation: "SL9001"
-             }
-           ]}
+      for {cause_id, {cause_description, cause_atom}} <- @reasons_map do
+        assert_notification(cause_atom, cause_description, cause_id, server,
+          operator_name: "CHARLIE",
+          operator_id: "56785678",
+          route_id_at_creation: "SL9001"
         )
+      end
+    end
 
-        assert String.contains?(log, "reason: :#{cause_atom}")
-        assert String.contains?(log, "route_ids: [\"1\", \"2\"]")
-        assert String.contains?(log, "run_ids: [\"run1\", \"run2\"]")
-        assert String.contains?(log, "trip_ids: [\"trip1\", \"trip2\"]")
+    test "broadcasts and logs new notifications for waivers with recognized reason for ghosts" do
+      reassign_env(:realtime, :peek_at_vehicles_fn, fn _ ->
+        [@ghost]
+      end)
+
+      {:ok, server} = setup_server()
+
+      for {cause_id, {cause_description, cause_atom}} <- @reasons_map do
+        assert_notification(cause_atom, cause_description, cause_id, server,
+          route_id_at_creation: "SL9001"
+        )
+      end
+    end
+
+    test "broadcasts and logs new notifications for waivers with recognized reason when no vehicle or ghost is associated" do
+      reassign_env(:realtime, :peek_at_vehicles_fn, fn _ ->
+        []
+      end)
+
+      {:ok, server} = setup_server()
+
+      for {cause_id, {cause_description, cause_atom}} <- @reasons_map do
+        assert_notification(cause_atom, cause_description, cause_id, server)
       end
     end
   end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -50,7 +50,7 @@ defmodule Realtime.ServerTest do
     id: "ghost-trip",
     direction_id: 0,
     route_id: "1",
-    trip_id: "trip",
+    trip_id: "t2",
     headsign: "headsign",
     block_id: "block",
     run_id: "123-9049",
@@ -239,6 +239,8 @@ defmodule Realtime.ServerTest do
       ets = :ets.new(__MODULE__, [:set, :protected, {:read_concurrency, true}])
 
       :ets.insert(ets, {{:route_id, "1"}, [@vehicle, @ghost]})
+      :ets.insert(ets, {{:trip_id, "t1"}, @vehicle})
+      :ets.insert(ets, {{:trip_id, "t2"}, @ghost})
       :ets.insert(ets, {:all_vehicles, [@vehicle, @shuttle]})
       :ets.insert(ets, {:all_shuttles, [@shuttle]})
 
@@ -259,6 +261,11 @@ defmodule Realtime.ServerTest do
 
     test "fetches all shuttles from the ets table", %{ets: ets} do
       assert Server.lookup({ets, :all_shuttles}) == [@shuttle]
+    end
+
+    test "fetches a vehicle by trip ID from the ets table", %{ets: ets} do
+      assert Server.lookup({ets, {:trip_id, "t1"}}) == @vehicle
+      assert Server.lookup({ets, {:trip_id, "t2"}}) == @ghost
     end
 
     test "searches all vehicles by any of run, vehicle, or operator", %{ets: ets} do


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1191003352789105

The realtime server now tracks vehicles by trip ID, and allows querying on one or more trip IDs. The notification server uses this feature to augment the `Notification`s that it creates by adding data from the active vehicle, if any.