### PR TITLE
fix: correctly handle conflicts on block_waivers

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -74,30 +74,32 @@ defmodule Notifications.Notification do
     changeset =
       DbNotification.changeset(%DbNotification{}, Map.from_struct(notification_without_id))
 
-    {:ok, notification_with_id} =
-      Skate.Repo.transaction(fn ->
-        db_record = insert!(changeset, on_conflict: :nothing)
+    db_record =
+      case Skate.Repo.transaction(fn ->
+             with db_record <- insert!(changeset, on_conflict: :nothing),
+                  false <- is_nil(db_record.id),
+                  notification_with_id <- %__MODULE__{notification_without_id | id: db_record.id},
+                  false <- is_nil(duplicate_to_block_waiver(db_record)) do
+               log_creation(notification_with_id)
+               link_notification_to_users(notification_with_id)
+               db_record
+             else
+               _ -> Skate.Repo.rollback(nil)
+             end
+           end) do
+        {:ok, db_record} when not is_nil(db_record) ->
+          db_record
 
-        db_record =
-          if db_record.id do
-            notification_with_id = %__MODULE__{notification_without_id | id: db_record.id}
-            duplicate_to_block_waiver(db_record)
-            log_creation(notification_with_id)
-            link_notification_to_users(notification_with_id)
-            db_record
-          else
-            identifying_fields =
-              notification_without_id
-              |> Map.take([:start_time, :end_time, :block_id, :service_id, :reason])
-              |> Map.to_list()
+        {:error, _} ->
+          identifying_fields =
+            notification_without_id
+            |> Map.take([:start_time, :end_time, :block_id, :service_id, :reason])
+            |> Map.to_list()
 
-            Skate.Repo.one(from(DbNotification, where: ^identifying_fields))
-          end
+          Skate.Repo.one!(from(DbNotification, where: ^identifying_fields))
+      end
 
-        %__MODULE__{notification_without_id | id: db_record.id}
-      end)
-
-    notification_with_id
+    %__MODULE__{notification_without_id | id: db_record.id}
   end
 
   def unexpired_notifications_for_user(username, now_fn \\ &Util.Time.now/0) do
@@ -127,18 +129,23 @@ defmodule Notifications.Notification do
     Skate.Repo.update_all(query, set: [state: read_state])
   end
 
+  @spec duplicate_to_block_waiver(DbNotification.t()) :: DbNotification.t() | nil
   def duplicate_to_block_waiver(db_notification) do
     new_waiver_params =
       Map.from_struct(db_notification)
       |> Map.put(:id, nil)
 
-    waiver =
-      DbBlockWaiver.changeset(%DbBlockWaiver{}, new_waiver_params)
-      |> Skate.Repo.insert!()
+    case %DbBlockWaiver{}
+         |> DbBlockWaiver.changeset(new_waiver_params)
+         |> Skate.Repo.insert() do
+      {:ok, waiver} ->
+        db_notification
+        |> DbNotification.changeset(%{block_waiver_id: waiver.id})
+        |> Skate.Repo.update()
 
-    db_notification
-    |> DbNotification.changeset(%{block_waiver_id: waiver.id})
-    |> Skate.Repo.update()
+      {:error, _} ->
+        nil
+    end
   end
 
   defp log_creation(notification) do

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -79,6 +79,36 @@ defmodule Notifications.NotificationTest do
       assert db_notification.start_time == db_block_waiver.start_time
       assert db_notification.end_time == db_block_waiver.end_time
     end
+
+    test "correctly handles conflict on block_waivers table" do
+      Skate.Repo.insert!(%DbBlockWaiver{
+        created_at: 12345,
+        block_id: "Z1-1",
+        service_id: "FallWeekday",
+        reason: :other,
+        route_ids: ["1", "2", "3"],
+        run_ids: ["56785678", "101010"],
+        trip_ids: ["250624", "250625"],
+        start_time: 1_000_000_000,
+        end_time: 1_000_086_400
+      })
+
+      notification_without_id = %Notification{
+        created_at: 12345,
+        block_id: "Z1-1",
+        service_id: "FallWeekday",
+        reason: :other,
+        route_ids: ["1", "2", "3"],
+        run_ids: ["56785678", "101010"],
+        trip_ids: ["250624", "250625"],
+        start_time: 1_000_000_000,
+        end_time: 1_000_086_400
+      }
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Notification.get_or_create(notification_without_id)
+      end
+    end
   end
 
   describe "unexpired_notifications_for_user/2" do


### PR DESCRIPTION
Ticket: [Properly handle case in transaction when inserting to block_waivers fails](https://app.asana.com/0/0/1199663255721070/f)

Currently if there's a conflict on the block_waivers table it will
blow up completely instead of just rolling back the transaction. This
changes that, so that we can now guard against duplicate notifications
just with the unique index on block_waivers and not relying on the
unique index on notifications, which we're about to drop.