### PR TITLE
Show at most one floating notification

### DIFF
--- a/assets/src/components/inactiveNotificationModal.tsx
+++ b/assets/src/components/inactiveNotificationModal.tsx
@@ -7,10 +7,10 @@ import { title } from "./notificationContent"
 
 const InactiveNotificationModal = ({
   notification,
-  hide,
+  hideNotification,
 }: {
   notification: Notification
-  hide: () => void
+  hideNotification: () => void
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
 
@@ -19,7 +19,7 @@ const InactiveNotificationModal = ({
   }
 
   const hideAndClose = () => {
-    hide()
+    hideNotification()
     closeModal()
   }
 

--- a/assets/src/components/inactiveNotificationModal.tsx
+++ b/assets/src/components/inactiveNotificationModal.tsx
@@ -1,16 +1,16 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { closeIcon } from "../helpers/icon"
-import { Notification, NotificationId } from "../realtime.d"
+import { Notification } from "../realtime.d"
 import { setNotification } from "../state"
 import { title } from "./notificationContent"
 
 const InactiveNotificationModal = ({
   notification,
-  removeNotification,
+  hide,
 }: {
   notification: Notification
-  removeNotification: (id: NotificationId) => void
+  hide: () => void
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
 
@@ -18,8 +18,8 @@ const InactiveNotificationModal = ({
     dispatch(setNotification(undefined))
   }
 
-  const removeNotificationAndClose = () => {
-    removeNotification(notification.id)
+  const hideAndClose = () => {
+    hide()
     closeModal()
   }
 
@@ -44,7 +44,7 @@ const InactiveNotificationModal = ({
           </button>
           <button
             className="m-inactive-notification-modal__discard-button"
-            onClick={removeNotificationAndClose}
+            onClick={hideAndClose}
           >
             Remove
           </button>

--- a/assets/src/components/modal.tsx
+++ b/assets/src/components/modal.tsx
@@ -12,7 +12,7 @@ const Modal = (): ReactElement | null => {
   const { connectionStatus } = useContext(SocketContext)
   const [{ selectedNotification }] = useContext(StateDispatchContext)
   const vehicleForNotification = useContext(VehicleForNotificationContext)
-  const { removeNotification } = useContext(NotificationsContext)
+  const { hide } = useContext(NotificationsContext)
 
   if (connectionStatus === ConnectionStatus.Disconnected) {
     return <DisconnectedModal />
@@ -22,7 +22,7 @@ const Modal = (): ReactElement | null => {
     return (
       <InactiveNotificationModal
         notification={selectedNotification}
-        removeNotification={removeNotification}
+        hide={hide}
       />
     )
   }

--- a/assets/src/components/modal.tsx
+++ b/assets/src/components/modal.tsx
@@ -12,7 +12,7 @@ const Modal = (): ReactElement | null => {
   const { connectionStatus } = useContext(SocketContext)
   const [{ selectedNotification }] = useContext(StateDispatchContext)
   const vehicleForNotification = useContext(VehicleForNotificationContext)
-  const { hide } = useContext(NotificationsContext)
+  const { hideNotification } = useContext(NotificationsContext)
 
   if (connectionStatus === ConnectionStatus.Disconnected) {
     return <DisconnectedModal />
@@ -22,7 +22,7 @@ const Modal = (): ReactElement | null => {
     return (
       <InactiveNotificationModal
         notification={selectedNotification}
-        hide={hide}
+        hideNotification={hideNotification}
       />
     )
   }

--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -44,7 +44,9 @@ const Content = () => {
     dispatch(setNotification(notification))
   }
 
-  if (notifications.length === 0) return <EmptyMessage />
+  if (notifications.length === 0) {
+    return <EmptyMessage />
+  }
 
   return (
     <div className="m-notification-drawer__cards">

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -2,12 +2,14 @@ import React, { useContext, useEffect, useState } from "react"
 import { NotificationsContext } from "../contexts/notificationsContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useCurrentTime from "../hooks/useCurrentTime"
-import { Notification, NotificationId } from "../realtime.d"
+import { Notification } from "../realtime.d"
 import { setNotification } from "../state"
 import { NotificationContent } from "./notificationContent"
 
 export const Notifications = () => {
-  const { notifications, removeNotification } = useContext(NotificationsContext)
+  const { notifications, showLatestNotification, hide } = useContext(
+    NotificationsContext
+  )
   const currentTime = useCurrentTime()
 
   const [, dispatch] = useContext(StateDispatchContext)
@@ -16,29 +18,31 @@ export const Notifications = () => {
     dispatch(setNotification(notification))
   }
 
+  const latestNotificationIndex = notifications.length - 1
+
   return (
     <div className="m-notifications">
-      {notifications.map((notification) => (
+      {showLatestNotification && latestNotificationIndex >= 0 && (
         <NotificationCard
-          key={notification.id}
-          notification={notification}
-          remove={removeNotification}
+          key={notifications[latestNotificationIndex].id}
+          notification={notifications[latestNotificationIndex]}
+          hide={hide}
           currentTime={currentTime}
           openVPPForCurrentVehicle={openVPPForCurrentVehicle}
         />
-      ))}
+      )}
     </div>
   )
 }
 
 export const NotificationCard = ({
   notification,
-  remove,
+  hide,
   currentTime,
   openVPPForCurrentVehicle,
 }: {
   notification: Notification
-  remove: (id: NotificationId) => void
+  hide: () => void
   currentTime: Date
   openVPPForCurrentVehicle: (notification: Notification) => void
 }) => {
@@ -63,11 +67,8 @@ export const NotificationCard = ({
           currentTime={currentTime}
         />
       </button>
-      <button
-        className="m-notifications__close"
-        onClick={() => remove(notification.id)}
-      >
-        Close
+      <button className="m-notifications__close" onClick={() => hide()}>
+        Hide
       </button>
     </div>
   )

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -7,9 +7,11 @@ import { setNotification } from "../state"
 import { NotificationContent } from "./notificationContent"
 
 export const Notifications = () => {
-  const { notifications, showLatestNotification, hide } = useContext(
-    NotificationsContext
-  )
+  const {
+    notifications,
+    showLatestNotification,
+    hideNotification,
+  } = useContext(NotificationsContext)
   const currentTime = useCurrentTime()
 
   const [, dispatch] = useContext(StateDispatchContext)
@@ -26,7 +28,7 @@ export const Notifications = () => {
         <NotificationCard
           key={notifications[latestNotificationIndex].id}
           notification={notifications[latestNotificationIndex]}
-          hide={hide}
+          hideNotification={hideNotification}
           currentTime={currentTime}
           openVPPForCurrentVehicle={openVPPForCurrentVehicle}
         />
@@ -37,12 +39,12 @@ export const Notifications = () => {
 
 export const NotificationCard = ({
   notification,
-  hide,
+  hideNotification,
   currentTime,
   openVPPForCurrentVehicle,
 }: {
   notification: Notification
-  hide: () => void
+  hideNotification: () => void
   currentTime: Date
   openVPPForCurrentVehicle: (notification: Notification) => void
 }) => {
@@ -67,7 +69,10 @@ export const NotificationCard = ({
           currentTime={currentTime}
         />
       </button>
-      <button className="m-notifications__close" onClick={() => hide()}>
+      <button
+        className="m-notifications__close"
+        onClick={() => hideNotification()}
+      >
         Hide
       </button>
     </div>

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -26,7 +26,6 @@ export const Notifications = () => {
     <div className="m-notifications">
       {showLatestNotification && latestNotificationIndex >= 0 && (
         <NotificationCard
-          key={notifications[latestNotificationIndex].id}
           notification={notifications[latestNotificationIndex]}
           hideNotification={hideNotification}
           currentTime={currentTime}

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -5,7 +5,7 @@ import { Notification } from "../realtime.d"
 export interface NotificationsStatus {
   notifications: Notification[]
   showLatestNotification: boolean
-  hide: () => void
+  hideNotification: () => void
 }
 
 // Codecov gets in a snit about not covering the "hide" no-op below.
@@ -15,7 +15,7 @@ export const NotificationsContext = createContext<NotificationsStatus>({
   notifications: [],
   showLatestNotification: false,
   // tslint:disable-next-line: no-empty
-  hide: () => {},
+  hideNotification: () => {},
 })
 
 const deliverFullstoryEvent = (numStacked: number): void => {
@@ -45,7 +45,7 @@ export const NotificationsProvider = ({
     setShowLatestNotification(true)
   }
 
-  const hide = () => setShowLatestNotification(false)
+  const hideNotification = () => setShowLatestNotification(false)
 
   useNotifications(addNotification)
 
@@ -54,7 +54,7 @@ export const NotificationsProvider = ({
       value={{
         notifications,
         showLatestNotification,
-        hide,
+        hideNotification,
       }}
     >
       {children}

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -1,19 +1,24 @@
 import React, { createContext, ReactElement, useState } from "react"
 import { useNotifications } from "../hooks/useNotifications"
-import { Notification, NotificationId } from "../realtime.d"
+import { Notification } from "../realtime.d"
 
 export interface NotificationsStatus {
   notifications: Notification[]
-  removeNotification: (notificationId: NotificationId) => void
+  showLatestNotification: boolean
+  hide: () => void
 }
+
+// Codecov gets in a snit about not covering the "hide" no-op below.
+/* istanbul ignore next */
 
 export const NotificationsContext = createContext<NotificationsStatus>({
   notifications: [],
+  showLatestNotification: false,
   // tslint:disable-next-line: no-empty
-  removeNotification: () => {},
+  hide: () => {},
 })
 
-const deliveryFullstoryEvent = (numStacked: number): void => {
+const deliverFullstoryEvent = (numStacked: number): void => {
   if (window.FS && window.username) {
     window.FS.event("Notification delivered", {
       num_stacked_int: numStacked,
@@ -27,16 +32,20 @@ export const NotificationsProvider = ({
   children: ReactElement<HTMLElement>
 }) => {
   const [notifications, setNotifications] = useState<Notification[]>([])
+  const [showLatestNotification, setShowLatestNotification] = useState<boolean>(
+    false
+  )
   const addNotification = (notification: Notification): void => {
     setNotifications((previous) => {
       const newNotifications = [...previous, notification]
-      deliveryFullstoryEvent(newNotifications.length)
+      deliverFullstoryEvent(newNotifications.length)
       return newNotifications
     })
+
+    setShowLatestNotification(true)
   }
-  const removeNotification = (id: NotificationId): void => {
-    setNotifications((previous) => previous.filter((n) => n.id !== id))
-  }
+
+  const hide = () => setShowLatestNotification(false)
 
   useNotifications(addNotification)
 
@@ -44,7 +53,8 @@ export const NotificationsProvider = ({
     <NotificationsContext.Provider
       value={{
         notifications,
-        removeNotification,
+        showLatestNotification,
+        hide,
       }}
     >
       {children}

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`NotificationDrawer renders empty state 1`] = `
 </div>
 `;
 
-exports[`NotificationDrawer renders latest notification 1`] = `
+exports[`NotificationDrawer renders notifications 1`] = `
 <div
   className="m-notification-drawer"
 >

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`NotificationDrawer renders empty state 1`] = `
 </div>
 `;
 
-exports[`NotificationDrawer renders notifications 1`] = `
+exports[`NotificationDrawer renders latest notification 1`] = `
 <div
   className="m-notification-drawer"
 >

--- a/assets/tests/components/__snapshots__/notifications.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notifications.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Notification renders empty state 1`] = `
 />
 `;
 
-exports[`Notification renders notifications 1`] = `
+exports[`Notification renders latest notification 1`] = `
 <div
   className="m-notifications"
 >
@@ -69,69 +69,7 @@ exports[`Notification renders notifications 1`] = `
       className="m-notifications__close"
       onClick={[Function]}
     >
-      Close
-    </button>
-  </div>
-  <div
-    className="m-notifications__card m-notifications__card--new"
-  >
-    <button
-      className="m-notifications__card-info"
-      onClick={[Function]}
-    >
-      <div
-        className="m-notification-content"
-      >
-        <div
-          className="m-notification-content__title-row"
-        >
-          <div
-            className="m-notification-content__title"
-          >
-            NO OPERATOR
-          </div>
-          <div
-            className="m-notification-content__age"
-          >
-            0 min
-          </div>
-        </div>
-        <div
-          className="m-notification-content__description"
-        >
-          OCC reported that an operator is not available on the route1, route2.
-        </div>
-        <div
-          className="m-properties-list"
-        >
-          <table
-            className="m-properties-list__table"
-          >
-            <tbody>
-              <tr
-                className="m-properties-list__property "
-              >
-                <td
-                  className="m-properties-list__property-label"
-                >
-                  Run
-                </td>
-                <td
-                  className="m-properties-list__property-value"
-                >
-                  run1, run2
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </button>
-    <button
-      className="m-notifications__close"
-      onClick={[Function]}
-    >
-      Close
+      Hide
     </button>
   </div>
 </div>
@@ -197,7 +135,7 @@ exports[`NotificationCard renders a notification with an unexpected reason 1`] =
     className="m-notifications__close"
     onClick={[Function]}
   >
-    Close
+    Hide
   </button>
 </div>
 `;
@@ -276,7 +214,7 @@ exports[`NotificationCard renders notification with matched vehicle 1`] = `
     className="m-notifications__close"
     onClick={[Function]}
   >
-    Close
+    Hide
   </button>
 </div>
 `;

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -21,12 +21,15 @@ describe("InactiveNotificationModal", () => {
     ...notification,
     startTime: new Date("20200-10-05"),
   }
-  const hide = jest.fn()
+  const hideNotification = jest.fn()
 
   test("renders for a notification with no runs", () => {
     const tree = renderer
       .create(
-        <InactiveNotificationModal notification={notification} hide={hide} />
+        <InactiveNotificationModal
+          notification={notification}
+          hideNotification={hideNotification}
+        />
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -37,7 +40,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111"] }}
-          hide={hide}
+          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -49,7 +52,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111", "222"] }}
-          hide={hide}
+          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -61,7 +64,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111"] }}
-          hide={hide}
+          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -73,7 +76,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111", "222"] }}
-          hide={hide}
+          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -82,37 +85,46 @@ describe("InactiveNotificationModal", () => {
 
   test("allows removing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal notification={notification} hide={hide} />
+      <InactiveNotificationModal
+        notification={notification}
+        hideNotification={hideNotification}
+      />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__discard-button")
       .first()
       .simulate("click")
-    expect(hide).toHaveBeenCalled()
+    expect(hideNotification).toHaveBeenCalled()
   })
 
   test("allows removing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal notification={notification} hide={hide} />
+      <InactiveNotificationModal
+        notification={notification}
+        hideNotification={hideNotification}
+      />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__discard-button")
       .first()
       .simulate("click")
-    expect(hide).toHaveBeenCalled()
+    expect(hideNotification).toHaveBeenCalled()
   })
 
   test("allows closing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal notification={notification} hide={hide} />
+      <InactiveNotificationModal
+        notification={notification}
+        hideNotification={hideNotification}
+      />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__keep-button")
       .first()
       .simulate("click")
-    expect(hide).not.toHaveBeenCalled()
+    expect(hideNotification).not.toHaveBeenCalled()
   })
 })

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -21,15 +21,12 @@ describe("InactiveNotificationModal", () => {
     ...notification,
     startTime: new Date("20200-10-05"),
   }
-  const removeNotification = jest.fn()
+  const hide = jest.fn()
 
   test("renders for a notification with no runs", () => {
     const tree = renderer
       .create(
-        <InactiveNotificationModal
-          notification={notification}
-          removeNotification={removeNotification}
-        />
+        <InactiveNotificationModal notification={notification} hide={hide} />
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -40,7 +37,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111"] }}
-          removeNotification={removeNotification}
+          hide={hide}
         />
       )
       .toJSON()
@@ -52,7 +49,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111", "222"] }}
-          removeNotification={removeNotification}
+          hide={hide}
         />
       )
       .toJSON()
@@ -64,7 +61,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111"] }}
-          removeNotification={removeNotification}
+          hide={hide}
         />
       )
       .toJSON()
@@ -76,7 +73,7 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111", "222"] }}
-          removeNotification={removeNotification}
+          hide={hide}
         />
       )
       .toJSON()
@@ -85,45 +82,37 @@ describe("InactiveNotificationModal", () => {
 
   test("allows removing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        removeNotification={removeNotification}
-      />
+      <InactiveNotificationModal notification={notification} hide={hide} />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__discard-button")
       .first()
       .simulate("click")
-    expect(removeNotification).toHaveBeenCalledWith(notification.id)
+    expect(hide).toHaveBeenCalled()
   })
+
   test("allows removing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        removeNotification={removeNotification}
-      />
+      <InactiveNotificationModal notification={notification} hide={hide} />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__discard-button")
       .first()
       .simulate("click")
-    expect(removeNotification).toHaveBeenCalledWith(notification.id)
+    expect(hide).toHaveBeenCalled()
   })
 
   test("allows closing the modal", () => {
     const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        removeNotification={removeNotification}
-      />
+      <InactiveNotificationModal notification={notification} hide={hide} />
     )
 
     wrapper
       .find(".m-inactive-notification-modal__keep-button")
       .first()
       .simulate("click")
-    expect(removeNotification).not.toHaveBeenCalled()
+    expect(hide).not.toHaveBeenCalled()
   })
 })

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -98,21 +98,6 @@ describe("InactiveNotificationModal", () => {
     expect(hideNotification).toHaveBeenCalled()
   })
 
-  test("allows removing the modal", () => {
-    const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        hideNotification={hideNotification}
-      />
-    )
-
-    wrapper
-      .find(".m-inactive-notification-modal__discard-button")
-      .first()
-      .simulate("click")
-    expect(hideNotification).toHaveBeenCalled()
-  })
-
   test("allows closing the modal", () => {
     const wrapper = mount(
       <InactiveNotificationModal

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -3,8 +3,8 @@ import React from "react"
 import renderer from "react-test-renderer"
 import NotificationDrawer from "../../src/components/notificationDrawer"
 import { NotificationsContext } from "../../src/contexts/notificationsContext"
-import { Notification } from "../../src/realtime.d"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import { Notification } from "../../src/realtime.d"
 import {
   closeNotificationDrawer,
   initialState,
@@ -30,13 +30,14 @@ describe("NotificationDrawer", () => {
     expect(dispatch).toHaveBeenCalledWith(closeNotificationDrawer())
   })
 
-  test("renders notifications", () => {
+  test("renders latest notification", () => {
     const tree = renderer
       .create(
         <NotificationsContext.Provider
           value={{
             notifications: [notification],
-            removeNotification: jest.fn(),
+            showLatestNotification: true,
+            hide: jest.fn(),
           }}
         >
           <NotificationDrawer />
@@ -53,7 +54,8 @@ describe("NotificationDrawer", () => {
         <NotificationsContext.Provider
           value={{
             notifications: [notification],
-            removeNotification: jest.fn(),
+            showLatestNotification: true,
+            hide: jest.fn(),
           }}
         >
           <NotificationDrawer />

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -37,7 +37,7 @@ describe("NotificationDrawer", () => {
           value={{
             notifications: [notification],
             showLatestNotification: true,
-            hide: jest.fn(),
+            hideNotification: jest.fn(),
           }}
         >
           <NotificationDrawer />
@@ -55,7 +55,7 @@ describe("NotificationDrawer", () => {
           value={{
             notifications: [notification],
             showLatestNotification: true,
-            hide: jest.fn(),
+            hideNotification: jest.fn(),
           }}
         >
           <NotificationDrawer />

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -30,7 +30,7 @@ describe("NotificationDrawer", () => {
     expect(dispatch).toHaveBeenCalledWith(closeNotificationDrawer())
   })
 
-  test("renders latest notification", () => {
+  test("renders notifications", () => {
     const tree = renderer
       .create(
         <NotificationsContext.Provider

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -63,7 +63,7 @@ describe("Notification", () => {
           value={{
             notifications,
             showLatestNotification: true,
-            hide: jest.fn(),
+            hideNotification: jest.fn(),
           }}
         >
           <Notifications />
@@ -74,13 +74,13 @@ describe("Notification", () => {
   })
 
   test("can hide notification", () => {
-    const hide = jest.fn()
+    const hideNotification = jest.fn()
     const wrapper = mount(
       <NotificationsContext.Provider
         value={{
           notifications: [notification],
           showLatestNotification: true,
-          hide,
+          hideNotification,
         }}
       >
         <Notifications />
@@ -88,7 +88,7 @@ describe("Notification", () => {
     )
     expect(wrapper.find(".m-notifications__card")).toHaveLength(1)
     wrapper.find(".m-notifications__close").simulate("click")
-    expect(hide).toHaveBeenCalled()
+    expect(hideNotification).toHaveBeenCalled()
   })
 })
 
@@ -98,7 +98,7 @@ describe("NotificationCard", () => {
       .create(
         <NotificationCard
           notification={notificationWithMatchedVehicle}
-          hide={jest.fn()}
+          hideNotification={jest.fn()}
           currentTime={now()}
           openVPPForCurrentVehicle={jest.fn()}
         />
@@ -112,7 +112,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -125,7 +125,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -139,7 +139,7 @@ describe("NotificationCard", () => {
       .create(
         <NotificationCard
           notification={n}
-          hide={jest.fn()}
+          hideNotification={jest.fn()}
           currentTime={now()}
           openVPPForCurrentVehicle={jest.fn()}
         />
@@ -158,7 +158,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -176,7 +176,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -194,7 +194,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -217,7 +217,7 @@ describe("NotificationCard", () => {
     mount(
       <NotificationCard
         notification={n}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -229,7 +229,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={notification}
-        hide={jest.fn()}
+        hideNotification={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -52,7 +52,7 @@ describe("Notification", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders notifications", () => {
+  test("renders latest notification", () => {
     const notifications = [
       { ...notification, id: "0" },
       { ...notification, id: "1" },
@@ -62,7 +62,8 @@ describe("Notification", () => {
         <NotificationsContext.Provider
           value={{
             notifications,
-            removeNotification: jest.fn(),
+            showLatestNotification: true,
+            hide: jest.fn(),
           }}
         >
           <Notifications />
@@ -72,13 +73,14 @@ describe("Notification", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("can close notification", () => {
-    const removeNotification = jest.fn()
+  test("can hide notification", () => {
+    const hide = jest.fn()
     const wrapper = mount(
       <NotificationsContext.Provider
         value={{
           notifications: [notification],
-          removeNotification,
+          showLatestNotification: true,
+          hide,
         }}
       >
         <Notifications />
@@ -86,7 +88,7 @@ describe("Notification", () => {
     )
     expect(wrapper.find(".m-notifications__card")).toHaveLength(1)
     wrapper.find(".m-notifications__close").simulate("click")
-    expect(removeNotification).toHaveBeenCalledWith(notification.id)
+    expect(hide).toHaveBeenCalled()
   })
 })
 
@@ -96,7 +98,7 @@ describe("NotificationCard", () => {
       .create(
         <NotificationCard
           notification={notificationWithMatchedVehicle}
-          remove={jest.fn()}
+          hide={jest.fn()}
           currentTime={now()}
           openVPPForCurrentVehicle={jest.fn()}
         />
@@ -110,7 +112,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -123,7 +125,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -137,7 +139,7 @@ describe("NotificationCard", () => {
       .create(
         <NotificationCard
           notification={n}
-          remove={jest.fn()}
+          hide={jest.fn()}
           currentTime={now()}
           openVPPForCurrentVehicle={jest.fn()}
         />
@@ -156,7 +158,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -174,7 +176,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -192,7 +194,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -215,7 +217,7 @@ describe("NotificationCard", () => {
     mount(
       <NotificationCard
         notification={n}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -227,7 +229,7 @@ describe("NotificationCard", () => {
     const wrapper = mount(
       <NotificationCard
         notification={notification}
-        remove={jest.fn()}
+        hide={jest.fn()}
         currentTime={now()}
         openVPPForCurrentVehicle={jest.fn()}
       />
@@ -246,6 +248,7 @@ describe("NotificationCard", () => {
       tripIds: ["123", "456", "789"],
     }
     mockUseStateOnce([updatedNotification])
+    mockUseStateOnce(true)
     const mockDispatch: Dispatch = jest.fn()
 
     const wrapper = mount(

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -87,7 +87,7 @@ describe("Notification", () => {
     })
     expect(result.current.showLatestNotification).toEqual(true)
     hooksAct(() => {
-      result.current.hide()
+      result.current.hideNotification()
     })
     expect(result.current.showLatestNotification).toEqual(false)
   })

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -79,15 +79,16 @@ describe("Notification", () => {
     window.username = originalUsername
   })
 
-  test("can close notification", () => {
+  test("can hide notification", () => {
     mockUseStateOnce([notification])
+    mockUseStateOnce(true)
     const { result } = renderHook(() => useContext(NotificationsContext), {
       wrapper: NotificationsProvider,
     })
-    expect(result.current.notifications).toHaveLength(1)
+    expect(result.current.showLatestNotification).toEqual(true)
     hooksAct(() => {
-      result.current.removeNotification(notification.id)
+      result.current.hide()
     })
-    expect(result.current.notifications).toHaveLength(0)
+    expect(result.current.showLatestNotification).toEqual(false)
   })
 })


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1192202587402579

Now we only show the most recent notification, which we can now hide but no longer remove. The distinction will become important when we start populating the drawer.