### PR TITLE
Store notifications in the database

### DIFF
--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -8,6 +8,7 @@ import { RouteId, TripId } from "../schedule.d"
 import { dateFromEpochSeconds } from "../util/dateTime"
 
 export interface NotificationData {
+  id: NotificationId
   created_at: number
   reason: NotificationReason
   route_ids: RouteId[]
@@ -22,7 +23,7 @@ export interface NotificationData {
 export const notificationFromData = (
   notificationData: NotificationData
 ): Notification => ({
-  id: generateId(notificationData),
+  id: notificationData.id,
   createdAt: dateFromEpochSeconds(notificationData.created_at),
   reason: notificationData.reason,
   routeIds: notificationData.route_ids,
@@ -33,14 +34,3 @@ export const notificationFromData = (
   routeIdAtCreation: notificationData.route_id_at_creation,
   startTime: new Date(notificationData.start_time),
 })
-
-const generateId = (notificationData: NotificationData): NotificationId => {
-  const stringifiedFields = [
-    notificationData.created_at,
-    notificationData.start_time,
-    notificationData.trip_ids,
-    notificationData.reason,
-  ].map((field) => field.toString())
-
-  return stringifiedFields.join("_")
-}

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -14,6 +14,7 @@ import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 // tslint:disable: react-hooks-nesting
 
 const notificationData: NotificationData = {
+  id: "12345",
   created_at: 0,
   reason: "manpower",
   route_ids: ["route"],

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -15,6 +15,8 @@ defmodule Notifications.Db.Notification do
     field(:operator_id, :string)
     field(:operator_name, :string)
     field(:route_id_at_creation, :string)
+    field(:block_id, :string)
+    field(:service_id, :string)
     field(:start_time, :integer)
     field(:end_time, :integer)
     timestamps()
@@ -32,6 +34,8 @@ defmodule Notifications.Db.Notification do
       :operator_id,
       :operator_name,
       :route_id_at_creation,
+      :block_id,
+      :service_id,
       :start_time,
       :end_time
     ])
@@ -41,6 +45,8 @@ defmodule Notifications.Db.Notification do
       :route_ids,
       :run_ids,
       :trip_ids,
+      :block_id,
+      :service_id,
       :start_time,
       :end_time
     ])

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -1,0 +1,45 @@
+defmodule Notifications.Db.Notification do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Notifications.NotificationReason
+
+  @type t() :: %__MODULE__{}
+
+  schema "notifications" do
+    field(:created_at, :integer)
+    field(:reason, NotificationReason)
+    field(:route_ids, {:array, :string})
+    field(:run_ids, {:array, :string})
+    field(:trip_ids, {:array, :string})
+    field(:operator_id, :string)
+    field(:operator_name, :string)
+    field(:route_id_at_creation, :string)
+    field(:start_time, :integer)
+    timestamps()
+  end
+
+  def changeset(notification, attrs \\ %{}) do
+    notification
+    |> cast(attrs, [
+      :id,
+      :created_at,
+      :reason,
+      :route_ids,
+      :run_ids,
+      :trip_ids,
+      :operator_id,
+      :operator_name,
+      :route_id_at_creation,
+      :start_time
+    ])
+    |> validate_required([
+      :created_at,
+      :reason,
+      :route_ids,
+      :run_ids,
+      :trip_ids,
+      :start_time
+    ])
+  end
+end

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -50,5 +50,15 @@ defmodule Notifications.Db.Notification do
       :start_time,
       :end_time
     ])
+    |> unique_constraint(
+      [
+        :start_time,
+        :end_time,
+        :block_id,
+        :service_id,
+        :reason
+      ],
+      name: "notifications_unique_index"
+    )
   end
 end

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -16,6 +16,7 @@ defmodule Notifications.Db.Notification do
     field(:operator_name, :string)
     field(:route_id_at_creation, :string)
     field(:start_time, :integer)
+    field(:end_time, :integer)
     timestamps()
   end
 
@@ -31,7 +32,8 @@ defmodule Notifications.Db.Notification do
       :operator_id,
       :operator_name,
       :route_id_at_creation,
