### PR TITLE
bugfix: Include migrations in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /deps
 /assets/node_modules
 /priv
+!/priv/repo/migrations


### PR DESCRIPTION
It was successfully running all the migrations it had, it just didn't know about any of them!

This will include the migrations folder in the docker image.

I checked the logs for the dev instance I deployed this on, and it did run the migration, and dev is working again.