### PR TITLE
feat: remove unused buttons on inactive notification modal

### DIFF
--- a/assets/src/components/inactiveNotificationModal.tsx
+++ b/assets/src/components/inactiveNotificationModal.tsx
@@ -7,20 +7,13 @@ import { title } from "./notificationContent"
 
 const InactiveNotificationModal = ({
   notification,
-  hideNotification,
 }: {
   notification: Notification
-  hideNotification: () => void
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
 
   const closeModal = () => {
     dispatch(setNotification(undefined))
-  }
-
-  const hideAndClose = () => {
-    hideNotification()
-    closeModal()
   }
 
   return (
@@ -34,20 +27,6 @@ const InactiveNotificationModal = ({
         </div>
         <div className="m-inactive-notification-modal__body">
           {bodyCopy(notification)}
-        </div>
-        <div className="m-inactive-notification-modal__buttons">
-          <button
-            className="m-inactive-notification-modal__keep-button"
-            onClick={closeModal}
-          >
-            Keep
-          </button>
-          <button
-            className="m-inactive-notification-modal__discard-button"
-            onClick={hideAndClose}
-          >
-            Remove
-          </button>
         </div>
       </div>
       <div className="c-modal-overlay" />

--- a/assets/src/components/modal.tsx
+++ b/assets/src/components/modal.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement, useContext } from "react"
-import { NotificationsContext } from "../contexts/notificationsContext"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import VehicleForNotificationContext from "../contexts/vehicleForNotificationContext"
-import { hideLatestNotification } from "../hooks/useNotificationsReducer"
 import { ConnectionStatus } from "../hooks/useSocket"
 import DisconnectedModal from "./disconnectedModal"
 import InactiveNotificationModal from "./inactiveNotificationModal"
@@ -13,22 +11,13 @@ const Modal = (): ReactElement | null => {
   const { connectionStatus } = useContext(SocketContext)
   const [{ selectedNotification }] = useContext(StateDispatchContext)
   const vehicleForNotification = useContext(VehicleForNotificationContext)
-  const { dispatch } = useContext(NotificationsContext)
 
   if (connectionStatus === ConnectionStatus.Disconnected) {
     return <DisconnectedModal />
   }
 
   if (selectedNotification && vehicleForNotification === null) {
-    return (
-      <InactiveNotificationModal
-        notification={selectedNotification}
-        hideNotification={() => {
-          /* istanbul ignore next */
-          dispatch(hideLatestNotification())
-        }}
-      />
-    )
+    return <InactiveNotificationModal notification={selectedNotification} />
   }
 
   if (selectedNotification && vehicleForNotification === undefined) {

--- a/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
@@ -32,22 +32,6 @@ Array [
     >
       Runs 111, 222 are not currently active in Skate. This notification may no longer be relevant.
     </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
-    </div>
   </div>,
   <div
     className="c-modal-overlay"
@@ -86,22 +70,6 @@ Array [
       className="m-inactive-notification-modal__body"
     >
       Runs 111, 222 are upcoming and not yet active in Skate. Please check back later to see details for these runs.
-    </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
     </div>
   </div>,
   <div
@@ -142,22 +110,6 @@ Array [
     >
       No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
     </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
-    </div>
   </div>,
   <div
     className="c-modal-overlay"
@@ -197,22 +149,6 @@ Array [
     >
       Run 111 is not currently active in Skate. This notification may no longer be relevant.
     </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
-    </div>
   </div>,
   <div
     className="c-modal-overlay"
@@ -251,22 +187,6 @@ Array [
       className="m-inactive-notification-modal__body"
     >
       Run 111 is upcoming and not yet active in Skate. Please check back later to see details for this run.
-    </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
     </div>
   </div>,
   <div

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -32,22 +32,6 @@ Array [
     >
       No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
     </div>
-    <div
-      className="m-inactive-notification-modal__buttons"
-    >
-      <button
-        className="m-inactive-notification-modal__keep-button"
-        onClick={[Function]}
-      >
-        Keep
-      </button>
-      <button
-        className="m-inactive-notification-modal__discard-button"
-        onClick={[Function]}
-      >
-        Remove
-      </button>
-    </div>
   </div>,
   <div
     className="c-modal-overlay"

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -1,4 +1,3 @@
-import { mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
 import InactiveNotificationModal from "../../src/components/inactiveNotificationModal"
@@ -22,16 +21,10 @@ describe("InactiveNotificationModal", () => {
     ...notification,
     startTime: new Date("20200-10-05"),
   }
-  const hideNotification = jest.fn()
 
   test("renders for a notification with no runs", () => {
     const tree = renderer
-      .create(
-        <InactiveNotificationModal
-          notification={notification}
-          hideNotification={hideNotification}
-        />
-      )
+      .create(<InactiveNotificationModal notification={notification} />)
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
@@ -41,7 +34,6 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111"] }}
-          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -53,7 +45,6 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...notification, runIds: ["111", "222"] }}
-          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -65,7 +56,6 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111"] }}
-          hideNotification={hideNotification}
         />
       )
       .toJSON()
@@ -77,40 +67,9 @@ describe("InactiveNotificationModal", () => {
       .create(
         <InactiveNotificationModal
           notification={{ ...futureNotification, runIds: ["111", "222"] }}
-          hideNotification={hideNotification}
         />
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
-  })
-
-  test("allows removing the modal", () => {
-    const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        hideNotification={hideNotification}
-      />
-    )
-
-    wrapper
-      .find(".m-inactive-notification-modal__discard-button")
-      .first()
-      .simulate("click")
-    expect(hideNotification).toHaveBeenCalled()
-  })
-
-  test("allows closing the modal", () => {
-    const wrapper = mount(
-      <InactiveNotificationModal
-        notification={notification}
-        hideNotification={hideNotification}
-      />
-    )
-
-    wrapper
-      .find(".m-inactive-notification-modal__keep-button")
-      .first()
-      .simulate("click")
-    expect(hideNotification).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Card: [Remove the "Keep" and "Remove" buttons from the modal when linking to VPP is not possible](https://app.asana.com/0/1148853526253426/1199696487088341/f)