### PR TITLE
Treat upcoming notifications separately when clickthrough fails

### DIFF
--- a/assets/src/components/inactiveNotificationModal.tsx
+++ b/assets/src/components/inactiveNotificationModal.tsx
@@ -33,8 +33,7 @@ const InactiveNotificationModal = ({
           {title(notification.reason)} NOTIFICATION
         </div>
         <div className="m-inactive-notification-modal__body">
-          {runIdPhrase(notification)} currently active in Skate. This
-          notification may no longer be relevant.
+          {bodyCopy(notification)}
         </div>
         <div className="m-inactive-notification-modal__buttons">
           <button
@@ -56,11 +55,32 @@ const InactiveNotificationModal = ({
   )
 }
 
-const runIdPhrase = (notification: Notification): string => {
+const bodyCopy = (notification: Notification): string => {
   if (notification.runIds.length === 0) {
-    return "No runs associated with this notification are"
+    return "No runs associated with this notification are currently active in Skate. This notification may no longer be relevant."
   }
 
+  return notification.startTime < new Date()
+    ? pastNotificationBodyCopy(notification)
+    : futureNotificationBodyCopy(notification)
+}
+
+const pastNotificationBodyCopy = (notification: Notification): string =>
+  `${pastRunIdPhrase(
+    notification
+  )} currently active in Skate. This notification may no longer be relevant.`
+
+const futureNotificationBodyCopy = (notification: Notification): string => {
+  if (notification.runIds.length === 1) {
+    return `Run ${notification.runIds[0]} is upcoming and not yet active in Skate. Please check back later to see details for this run.`
+  }
+
+  return `Runs ${notification.runIds.join(
+    ", "
+  )} are upcoming and not yet active in Skate. Please check back later to see details for these runs.`
+}
+
+const pastRunIdPhrase = (notification: Notification): string => {
   if (notification.runIds.length === 1) {
     return `Run ${notification.runIds[0]} is not`
   }

--- a/assets/src/hooks/useVehicleAndRouteForNotification.ts
+++ b/assets/src/hooks/useVehicleAndRouteForNotification.ts
@@ -66,7 +66,11 @@ const useVehicleAndRouteForNotification = (
           }
         } else if (notification && newVehicleOrGhostAndRoute === null) {
           setClickthroughLogged(true)
-          window.FS.event("Notification link failed")
+          window.FS.event(
+            new Date() < notification.startTime
+              ? "Notification link failed upcoming"
+              : "Notification link failed"
+          )
         }
       }
     }

--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -11,6 +11,7 @@ export interface NotificationData {
   operator_name: string | null
   operator_id: string | null
   route_id_at_creation: string | null
+  start_time: number
 }
 
 export const notificationsFromData = (
@@ -32,4 +33,5 @@ const notificationFromData = (
   operatorName: notificationData.operator_name,
   operatorId: notificationData.operator_id,
   routeIdAtCreation: notificationData.route_id_at_creation,
+  startTime: new Date(notificationData.start_time),
 })

--- a/assets/src/realtime.d.ts
+++ b/assets/src/realtime.d.ts
@@ -60,6 +60,7 @@ export interface Notification {
   operatorName: string | null
   operatorId: string | null
   routeIdAtCreation: string | null
+  startTime: Date
 }
 
 export type NotificationReason =

--- a/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InactiveNotificationModal renders for a notification with multiple runs 1`] = `
+exports[`InactiveNotificationModal renders for a notification with multiple current or past runs 1`] = `
 Array [
   <div
     className="c-modal"
@@ -30,8 +30,62 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      Runs 111, 222 are not
-       currently active in Skate. This notification may no longer be relevant.
+      Runs 111, 222 are not currently active in Skate. This notification may no longer be relevant.
+    </div>
+    <div
+      className="m-inactive-notification-modal__buttons"
+    >
+      <button
+        className="m-inactive-notification-modal__keep-button"
+        onClick={[Function]}
+      >
+        Keep
+      </button>
+      <button
+        className="m-inactive-notification-modal__discard-button"
+        onClick={[Function]}
+      >
+        Remove
+      </button>
+    </div>
+  </div>,
+  <div
+    className="c-modal-overlay"
+  />,
+]
+`;
+
+exports[`InactiveNotificationModal renders for a notification with multiple upcoming runs 1`] = `
+Array [
+  <div
+    className="c-modal"
+  >
+    <div
+      className="m-inactive-notification-modal__close-button"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-notification__title"
+    >
+      OTHER
+       NOTIFICATION
+    </div>
+    <div
+      className="m-inactive-notification-modal__body"
+    >
+      Runs 111, 222 are upcoming and not yet active in Skate. Please check back later to see details for these runs.
     </div>
     <div
       className="m-inactive-notification-modal__buttons"
@@ -86,8 +140,7 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      No runs associated with this notification are
-       currently active in Skate. This notification may no longer be relevant.
+      No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
     </div>
     <div
       className="m-inactive-notification-modal__buttons"
@@ -112,7 +165,7 @@ Array [
 ]
 `;
 
-exports[`InactiveNotificationModal renders for a notification with one run 1`] = `
+exports[`InactiveNotificationModal renders for a notification with one current or past run 1`] = `
 Array [
   <div
     className="c-modal"
@@ -142,8 +195,62 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      Run 111 is not
-       currently active in Skate. This notification may no longer be relevant.
+      Run 111 is not currently active in Skate. This notification may no longer be relevant.
+    </div>
+    <div
+      className="m-inactive-notification-modal__buttons"
+    >
+      <button
+        className="m-inactive-notification-modal__keep-button"
+        onClick={[Function]}
+      >
+        Keep
+      </button>
+      <button
+        className="m-inactive-notification-modal__discard-button"
+        onClick={[Function]}
+      >
+        Remove
+      </button>
+    </div>
+  </div>,
+  <div
+    className="c-modal-overlay"
+  />,
+]
+`;
+
+exports[`InactiveNotificationModal renders for a notification with one upcoming run 1`] = `
+Array [
+  <div
+    className="c-modal"
+  >
+    <div
+      className="m-inactive-notification-modal__close-button"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-notification__title"
+    >
+      OTHER
+       NOTIFICATION
+    </div>
+    <div
+      className="m-inactive-notification-modal__body"
+    >
+      Run 111 is upcoming and not yet active in Skate. Please check back later to see details for this run.
     </div>
     <div
       className="m-inactive-notification-modal__buttons"

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -30,8 +30,7 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      No runs associated with this notification are
-       currently active in Skate. This notification may no longer be relevant.
+      No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
     </div>
     <div
       className="m-inactive-notification-modal__buttons"

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -15,7 +15,11 @@ describe("InactiveNotificationModal", () => {
     operatorName: null,
     operatorId: null,
     routeIdAtCreation: null,
-    startTime: new Date(),
+    startTime: new Date("2020-10-05"),
+  }
+  const futureNotification = {
+    ...notification,
+    startTime: new Date("20200-10-05"),
   }
   const removeNotification = jest.fn()
 
@@ -31,7 +35,7 @@ describe("InactiveNotificationModal", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders for a notification with one run", () => {
+  test("renders for a notification with one current or past run", () => {
     const tree = renderer
       .create(
         <InactiveNotificationModal
@@ -43,7 +47,7 @@ describe("InactiveNotificationModal", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders for a notification with multiple runs", () => {
+  test("renders for a notification with multiple current or past runs", () => {
     const tree = renderer
       .create(
         <InactiveNotificationModal
@@ -55,6 +59,44 @@ describe("InactiveNotificationModal", () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test("renders for a notification with one upcoming run", () => {
+    const tree = renderer
+      .create(
+        <InactiveNotificationModal
+          notification={{ ...futureNotification, runIds: ["111"] }}
+          removeNotification={removeNotification}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders for a notification with multiple upcoming runs", () => {
+    const tree = renderer
+      .create(
+        <InactiveNotificationModal
+          notification={{ ...futureNotification, runIds: ["111", "222"] }}
+          removeNotification={removeNotification}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("allows removing the modal", () => {
+    const wrapper = mount(
+      <InactiveNotificationModal
+        notification={notification}
+        removeNotification={removeNotification}
+      />
+    )
+
+    wrapper
+      .find(".m-inactive-notification-modal__discard-button")
+      .first()
+      .simulate("click")
+    expect(removeNotification).toHaveBeenCalledWith(notification.id)
+  })
   test("allows removing the modal", () => {
     const wrapper = mount(
       <InactiveNotificationModal

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -15,6 +15,7 @@ describe("InactiveNotificationModal", () => {
     operatorName: null,
     operatorId: null,
     routeIdAtCreation: null,
+    startTime: new Date(),
   }
   const removeNotification = jest.fn()
 

--- a/assets/tests/components/modal.test.tsx
+++ b/assets/tests/components/modal.test.tsx
@@ -17,6 +17,7 @@ describe("Modal", () => {
       operatorName: null,
       operatorId: null,
       routeIdAtCreation: null,
+      startTime: new Date(),
     }
 
     const state: State = {

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -36,6 +36,7 @@ const notification: Notification = {
   operatorName: null,
   operatorId: null,
   routeIdAtCreation: null,
+  startTime: now(),
 }
 
 const notificationWithMatchedVehicle: Notification = {

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -31,6 +31,7 @@ const notification: Notification = {
   operatorName: null,
   operatorId: null,
   routeIdAtCreation: null,
+  startTime: now(),
 }
 
 // tslint:disable: react-hooks-nesting

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -22,6 +22,7 @@ const notificationData: NotificationData = {
   operator_name: null,
   operator_id: null,
   route_id_at_creation: null,
+  start_time: 123_456,
 }
 
 describe("useNotifications", () => {

--- a/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
+++ b/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
@@ -273,7 +273,7 @@ describe("useVehicleAndRouteForNotification", () => {
     window.username = originalUsername
   })
 
-  test("handles missing data from channel", () => {
+  test("handles missing data from channel for a current or past notification", () => {
     const originalFS = window.FS
     const originalUsername = window.username
     window.FS = { event: jest.fn(), identify: jest.fn() }
@@ -286,12 +286,43 @@ describe("useVehicleAndRouteForNotification", () => {
     // tslint:disable: react-hooks-nesting
     const { result } = renderHook(
       () => {
-        return useVehicleAndRouteForNotification(notification)
+        return useVehicleAndRouteForNotification({
+          ...notification,
+          startTime: new Date("2019-10-06"),
+        })
       },
       { wrapper: wrapper(mockSocket) }
     )
     expect(result.current).toBeNull()
     expect(window.FS!.event).toHaveBeenCalledWith("Notification link failed")
+    window.FS = originalFS
+    window.username = originalUsername
+  })
+
+  test("handles missing data from channel for an upcoming notification", () => {
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: {} })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    // tslint:disable: react-hooks-nesting
+    const { result } = renderHook(
+      () => {
+        return useVehicleAndRouteForNotification({
+          ...notification,
+          startTime: new Date("20200-10-06"),
+        })
+      },
+      { wrapper: wrapper(mockSocket) }
+    )
+    expect(result.current).toBeNull()
+    expect(window.FS!.event).toHaveBeenCalledWith(
+      "Notification link failed upcoming"
+    )
     window.FS = originalFS
     window.username = originalUsername
   })

--- a/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
+++ b/assets/tests/hooks/useVehicleAndRouteForNotification.test.tsx
@@ -123,6 +123,7 @@ describe("useVehicleAndRouteForNotification", () => {
     operatorName: null,
     operatorId: null,
     routeIdAtCreation: null,
+    startTime: new Date(),
   }
 
   test("parses vehicle and route data from channel", () => {

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -250,6 +250,7 @@ describe("reducer", () => {
       operatorName: null,
       operatorId: null,
       routeIdAtCreation: null,
+      startTime: new Date(),
     }
     const state = initialState
     const newState = reducer(state, State.setNotification(notification))

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -12,7 +12,8 @@ defmodule Notifications.Notification do
           trip_ids: [Trip.id()],
           operator_id: String.t() | nil,
           operator_name: String.t() | nil,
-          route_id_at_creation: Route.id() | nil
+          route_id_at_creation: Route.id() | nil,
+          start_time: Util.Time.timestamp()
         }
 
   @derive Jason.Encoder
@@ -25,6 +26,7 @@ defmodule Notifications.Notification do
     :trip_ids,
     :operator_id,
     :operator_name,
-    :route_id_at_creation
+    :route_id_at_creation,
+    :start_time
   ]
 end

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -121,7 +121,8 @@ defmodule Notifications.NotificationServer do
         trip_ids: trip_ids,
         operator_id: operator_id,
         operator_name: operator_name,
-        route_id_at_creation: route_id
+        route_id_at_creation: route_id,
+        start_time: block_waiver.start_time
       }
     end
   end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -127,6 +127,8 @@ defmodule Notifications.NotificationServerTest do
     operator_id = Keyword.get(opts, :operator_id)
     route_id_at_creation = Keyword.get(opts, :route_id_at_creation)
 
+    start_time = @midnight + 100
+
     assert_received(
       {:notifications,
        [
@@ -138,7 +140,8 @@ defmodule Notifications.NotificationServerTest do
            trip_ids: ["trip1", "trip2"],
            operator_name: ^operator_name,
            operator_id: ^operator_id,
-           route_id_at_creation: ^route_id_at_creation
+           route_id_at_creation: ^route_id_at_creation,
+           start_time: ^start_time
          }
        ]}
     )
@@ -147,6 +150,7 @@ defmodule Notifications.NotificationServerTest do
     assert String.contains?(log, "route_ids: [\"1\", \"2\"]")
     assert String.contains?(log, "run_ids: [\"run1\", \"run2\"]")
     assert String.contains?(log, "trip_ids: [\"trip1\", \"trip2\"]")
+    assert String.contains?(log, "start_time: #{start_time}")
   end
 
   def setup_server do


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1194634240558553

We have a separate Fullstory event, and different copy, for when the run or runs in question are in the future.