### PR TITLE
fix: highlight ghost/vehicle on ladder if selected from notification

### DIFF
--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -1,9 +1,11 @@
+import * as Sentry from "@sentry/react"
 import { Socket } from "phoenix"
 import React, { ReactElement, useContext } from "react"
 import RoutesContext from "../contexts/routesContext"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { VehiclesByRouteIdProvider } from "../contexts/vehiclesByRouteIdContext"
+import VehicleForNotificationContext from "../contexts/vehicleForNotificationContext"
 import useTimepoints from "../hooks/useTimepoints"
 import useVehicles from "../hooks/useVehicles"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
@@ -52,6 +54,18 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
     selectedVehicleId
   )
 
+  // undefined means loading. null means failed
+  const vehicleForNotification: VehicleOrGhost | null | undefined = useContext(
+    VehicleForNotificationContext
+  )
+
+  if (vehicleForNotification && selectedVehicleOrGhost) {
+    /* istanbul ignore next */
+    Sentry.captureMessage(
+      "vehicleForNotification and selectedVehicleOrGhost both set, which should be impossible"
+    )
+  }
+
   return (
     <div className="m-ladder-page">
       <Notifications />
@@ -62,9 +76,13 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
           <RouteLadders
             routes={selectedRoutes}
             timepointsByRouteId={timepointsByRouteId}
-            selectedVehicleId={selectedVehicleId}
+            selectedVehicleId={selectedVehicleId || vehicleForNotification?.id}
           />
-          <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
+          <RightPanel
+            selectedVehicleOrGhost={
+              vehicleForNotification || selectedVehicleOrGhost
+            }
+          />
         </>
       </VehiclesByRouteIdProvider>
     </div>

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -1,8 +1,6 @@
-import * as Sentry from "@sentry/react"
 import React, { ReactElement, useContext } from "react"
 import { useHistory } from "react-router-dom"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import VehicleForNotificationContext from "../contexts/vehicleForNotificationContext"
 import { VehicleOrGhost } from "../realtime.d"
 import { setNotification } from "../state"
 import NotificationDrawer from "./notificationDrawer"
@@ -14,11 +12,6 @@ const RightPanel = ({
   selectedVehicleOrGhost?: VehicleOrGhost
 }): ReactElement<HTMLElement> | null => {
   const [state, dispatch] = useContext(StateDispatchContext)
-  const { selectedNotification } = state
-  // undefined means loading. null means failed
-  const vehicleForNotification: VehicleOrGhost | null | undefined = useContext(
-    VehicleForNotificationContext
-  )
 
   // close notification if you move away from ladder page
   // TODO delete when notifications are viewable from anywhere
@@ -28,19 +21,7 @@ const RightPanel = ({
     history.listen(() => dispatch(setNotification(undefined)))
   }
 
-  if (vehicleForNotification && selectedVehicleOrGhost) {
-    /* istanbul ignore next */
-    Sentry.captureMessage(
-      "vehicleForNotification and selectedVehicleOrGhost both set, which should be impossible"
-    )
-  }
-
-  if (selectedNotification && vehicleForNotification) {
-    return <PropertiesPanel selectedVehicleOrGhost={vehicleForNotification} />
-  } else if (
-    state.selectedVehicleId &&
-    selectedVehicleOrGhost?.id === state.selectedVehicleId
-  ) {
+  if (selectedVehicleOrGhost) {
     return <PropertiesPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
   } else if (state.notificationDrawerIsOpen) {
     return <NotificationDrawer />

--- a/assets/tests/components/rightPanel.test.tsx
+++ b/assets/tests/components/rightPanel.test.tsx
@@ -3,9 +3,8 @@ import React from "react"
 import renderer from "react-test-renderer"
 import RightPanel from "../../src/components/rightPanel"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
-import { VehicleForNotificationProvider } from "../../src/contexts/vehicleForNotificationContext"
 import { HeadwaySpacing } from "../../src/models/vehicleStatus"
-import { Ghost, Notification, Vehicle } from "../../src/realtime"
+import { Ghost, Vehicle } from "../../src/realtime"
 import { initialState, State } from "../../src/state"
 import * as dateTime from "../../src/util/dateTime"
 
@@ -44,49 +43,6 @@ describe("rightPanel", () => {
       </StateDispatchProvider>
     )
     expect(wrapper.html()).toContain(ghost.runId)
-  })
-
-  test("shows a vehicle from a selected notification", () => {
-    const notification: Notification = { runIds: ["run_id"] } as Notification
-    const state: State = { ...initialState, selectedNotification: notification }
-    const wrapper = mount(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <VehicleForNotificationProvider vehicleForNotification={vehicle}>
-          <RightPanel />
-        </VehicleForNotificationProvider>
-      </StateDispatchProvider>
-    )
-    expect(wrapper.html()).toContain(vehicle.runId)
-  })
-
-  test("if a vehicle from a notification is loading, show nothing", () => {
-    const notification: Notification = { runIds: ["run_id"] } as Notification
-    const state: State = { ...initialState, selectedNotification: notification }
-    const tree = renderer
-      .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <VehicleForNotificationProvider vehicleForNotification={undefined}>
-            <RightPanel />
-          </VehicleForNotificationProvider>
-        </StateDispatchProvider>
-      )
-      .toJSON()
-    expect(tree).toEqual(null)
-  })
-
-  test("if a vehicle from a notification failed to load, show nothing", () => {
-    const notification: Notification = { runIds: ["run_id"] } as Notification
-    const state: State = { ...initialState, selectedNotification: notification }
-    const tree = renderer
-      .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <VehicleForNotificationProvider vehicleForNotification={null}>
-            <RightPanel />
-          </VehicleForNotificationProvider>
-        </StateDispatchProvider>
-      )
-      .toJSON()
-    expect(tree).toEqual(null)
   })
 
   test("shows notification drawer", () => {


### PR DESCRIPTION
Card: [When successfully linking to a ghost or VPP for a vehicle from a notification, highlight the applicable vehicle or ghost on the ladder](https://app.asana.com/0/1148853526253426/1199224182441183/f)

This refactors things a bit so that the `RightPanel` component no longer has a separate idea of "selected vehicle" versus "vehicle from notification," and the matter is instead handled one level up so that the vehicle selected from a notification can also be passed through as the vehicle to highlight.