### PR TITLE
bugfix tab bar was showing on mobile search page VPP

### DIFF
--- a/assets/css/_search_page.scss
+++ b/assets/css/_search_page.scss
@@ -4,7 +4,7 @@
   flex-direction: row;
   height: 100%;
   position: relative;
-  overflow-y: hidden;
+  overflow: visible;
 }
 
 .m-search-page__input-and-results {
@@ -50,12 +50,11 @@
     .m-search-page__input-and-results {
       flex: 1 1 auto;
       height: 100%;
-      overflow: scroll;
     }
 
     .m-search-page__map {
       // Needs to be hidden instead of not displayed so the map still gets drawn properly
-      position: absolute;
+      position: fixed;
       top: 100vh;
     }
   }


### PR DESCRIPTION
Asana Task: [🐛Left hand navigation bar overlaps VPP when I'm on search](https://app.asana.com/0/1148853526253426/1185722272692287)

the search page is smaller than the full screen to show the tab bar
the VPP needs overflow-x: visible to see it fullscreen over the tab bar
on mobile, the map is hidden by showing it below the screen
which needed overflow-y: hidden to keep the user from scrolling to it

this combination of overflow-x: visible; overflow-y: hidden doesn't work

this commit moves the map from position: absolute to position: fixed
so it doesn't need overflow-y: hidden to stay hidden