### PR TITLE
Duplicate notifications to block waivers

### DIFF
--- a/lib/notifications/block_waiver_backfiller.ex
+++ b/lib/notifications/block_waiver_backfiller.ex
@@ -1,0 +1,47 @@
+defmodule Notifications.BlockWaiverBackfiller do
+  use GenServer
+  import Ecto.Query
+  alias Notifications.Db.Notification, as: DbNotification
+  require Logger
+
+  @sleep_interval 5000
+
+  @batch_size 5
+
+  @spec default_name() :: GenServer.name()
+  def default_name(), do: Notifications.NotificationServer
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, nil)
+  end
+
+  @impl true
+  def init(_) do
+    Process.send_after(self(), :backfill_batch, 0)
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:backfill_batch, state) do
+    notifications_requiring_backfill_count =
+      Skate.Repo.one(
+        from(n in DbNotification, select: count(n), where: is_nil(n.block_waiver_id))
+      )
+
+    Logger.info(
+      "backfill_batch notifications_requiring_backfill_count=#{
+        notifications_requiring_backfill_count
+      }"
+    )
+
+    Skate.Repo.all(
+      from(n in DbNotification, where: is_nil(n.block_waiver_id), limit: @batch_size)
+    )
+    |> Enum.each(&Notifications.Notification.duplicate_to_block_waiver/1)
+
+    Process.send_after(self(), :backfill_batch, @sleep_interval)
+
+    {:noreply, state}
+  end
+end

--- a/lib/notifications/db/block_waiver.ex
+++ b/lib/notifications/db/block_waiver.ex
@@ -1,15 +1,11 @@
-defmodule Notifications.Db.Notification do
+defmodule Notifications.Db.BlockWaiver do
   use Ecto.Schema
   import Ecto.Changeset
-
   alias Notifications.NotificationReason
-  alias Notifications.Db.BlockWaiver, as: DbBlockWaiver
-  alias Notifications.Db.NotificationUser, as: DbNotificationUser
-  alias Skate.Settings.Db.User, as: DbUser
 
   @type t() :: %__MODULE__{}
 
-  schema "notifications" do
+  schema "block_waivers" do
     field(:created_at, :integer)
     field(:reason, NotificationReason)
     field(:route_ids, {:array, :string})
@@ -22,17 +18,11 @@ defmodule Notifications.Db.Notification do
     field(:service_id, :string)
     field(:start_time, :integer)
     field(:end_time, :integer)
-    field(:state, :string, virtual: true)
     timestamps()
-
-    has_many(:notification_users, DbNotificationUser)
-    many_to_many(:users, DbUser, join_through: DbNotificationUser)
-
-    belongs_to(:block_waiver, DbBlockWaiver)
   end
 
-  def changeset(notification, attrs \\ %{}) do
-    notification
+  def changeset(block_waiver, attrs \\ %{}) do
+    block_waiver
     |> cast(attrs, [
       :id,
       :created_at,
@@ -46,8 +36,7 @@ defmodule Notifications.Db.Notification do
       :block_id,
       :service_id,
       :start_time,
-      :end_time,
-      :block_waiver_id
+      :end_time
     ])
     |> validate_required([
       :created_at,
@@ -68,7 +57,7 @@ defmodule Notifications.Db.Notification do
         :service_id,
         :reason
       ],
-      name: "notifications_unique_index"
+      name: "block_waivers_unique_index"
     )
   end
 end

