### PR TITLE
Index vehicles by run ID for notification purposes

### DIFF
--- a/assets/src/hooks/useVehicleAndRouteForNotification.ts
+++ b/assets/src/hooks/useVehicleAndRouteForNotification.ts
@@ -37,7 +37,7 @@ const useVehicleAndRouteForNotification = (
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
 
   const topic: string | null = notification
-    ? `vehicle:trip_ids:${notification.tripIds.join(",")}`
+    ? `vehicle:run_ids:${notification.runIds.join(",")}`
     : null
 
   // undefined means we're still trying to load the vehicle,

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -101,7 +101,7 @@ defmodule Notifications.NotificationServer do
         Application.get_env(:realtime, :peek_at_vehicles_fn, &Realtime.Server.peek_at_vehicles/1)
 
       vehicle_or_ghost =
-        case peek_at_vehicles_fn.(trip_ids) do
+        case peek_at_vehicles_fn.(run_ids) do
           [v] -> v
           _ -> nil
         end

--- a/lib/skate_web/channels/vehicle_channel.ex
+++ b/lib/skate_web/channels/vehicle_channel.ex
@@ -12,9 +12,9 @@ defmodule SkateWeb.VehicleChannel do
   end
 
   @impl Phoenix.Channel
-  def join("vehicle:trip_ids:" <> trip_ids, _message, socket) do
-    trip_ids = String.split(trip_ids, ",")
-    vehicle_or_ghost = Realtime.Server.peek_at_vehicles(trip_ids) |> List.first()
+  def join("vehicle:run_ids:" <> run_ids, _message, socket) do
+    run_ids = String.split(run_ids, ",")
+    vehicle_or_ghost = Realtime.Server.peek_at_vehicles(run_ids) |> List.first()
     payload = make_payload(vehicle_or_ghost)
 
     if vehicle_or_ghost do

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -353,11 +353,15 @@ defmodule Realtime.ServerTest do
       Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)
 
       assert Server.peek_at_vehicles([], server_pid) == []
-      assert Server.peek_at_vehicles(["no_such_t"], server_pid) == []
-      assert Server.peek_at_vehicles(["t1"], server_pid) == [@vehicle]
-      assert Server.peek_at_vehicles(["t2"], server_pid) == [@ghost]
-      assert Server.peek_at_vehicles(["t1", "t2"], server_pid) == [@vehicle, @ghost]
-      assert Server.peek_at_vehicles(["t1", "no_such_t", "t2"], server_pid) == [@vehicle, @ghost]
+      assert Server.peek_at_vehicles(["no_such_run"], server_pid) == []
+      assert Server.peek_at_vehicles(["123-9048"], server_pid) == [@vehicle]
+      assert Server.peek_at_vehicles(["123-9049"], server_pid) == [@ghost]
+      assert Server.peek_at_vehicles(["123-9048", "123-9049"], server_pid) == [@vehicle, @ghost]
+
+      assert Server.peek_at_vehicles(["123-9048", "no_such_run", "123-9049"], server_pid) == [
+               @vehicle,
+               @ghost
+             ]
     end
   end
 end

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -54,18 +54,18 @@ defmodule SkateWeb.VehicleChannelTest do
   end
 
   describe "join/3" do
-    test "subscribes to the active vehicle for given trip IDs and returns that vehicle", %{
+    test "subscribes to the active vehicle for given run IDs and returns that vehicle", %{
       socket: socket
     } do
       assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
-      assert Realtime.Server.peek_at_vehicles(["123", "456", "789"]) == [@vehicle]
+      assert Realtime.Server.peek_at_vehicles(["123-4567"]) == [@vehicle]
 
       expected_payload = %{
         data: %{vehicleOrGhostData: @vehicle, routeData: nil}
       }
 
       assert {:ok, ^expected_payload, %Socket{} = socket} =
-               subscribe_and_join(socket, VehicleChannel, "vehicle:trip_ids:123,456,789")
+               subscribe_and_join(socket, VehicleChannel, "vehicle:run_ids:123-4567")
     end
   end
 
@@ -76,8 +76,7 @@ defmodule SkateWeb.VehicleChannelTest do
       ets = GenServer.call(Realtime.Server.default_name(), :ets)
       assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
 
-      {:ok, _, socket} =
-        subscribe_and_join(socket, VehicleChannel, "vehicle:trip_ids:111,222,333")
+      {:ok, _, socket} = subscribe_and_join(socket, VehicleChannel, "vehicle:run_ids:123-4567")
 
       assert {:noreply, socket} =
                VehicleChannel.handle_info(

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -5,6 +5,7 @@ defmodule SkateWeb.VehicleChannelTest do
 
   alias Phoenix.Socket
   alias Realtime.Vehicle
+
   alias SkateWeb.{UserSocket, VehicleChannel}
 
   @vehicle %Vehicle{


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1197215845308509

We had been indexing vehicles by trip ID in the realtime server, so that
when a user clicked a notification, we could use the trip IDs associated
with the notification to look up the pertinent vehicle.

This led to a counterintuitive behavior where, if a vehicle was on a run
affected by a block waiver, but not on one of the affected trips, it
would not be considered associated with the waiver.

Here we change to indexing and retrieving vehicles by run ID instead, to
avoid that problem.