### PR TITLE
Show notifications only on ladder page 

### DIFF
--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -11,7 +11,6 @@ import SearchPage from "./searchPage"
 import SettingsPage from "./settingsPage"
 import ShuttleMapPage from "./shuttleMapPage"
 import TabBar from "./tabBar"
-import { Notifications } from "./notifications"
 
 const AppRoutes = () => {
   useAppcues()
@@ -25,7 +24,6 @@ const AppRoutes = () => {
         <DataStatusBanner />
       </div>
       <div className="m-app__main">
-        <Notifications />
         <TabBar pickerContainerIsVisible={pickerContainerIsVisible} />
         <BrowserRoute exact={true} path="/" component={LadderPage} />
         <BrowserRoute

--- a/assets/src/components/appStateWrapper.tsx
+++ b/assets/src/components/appStateWrapper.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { NotificationsProvider } from "../contexts/notificationsContext"
 import { SocketProvider } from "../contexts/socketContext"
 import { StateDispatchProvider } from "../contexts/stateDispatchContext"
 import usePersistedStateReducer from "../hooks/usePersistedStateReducer"
@@ -8,13 +9,14 @@ import App from "./app"
 
 const AppStateWrapper = (): JSX.Element => {
   const [state, dispatch] = usePersistedStateReducer(reducer, initialState)
-
   const socketStatus = useSocket()
 
   return (
     <StateDispatchProvider state={state} dispatch={dispatch}>
       <SocketProvider socketStatus={socketStatus}>
-        <App />
+        <NotificationsProvider>
+          <App />
+        </NotificationsProvider>
       </SocketProvider>
     </StateDispatchProvider>
   )

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -10,6 +10,7 @@ import useVehicles from "../hooks/useVehicles"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { ByRouteId, Route, RouteId, TimepointsByRouteId } from "../schedule.d"
+import { Notifications } from "./notifications"
 import PropertiesPanel from "./propertiesPanel"
 import RouteLadders from "./routeLadders"
 import RoutePicker from "./routePicker"
@@ -62,6 +63,7 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
   return (
     <RoutesContext.Provider value={routes}>
       <div className="m-ladder-page">
+        <Notifications />
         <RoutePicker selectedRouteIds={selectedRouteIds} />
 
         <VehiclesByRouteIdProvider vehiclesByRouteId={vehiclesByRouteId}>

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -1,35 +1,12 @@
-import React, { useEffect, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
+import { NotificationsContext } from "../contexts/notificationsContext"
 import useInterval from "../hooks/useInterval"
-import { useNotifications } from "../hooks/useNotifications"
-import featureIsEnabled from "../laboratoryFeatures"
 import { Notification, NotificationReason } from "../realtime.d"
 import { formattedTimeDiff, now } from "../util/dateTime"
 import PropertiesList from "./propertiesList"
 
-const deliveryFullstoryEvent = (numStacked: number): void => {
-  if (window.FS && window.username) {
-    window.FS.event("Notification delivered", {
-      num_stacked_int: numStacked,
-    })
-  }
-}
-
 export const Notifications = () => {
-  const [notifications, setNotifications] = useState<Notification[]>([])
-  const addNotification = (notification: Notification): void => {
-    if (featureIsEnabled("notifications")) {
-      setNotifications((previous) => {
-        const newNotifications = [...previous, notification]
-        deliveryFullstoryEvent(newNotifications.length)
-        return newNotifications
-      })
-    }
-  }
-  const removeNotification = (id: number): void => {
-    setNotifications((previous) => previous.filter((n) => n.id !== id))
-  }
-  useNotifications(addNotification)
-
+  const { notifications, removeNotification } = useContext(NotificationsContext)
   const [currentTime, setCurrentTime] = useState(now())
   useInterval(() => setCurrentTime(now()), 1000)
 

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, ReactElement, useState } from "react"
+import { useNotifications } from "../hooks/useNotifications"
+import featureIsEnabled from "../laboratoryFeatures"
+import { Notification, NotificationId } from "../realtime.d"
+
+export interface NotificationsStatus {
+  notifications: Notification[]
+  removeNotification: (notificationId: NotificationId) => void
+}
+
+export const NotificationsContext = createContext<NotificationsStatus>({
+  notifications: [],
+  // tslint:disable-next-line: no-empty
+  removeNotification: () => {},
+})
+
+const deliveryFullstoryEvent = (numStacked: number): void => {
+  if (window.FS && window.username) {
+    window.FS.event("Notification delivered", {
+      num_stacked_int: numStacked,
+    })
+  }
+}
+
+export const NotificationsProvider = ({
+  children,
+}: {
+  children: ReactElement<HTMLElement>
+}) => {
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const addNotification = (notification: Notification): void => {
+    if (featureIsEnabled("notifications")) {
+      setNotifications((previous) => {
+        const newNotifications = [...previous, notification]
+        deliveryFullstoryEvent(newNotifications.length)
+        return newNotifications
+      })
+    }
+  }
+  const removeNotification = (id: number): void => {
+    setNotifications((previous) => previous.filter((n) => n.id !== id))
+  }
+
+  useNotifications(addNotification)
+
+  return (
+    <NotificationsContext.Provider
+      value={{
+        notifications,
+        removeNotification,
+      }}
+    >
+      {children}
+    </NotificationsContext.Provider>
+  )
+}

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -47,8 +47,10 @@ export interface Ghost {
   blockWaivers: BlockWaiver[]
 }
 
+export type NotificationId = number
+
 export interface Notification {
-  id: number
+  id: NotificationId
   createdAt: Date
   reason: NotificationReason
   routeIds: RouteId[]

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -11,9 +11,6 @@ exports[`App renders 1`] = `
     className="m-app__main"
   >
     <div
-      className="m-notifications"
-    />
-    <div
       className="m-tab-bar visible"
     >
       <button
@@ -163,6 +160,9 @@ exports[`App renders 1`] = `
     <div
       className="m-ladder-page"
     >
+      <div
+        className="m-notifications"
+      />
       <div
         className="m-picker-container m-picker-container--narrow visible"
       >
@@ -265,9 +265,6 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
     className="m-app__main"
   >
     <div
-      className="m-notifications"
-    />
-    <div
       className="m-tab-bar visible"
     >
       <button
@@ -417,6 +414,9 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
     <div
       className="m-ladder-page"
     >
+      <div
+        className="m-notifications"
+      />
       <div
         className="m-picker-container m-picker-container--narrow visible"
       >

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -11,9 +11,6 @@ exports[`renders 1`] = `
     className="m-app__main"
   >
     <div
-      className="m-notifications"
-    />
-    <div
       className="m-tab-bar visible"
     >
       <button
@@ -163,6 +160,9 @@ exports[`renders 1`] = `
     <div
       className="m-ladder-page"
     >
+      <div
+        className="m-notifications"
+      />
       <div
         className="m-picker-container m-picker-container--narrow visible"
       >

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -5,6 +5,9 @@ exports[`LadderPage renders the empty state 1`] = `
   className="m-ladder-page"
 >
   <div
+    className="m-notifications"
+  />
+  <div
     className="m-picker-container m-picker-container--narrow visible"
   >
     <div
@@ -82,6 +85,9 @@ exports[`LadderPage renders with routes 1`] = `
 <div
   className="m-ladder-page"
 >
+  <div
+    className="m-notifications"
+  />
   <div
     className="m-picker-container m-picker-container--narrow visible"
   >
@@ -230,6 +236,9 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
 <div
   className="m-ladder-page"
 >
+  <div
+    className="m-notifications"
+  />
   <div
     className="m-picker-container m-picker-container--narrow visible"
   >
@@ -428,6 +437,9 @@ exports[`LadderPage renders with timepoints 1`] = `
   className="m-ladder-page"
 >
   <div
+    className="m-notifications"
+  />
+  <div
     className="m-picker-container m-picker-container--narrow visible"
   >
     <div
@@ -524,6 +536,9 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
 <div
   className="m-ladder-page"
 >
+  <div
+    className="m-notifications"
+  />
   <div
     className="m-picker-container m-picker-container--narrow visible"
   >

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -1,0 +1,92 @@
+import { act as hooksAct, renderHook } from "@testing-library/react-hooks"
+import { mount } from "enzyme"
+import React, { useContext } from "react"
+import { act as testUtilsAct } from "react-dom/test-utils"
+import {
+  NotificationsContext,
+  NotificationsProvider,
+} from "../../src/contexts/notificationsContext"
+import { useNotifications } from "../../src/hooks/useNotifications"
+import { Notification } from "../../src/realtime.d"
+import { now } from "../../src/util/dateTime"
+import { mockUseStateOnce } from "../testHelpers/mockHelpers"
+
+jest.mock("../../src/hooks/useNotifications", () => ({
+  __esModule: true,
+  useNotifications: jest.fn(),
+}))
+
+jest.mock("../../src/laboratoryFeatures", () => ({
+  __esModule: true,
+  default: () => true,
+}))
+
+const notification: Notification = {
+  id: 0,
+  createdAt: now(),
+  reason: "manpower",
+  routeIds: ["route1", "route2"],
+  runIds: ["run1", "run2"],
+  tripIds: [],
+  operatorName: null,
+  operatorId: null,
+  routeIdAtCreation: null,
+}
+
+// tslint:disable: react-hooks-nesting
+
+describe("Notification", () => {
+  test("starts empty", () => {
+    const { result } = renderHook(() => useContext(NotificationsContext), {
+      wrapper: NotificationsProvider,
+    })
+    expect(result.current.notifications).toEqual([])
+  })
+
+  test("receives incoming notifications", () => {
+    let handler: (notification: Notification) => void
+    ;(useNotifications as jest.Mock).mockImplementationOnce((h) => {
+      handler = h
+    })
+    const { result } = renderHook(() => useContext(NotificationsContext), {
+      wrapper: NotificationsProvider,
+    })
+    expect(result.current.notifications).toHaveLength(0)
+    hooksAct(() => {
+      handler!(notification)
+    })
+    expect(result.current.notifications).toHaveLength(1)
+  })
+
+  test("makes a fullstory event when a notification arrives", () => {
+    let handler: (notification: Notification) => void
+    ;(useNotifications as jest.Mock).mockImplementationOnce((h) => {
+      handler = h
+    })
+    mount(<NotificationsProvider children={<></>} />)
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+    testUtilsAct(() => {
+      handler!(notification)
+    })
+    expect(window.FS!.event).toHaveBeenCalledWith("Notification delivered", {
+      num_stacked_int: 1,
+    })
+    window.FS = originalFS
+    window.username = originalUsername
+  })
+
+  test("can close notification", () => {
+    mockUseStateOnce([notification])
+    const { result } = renderHook(() => useContext(NotificationsContext), {
+      wrapper: NotificationsProvider,
+    })
+    expect(result.current.notifications).toHaveLength(1)
+    hooksAct(() => {
+      result.current.removeNotification(notification.id)
+    })
+    expect(result.current.notifications).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Asana Task: [Restrict notification cards to only appear on route ladder view](https://app.asana.com/0/1148853526253426/1194621236689393)