-      :start_time
+      :start_time,
+      :end_time
     ])
     |> validate_required([
       :created_at,
@@ -39,7 +41,8 @@ defmodule Notifications.Db.Notification do
       :route_ids,
       :run_ids,
       :trip_ids,
-      :start_time
+      :start_time,
+      :end_time
     ])
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -57,7 +57,7 @@ defmodule Notifications.Notification do
     :end_time
   ]
 
-  @spec create([t()]) :: [t()]
+  @spec create(t(), (DbNotification.t() -> t())) :: t()
   def create(notification_without_id, insertion_callback \\ fn _ -> nil end) do
     changeset =
       DbNotification.changeset(
@@ -76,6 +76,6 @@ defmodule Notifications.Notification do
           nil
       end
 
-    %{notification_without_id | id: id}
+    %__MODULE__{notification_without_id | id: id}
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -60,8 +60,8 @@ defmodule Notifications.Notification do
     :end_time
   ]
 
-  @spec get_or_create(t(), (DbNotification.t() -> t())) :: t()
-  def get_or_create(notification_without_id, insertion_callback \\ fn _ -> nil end) do
+  @spec get_or_create(t()) :: t()
+  def get_or_create(notification_without_id) do
     identifying_fields =
       Map.take(notification_without_id, [:start_time, :end_time, :block_id, :service_id, :reason])
       |> Map.to_list()
@@ -82,7 +82,6 @@ defmodule Notifications.Notification do
           db_notification = insert!(changeset)
           notification_with_id = %{notification_without_id | id: db_notification.id}
           log_creation(notification_with_id)
-          insertion_callback.(notification_with_id)
           db_notification
         end
       end)

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -1,6 +1,7 @@
 defmodule Notifications.Notification do
   alias Schedule.Route
   alias Schedule.Trip
+  alias Schedule.Hastus.Run
 
   @type notification_reason :: :manpower | :disabled | :diverted | :accident
 
@@ -8,7 +9,7 @@ defmodule Notifications.Notification do
           created_at: Util.Time.timestamp(),
           reason: notification_reason(),
           route_ids: [Route.id()],
-          run_ids: [String.t()],
+          run_ids: [Run.id()],
           trip_ids: [Trip.id()],
           operator_id: String.t() | nil,
           operator_name: String.t() | nil,

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -1,13 +1,18 @@
 defmodule Notifications.Notification do
+  import Skate.Repo
+
   alias Schedule.Route
   alias Schedule.Trip
   alias Schedule.Hastus.Run
+  alias Notifications.NotificationReason
+  alias Notifications.Db.Notification, as: DbNotification
 
