### PR TITLE
Better link failure modal copy

### DIFF
--- a/assets/src/components/inactiveNotificationModal.tsx
+++ b/assets/src/components/inactiveNotificationModal.tsx
@@ -1,9 +1,15 @@
 import React, { useContext } from "react"
+import Loading from "./loading"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import { useMinischeduleRuns } from "../hooks/useMinischedule"
 import { closeIcon } from "../helpers/icon"
-import { Notification } from "../realtime.d"
+import { Activity, Run, Piece, Trip } from "../minischedule"
+import { Notification, RunId } from "../realtime.d"
 import { setNotification } from "../state"
+import { now, serviceDaySeconds } from "../util/dateTime"
 import { title } from "./notificationContent"
+
+type RunScheduleRelationship = "current" | "break" | "past"
 
 const InactiveNotificationModal = ({
   notification,
@@ -12,42 +18,135 @@ const InactiveNotificationModal = ({
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
 
+  const runs: (Run | null)[] | undefined = useMinischeduleRuns(
+    notification.tripIds
+  )
+
   const closeModal = () => {
     dispatch(setNotification(undefined))
   }
 
-  return (
-    <>
-      <div className="c-modal">
-        <div className="m-inactive-notification-modal__close-button">
-          <button onClick={closeModal}>{closeIcon()}</button>
-        </div>
-        <div className="m-notification__title">
-          {title(notification.reason)} NOTIFICATION
-        </div>
-        <div className="m-inactive-notification-modal__body">
-          {bodyCopy(notification)}
-        </div>
-      </div>
-      <div className="c-modal-overlay" />
-    </>
-  )
-}
+  if (runs !== undefined) {
+    const uniqueRuns = Object.values(
+      (runs.filter((run) => run !== null) as Run[]).reduce(
+        (acc: Record<RunId, Run>, run: Run) => {
+          acc[run.id] = run
+          return acc
+        },
+        {}
+      )
+    )
 
-const bodyCopy = (notification: Notification): string => {
-  if (notification.runIds.length === 0) {
-    return "No runs associated with this notification are currently active in Skate. This notification may no longer be relevant."
+    return (
+      <>
+        <div className="c-modal">
+          <div className="m-inactive-notification-modal__close-button">
+            <button onClick={closeModal}>{closeIcon()}</button>
+          </div>
+          <div className="m-notification__title">
+            {title(notification.reason)} NOTIFICATION
+          </div>
+          <div className="m-inactive-notification-modal__body">
+            {bodyCopy(notification, uniqueRuns)}
+          </div>
+        </div>
+        <div className="c-modal-overlay" />
+      </>
+    )
   }
 
-  return notification.startTime < new Date()
-    ? pastNotificationBodyCopy(notification)
-    : futureNotificationBodyCopy(notification)
+  return <Loading />
 }
 
-const pastNotificationBodyCopy = (notification: Notification): string =>
-  `${pastRunIdPhrase(
-    notification
-  )} currently active in Skate. This notification may no longer be relevant.`
+const runScheduleRelationshipForRuns = (
+  runs: (Run | null)[]
+): [RunScheduleRelationship, RunId | null] => {
+  const activitiesWithRunIds = (runs.filter((run) => run != null) as Run[])
+    .reduce(
+      (acc: [Activity, RunId][], run: Run) =>
+        acc.concat(run.activities.map((a) => [a, run.id])),
+      []
+    )
+    .sort((a1, a2) => a1[0].endTime - a2[0].endTime)
+
+  const currentTime = serviceDaySeconds(now())
+
+  const [lastPiece, lastPieceRunId] = activitiesWithRunIds.reduce(
+    (
+      currentLastPieceWithRunId: [Piece | null, RunId | null],
+      activityWithRunId
+    ) => {
+      if (activityWithRunId[0].hasOwnProperty("trips")) {
+        return [activityWithRunId[0] as Piece, activityWithRunId[1]]
+      } else {
+        return currentLastPieceWithRunId
+      }
+    },
+    [null, null]
+  )
+
+  if (lastPiece && lastPiece.trips.length > 0) {
+    const lastRevenueTrip = lastPiece.trips.reduce(
+      (currentLastRevenueTrip: Trip | null, trip) => {
+        if (trip.hasOwnProperty("routeId") && (trip as Trip).routeId !== null) {
+          return trip as Trip
+        } else {
+          return currentLastRevenueTrip
+        }
+      },
+      null
+    )
+
+    if (
+      lastRevenueTrip &&
+      lastRevenueTrip.routeId &&
+      lastRevenueTrip.endTime < currentTime
+    ) {
+      return ["past", lastPieceRunId]
+    }
+  }
+
+  for (const a of activitiesWithRunIds) {
+    if (
+      a[0].hasOwnProperty("breakType") &&
+      a[0].startTime < currentTime &&
+      currentTime < a[0].endTime
+    ) {
+      return ["break", a[1]]
+    }
+  }
+
+  return ["current", null]
+}
+
+const bodyCopy = (notification: Notification, runs: (Run | null)[]): string => {
+  if (notification.runIds.length === 0) {
+    return "Sorry, there's no additional information that we can provide you about this notification."
+  }
+
+  const [relationship, runId] = runScheduleRelationshipForRuns(runs)
+
+  switch (relationship) {
+    case "past":
+      return `Run ${runId} has ended and is no longer active in Skate.`
+    case "break":
+      return `Sorry, we can't show you details for run ${runId} because it is on a scheduled break.`
+    case "current":
+      return notification.startTime < new Date()
+        ? pastNotificationBodyCopy(notification)
+        : futureNotificationBodyCopy(notification)
+  }
+}
+
+const pastNotificationBodyCopy = (notification: Notification): string => {
+  if (notification.runIds.length === 1) {
+    return `Sorry, we can't show you details for run ${notification.runIds[0]} because nobody is logged into it.`
+  }
+
+  return `Sorry, we can't show you details for runs ${notification.runIds.join(
+    ", "
+  )} because nobody is logged into them.`
+}
 
 const futureNotificationBodyCopy = (notification: Notification): string => {
   if (notification.runIds.length === 1) {
@@ -57,14 +156,6 @@ const futureNotificationBodyCopy = (notification: Notification): string => {
   return `Runs ${notification.runIds.join(
     ", "
   )} are upcoming and not yet active in Skate. Please check back later to see details for these runs.`
-}
-
-const pastRunIdPhrase = (notification: Notification): string => {
-  if (notification.runIds.length === 1) {
-    return `Run ${notification.runIds[0]} is not`
-  }
-
-  return `Runs ${notification.runIds.join(", ")} are not`
 }
 
 export default InactiveNotificationModal

--- a/assets/src/hooks/useMinischedule.ts
+++ b/assets/src/hooks/useMinischedule.ts
@@ -19,6 +19,22 @@ export const useMinischeduleRun = (tripId: TripId): Run | null | undefined => {
  * undefined means loading
  * null means loaded, but there was no run found
  */
+export const useMinischeduleRuns = (
+  tripIds: TripId[]
+): (Run | null)[] | undefined => {
+  const [runs, setRuns] = useState<(Run | null)[] | undefined>(undefined)
+  useEffect(() => {
+    Promise.all(tripIds.map((tripId) => fetchMinischeduleRun(tripId))).then(
+      setRuns
+    )
+  }, [JSON.stringify(tripIds)])
+  return runs
+}
+
+/**
+ * undefined means loading
+ * null means loaded, but there was no run found
+ */
 export const useMinischeduleBlock = (
   tripId: TripId
 ): Block | null | undefined => {

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -1,5 +1,21 @@
 export const now = (): Date => new Date()
 
+export const serviceDaySeconds = (currentTime: Date): number => {
+  const serviceDateStart = new Date(currentTime.getTime())
+
+  if (serviceDateStart.getHours() < 3) {
+    serviceDateStart.setDate(serviceDateStart.getDate() - 1)
+  }
+
+  serviceDateStart.setHours(12)
+  serviceDateStart.setMinutes(0)
+  serviceDateStart.setSeconds(0)
+  serviceDateStart.setMilliseconds(0)
+  serviceDateStart.setTime(serviceDateStart.getTime() - 12 * 60 * 60 * 1000)
+
+  return currentTime.getTime() / 1000 - serviceDateStart.getTime() / 1000
+}
+
 export const dateFromEpochSeconds = (time: number): Date =>
   new Date(time * 1_000)
 

--- a/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/inactiveStateModal.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InactiveNotificationModal renders for a notification with multiple current or past runs 1`] = `
+exports[`InactiveNotificationModal renders for a notification with a run currently on break 1`] = `
 Array [
   <div
     className="c-modal"
@@ -30,7 +30,124 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      Runs 111, 222 are not currently active in Skate. This notification may no longer be relevant.
+      Sorry, we can't show you details for run 111 because it is on a scheduled break.
+    </div>
+  </div>,
+  <div
+    className="c-modal-overlay"
+  />,
+]
+`;
+
+exports[`InactiveNotificationModal renders for a notification with a run that finished in the past 1`] = `
+Array [
+  <div
+    className="c-modal"
+  >
+    <div
+      className="m-inactive-notification-modal__close-button"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-notification__title"
+    >
+      OTHER
+       NOTIFICATION
+    </div>
+    <div
+      className="m-inactive-notification-modal__body"
+    >
+      Run 222 has ended and is no longer active in Skate.
+    </div>
+  </div>,
+  <div
+    className="c-modal-overlay"
+  />,
+]
+`;
+
+exports[`InactiveNotificationModal renders for a notification with a run that has only nonrevenue work left 1`] = `
+Array [
+  <div
+    className="c-modal"
+  >
+    <div
+      className="m-inactive-notification-modal__close-button"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-notification__title"
+    >
+      OTHER
+       NOTIFICATION
+    </div>
+    <div
+      className="m-inactive-notification-modal__body"
+    >
+      Run 222 has ended and is no longer active in Skate.
+    </div>
+  </div>,
+  <div
+    className="c-modal-overlay"
+  />,
+]
+`;
+
+exports[`InactiveNotificationModal renders for a notification with multiple current runs 1`] = `
+Array [
+  <div
+    className="c-modal"
+  >
+    <div
+      className="m-inactive-notification-modal__close-button"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-notification__title"
+    >
+      OTHER
+       NOTIFICATION
+    </div>
+    <div
+      className="m-inactive-notification-modal__body"
+    >
+      Sorry, we can't show you details for runs 111, 222 because nobody is logged into them.
     </div>
   </div>,
   <div
@@ -108,7 +225,7 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
+      Sorry, there's no additional information that we can provide you about this notification.
     </div>
   </div>,
   <div
@@ -117,7 +234,7 @@ Array [
 ]
 `;
 
-exports[`InactiveNotificationModal renders for a notification with one current or past run 1`] = `
+exports[`InactiveNotificationModal renders for a notification with one current run 1`] = `
 Array [
   <div
     className="c-modal"
@@ -147,7 +264,7 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      Run 111 is not currently active in Skate. This notification may no longer be relevant.
+      Sorry, we can't show you details for run 111 because nobody is logged into it.
     </div>
   </div>,
   <div
@@ -194,3 +311,5 @@ Array [
   />,
 ]
 `;
+
+exports[`InactiveNotificationModal renders loading message 1`] = `"loading..."`;

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -30,7 +30,7 @@ Array [
     <div
       className="m-inactive-notification-modal__body"
     >
-      No runs associated with this notification are currently active in Skate. This notification may no longer be relevant.
+      Sorry, there's no additional information that we can provide you about this notification.
     </div>
   </div>,
   <div

--- a/assets/tests/components/inactiveStateModal.test.tsx
+++ b/assets/tests/components/inactiveStateModal.test.tsx
@@ -1,7 +1,17 @@
 import React from "react"
 import renderer from "react-test-renderer"
 import InactiveNotificationModal from "../../src/components/inactiveNotificationModal"
+import { Break, Piece, Run, Trip } from "../../src/minischedule"
+import { useMinischeduleRuns } from "../../src/hooks/useMinischedule"
 import { Notification, NotificationState } from "../../src/realtime.d"
+import * as dateTime from "../../src/util/dateTime"
+
+jest.mock("../../src/hooks/useMinischedule", () => ({
+  __esModule: true,
+  useMinischeduleRuns: jest.fn(),
+}))
+
+jest.spyOn(dateTime, "serviceDaySeconds").mockImplementation(() => 1000)
 
 describe("InactiveNotificationModal", () => {
   const notification: Notification = {
@@ -22,14 +32,62 @@ describe("InactiveNotificationModal", () => {
     startTime: new Date("20200-10-05"),
   }
 
-  test("renders for a notification with no runs", () => {
+  const revenueTrip: Trip = {
+    id: "trip",
+    blockId: "block",
+    routeId: "R",
+    headsign: "Revenue",
+    directionId: 1,
+    viaVariant: "X",
+    runId: "111",
+    startTime: 900,
+    endTime: 1100,
+    startPlace: "Red Square",
+    endPlace: "Blue Triangle",
+  }
+
+  const piece: Piece = {
+    runId: "111",
+    blockId: "block",
+    startTime: 900,
+    startPlace: "start",
+    trips: [revenueTrip],
+    endTime: 1100,
+    endPlace: "end",
+    startMidRoute: null,
+    endMidRoute: false,
+  }
+
+  const breakk: Break = {
+    breakType: "Split break",
+    startTime: 900,
+    endTime: 1100,
+    endPlace: "spot",
+  }
+
+  test("renders loading message", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => undefined)
     const tree = renderer
       .create(<InactiveNotificationModal notification={notification} />)
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders for a notification with one current or past run", () => {
+  test("renders for a notification with no runs", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [])
+    const tree = renderer
+      .create(<InactiveNotificationModal notification={notification} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders for a notification with one current run", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [piece],
+      } as Run,
+    ])
     const tree = renderer
       .create(
         <InactiveNotificationModal
@@ -40,7 +98,17 @@ describe("InactiveNotificationModal", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders for a notification with multiple current or past runs", () => {
+  test("renders for a notification with multiple current runs", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [piece],
+      } as Run,
+      {
+        id: "222",
+        activities: [{ ...piece, startTime: 1200, endTime: 1400 }],
+      } as Run,
+    ])
     const tree = renderer
       .create(
         <InactiveNotificationModal
@@ -52,6 +120,12 @@ describe("InactiveNotificationModal", () => {
   })
 
   test("renders for a notification with one upcoming run", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [{ ...piece, startTime: 1100, endTime: 1300 }],
+      } as Run,
+    ])
     const tree = renderer
       .create(
         <InactiveNotificationModal
@@ -63,6 +137,95 @@ describe("InactiveNotificationModal", () => {
   })
 
   test("renders for a notification with multiple upcoming runs", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [{ ...piece, startTime: 1100, endTime: 1300 }],
+      } as Run,
+      {
+        id: "222",
+        activities: [{ ...piece, startTime: 1400, endTime: 1600 }],
+      } as Run,
+    ])
+    const tree = renderer
+      .create(
+        <InactiveNotificationModal
+          notification={{ ...futureNotification, runIds: ["111", "222"] }}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders for a notification with a run currently on break", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [breakk],
+      } as Run,
+    ])
+    const tree = renderer
+      .create(
+        <InactiveNotificationModal
+          notification={{ ...notification, runIds: ["111"] }}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders for a notification with a run that finished in the past", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "111",
+        activities: [
+          {
+            ...piece,
+            startTime: 500,
+            endTime: 700,
+            trips: [{ ...revenueTrip, startTime: 500, endTime: 700 }],
+          },
+        ],
+      } as Run,
+      {
+        id: "222",
+        activities: [
+          {
+            ...piece,
+            startTime: 700,
+            endTime: 900,
+            trips: [{ ...revenueTrip, startTime: 700, endTime: 900 }],
+          },
+        ],
+      } as Run,
+    ])
+    const tree = renderer
+      .create(
+        <InactiveNotificationModal
+          notification={{ ...futureNotification, runIds: ["111", "222"] }}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders for a notification with a run that has only nonrevenue work left", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [
+      {
+        id: "222",
+        activities: [
+          {
+            ...piece,
+            startTime: 700,
+            endTime: 1100,
+            trips: [
+              { ...revenueTrip, startTime: 700, endTime: 900 },
+              { ...revenueTrip, routeId: null, startTime: 900, endTime: 1100 },
+            ],
+          },
+        ],
+      } as Run,
+    ])
     const tree = renderer
       .create(
         <InactiveNotificationModal

--- a/assets/tests/components/modal.test.tsx
+++ b/assets/tests/components/modal.test.tsx
@@ -3,6 +3,7 @@ import renderer from "react-test-renderer"
 import Modal from "../../src/components/modal"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { VehicleForNotificationProvider } from "../../src/contexts/vehicleForNotificationContext"
+import { useMinischeduleRuns } from "../../src/hooks/useMinischedule"
 import {
   Notification,
   NotificationReason,
@@ -10,8 +11,14 @@ import {
 } from "../../src/realtime"
 import { initialState, State } from "../../src/state"
 
+jest.mock("../../src/hooks/useMinischedule", () => ({
+  __esModule: true,
+  useMinischeduleRuns: jest.fn(),
+}))
+
 describe("Modal", () => {
   test("renders inactive notification modal when appropriate", () => {
+    ;(useMinischeduleRuns as jest.Mock).mockImplementationOnce(() => [])
     const notification: Notification = {
       id: "123",
       createdAt: new Date(),

--- a/assets/tests/hooks/useMinischedule.test.ts
+++ b/assets/tests/hooks/useMinischedule.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/hooks/useMinischedule"
 import { Block, Run } from "../../src/minischedule"
 import { instantPromise, neverPromise } from "../testHelpers/mockHelpers"
+import { TripId } from "../../src/schedule"
 
 // tslint:disable: react-hooks-nesting
 
@@ -78,6 +79,18 @@ describe("useMinischeduleRuns", () => {
     })
     rerender()
     expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
+  })
+
+  test("does refetch when trip IDs changed", () => {
+    const mockFetchMinischeduleRun: jest.Mock = Api.fetchMinischeduleRun as jest.Mock
+    const { rerender } = renderHook(
+      (tripIds: TripId[]) => {
+        return useMinischeduleRuns(tripIds)
+      },
+      { initialProps: ["trip1"] }
+    )
+    rerender(["trip2"])
+    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/assets/tests/hooks/useMinischedule.test.ts
+++ b/assets/tests/hooks/useMinischedule.test.ts
@@ -3,6 +3,7 @@ import * as Api from "../../src/api"
 import {
   useMinischeduleBlock,
   useMinischeduleRun,
+  useMinischeduleRuns,
 } from "../../src/hooks/useMinischedule"
 import { Block, Run } from "../../src/minischedule"
 import { instantPromise, neverPromise } from "../testHelpers/mockHelpers"
@@ -42,6 +43,41 @@ describe("useMinischeduleRun", () => {
     })
     rerender()
     expect(mockFetchShuttles).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("useMinischeduleRuns", () => {
+  test("returns undefined while loading", () => {
+    const mockFetchMinischeduleRun: jest.Mock = Api.fetchMinischeduleRun as jest.Mock
+    const { result } = renderHook(() => {
+      return useMinischeduleRuns(["trip"])
+    })
+    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
+    expect(result.current).toEqual(undefined)
+  })
+
+  test("returns runs", async () => {
+    const run1: Run = ("run1" as any) as Run
+    const run2: Run = ("run2" as any) as Run
+    const mockFetchMinischeduleRun: jest.Mock = Api.fetchMinischeduleRun as jest.Mock
+    mockFetchMinischeduleRun
+      .mockImplementationOnce(() => instantPromise(run1))
+      .mockImplementationOnce(() => instantPromise(run2))
+    const { result, waitForNextUpdate } = renderHook(() => {
+      return useMinischeduleRuns(["trip1", "trip2"])
+    })
+    await waitForNextUpdate()
+
+    expect(result.current).toEqual([run1, run2])
+  })
+
+  test("doesn't refetch on every render", () => {
+    const mockFetchMinischeduleRun: jest.Mock = Api.fetchMinischeduleRun as jest.Mock
+    const { rerender } = renderHook(() => {
+      return useMinischeduleRuns(["trip"])
+    })
+    rerender()
+    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/assets/tests/util/dateTime.test.ts
+++ b/assets/tests/util/dateTime.test.ts
@@ -6,11 +6,36 @@ import {
   formattedTimeDiffUnderThreshold,
   now,
   formattedScheduledTime,
+  serviceDaySeconds,
 } from "../../src/util/dateTime"
 
 describe("now", () => {
   test("returns a Date for the current date-time", () => {
     expect(now() instanceof Date).toBeTruthy()
+  })
+})
+
+describe("serviceDaySeconds", () => {
+  test("returns number for a time before midnight", () => {
+    expect(serviceDaySeconds(new Date("February 10, 2021 08:12"))).toEqual(
+      29_520
+    )
+  })
+
+  test("returns number for a time after midnight", () => {
+    expect(serviceDaySeconds(new Date("February 11, 2021 01:05"))).toEqual(
+      90_300
+    )
+  })
+
+  test("correctly handles transition to DST", () => {
+    expect(serviceDaySeconds(new Date("March 8, 2020 08:12"))).toEqual(29_520)
+  })
+
+  test("correctly handles transition from DST", () => {
+    expect(serviceDaySeconds(new Date("November 1, 2020 08:12"))).toEqual(
+      29_520
+    )
   })
 })
 


### PR DESCRIPTION
Ticket: [More detailed modals when linking to a run from a notification isn't possible](https://app.asana.com/0/1148853526253426/1199873489874876/f)

Note that I'm still trying to reproduce / dig into an issue with runs saying they're on break when the break is actually done, but so far I've tried several cases with no luck.

The current API for fetching schedules relies on GTFS trip IDs, and the notifications code already maps the original run to trip IDs. Fetching a run by run ID would require also knowing the current service, which is a bit of a hairier problem. I think the run ID -> GTFS trip ID(s) -> run ID mapping should be consistent, though. For fetching runs for potentially several trip IDs I just did multiple API calls because the number is going to be at most a few in any given case and going forward we'll probably want to use run IDs / block IDs where possible, but let me know if you'd rather that I make the back-end support querying for several GTFS trip IDs at once.

This does result in `incativeNotificationModal.tsx` having a fair bit of code that deals with the structure of run data. I'm not sure that there's really another good place to put it, though, since the logic is so specific to this use case. Let me know if you have any thoughts, though.