### PR TITLE
Notifiations show details from the matched vehicle

### DIFF
--- a/assets/css/_notifications.scss
+++ b/assets/css/_notifications.scss
@@ -51,7 +51,7 @@
 }
 
 .m-notification__description {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.5rem;
   margin-top: 0.25rem;
 }
 

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -124,17 +124,25 @@ const description = (notification: Notification): string => {
     case "manpower":
       return `OCC reported that an operator is not available on the ${routeIds}.`
     case "disabled":
-      return `OCC reported that a vehicle is disabled on the ${routeIds}.`
+      return `OCC reported that a vehicle is disabled on the ${
+        notification.routeIdAtCreation || routeIds
+      }.`
     case "diverted":
       return `OCC reported that an operator has been diverted from the ${routeIds}.`
     case "accident":
-      return `OCC reported that an operator has been in an accident on the ${routeIds}.`
+      return `OCC reported that an operator has been in an accident on the ${
+        notification.routeIdAtCreation || routeIds
+      }.`
     case "adjusted":
       return `OCC reported an adjustment on the ${routeIds}.`
     case "operator_error":
-      return `OCC reported an operator error on the ${routeIds}.`
+      return `OCC reported an operator error on the ${
+        notification.routeIdAtCreation || routeIds
+      }.`
     case "traffic":
-      return `OCC created a dispatcher note due to traffic on the ${routeIds}.`
+      return `OCC created a dispatcher note due to traffic on the ${
+        notification.routeIdAtCreation || routeIds
+      }.`
     case "other":
     default:
       return `OCC created a dispatcher note for the ${routeIds}.`

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -86,6 +86,14 @@ export const NotificationCard = ({
               label: "Run",
               value: notification.runIds.join(", "),
             },
+            {
+              label: "Operator",
+              value:
+                notification.operatorName !== undefined &&
+                notification.operatorId !== undefined
+                  ? `${notification.operatorName} #${notification.operatorId}`
+                  : null,
+            },
           ]}
         />
       </button>

--- a/assets/src/components/propertiesList.tsx
+++ b/assets/src/components/propertiesList.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export interface Property {
   label: string
-  value: string
+  value: string | null
   classNameModifier?: string
 }
 
