### PR TITLE
use null for missing notification data instead of undefined

### DIFF
--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -89,8 +89,8 @@ export const NotificationCard = ({
             {
               label: "Operator",
               value:
-                notification.operatorName !== undefined &&
-                notification.operatorId !== undefined
+                notification.operatorName !== null &&
+                notification.operatorId !== null
                   ? `${notification.operatorName} #${notification.operatorId}`
                   : null,
             },

--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -8,9 +8,9 @@ export interface NotificationData {
   route_ids: RouteId[]
   run_ids: RunId[]
   trip_ids: TripId[]
-  operator_name?: string
-  operator_id?: string
-  route_id_at_creation?: string
+  operator_name: string | null
+  operator_id: string | null
+  route_id_at_creation: string | null
 }
 
 export const notificationsFromData = (

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -54,9 +54,9 @@ export interface Notification {
   routeIds: RouteId[]
   runIds: RunId[]
   tripIds: TripId[]
-  operatorName?: string
-  operatorId?: string
-  routeIdAtCreation?: string
+  operatorName: string | null
+  operatorId: string | null
+  routeIdAtCreation: string | null
 }
 
 export type NotificationReason =

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -28,6 +28,9 @@ const notification: Notification = {
   routeIds: ["route1", "route2"],
   runIds: ["run1", "run2"],
   tripIds: [],
+  operatorName: null,
+  operatorId: null,
+  routeIdAtCreation: null,
 }
 
 const notificationWithMatchedVehicle: Notification = {
@@ -169,7 +172,7 @@ describe("NotificationCard", () => {
       ...notification,
       reason: "accident",
       routeIds: ["r2", "r3"],
-      routeIdAtCreation: undefined,
+      routeIdAtCreation: null,
     }
     const wrapper = mount(
       <NotificationCard

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -19,6 +19,9 @@ const notificationData: NotificationData = {
   route_ids: ["route"],
   run_ids: ["run"],
   trip_ids: ["trip"],
+  operator_name: null,
+  operator_id: null,
+  route_id_at_creation: null,
 }
 
 describe("useNotifications", () => {


### PR DESCRIPTION
Asana Task: [🐛Notification has "null" value for operator, and doesn't link to a run that is currently active/has a waiver](https://app.asana.com/0/1148853526253420/1194947689037481)

We were checking for the operator being `undefined`. This change changes that to match the `null` that the backend is sending us.