### PR TITLE
fix: keep Green Line locations up-to-date with API stream

### DIFF
--- a/test/realtime/train_vehicles_store_test.exs
+++ b/test/realtime/train_vehicles_store_test.exs
@@ -18,15 +18,23 @@ defmodule Realtime.TrainVehiclesStoreTest do
     longitude: -71.00369,
     bearing: 15
   }
+  @green_b_train_vehicle %TrainVehicle{
+    id: "green1",
+    route_id: "Green-B",
+    latitude: 42.24615,
+    longitude: -71.00369,
+    bearing: 15
+  }
   @train_vehicles_by_route_id %{
     "Blue" => [@blue_train_vehicle],
-    "Red" => [@red_train_vehicle]
+    "Red" => [@red_train_vehicle],
+    "Green" => [@green_b_train_vehicle]
   }
 
   describe "reset/2" do
     test "resets to the given vehicles" do
       initial = %TrainVehiclesStore{}
-      new_vehicles = [@blue_train_vehicle, @red_train_vehicle]
+      new_vehicles = [@blue_train_vehicle, @red_train_vehicle, @green_b_train_vehicle]
 
       assert TrainVehiclesStore.reset(initial, new_vehicles).train_vehicles_by_route_id ==
                @train_vehicles_by_route_id
@@ -36,7 +44,7 @@ defmodule Realtime.TrainVehiclesStoreTest do
   describe "add/2" do
     test "adds the given vehicles to the store" do
       initial = %TrainVehiclesStore{}
-      new_vehicles = [@blue_train_vehicle, @red_train_vehicle]
+      new_vehicles = [@blue_train_vehicle, @red_train_vehicle, @green_b_train_vehicle]
 
       assert TrainVehiclesStore.add(initial, new_vehicles).train_vehicles_by_route_id ==
                @train_vehicles_by_route_id
@@ -46,14 +54,14 @@ defmodule Realtime.TrainVehiclesStoreTest do
   describe "update/2" do
     test "updates the given vehicles in the store" do
       initial = %TrainVehiclesStore{train_vehicles_by_route_id: @train_vehicles_by_route_id}
-      new_red_train_vehicle = %{@red_train_vehicle | bearing: 20}
+      new_green_b_train_vehicle = %{@green_b_train_vehicle | bearing: 20}
 
       expected = %{
         @train_vehicles_by_route_id
-        | "Red" => [new_red_train_vehicle]
+        | "Green" => [new_green_b_train_vehicle]
       }
 
-      assert TrainVehiclesStore.update(initial, [new_red_train_vehicle]).train_vehicles_by_route_id ==
+      assert TrainVehiclesStore.update(initial, [new_green_b_train_vehicle]).train_vehicles_by_route_id ==
                expected
     end
   end
@@ -65,7 +73,8 @@ defmodule Realtime.TrainVehiclesStoreTest do
 
       expected = %{
         "Blue" => [],
-        "Red" => [@red_train_vehicle]
+        "Red" => [@red_train_vehicle],
+        "Green" => [@green_b_train_vehicle]
       }
 
       assert TrainVehiclesStore.remove(initial, ids_to_remove).train_vehicles_by_route_id ==


### PR DESCRIPTION
Card: [🐞 Skate missing GL vehicles](https://app.asana.com/0/1148853526253426/1185722272692310/f)

The gist of the problem has to do with the transformation of the `Green-B`, `Green-C`, etc. GTFS route IDs into one combined `Green` route for sending to the front-end. Some parts of the code were doing this transformation correctly, others weren't, so updated and new vehicles weren't being reflected.