### PR TITLE
feat: CSS classes to differentiate mark read / unread links

### DIFF
--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -120,6 +120,7 @@ const EllipsisSubmenu = ({
           dispatch(toggleReadState(notification))
           setShowSubmenu(false)
         }}
+        className={`m-notification-drawer__submenu-mark-${otherReadState}`}
       >
         mark as {otherReadState}
       </a>

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -149,7 +149,9 @@ describe("NotificationDrawer", () => {
       .simulate("click")
     wrapper
       .find(
-        ".m-notification-drawer__card--unread .m-notification-drawer__submenu a"
+        ".m-notification-drawer__card--unread " +
+          ".m-notification-drawer__submenu " +
+          ".m-notification-drawer__submenu-mark-read"
       )
       .first()
       .simulate("click")
@@ -164,7 +166,9 @@ describe("NotificationDrawer", () => {
       .simulate("click")
     wrapper
       .find(
-        ".m-notification-drawer__card--read .m-notification-drawer__submenu a"
+        ".m-notification-drawer__card--read " +
+          ".m-notification-drawer__submenu " +
+          ".m-notification-drawer__submenu-mark-unread"
       )
       .first()
       .simulate("click")


### PR DESCRIPTION
Card: [Notification drawer tracking](https://app.asana.com/0/1148853526253426/1199209745954664/f)

See my comments on the ticket - everything listed in the requirements already had a distinct CSS class, except for these two things.