### PR TITLE
Log warning if data status goes to :outage

### DIFF
--- a/lib/realtime/data_status_alerter.ex
+++ b/lib/realtime/data_status_alerter.ex
@@ -1,0 +1,38 @@
+defmodule Realtime.DataStatusAlerter do
+  use GenServer
+  require Logger
+
+  def default_name, do: __MODULE__
+
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, default_name())
+
+    subscribe_fn =
+      Keyword.get(
+        opts,
+        :subscribe_fn,
+        &Realtime.DataStatusPubSub.subscribe/0
+      )
+
+    initial_state = %{subscribe_fn: subscribe_fn}
+
+    GenServer.start_link(__MODULE__, initial_state, name: name)
+  end
+
+  @impl GenServer
+  def init(%{subscribe_fn: subscribe_fn}) do
+    _ = subscribe_fn.()
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def handle_info({:new_data_status, data_status}, state) do
+    if data_status == :outage do
+      Logger.warn("Data outage detected data_outage_detected")
+    end
+
+    {:noreply, state}
+  end
+end

--- a/lib/realtime/data_status_alerter.ex
+++ b/lib/realtime/data_status_alerter.ex
@@ -4,7 +4,6 @@ defmodule Realtime.DataStatusAlerter do
 
   def default_name, do: __MODULE__
 
-  @spec start_link() :: GenServer.on_start()
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, default_name())

--- a/lib/realtime/supervisor.ex
+++ b/lib/realtime/supervisor.ex
@@ -23,7 +23,8 @@ defmodule Realtime.Supervisor do
          swiftly_realtime_vehicles_url:
            Application.get_env(:skate, :swiftly_realtime_vehicles_url),
          trip_updates_url: Application.get_env(:skate, :trip_updates_url)
-       ]}
+       ]},
+      {Realtime.DataStatusAlerter, []}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/test/realtime/data_status_alerter_test.exs
+++ b/test/realtime/data_status_alerter_test.exs
@@ -1,0 +1,45 @@
+defmodule Realtime.DataStatusAlerterTest do
+  use ExUnit.Case
+  import(ExUnit.CaptureLog)
+
+  alias Realtime.DataStatusAlerter
+
+  describe "start_link/1" do
+    test "starts up and lives" do
+      {:ok, server} = DataStatusAlerter.start_link(name: :start_link, subscribe_fn: fn -> nil end)
+
+      Process.sleep(10)
+
+      assert Process.alive?(server)
+    end
+  end
+
+  describe "init/1" do
+    test "calls the supplied subscribe_fn" do
+      test_pid = self()
+      mock_subscribe_fn = fn -> send(test_pid, "hi") end
+      DataStatusAlerter.init(%{subscribe_fn: mock_subscribe_fn})
+      assert_received("hi")
+    end
+  end
+
+  describe "handle_info/2" do
+    test "logs a warning if data status is :outage" do
+      log =
+        capture_log(fn ->
+          DataStatusAlerter.handle_info({:new_data_status, :outage}, nil)
+        end)
+
+      assert String.contains?(log, "Data outage detected data_outage_detected")
+    end
+
+    test "logs nothing if data status is :good" do
+      log =
+        capture_log(fn ->
+          DataStatusAlerter.handle_info({:new_data_status, :good}, nil)
+        end)
+
+      assert log == ""
+    end
+  end
+end

--- a/test/realtime/data_status_alerter_test.exs
+++ b/test/realtime/data_status_alerter_test.exs
@@ -1,6 +1,6 @@
 defmodule Realtime.DataStatusAlerterTest do
   use ExUnit.Case
-  import(ExUnit.CaptureLog)
+  import ExUnit.CaptureLog
 
   alias Realtime.DataStatusAlerter
 
@@ -39,7 +39,7 @@ defmodule Realtime.DataStatusAlerterTest do
           DataStatusAlerter.handle_info({:new_data_status, :good}, nil)
         end)
 
-      assert log == ""
+      refute String.contains?(log, "data_outage_detected")
     end
   end
 end


### PR DESCRIPTION
Card: https://app.asana.com/0/1148853526253426/1199651591931861

One subtlety here is that, on a deploy or other server restart, it will be normal to possibly have a couple of `:outage` statuses as data is in the process of being loaded. To avoid unnecessary pages, we should check the logs after deploying to dev, to get an idea of how many messages will be generated normally, and then we'll set the threshold for alerting somewhere above that.