-  @type notification_reason :: :manpower | :disabled | :diverted | :accident
+  @type id :: integer()
 
   @type t() :: %__MODULE__{
+          id: id() | nil,
           created_at: Util.Time.timestamp(),
-          reason: notification_reason(),
+          reason: NotificationReason.t(),
           route_ids: [Route.id()],
           run_ids: [Run.id()],
           trip_ids: [Trip.id()],
@@ -19,7 +24,17 @@ defmodule Notifications.Notification do
 
   @derive Jason.Encoder
 
+  @enforce_keys [
+    :created_at,
+    :reason,
+    :route_ids,
+    :run_ids,
+    :trip_ids,
+    :start_time
+  ]
+
   defstruct [
+    :id,
     :created_at,
     :reason,
     :route_ids,
@@ -30,4 +45,13 @@ defmodule Notifications.Notification do
     :route_id_at_creation,
     :start_time
   ]
+
+  @spec create([t()]) :: [t()]
+  def create(notification_without_id) do
+    id = insert!(
+      DbNotification.changeset(%DbNotification{}, notification_without_id),
+      returning: :id
+    )
+    %{notification_without_id | id: id}
+  end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -1,6 +1,8 @@
 defmodule Notifications.Notification do
   import Skate.Repo
 
+  alias Schedule.Block
+  alias Schedule.Gtfs.Service
   alias Schedule.Route
   alias Schedule.Trip
   alias Schedule.Hastus.Run
@@ -12,6 +14,8 @@ defmodule Notifications.Notification do
   @type t() :: %__MODULE__{
           id: id() | nil,
           created_at: Util.Time.timestamp(),
+          block_id: Block.id(),
+          service_id: Service.id(),
           reason: NotificationReason.t(),
           route_ids: [Route.id()],
           run_ids: [Run.id()],
@@ -26,6 +30,8 @@ defmodule Notifications.Notification do
   @derive Jason.Encoder
 
   @enforce_keys [
+    :block_id,
+    :service_id,
     :created_at,
     :reason,
     :route_ids,
@@ -37,6 +43,8 @@ defmodule Notifications.Notification do
 
   defstruct [
     :id,
+    :block_id,
+    :service_id,
     :created_at,
     :reason,
     :route_ids,
@@ -57,8 +65,9 @@ defmodule Notifications.Notification do
         Map.from_struct(notification_without_id)
       )
 
-    id = insert!(changeset, returning: [:id])
+    _id = insert!(changeset)
 
-    %{notification_without_id | id: id}
+    # %{notification_without_id | id: id}
+    notification_without_id
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -86,6 +86,6 @@ defmodule Notifications.Notification do
   end
 
   defp log_creation(notification) do
-    Logger.warn("Notification created new notification new_notification=#{inspect(notification)}")
+    Logger.warn("Notification created new_notification=#{inspect(notification)}")
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -19,7 +19,8 @@ defmodule Notifications.Notification do
           operator_id: String.t() | nil,
           operator_name: String.t() | nil,
           route_id_at_creation: Route.id() | nil,
-          start_time: Util.Time.timestamp()
+          start_time: Util.Time.timestamp(),
+          end_time: Util.Time.timestamp()
         }
 
   @derive Jason.Encoder
@@ -30,7 +31,8 @@ defmodule Notifications.Notification do
     :route_ids,
     :run_ids,
     :trip_ids,
-    :start_time
+    :start_time,
+    :end_time
   ]
 
   defstruct [
@@ -43,15 +45,20 @@ defmodule Notifications.Notification do
     :operator_id,
     :operator_name,
     :route_id_at_creation,
-    :start_time
+    :start_time,
+    :end_time
   ]
 
   @spec create([t()]) :: [t()]
   def create(notification_without_id) do
-    id = insert!(
-      DbNotification.changeset(%DbNotification{}, notification_without_id),
-      returning: :id
-    )
+    changeset =
+      DbNotification.changeset(
+        %DbNotification{},
+        Map.from_struct(notification_without_id)
+      )
+
+    id = insert!(changeset, returning: [:id])
+
     %{notification_without_id | id: id}
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -9,6 +9,8 @@ defmodule Notifications.Notification do
   alias Notifications.NotificationReason
   alias Notifications.Db.Notification, as: DbNotification
 
+  require Logger
+
   @type id :: integer()
 
   @type t() :: %__MODULE__{
@@ -69,6 +71,7 @@ defmodule Notifications.Notification do
       case insert(changeset) do
         {:ok, db_notification} ->
           notification_with_id = %{notification_without_id | id: db_notification.id}
+          log_creation(notification_with_id)
           insertion_callback.(notification_with_id)
           db_notification.id
 
@@ -77,5 +80,9 @@ defmodule Notifications.Notification do
       end
 
     %__MODULE__{notification_without_id | id: id}
+  end
+
+  defp log_creation(notification) do
+    Logger.warn("Notification created new notification new_notification=#{inspect(notification)}")
   end
 end

--- a/lib/notifications/notification_reason.ex
+++ b/lib/notifications/notification_reason.ex
@@ -1,0 +1,28 @@
+defmodule Notifications.NotificationReason do
+  use Ecto.Type
+
+  @type t :: :manpower | :disabled | :diverted | :accident
+
+  @impl true
+  def type, do: :string
+
+  @impl true
+  def cast(:manpower), do: {:ok, :manpower}
+  def cast(:disabled), do: {:ok, :disabled}
+  def cast(:diverted), do: {:ok, :diverted}
+  def cast(:accident), do: {:ok, :accident}
+  def cast(_), do: :error
+
+  @impl true
+  def load("manpower"), do: {:ok, :manpower}
+  def load("disabled"), do: {:ok, :disabled}
+  def load("diverted"), do: {:ok, :diverted}
+  def load("accident"), do: {:ok, :accident}
+  def load(_), do: :error
+
+  @impl true
+  def dump(:manpower), do: {:ok, "manpower"}
+  def dump(:disabled), do: {:ok, "disabled"}
+  def dump(:diverted), do: {:ok, "diverted"}
+  def dump(:accident), do: {:ok, "accident"}
+end

--- a/lib/notifications/notification_reason.ex
+++ b/lib/notifications/notification_reason.ex
@@ -1,28 +1,56 @@
 defmodule Notifications.NotificationReason do
   use Ecto.Type
 
-  @type t :: :manpower | :disabled | :diverted | :accident
+  @type t ::
+          :manpower
+          | :disabled
+          | :diverted
+          | :accident
+          | :other
+          | :adjusted
+          | :operator_error
+          | :traffic
+
+  @valid_reasons [
+    :manpower,
+    :disabled,
+    :diverted,
+    :accident,
+    :other,
+    :adjusted,
+    :operator_error,
+    :traffic
+  ]
 
   @impl true
   def type, do: :string
 
   @impl true
-  def cast(:manpower), do: {:ok, :manpower}
-  def cast(:disabled), do: {:ok, :disabled}
-  def cast(:diverted), do: {:ok, :diverted}
-  def cast(:accident), do: {:ok, :accident}
-  def cast(_), do: :error
+  def cast(reason) do
+    if reason in @valid_reasons do
+      {:ok, reason}
+    else
+      :error
+    end
+  end
 
   @impl true
-  def load("manpower"), do: {:ok, :manpower}
-  def load("disabled"), do: {:ok, :disabled}
-  def load("diverted"), do: {:ok, :diverted}
-  def load("accident"), do: {:ok, :accident}
-  def load(_), do: :error
+  def load(reason) do
+    reason_as_atom = String.to_atom(reason)
+
+    if reason_as_atom in @valid_reasons do
+      {:ok, reason_as_atom}
+    else
+      :error
+    end
+  end
 
   @impl true
-  def dump(:manpower), do: {:ok, "manpower"}
-  def dump(:disabled), do: {:ok, "disabled"}
-  def dump(:diverted), do: {:ok, "diverted"}
-  def dump(:accident), do: {:ok, "accident"}
+  def dump(reason) do
+    if reason in @valid_reasons do
+      {:ok, Atom.to_string(reason)}
+    else
+      :error
+    end
+  end
 end

--- a/lib/notifications/notification_reason.ex
+++ b/lib/notifications/notification_reason.ex
@@ -36,7 +36,7 @@ defmodule Notifications.NotificationReason do
 
   @impl true
   def load(reason) do
-    reason_as_atom = String.to_atom(reason)
+    reason_as_atom = String.to_existing_atom(reason)
 
     if reason_as_atom in @valid_reasons do
       {:ok, reason_as_atom}

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -40,6 +40,7 @@ defmodule Notifications.NotificationServer do
 
   @impl true
   def handle_cast({:new_block_waivers, new_block_waivers_by_block_key}, state) do
+    IO.inspect(new_block_waivers_by_block_key)
     new_notifications =
       new_block_waivers_by_block_key
       |> convert_new_block_waivers_to_notifications()

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -40,7 +40,6 @@ defmodule Notifications.NotificationServer do
 
   @impl true
   def handle_cast({:new_block_waivers, new_block_waivers_by_block_key}, state) do
-    IO.inspect(new_block_waivers_by_block_key)
     new_notifications =
       new_block_waivers_by_block_key
       |> convert_new_block_waivers_to_notifications()

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -43,6 +43,7 @@ defmodule Notifications.NotificationServer do
     new_notifications =
       new_block_waivers_by_block_key
       |> convert_new_block_waivers_to_notifications()
+      |> Enum.map(&Notification.create/1)
 
     if !Enum.empty?(new_notifications) do
       Logger.warn(

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -124,7 +124,8 @@ defmodule Notifications.NotificationServer do
         operator_id: operator_id,
         operator_name: operator_name,
         route_id_at_creation: route_id,
-        start_time: block_waiver.start_time
+        start_time: block_waiver.start_time,
+        end_time: block_waiver.end_time
       }
     end
   end

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -44,10 +44,8 @@ defmodule Notifications.NotificationServer do
       |> convert_new_block_waivers_to_notifications()
 
     Enum.each(new_notifications, fn new_notification ->
-      Notification.create(new_notification, fn new_notification ->
-        broadcast(new_notification, self())
-        nil
-      end)
+      notification_with_id = Notification.get_or_create(new_notification)
+      broadcast(notification_with_id, self())
     end)
 
     {:noreply, state}

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -7,8 +7,6 @@ defmodule Notifications.NotificationServer do
   alias Schedule.Block
   alias Skate.Settings.User
 
-  require Logger
-
   # Client
 
   @spec default_name() :: GenServer.name()
@@ -47,12 +45,6 @@ defmodule Notifications.NotificationServer do
 
     Enum.each(new_notifications, fn new_notification ->
       Notification.create(new_notification, fn new_notification ->
-        Logger.warn(
-          "NotificationServer created new notification new_notification=#{
-            inspect(new_notification)
-          }"
-        )
-
         broadcast(new_notification, self())
         nil
       end)

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -2,6 +2,7 @@ defmodule Notifications.NotificationServer do
   use GenServer
 
   alias Notifications.Notification
+  alias Notifications.NotificationReason
   alias Realtime.{BlockWaiver, Ghost, Vehicle}
   alias Schedule.Block
   alias Skate.Settings.User
@@ -136,7 +137,7 @@ defmodule Notifications.NotificationServer do
 
   # See Realtime.BlockWaiver for the full mapping between numeric
   # `cause_id`s and textual `cause_description`s.
-  @spec get_notification_reason(BlockWaiver.t()) :: Notification.notification_reason() | nil
+  @spec get_notification_reason(BlockWaiver.t()) :: NotificationReason.t() | nil
   defp get_notification_reason(block_waiver) do
     case block_waiver.cause_id do
       1 -> :other

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -116,6 +116,8 @@ defmodule Notifications.NotificationServer do
         end
 
       %Notification{
+        block_id: block_id,
+        service_id: service_id,
         reason: reason,
         created_at: created_at,
         route_ids: route_ids,

--- a/lib/realtime/block_waiver_store.ex
+++ b/lib/realtime/block_waiver_store.ex
@@ -82,15 +82,6 @@ defmodule Realtime.BlockWaiverStore do
       new_block_waivers =
         waiver_diff(state.block_waivers_by_block_key, new_block_waivers_by_block_key)
 
-      fake_block_key = {"C01-8", "abc40ns1"}
-      fake_block_waiver = %BlockWaiver{
-          start_time: 1605186000,
-          end_time: 1605225540,
-          cause_id: 23,
-          cause_description: "Manpower",
-          remark: "testing"
-      }
-
       notification_server_new_block_waivers_fn =
         Application.get_env(
           :notifications,
@@ -98,7 +89,7 @@ defmodule Realtime.BlockWaiverStore do
           &Notifications.NotificationServer.new_block_waivers/1
         )
 
-      notification_server_new_block_waivers_fn.(Map.put(new_block_waivers, fake_block_key, fake_block_waiver))
+      notification_server_new_block_waivers_fn.(new_block_waivers)
     end
 
     {:noreply,

--- a/lib/realtime/block_waiver_store.ex
+++ b/lib/realtime/block_waiver_store.ex
@@ -82,6 +82,15 @@ defmodule Realtime.BlockWaiverStore do
       new_block_waivers =
         waiver_diff(state.block_waivers_by_block_key, new_block_waivers_by_block_key)
 
+      fake_block_key = {"C01-8", "abc40ns1"}
+      fake_block_waiver = %BlockWaiver{
+          start_time: 1605186000,
+          end_time: 1605225540,
+          cause_id: 23,
+          cause_description: "Manpower",
+          remark: "testing"
+      }
+
       notification_server_new_block_waivers_fn =
         Application.get_env(
           :notifications,
@@ -89,7 +98,7 @@ defmodule Realtime.BlockWaiverStore do
           &Notifications.NotificationServer.new_block_waivers/1
         )
 
-      notification_server_new_block_waivers_fn.(new_block_waivers)
+      notification_server_new_block_waivers_fn.(Map.put(new_block_waivers, fake_block_key, fake_block_waiver))
     end
 
     {:noreply,

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -11,6 +11,8 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
       add(:operator_id, :string)
       add(:operator_name, :string)
       add(:route_id_at_creation, :string)
+      add(:block_id, :string, null: false)
+      add(:service_id, :string, null: false)
       add(:start_time, :bigint, null: false)
       add(:end_time, :bigint, null: false)
       timestamps()

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -1,0 +1,18 @@
+defmodule Skate.Repo.Migrations.StoreNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:notifications) do
+      add(:created_at, :bigint, null: false)
+      add(:reason, :string, null: false)
+      add(:route_ids, {:array, :string}, null: false)
+      add(:run_ids, {:array, :string}, null: false)
+      add(:trip_ids, {:array, :string}, null: false)
+      add(:operator_id, :string)
+      add(:operator_name, :string)
+      add(:route_id_at_creation, :string)
+      add(:start_time, :bigint, null: false)
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -33,7 +33,7 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
   end
 
   def down do
-    execute("DROP TYPE notification_reason")
     drop(table(:notifications))
+    execute("DROP TYPE notification_reason")
   end
 end

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -1,7 +1,7 @@
 defmodule Skate.Repo.Migrations.StoreNotifications do
   use Ecto.Migration
 
-  def change do
+  def up do
     create table(:notifications) do
       add(:created_at, :bigint, null: false)
       add(:reason, :string, null: false)
@@ -17,5 +17,18 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
       add(:end_time, :bigint, null: false)
       timestamps()
     end
+
+    create(
+      index(
+        :notifications,
+        [:start_time, :end_time, :block_id, :service_id, :reason],
+        unique: true,
+        name: "notifications_unique_index"
+      )
+    )
+  end
+
+  def down do
+    drop(table(:notifications))
   end
 end

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -12,6 +12,7 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
       add(:operator_name, :string)
       add(:route_id_at_creation, :string)
       add(:start_time, :bigint, null: false)
+      add(:end_time, :bigint, null: false)
       timestamps()
     end
   end

--- a/priv/repo/migrations/20201110152910_create_notifications.exs
+++ b/priv/repo/migrations/20201110152910_create_notifications.exs
@@ -2,9 +2,13 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
   use Ecto.Migration
 
   def up do
+    execute(
+      "CREATE TYPE notification_reason AS ENUM ('manpower', 'disabled', 'diverted', 'accident', 'other', 'adjusted', 'operator_error', 'traffic')"
+    )
+
     create table(:notifications) do
       add(:created_at, :bigint, null: false)
-      add(:reason, :string, null: false)
+      add(:reason, :notification_reason, null: false)
       add(:route_ids, {:array, :string}, null: false)
       add(:run_ids, {:array, :string}, null: false)
       add(:trip_ids, {:array, :string}, null: false)
@@ -29,6 +33,7 @@ defmodule Skate.Repo.Migrations.StoreNotifications do
   end
 
   def down do
+    execute("DROP TYPE notification_reason")
     drop(table(:notifications))
   end
 end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -136,6 +136,7 @@ defmodule Notifications.NotificationServerTest do
           assert_receive(
             {:notification,
              %Notifications.Notification{
+               id: ^notification_id,
                created_at: _,
                reason: ^cause_atom,
                route_ids: ["39", "2"],
@@ -152,7 +153,6 @@ defmodule Notifications.NotificationServerTest do
           assert_receive(
             {:notification,
              %Notifications.Notification{
-               id: notification_id,
                created_at: _,
                reason: ^cause_atom,
                route_ids: ["39", "2"],
@@ -338,6 +338,14 @@ defmodule Notifications.NotificationServerTest do
       Process.sleep(100)
       assert_n_notifications_in_db(1)
       existing_record = Skate.Repo.one(from(DbNotification))
+
+      assert_notification(:other, "Other", 1, server,
+        operator_name: "CHARLIE",
+        operator_id: "56785678",
+        route_id_at_creation: "SL9001",
+        log_expected: false,
+        notification_id: existing_record.id
+      )
 
       # Throw away message from first go-round
       receive do


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1192202587402599

We now store notifications in the database when they come in. There is some extra logic that prevents identical notifications from being logged or written by multiple nodes at once.