### PR TITLE
fix: hide "mark all as read" link when no notifications are unread

### DIFF
--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -94,12 +94,14 @@ const Content = () => {
         <span className="m-notification-drawer__n-unread">
           {unreadNotificationsCount} new
         </span>
-        <a
-          className="m-notification-drawer__mark-all-read-link"
-          onClick={() => notificationsDispatch(markAllAsRead())}
-        >
-          Mark all as read
-        </a>
+        {unreadNotificationsCount > 0 ? (
+          <a
+            className="m-notification-drawer__mark-all-read-link"
+            onClick={() => notificationsDispatch(markAllAsRead())}
+          >
+            Mark all as read
+          </a>
+        ) : null}
       </div>
       {notifications.map((notification) => (
         <NotificationCard

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -140,6 +140,33 @@ describe("NotificationDrawer", () => {
     expect(notificationsDispatch).toHaveBeenCalledWith(markAllAsRead())
   })
 
+  test("no make all read link when there are no unread notifications", () => {
+    const stateDispatch = jest.fn()
+    const notificationsDispatch = jest.fn()
+
+    const wrapper = mount(
+      <StateDispatchProvider state={initialState} dispatch={stateDispatch}>
+        <NotificationsContext.Provider
+          value={{
+            notifications: [readNotification],
+            showLatestNotification: true,
+            dispatch: notificationsDispatch,
+            rememberScrollPosition: jest.fn(),
+            scrollPosition: 0,
+            notificationWithOpenSubmenuId: null,
+            setNotificationWithOpenSubmenuId: jest.fn(),
+          }}
+        >
+          <NotificationDrawer />
+        </NotificationsContext.Provider>
+      </StateDispatchProvider>
+    )
+
+    expect(
+      wrapper.exists(".m-notification-drawer__mark-all-read-link")
+    ).toBeFalsy()
+  })
+
   test("can make unread to read and vice versa", () => {
     const notificationsDispatch = jest.fn()
 


### PR DESCRIPTION
Card: [Don't show "Mark all as read" link in the inbox if all notifications are already read](https://app.asana.com/0/1148853526253420/1199718135066077/f)