### PR TITLE
Return unexpired notifications on channel join

### DIFF
--- a/assets/src/hooks/useNotifications.ts
+++ b/assets/src/hooks/useNotifications.ts
@@ -3,7 +3,10 @@ import { useContext, useEffect } from "react"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { reload } from "../models/browser"
-import { notificationFromData } from "../models/notificationData"
+import {
+  NotificationData,
+  notificationFromData,
+} from "../models/notificationData"
 import { Notification } from "../realtime.d"
 
 export const useNotifications = (
@@ -25,6 +28,15 @@ export const useNotifications = (
       })
       channel
         .join()
+        .receive(
+          "ok",
+          (data) =>
+            data.initial_notifications &&
+            data.initial_notifications.forEach(
+              (notificationData: NotificationData) =>
+                handleNewNotification(notificationFromData(notificationData))
+            )
+        )
         .receive("error", ({ reason }) =>
           // tslint:disable-next-line: no-console
           console.error(`joining topic ${topic} failed`, reason)

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -27,11 +27,12 @@ const notificationData: NotificationData = {
 }
 
 describe("useNotifications", () => {
-  test("opens a channel", () => {
+  test("opens a channel and processes any initial notifications", () => {
     const handler = jest.fn()
     const mockSocket = makeMockSocket()
-    // We don't return data on join, so it defaults to {}
-    const mockChannel = makeMockChannel("ok", {})
+    const mockChannel = makeMockChannel("ok", {
+      initial_notifications: ["notification1", "notification2"],
+    })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
 
     renderHook(
@@ -42,7 +43,7 @@ describe("useNotifications", () => {
     )
 
     expect(mockChannel.join).toHaveBeenCalled()
-    expect(handler).not.toHaveBeenCalled()
+    expect(handler).toHaveBeenCalledTimes(2)
   })
 
   test("applies the callback on new notifications", () => {

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -3,6 +3,8 @@ defmodule Notifications.Db.Notification do
   import Ecto.Changeset
 
   alias Notifications.NotificationReason
+  alias Notifications.Db.NotificationUser, as: DbNotificationUser
+  alias Skate.Settings.Db.User, as: DbUser
 
   @type t() :: %__MODULE__{}
 
@@ -20,6 +22,9 @@ defmodule Notifications.Db.Notification do
     field(:start_time, :integer)
     field(:end_time, :integer)
     timestamps()
+
+    has_many(:notification_users, DbNotificationUser)
+    many_to_many(:users, DbUser, join_through: DbNotificationUser)
   end
 
   def changeset(notification, attrs \\ %{}) do

--- a/lib/notifications/db/notification_user.ex
+++ b/lib/notifications/db/notification_user.ex
@@ -1,15 +1,17 @@
 defmodule Notifications.Db.NotificationUser do
   use Ecto.Schema
 
+  alias Notifications.Db.Notification, as: DbNotification
   alias Notifications.NotificationState
+  alias Skate.Settings.Db.User, as: DbUser
 
   @primary_key false
 
   @type t() :: %__MODULE__{}
 
   schema "notifications_users" do
-    field(:notification_id, :integer, primary_key: true)
-    field(:user_id, :integer, primary_key: true)
+    belongs_to(:notification, DbNotification)
+    belongs_to(:user, DbUser)
     field(:state, NotificationState)
     timestamps()
   end

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -2,16 +2,21 @@ defmodule Skate.Settings.Db.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Skate.Settings.Db.RouteSettings
-  alias Skate.Settings.Db.UserSettings
+  alias Notifications.Db.Notification, as: DbNotification
+  alias Notifications.Db.NotificationUser, as: DbNotificationUser
+  alias Skate.Settings.Db.RouteSettings, as: DbRouteSettings
+  alias Skate.Settings.Db.UserSettings, as: DbUserSettings
 
   @type t :: %__MODULE__{}
 
   schema "users" do
     field(:username, :string)
-    has_one(:user_settings, UserSettings)
-    has_one(:route_settings, RouteSettings)
+    has_one(:user_settings, DbUserSettings)
+    has_one(:route_settings, DbRouteSettings)
     timestamps()
+
+    has_many(:notification_users, DbNotificationUser)
+    many_to_many(:notifications, DbNotification, join_through: DbNotificationUser)
   end
 
   def changeset(user, attrs \\ %{}) do

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -24,8 +24,18 @@ defmodule SkateWeb.NotificationsChannel do
         &SkateWeb.AuthManager.username_from_socket!/1
       )
 
+    notification_fetch =
+      Application.get_env(
+        :skate,
+        :unexpired_notifications_for_user,
+        &Notifications.Notification.unexpired_notifications_for_user/1
+      )
+
     username = username_from_socket!.(socket)
     Notifications.NotificationServer.subscribe(username)
-    {:ok, socket}
+
+    initial_notifications = notification_fetch.(username)
+
+    {:ok, %{initial_notifications: initial_notifications}, socket}
   end
 end

--- a/lib/util/time.ex
+++ b/lib/util/time.ex
@@ -24,6 +24,11 @@ defmodule Util.Time do
     |> date_of_timestamp()
   end
 
+  @spec naive_now() :: NaiveDateTime.t()
+  def naive_now do
+    NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+  end
+
   @doc """
   Times greater than 24:00:00 are allowed.
 

--- a/priv/repo/migrations/20201203204900_add_indexes_for_notification_fetch_on_page_load.exs
+++ b/priv/repo/migrations/20201203204900_add_indexes_for_notification_fetch_on_page_load.exs
@@ -1,0 +1,9 @@
+defmodule Skate.Repo.Migrations.AddIndexesForNotificationFetchOnPageLoad do
+  use Ecto.Migration
+
+  def change do
+    create(index(:route_settings, [:selected_route_ids], using: :gin))
+    create(index(:notifications, [:route_ids], using: :gin))
+    create(index(:notifications, [:end_time]))
+  end
+end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -369,7 +369,7 @@ defmodule Notifications.NotificationServerTest do
         end)
 
       assert_n_notifications_in_db(1)
-      assert String.contains?(log, "new_notification") == false
+      refute log =~ "new_notification"
     end
   end
 end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -369,7 +369,7 @@ defmodule Notifications.NotificationServerTest do
         end)
 
       assert_n_notifications_in_db(1)
-      assert log == ""
+      assert String.contains?(log, "new_notification") == false
     end
   end
 end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -6,6 +6,8 @@ defmodule Notifications.NotificationTest do
   alias Skate.Settings.RouteSettings
   alias Skate.Settings.User
 
+  import Ecto.Query
+
   describe "get_or_create/1" do
     test "associates a new notification with users subscribed to an affected route" do
       user1 = User.get_or_create("user1")
@@ -43,6 +45,169 @@ defmodule Notifications.NotificationTest do
         notification_users |> Enum.map(& &1.user_id) |> Enum.sort() ==
           [user1.id, user2.id] |> Enum.sort()
       )
+    end
+  end
+
+  describe "unexpired_notifications_for_user/2" do
+    test "returns all unexpired notifications for the given user, in chronological order by creation timestamp" do
+      baseline_time = 1_000_000_000
+      now_fn = fn -> baseline_time end
+      naive_now_fn = fn -> baseline_time |> DateTime.from_unix!() |> DateTime.to_naive() end
+      Application.put_env(:skate, :naive_now_fn, naive_now_fn)
+      eight_hours = 8 * 60 * 60
+
+      RouteSettings.get_or_create("user1")
+      RouteSettings.get_or_create("user2")
+      RouteSettings.set("user1", selected_route_ids: ["1", "2"])
+      RouteSettings.set("user2", selected_route_ids: ["1", "3"])
+
+      route_1_unexpired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 0,
+          created_at: 10000,
+          route_ids: ["1"],
+          end_time: baseline_time - eight_hours + 10
+        })
+
+      _route_1_expired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 1,
+          created_at: 2,
+          route_ids: ["1"],
+          end_time: baseline_time - eight_hours
+        })
+
+      route_2_unexpired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 4,
+          created_at: 5000,
+          route_ids: ["2"],
+          end_time: baseline_time - eight_hours + 1
+        })
+
+      _route_2_expired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 6,
+          created_at: 7,
+          route_ids: ["2"],
+          end_time: baseline_time - eight_hours
+        })
+
+      route_3_unexpired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 8,
+          created_at: 9000,
+          route_ids: ["3"],
+          end_time: baseline_time - eight_hours + 5
+        })
+
+      _route_3_expired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 10,
+          created_at: 11,
+          route_ids: ["3"],
+          end_time: baseline_time - eight_hours
+        })
+
+      multiroute_unexpired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 12,
+          created_at: 8000,
+          route_ids: ["2", "3"],
+          end_time: baseline_time - eight_hours + 3
+        })
+
+      _multiroute_expired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 14,
+          created_at: 15,
+          route_ids: ["2", "3"],
+          end_time: baseline_time - eight_hours
+        })
+
+      _route_4_unexpired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 16,
+          created_at: 17,
+          route_ids: ["4"],
+          end_time: baseline_time - eight_hours + 3
+        })
+
+      _route_4_expired =
+        Notification.get_or_create(%Notification{
+          block_id: "block",
+          service_id: "service",
+          reason: :other,
+          run_ids: [],
+          trip_ids: [],
+          start_time: 18,
+          created_at: 19,
+          route_ids: ["4"],
+          end_time: baseline_time - eight_hours
+        })
+
+      user1_notification_ids =
+        Notification.unexpired_notifications_for_user("user1", now_fn) |> Enum.map(& &1.id)
+
+      user2_notification_ids =
+        Notification.unexpired_notifications_for_user("user2", now_fn) |> Enum.map(& &1.id)
+
+      assert user1_notification_ids == [
+               route_2_unexpired.id,
+               multiroute_unexpired.id,
+               route_1_unexpired.id
+             ]
+
+      assert user2_notification_ids == [
+               multiroute_unexpired.id,
+               route_3_unexpired.id,
+               route_1_unexpired.id
+             ]
     end
   end
 end

--- a/test/skate/application_test.exs
+++ b/test/skate/application_test.exs
@@ -2,6 +2,15 @@ defmodule Skate.ApplicationTest do
   use ExUnit.Case, async: true
   import Test.Support.Helpers
 
+  # TODO: some of these tests sometimes hit live AWS servers, causing
+  # errors such as the following:
+  #
+  #   1) test load_runtime_config replaces {:secret, var_name} with secret from AWS SecretsManager (Skate.ApplicationTest)
+  #    test/skate/application_test.exs:15
+  #    ** (ExAws.Error) ExAws Request Error!
+  #
+  #    {:error, {:http_error, 400, %{body: "{\"__type\":\"AccessDeniedException\",\"Message\":\"User: arn:aws:iam::[REDACTED]:user/pdarnowsky is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:us-east-1:[REDACTED]:secret:TEST-test-variable-REDACTED\"}", headers: [{"Date", "Mon, 07 Dec 2020 12:03:39 GMT"}, {"Content-Type", "application/x-amz-json-1.1"}, {"Content-Length", "246"}, {"Connection", "keep-alive"}, {"x-amzn-RequestId", "d2ed6c3d-c632-4eb8-9d88-439b30188920"}], status_code: 400}}}
+
   describe "load_runtime_config" do
     test "replaces {:system, \"VAR\"} with environment variable" do
       Application.put_env(:skate, :gtfs_url, {:system, "TEST_VARIABLE"})

--- a/test/skate/application_test.exs
+++ b/test/skate/application_test.exs
@@ -2,15 +2,6 @@ defmodule Skate.ApplicationTest do
   use ExUnit.Case, async: true
   import Test.Support.Helpers
 
-  # TODO: some of these tests sometimes hit live AWS servers, causing
-  # errors such as the following:
-  #
-  #   1) test load_runtime_config replaces {:secret, var_name} with secret from AWS SecretsManager (Skate.ApplicationTest)
-  #    test/skate/application_test.exs:15
-  #    ** (ExAws.Error) ExAws Request Error!
-  #
-  #    {:error, {:http_error, 400, %{body: "{\"__type\":\"AccessDeniedException\",\"Message\":\"User: arn:aws:iam::[REDACTED]:user/pdarnowsky is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:us-east-1:[REDACTED]:secret:TEST-test-variable-REDACTED\"}", headers: [{"Date", "Mon, 07 Dec 2020 12:03:39 GMT"}, {"Content-Type", "application/x-amz-json-1.1"}, {"Content-Length", "246"}, {"Connection", "keep-alive"}, {"x-amzn-RequestId", "d2ed6c3d-c632-4eb8-9d88-439b30188920"}], status_code: 400}}}
-
   describe "load_runtime_config" do
     test "replaces {:system, \"VAR\"} with environment variable" do
       Application.put_env(:skate, :gtfs_url, {:system, "TEST_VARIABLE"})

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -1,5 +1,6 @@
 defmodule SkateWeb.NotificationsChannelTest do
   use SkateWeb.ChannelCase
+  use Skate.DataCase
   import Test.Support.Helpers
 
   alias Phoenix.Socket
@@ -21,11 +22,14 @@ defmodule SkateWeb.NotificationsChannelTest do
   end
 
   describe "join/3" do
-    test "subscribes to notifications", %{
+    test "subscribes to notifications, returning recent ones", %{
       socket: socket
     } do
-      assert {:ok, %{}, %Socket{}} =
-               subscribe_and_join(socket, NotificationsChannel, "notifications")
+      mock_fetch = fn _ -> ["fake notification 1", "fake notification 2"] end
+      reassign_env(:skate, :unexpired_notifications_for_user, mock_fetch)
+
+      assert {:ok, %{initial_notifications: ["fake notification 1", "fake notification 2"]},
+              %Socket{}} = subscribe_and_join(socket, NotificationsChannel, "notifications")
     end
   end
 


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1192202587402591

When a user opens Skate, they get any notifications that are for routes they subscribe to, and that have an `end_time` no more than 8 hours in the past.