--- a/lib/notifications/supervisor.ex
+++ b/lib/notifications/supervisor.ex
@@ -14,7 +14,9 @@ defmodule Notifications.Supervisor do
   def init(:ok) do
     children = [
       {Registry, keys: :duplicate, name: registry_name()},
-      {Notifications.NotificationServer, name: Notifications.NotificationServer.default_name()}
+      {Notifications.NotificationServer, name: Notifications.NotificationServer.default_name()},
+      {Notifications.BlockWaiverBackfiller,
+       name: Notifications.BlockWaiverBackfiller.default_name()}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/priv/repo/migrations/20210106131944_create_block_waivers.exs
+++ b/priv/repo/migrations/20210106131944_create_block_waivers.exs
@@ -1,0 +1,41 @@
+defmodule Skate.Repo.Migrations.CreateBlockWaivers do
+  use Ecto.Migration
+
+  def up do
+    create table(:block_waivers) do
+      add(:created_at, :bigint, null: false)
+      add(:reason, :notification_reason, null: false)
+      add(:route_ids, {:array, :string}, null: false)
+      add(:run_ids, {:array, :string}, null: false)
+      add(:trip_ids, {:array, :string}, null: false)
+      add(:operator_id, :string)
+      add(:operator_name, :string)
+      add(:route_id_at_creation, :string)
+      add(:block_id, :string, null: false)
+      add(:service_id, :string, null: false)
+      add(:start_time, :bigint, null: false)
+      add(:end_time, :bigint, null: false)
+      timestamps()
+    end
+
+    create(
+      index(
+        :block_waivers,
+        [:start_time, :end_time, :block_id, :service_id, :reason],
+        unique: true,
+        name: "block_waivers_unique_index"
+      )
+    )
+
+    alter table("notifications") do
+      add :block_waiver_id, :bigint
+    end
+  end
+
+  def down do
+    alter table("notifications") do
+      remove :block_waiver_id
+    end
+    drop(table(:block_waivers))
+  end
+end

--- a/test/notifications/block_waiver_backfiller_test.exs
+++ b/test/notifications/block_waiver_backfiller_test.exs
@@ -1,0 +1,58 @@
+defmodule Notifications.BlockWaiverBackfillerTest do
+  use Skate.DataCase
+  import ExUnit.CaptureLog
+
+  alias Notifications.Db.BlockWaiver, as: DbBlockWaiver
+  alias Notifications.Db.Notification, as: DbNotification
+  alias Notifications.BlockWaiverBackfiller
+
+  setup do
+    1..6
+    |> Enum.each(fn index ->
+      changeset =
+        DbNotification.changeset(
+          %DbNotification{},
+          %{
+            created_at: index,
+            reason: :manpower,
+            route_ids: [],
+            run_ids: [],
+            trip_ids: [],
+            block_id: "blk_#{index}",
+            service_id: "WinterWeekday",
+            start_time: index * 100,
+            end_time: index * 500
+          }
+        )
+
+      Skate.Repo.insert!(changeset)
+    end)
+  end
+
+  test "logs the number of notifications still needing backfill" do
+    Logger.configure(level: :info)
+
+    log =
+      capture_log(fn ->
+        BlockWaiverBackfiller.handle_info(:backfill_batch, nil)
+      end)
+
+    assert(String.contains?(log, "backfill_batch notifications_requiring_backfill_count=6"))
+
+    Logger.configure(level: :warn)
+  end
+
+  test "backfills a batch of notifications" do
+    BlockWaiverBackfiller.handle_info(:backfill_batch, nil)
+
+    updated_notifications = Skate.Repo.all(from(DbNotification))
+    block_waivers = Skate.Repo.all(from(DbBlockWaiver))
+
+    assert length(block_waivers) == 5
+
+    notifications_with_block_waivers =
+      Enum.reject(updated_notifications, &(&1.block_waiver_id == nil))
+
+    assert length(notifications_with_block_waivers) == 5
+  end
+end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -2,6 +2,8 @@ defmodule Notifications.NotificationTest do
   use Skate.DataCase
 
   alias Notifications.Notification
+  alias Notifications.Db.BlockWaiver, as: DbBlockWaiver
+  alias Notifications.Db.Notification, as: DbNotification
   alias Notifications.Db.NotificationUser, as: DbNotificationUser
   alias Skate.Settings.RouteSettings
   alias Skate.Settings.User
@@ -45,6 +47,37 @@ defmodule Notifications.NotificationTest do
         notification_users |> Enum.map(& &1.user_id) |> Enum.sort() ==
           [user1.id, user2.id] |> Enum.sort()
       )
+    end
+
+    test "duplicates the block waiver data to the block_waivers table" do
+      notification_without_id = %Notification{
+        created_at: 12345,
+        block_id: "Z1-1",
+        service_id: "FallWeekday",
+        reason: :other,
+        route_ids: ["1", "2", "3"],
+        run_ids: ["56785678", "101010"],
+        trip_ids: ["250624", "250625"],
+        start_time: 1_000_000_000,
+        end_time: 1_000_086_400
+      }
+
+      Notification.get_or_create(notification_without_id)
+
+      db_notification = Skate.Repo.one!(from(DbNotification))
+      db_block_waiver = Skate.Repo.one!(from(DbBlockWaiver))
+
+      assert db_notification.block_waiver_id == db_block_waiver.id
+
+      assert db_notification.created_at == db_block_waiver.created_at
+      assert db_notification.block_id == db_block_waiver.block_id
+      assert db_notification.service_id == db_block_waiver.service_id
+      assert db_notification.reason == db_block_waiver.reason
+      assert db_notification.route_ids == db_block_waiver.route_ids
+      assert db_notification.run_ids == db_block_waiver.run_ids
+      assert db_notification.trip_ids == db_block_waiver.trip_ids
+      assert db_notification.start_time == db_block_waiver.start_time
+      assert db_notification.end_time == db_block_waiver.end_time
     end
   end
 


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1199525699944668

This PR does two things:

* Notifications created going forward will have block-waiver-specific fields duplicated to the new `block_waivers` table
* Existing notifications will get gradually backfilled with the same

This is the first part of a gradual refactoring of our notifications DB schema to support polymorphic associations.