@@ -118,18 +118,19 @@ const PropertyRow = ({
 }: {
   property: Property
   highlightText?: string
-}) => (
-  <tr
-    className={`m-properties-list__property ${modifiedClassName(
-      classNameModifier
-    )}`}
-  >
-    <td className="m-properties-list__property-label">{label}</td>
-    <td className="m-properties-list__property-value">
-      <Highlighted content={value} highlightText={highlightText} />
-    </td>
-  </tr>
-)
+}) =>
+  value === null ? null : (
+    <tr
+      className={`m-properties-list__property ${modifiedClassName(
+        classNameModifier
+      )}`}
+    >
+      <td className="m-properties-list__property-label">{label}</td>
+      <td className="m-properties-list__property-value">
+        <Highlighted content={value} highlightText={highlightText} />
+      </td>
+    </tr>
+  )
 
 const PropertiesList = ({ properties, highlightText }: Props) => (
   <div className="m-properties-list">

--- a/assets/tests/components/__snapshots__/notifications.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notifications.test.tsx.snap
@@ -186,3 +186,77 @@ exports[`NotificationCard renders a notification with an unexpected reason 1`] =
   </button>
 </div>
 `;
+
+exports[`NotificationCard renders notification with matched vehicle 1`] = `
+<div
+  className="m-notifications__card m-notifications__card--new"
+>
+  <button
+    className="m-notifications__card-info"
+  >
+    <div
+      className="m-notification__title-row"
+    >
+      <div
+        className="m-notification__title"
+      >
+        NO OPERATOR
+      </div>
+      <div
+        className="m-notification__age"
+      >
+        0 min
+      </div>
+    </div>
+    <div
+      className="m-notification__description"
+    >
+      OCC reported that an operator is not available on the route1, route2.
+    </div>
+    <div
+      className="m-properties-list"
+    >
+      <table
+        className="m-properties-list__table"
+      >
+        <tbody>
+          <tr
+            className="m-properties-list__property "
+          >
+            <td
+              className="m-properties-list__property-label"
+            >
+              Run
+            </td>
+            <td
+              className="m-properties-list__property-value"
+            >
+              run1, run2
+            </td>
+          </tr>
+          <tr
+            className="m-properties-list__property "
+          >
+            <td
+              className="m-properties-list__property-label"
+            >
+              Operator
+            </td>
+            <td
+              className="m-properties-list__property-value"
+            >
+              operatorName #operatorId
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </button>
+  <button
+    className="m-notifications__close"
+    onClick={[Function]}
+  >
+    Close
+  </button>
+</div>
+`;

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -30,6 +30,13 @@ const notification: Notification = {
   tripIds: [],
 }
 
+const notificationWithMatchedVehicle: Notification = {
+  ...notification,
+  operatorName: "operatorName",
+  operatorId: "operatorId",
+  routeIdAtCreation: "route1",
+}
+
 describe("Notification", () => {
   test("renders empty state", () => {
     const tree = renderer.create(<Notifications />).toJSON()
@@ -89,6 +96,19 @@ describe("Notification", () => {
 })
 
 describe("NotificationCard", () => {
+  test("renders notification with matched vehicle", () => {
+    const tree = renderer
+      .create(
+        <NotificationCard
+          notification={notificationWithMatchedVehicle}
+          remove={jest.fn()}
+          currentTime={now()}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   test("transforms reasons into human-readable titles", () => {
     const n: Notification = { ...notification, reason: "operator_error" }
     const wrapper = mount(
@@ -125,6 +145,57 @@ describe("NotificationCard", () => {
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
+  })
+
+  test("routeIdAtCreation shows when relevant", () => {
+    const n: Notification = {
+      ...notificationWithMatchedVehicle,
+      reason: "accident",
+      routeIds: ["r2", "r3"],
+      routeIdAtCreation: "r1",
+    }
+    const wrapper = mount(
+      <NotificationCard
+        notification={n}
+        remove={jest.fn()}
+        currentTime={now()}
+      />
+    )
+    expect(wrapper.html()).toContain("r1")
+  })
+
+  test("falls back to affected routeIds if routeIdAtCreation is missing", () => {
+    const n: Notification = {
+      ...notification,
+      reason: "accident",
+      routeIds: ["r2", "r3"],
+      routeIdAtCreation: undefined,
+    }
+    const wrapper = mount(
+      <NotificationCard
+        notification={n}
+        remove={jest.fn()}
+        currentTime={now()}
+      />
+    )
+    expect(wrapper.html()).toContain("r2, r3")
+  })
+
+  test("shows affected routeIds if routeIdAtCreation isn't relevant", () => {
+    const n: Notification = {
+      ...notificationWithMatchedVehicle,
+      reason: "diverted",
+      routeIds: ["r2", "r3"],
+      routeIdAtCreation: "r1",
+    }
+    const wrapper = mount(
+      <NotificationCard
+        notification={n}
+        remove={jest.fn()}
+        currentTime={now()}
+      />
+    )
+    expect(wrapper.html()).toContain("r2, r3")
   })
 
   const reasons: NotificationReason[] = [

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme"
+import { shallow, mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
 import PropertiesList, {
@@ -130,6 +130,22 @@ describe("PropertiesList", () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  test("ignores properties with null values", () => {
+    const wrapper = mount(
+      <PropertiesList
+        properties={[
+          {
+            label: "Label",
+            value: null,
+          },
+        ]}
+        highlightText="run"
+      />
+    )
+
+    expect(wrapper.html()).not.toContain("Label")
   })
 })
 


### PR DESCRIPTION
If we successfully matched a vehicle when the notification was made.

Asana Task: [Update notification card templates with operator and vehicle information](https://app.asana.com/0/1148853526253426/1191564362053833)

<img width="760" alt="Screen Shot 2020-09-17 at 13 20 10" src="https://user-images.githubusercontent.com/23065557/93505729-3ba5a000-f8e9-11ea-920d-4c035399416e.png">

In those fake notifications, the bottom one is as if it was matched to a vehicle, and the top one wasn't matched.

