### PR TITLE
chore: migration for vehicle adherence color setting

### DIFF
--- a/priv/repo/migrations/20210216142615_add_vehicle_adherence_color_to_user_setting.exs
+++ b/priv/repo/migrations/20210216142615_add_vehicle_adherence_color_to_user_setting.exs
@@ -1,0 +1,16 @@
+defmodule Skate.Repo.Migrations.AddVehicleAdherenceColorToUserSetting do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE TYPE vehicle_adherence_colors AS ENUM ('early_red', 'early_blue')",
+      "DROP TYPE vehicle_adherence_colors"
+    )
+
+    alter table(:user_settings) do
+      add(:vehicle_adherence_colors, :vehicle_adherence_colors, default: "early_red")
+    end
+
+    execute("UPDATE user_settings SET vehicle_adherence_colors = 'early_red'", fn -> end)
+  end
+end


### PR DESCRIPTION
First part of work for [Allow user to toggle late and early adherence colors](https://app.asana.com/0/1148853526253426/1199900940371686/f)

I chose the names `early_red` and `early_blue` as a quick description of each state that the setting could be in, but let me know if you have any other suggestions for terminology. I think it's reasonably intuitive, though, especially based on the mock-ups for the [settings overhaul ticket](https://app.asana.com/0/1148853526253426/1199930082433254/f).