### PR TITLE
Fix tracking in useVehicleAndRouteForNotification

### DIFF
--- a/assets/src/hooks/useVehicleAndRouteForNotification.ts
+++ b/assets/src/hooks/useVehicleAndRouteForNotification.ts
@@ -55,7 +55,6 @@ const useVehicleAndRouteForNotification = (
   const [clickthroughLogged, setClickthroughLogged] = useState<boolean>(false)
 
   useEffect(() => {
-    /* istanbul ignore next */
     if (window.FS) {
       if (!clickthroughLogged) {
         if (newVehicleOrGhostAndRoute) {
@@ -65,7 +64,7 @@ const useVehicleAndRouteForNotification = (
           } else {
             window.FS.event("Notification linked to ghost")
           }
-        } else if (notification) {
+        } else if (notification && newVehicleOrGhostAndRoute === null) {
           setClickthroughLogged(true)
           window.FS.event("Notification link failed")
         }

--- a/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
+++ b/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
@@ -126,6 +126,11 @@ describe("useVehicleAndRouteForNotification", () => {
   }
 
   test("parses vehicle and route data from channel", () => {
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+
     const vehicleAndRouteData: VehicleOrGhostAndRouteData = {
       vehicleOrGhostData: vehicleData,
       routeData,
@@ -209,8 +214,17 @@ describe("useVehicleAndRouteForNotification", () => {
         viaVariant: "3",
       },
     })
+    expect(window.FS!.event).toHaveBeenCalledWith("Notification linked to VPP")
+    window.FS = originalFS
+    window.username = originalUsername
   })
+
   test("parses ghost and route data from channel", () => {
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+
     const vehicleAndRouteData: VehicleOrGhostAndRouteData = {
       vehicleOrGhostData: ghostData,
       routeData,
@@ -251,8 +265,19 @@ describe("useVehicleAndRouteForNotification", () => {
         viaVariant: "3",
       },
     })
+    expect(window.FS!.event).toHaveBeenCalledWith(
+      "Notification linked to ghost"
+    )
+    window.FS = originalFS
+    window.username = originalUsername
   })
+
   test("handles missing data from channel", () => {
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok", { data: {} })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -265,5 +290,8 @@ describe("useVehicleAndRouteForNotification", () => {
       { wrapper: wrapper(mockSocket) }
     )
     expect(result.current).toBeNull()
+    expect(window.FS!.event).toHaveBeenCalledWith("Notification link failed")
+    window.FS = originalFS
+    window.username = originalUsername
   })
 })


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1197215845308505

We introduced the convention that an undefined result here indicated
that we were in the process of loading the vehicle, whereas a null
result would indicate we tried and failed. However, we didn't adjust the
Fullstory tracking code accordingly. Fixed.