### PR TITLE
feat: send FullStory notification when bus goes invalid

### DIFF
--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -1,12 +1,19 @@
 import { Channel, Socket } from "phoenix"
-import { Dispatch as ReactDispatch, useEffect, useReducer } from "react"
+import {
+  Dispatch as ReactDispatch,
+  useEffect,
+  useReducer,
+  useState,
+} from "react"
 import { reload } from "../models/browser"
 import {
   VehicleOrGhostData,
   vehicleOrGhostFromData,
 } from "../models/vehicleData"
-import { VehicleOrGhost } from "../realtime.d"
+import { isVehicle } from "../models/vehicle"
+import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { ByRouteId, RouteId } from "../schedule.d"
+import { flatten } from "../helpers/array"
 
 interface State {
   channelsByRouteId: ByRouteId<Channel>
@@ -149,6 +156,7 @@ const useVehicles = (
   selectedRouteIds: RouteId[]
 ): ByRouteId<VehicleOrGhost[]> => {
   const [state, dispatch] = useReducer(reducer, initialState)
+  const [invalidVehicleIds, setInvalidVehicleIds] = useState<VehicleId[]>([])
   const { channelsByRouteId, vehiclesByRouteId } = state
 
   useEffect(() => {
@@ -170,6 +178,29 @@ const useVehicles = (
       })
     }
   }, [socket, selectedRouteIds])
+
+  useEffect(() => {
+    const newInvalidVehicles = flatten(Object.values(vehiclesByRouteId)).filter(
+      (vehicleOrGhost) =>
+        isVehicle(vehicleOrGhost) && vehicleOrGhost.isOffCourse
+    )
+
+    const oldInvalidVehicleIds = new Set(invalidVehicleIds)
+
+    newInvalidVehicles.forEach((vehicle) => {
+      if (
+        !oldInvalidVehicleIds.has(vehicle.id) &&
+        window.FS &&
+        window.username
+      ) {
+        window.FS.event("Vehicle went invalid", {
+          route_id: vehicle.routeId,
+        })
+      }
+    })
+
+    setInvalidVehicleIds(newInvalidVehicles.map((vehicle) => vehicle.id))
+  }, [vehiclesByRouteId])
 
   return vehiclesByRouteId
 }

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -192,6 +192,97 @@ describe("useVehicles", () => {
       crowding: null,
     },
   ]
+  const vehiclesDataWithInvalid: VehicleData[] = [
+    {
+      bearing: 33,
+      block_id: "block-1",
+      data_discrepancies: [
+        {
+          attribute: "trip_id",
+          sources: [
+            {
+              id: "swiftly",
+              value: "swiftly-trip-id",
+            },
+            {
+              id: "busloc",
+              value: "busloc-trip-id",
+            },
+          ],
+        },
+        {
+          attribute: "route_id",
+          sources: [
+            {
+              id: "swiftly",
+              value: null,
+            },
+            {
+              id: "busloc",
+              value: "busloc-route-id",
+            },
+          ],
+        },
+      ],
+      direction_id: 0,
+      headsign: "Forest Hills",
+      headway_secs: 859.1,
+      headway_spacing: null,
+      id: "v1",
+      is_shuttle: false,
+      is_overload: false,
+      is_off_course: true,
+      layover_departure_time: null,
+      label: "v1-label",
+      latitude: 0,
+      longitude: 0,
+      operator_id: "op1",
+      operator_name: "SMITH",
+      operator_logon_time: 1_534_340_301,
+      previous_vehicle_id: "v2",
+      route_id: "39",
+      run_id: "run-1",
+      schedule_adherence_secs: 0,
+      scheduled_headway_secs: 120,
+      scheduled_location: {
+        route_id: "39",
+        direction_id: 0,
+        trip_id: "scheduled trip",
+        run_id: "scheduled run",
+        time_since_trip_start_time: 0,
+        headsign: "scheduled headsign",
+        via_variant: "scheduled via variant",
+        timepoint_status: {
+          fraction_until_timepoint: 0.5,
+          timepoint_id: "tp1",
+        },
+      },
+      sources: ["swiftly", "busloc"],
+      stop_status: {
+        stop_id: "s1",
+        stop_name: "Stop Name",
+      },
+      timepoint_status: {
+        fraction_until_timepoint: 0.5,
+        timepoint_id: "tp1",
+      },
+      timestamp: 123,
+      trip_id: "t1",
+      via_variant: "X",
+      route_status: "on_route",
+      end_of_trip_type: "another_trip",
+      block_waivers: [
+        {
+          start_time: 1_534_340_301,
+          end_time: 1_534_340_321,
+          cause_id: 0,
+          cause_description: "Block Waiver",
+          remark: null,
+        },
+      ],
+      crowding: null,
+    },
+  ]
 
   test("vehicles is empty to start with", () => {
     const { result } = renderHook(() => useVehicles(undefined, []))
@@ -388,5 +479,25 @@ describe("useVehicles", () => {
 
     expect(reloadSpy).toHaveBeenCalled()
     reloadSpy.mockRestore()
+  })
+
+  test("makes a FullStory event when a bus goes invalid", async () => {
+    const originalFS = window.FS
+    const originalUsername = window.username
+    window.FS = { event: jest.fn(), identify: jest.fn() }
+    window.username = "username"
+
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: vehiclesDataWithInvalid })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    renderHook(() => useVehicles(mockSocket, ["39"]))
+
+    expect(window.FS!.event).toHaveBeenCalledWith("Vehicle went invalid", {
+      route_id: "39",
+    })
+
+    window.FS = originalFS
+    window.username = originalUsername
   })
 })


### PR DESCRIPTION
Card: [Add FS custom event tracking when a bus goes invalid on a ladder](https://app.asana.com/0/1148853526253426/1199159279046397/f)

This is my first PR, and it has side-effects in a system that I don't yet have access to, so it should receive extra-careful product review. 😅 

I got a little tangled up with the intricacies of testing channels since I haven't done much with that in the past. I'd _like_ to additionally test that a FullStory event _doesn't_ get triggered when a bus stays valid between two different messages, but I was having a lot of trouble crafting a test where the channel receives one message and then another.