### PR TITLE
Add more timepoint order hints

### DIFF
--- a/data/timepoint_order.json
+++ b/data/timepoint_order.json
@@ -1,18 +1,55 @@
 {
+  "11": {
+    "1": ["brway", "waher", "tumed", "sosta", "bdfch"]
+  },
   "15": {
-    "0": ["roxbs", "malcx", "nubn", "kane", "peter", "genbo"]
+    "comment": "malcx and peter are timepoints when they're a short turn terminal",
+    "0": [
+      "roxbs",
+      "malcx",
+      "nubn",
+      "upham",
+      "kane",
+      "peter",
+      "genbo",
+      "fldcr",
+      "dotav",
+      "ashmt"
+    ]
   },
   "19": {
-    "0": ["brlng", "louis", "hrugg", "rugg", "malcx", "nubn"],
-    "1": ["nubn", "roxbs", "louis"]
+    "0": ["brlng", "louis", "hrugg", "rugg", "malcx", "nubn"]
   },
   "23": {
+    "comment": "malcx is a timepoint only for school trip short turns",
     "0": ["roxbs", "malcx", "nubn"]
   },
   "28": {
+    "comment": "malcx is a timepoint only for school trip short turns",
     "0": ["roxbs", "malcx", "nubn"]
   },
   "47": {
     "1": ["brlng", "child", "rugg"]
+  },
+  "60": {
+    "comment": "all round trips loop boham-cnhlm-botul-boham, but some layovers are at cnhlm, and some at botul",
+    "1": ["cnhlm", "botul", "boham"]
+  },
+  "101": {
+    "comment": "mnhen is a short turn terminal between tufts and whill. show school branch to west medford (mngrg,wnbrk) before main brain (medfd)",
+    "0": ["whill", "mnhen", "tufts", "mngrg", "wnbrk", "medfd"]
+  },
+  "426": {
+    "comment": "wlynn is terminal for trips to/from boston. osbrn and holyk are terminals for trips to/from lynn. no trips go to wondw and hayms so force hayms to be later",
+    "0": ["esaug", "wlynn", "osbrn", "holyk", "wasum"],
+    "1": ["lindn", "brown", "bell", "wondw", "hayms"]
+  },
+  "435": {
+    "comment": "435-4-0 visits libtr twice",
+    "0": ["libtr", "danvr"]
+  },
+  "708": {
+    "comment": "all round trips loop hrugg-louis-child-bethi-hrugg, but some layovers are at louis, and some at bethi",
+    "0": ["louis", "child", "bethi"]
   }
 }

--- a/lib/schedule/helpers.ex
+++ b/lib/schedule/helpers.ex
@@ -16,6 +16,9 @@ defmodule Schedule.Helpers do
       iex> Schedule.Helpers.merge_lists([[:a, :b], [:b, :c], [:c, :a]])
       [:a, :b, :c]
 
+      iex> Schedule.Helpers.merge_lists([[:a, :b], [:b, :a, :b]])
+      [:a, :b]
+
   Non-greedily avoids conflicts when possible.
 
       iex> Schedule.Helpers.merge_lists([[:a, :b], [:a, :c], [:b, :c]])
@@ -27,7 +30,9 @@ defmodule Schedule.Helpers do
   """
   @spec merge_lists([[any()]]) :: [any()]
   def merge_lists(lists) do
-    Enum.reduce(lists, [], fn next_order, previously_defined_orders ->
+    lists
+    |> Enum.map(&Enum.uniq/1)
+    |> Enum.reduce([], fn next_order, previously_defined_orders ->
       merge_two_lists(previously_defined_orders, next_order)
     end)
   end

--- a/lib/schedule/timepoint_order.ex
+++ b/lib/schedule/timepoint_order.ex
@@ -90,7 +90,9 @@ defmodule Schedule.TimepointOrder do
     file_binary
     |> Jason.decode!()
     |> Helpers.map_values(fn timepoint_ids_by_direction ->
-      Helpers.map_keys(timepoint_ids_by_direction, &Direction.id_from_string/1)
+      timepoint_ids_by_direction
+      |> Map.delete("comment")
+      |> Helpers.map_keys(&Direction.id_from_string/1)
     end)
   end
 end


### PR DESCRIPTION
Followup to #895 

I looked for all the routes that ran into [this kind of conflict](https://github.com/mbta/skate/pull/895#discussion_r508555899) and added hints (manual overrides) to straighten them out.

<img width="1479" alt="Screen Shot 2020-10-20 at 15 04 09" src="https://user-images.githubusercontent.com/23065557/96632837-49828280-12e6-11eb-887d-ef46ae637f89.png">

There are still conflicts that can't be straightened into a line with timepoint order hints in:
* 708 and 60 (there's a loop with multiple layover points)
* 26 (a loop that sometimes goes clockwise and sometimes counterclockwise)
* 23 (a [bug in GTFS](https://app.asana.com/0/881264583703207/1198563159603145) means one of the variants is listed in the wrong direction)
* 435 (a variant loops to the same timepoint twice, which we can't show)
but I've added hints to be sure those cases are being drawn in the best way possible.

I did not search for places where a branch or short turn (like route 28's malcx school short turn) had an ambiguous resolution to the merge, only places with a conflict with a clearly incorrect resolution, so it's still possible for inspectors to report timepoints being out of order. But this should get the worst of them.