### PR TITLE
fix: display route name (rather than ID) for notifications

### DIFF
--- a/assets/src/components/notificationContent.tsx
+++ b/assets/src/components/notificationContent.tsx
@@ -1,5 +1,7 @@
 import React from "react"
+import { useRoute, useRoutes } from "../contexts/routesContext"
 import { Notification, NotificationReason } from "../realtime.d"
+import { Route } from "../schedule"
 import { formattedTimeDiffUnderThreshold } from "../util/dateTime"
 import PropertiesList from "./propertiesList"
 
@@ -10,6 +12,8 @@ export const NotificationContent = ({
   notification: Notification
   currentTime: Date
 }) => {
+  const routes = useRoutes(notification.routeIds)
+  const routeAtCreation = useRoute(notification.routeIdAtCreation)
   return (
     <div className="m-notification-content">
       <div className="m-notification-content__title-row">
@@ -25,7 +29,7 @@ export const NotificationContent = ({
         </div>
       </div>
       <div className="m-notification-content__description">
-        {description(notification)}
+        {description(notification, routes, routeAtCreation)}
       </div>
       <PropertiesList
         properties={[
@@ -58,33 +62,40 @@ export const title = (reason: NotificationReason): string => {
   }
 }
 
-const description = (notification: Notification): string => {
-  const routeIds = notification.routeIds.join(", ")
+const description = (
+  notification: Notification,
+  routes: Route[],
+  routeAtCreation: Route | null
+): string => {
+  const routeNames = routes.map((route) => route.name).join(", ")
+  const routeNameAtCreation = routeAtCreation
+    ? routeAtCreation.name
+    : notification.routeIdAtCreation
   switch (notification.reason) {
     case "manpower":
-      return `OCC reported that an operator is not available on the ${routeIds}.`
+      return `OCC reported that an operator is not available on the ${routeNames}.`
     case "disabled":
       return `OCC reported that a vehicle is disabled on the ${
-        notification.routeIdAtCreation || routeIds
+        routeNameAtCreation || routeNames
       }.`
     case "diverted":
-      return `OCC reported that an operator has been diverted from the ${routeIds}.`
+      return `OCC reported that an operator has been diverted from the ${routeNames}.`
     case "accident":
       return `OCC reported that an operator has been in an accident on the ${
-        notification.routeIdAtCreation || routeIds
+        routeNameAtCreation || routeNames
       }.`
     case "adjusted":
-      return `OCC reported an adjustment on the ${routeIds}.`
+      return `OCC reported an adjustment on the ${routeNames}.`
     case "operator_error":
       return `OCC reported an operator error on the ${
-        notification.routeIdAtCreation || routeIds
+        routeNameAtCreation || routeNames
       }.`
     case "traffic":
       return `OCC created a dispatcher note due to traffic on the ${
-        notification.routeIdAtCreation || routeIds
+        routeNameAtCreation || routeNames
       }.`
     case "other":
     default:
-      return `OCC created a dispatcher note for the ${routeIds}.`
+      return `OCC created a dispatcher note for the ${routeNames}.`
   }
 }

--- a/assets/src/contexts/routesContext.tsx
+++ b/assets/src/contexts/routesContext.tsx
@@ -8,6 +8,11 @@ export const useRoute = (routeId: RouteId | null | undefined): Route | null => {
   return (routes || []).find((route) => route.id === routeId) || null
 }
 
+export const useRoutes = (routeIds: RouteId[]): Route[] => {
+  const routes: Route[] | null = useContext(RoutesContext)
+  return (routes || []).filter((route) => routeIds.includes(route.id))
+}
+
 export const RoutesProvider = ({
   routes,
   children,

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`NotificationDrawer renders notifications 1`] = `
           <div
             className="m-notification-content__description"
           >
-            OCC reported that an operator is not available on the route1, route2.
+            OCC reported that an operator is not available on the r1, r2.
           </div>
           <div
             className="m-properties-list"

--- a/assets/tests/components/__snapshots__/notifications.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notifications.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Notification renders latest notification 1`] = `
         <div
           className="m-notification-content__description"
         >
-          OCC reported that an operator is not available on the route1, route2.
+          OCC reported that an operator is not available on the r1, r2.
         </div>
         <div
           className="m-properties-list"
@@ -103,7 +103,7 @@ exports[`NotificationCard renders a notification with an unexpected reason 1`] =
       <div
         className="m-notification-content__description"
       >
-        OCC created a dispatcher note for the route1, route2.
+        OCC created a dispatcher note for the r1, r2.
       </div>
       <div
         className="m-properties-list"
@@ -168,7 +168,7 @@ exports[`NotificationCard renders notification with matched vehicle 1`] = `
       <div
         className="m-notification-content__description"
       >
-        OCC reported that an operator is not available on the route1, route2.
+        OCC reported that an operator is not available on the r1, r2.
       </div>
       <div
         className="m-properties-list"

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -3,18 +3,59 @@ import React from "react"
 import renderer from "react-test-renderer"
 import NotificationDrawer from "../../src/components/notificationDrawer"
 import { NotificationsContext } from "../../src/contexts/notificationsContext"
+import { RoutesProvider } from "../../src/contexts/routesContext"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import {
   markAllAsRead,
   toggleReadState,
 } from "../../src/hooks/useNotificationsReducer"
 import { Notification, NotificationState } from "../../src/realtime.d"
+import { Route } from "../../src/schedule"
 import {
   closeNotificationDrawer,
   initialState,
   setNotification,
 } from "../../src/state"
 import { now } from "../../src/util/dateTime"
+
+const notification: Notification = {
+  id: "0",
+  createdAt: now(),
+  reason: "manpower",
+  routeIds: ["route1", "route2"],
+  runIds: ["run1", "run2"],
+  tripIds: [],
+  operatorName: null,
+  operatorId: null,
+  routeIdAtCreation: null,
+  startTime: now(),
+  state: "unread" as NotificationState,
+}
+
+const readNotification: Notification = {
+  ...notification,
+  id: "1",
+  state: "read" as NotificationState,
+}
+
+const routes: Route[] = [
+  {
+    id: "route1",
+    directionNames: {
+      0: "Outbound",
+      1: "Inbound",
+    },
+    name: "r1",
+  },
+  {
+    id: "route2",
+    directionNames: {
+      0: "Outbound",
+      1: "Inbound",
+    },
+    name: "r2",
+  },
+]
 
 describe("NotificationDrawer", () => {
   test("renders empty state", () => {
@@ -26,7 +67,9 @@ describe("NotificationDrawer", () => {
     const dispatch = jest.fn()
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <NotificationDrawer />
+        <RoutesProvider routes={routes}>
+          <NotificationDrawer />
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -37,19 +80,21 @@ describe("NotificationDrawer", () => {
   test("renders notifications", () => {
     const tree = renderer
       .create(
-        <NotificationsContext.Provider
-          value={{
-            notifications: [notification],
-            showLatestNotification: true,
-            dispatch: jest.fn(),
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [notification],
+              showLatestNotification: true,
+              dispatch: jest.fn(),
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -59,19 +104,21 @@ describe("NotificationDrawer", () => {
     const dispatch = jest.fn()
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [notification],
-            showLatestNotification: true,
-            dispatch: jest.fn(),
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [notification],
+              showLatestNotification: true,
+              dispatch: jest.fn(),
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -89,19 +136,21 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [updatedNotification],
-            showLatestNotification: true,
-            dispatch: mockNotificationsDispatch,
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [updatedNotification],
+              showLatestNotification: true,
+              dispatch: mockNotificationsDispatch,
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -117,19 +166,21 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={stateDispatch}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [notification],
-            showLatestNotification: true,
-            dispatch: notificationsDispatch,
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [notification],
+              showLatestNotification: true,
+              dispatch: notificationsDispatch,
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -146,19 +197,21 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={stateDispatch}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [readNotification],
-            showLatestNotification: true,
-            dispatch: notificationsDispatch,
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [readNotification],
+              showLatestNotification: true,
+              dispatch: notificationsDispatch,
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -186,9 +239,11 @@ describe("NotificationDrawer", () => {
 
     const unreadWrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={unreadProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -206,9 +261,11 @@ describe("NotificationDrawer", () => {
 
     const readWrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={readProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={readProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -236,19 +293,21 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={stateDispatch}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [notification],
-            showLatestNotification: true,
-            dispatch: notificationsDispatch,
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: notification.id,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [notification],
+              showLatestNotification: true,
+              dispatch: notificationsDispatch,
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: notification.id,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -273,19 +332,21 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [notification],
-            showLatestNotification: true,
-            dispatch: jest.fn(),
-            rememberScrollPosition,
-            scrollPosition: 123,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [notification],
+              showLatestNotification: true,
+              dispatch: jest.fn(),
+              rememberScrollPosition,
+              scrollPosition: 123,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
     expect(rememberScrollPosition).not.toHaveBeenCalled()
@@ -308,9 +369,11 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={unreadProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -340,9 +403,11 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={unreadProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -377,9 +442,11 @@ describe("NotificationDrawer", () => {
 
     mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={unreadProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 
@@ -403,9 +470,11 @@ describe("NotificationDrawer", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadProviderValue}>
-          <NotificationDrawer />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider value={unreadProviderValue}>
+            <NotificationDrawer />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
     expect(document.removeEventListener).not.toHaveBeenCalled()
@@ -413,23 +482,3 @@ describe("NotificationDrawer", () => {
     expect(document.removeEventListener).toHaveBeenCalled()
   })
 })
-
-const notification: Notification = {
-  id: "0",
-  createdAt: now(),
-  reason: "manpower",
-  routeIds: ["route1", "route2"],
-  runIds: ["run1", "run2"],
-  tripIds: [],
-  operatorName: null,
-  operatorId: null,
-  routeIdAtCreation: null,
-  startTime: now(),
-  state: "unread" as NotificationState,
-}
-
-const readNotification: Notification = {
-  ...notification,
-  id: "1",
-  state: "read" as NotificationState,
-}

--- a/assets/tests/components/notifications.test.tsx
+++ b/assets/tests/components/notifications.test.tsx
@@ -7,12 +7,14 @@ import {
   Notifications,
 } from "../../src/components/notifications"
 import { NotificationsContext } from "../../src/contexts/notificationsContext"
+import { RoutesProvider } from "../../src/contexts/routesContext"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import {
   hideLatestNotification,
   toggleReadState,
 } from "../../src/hooks/useNotificationsReducer"
 import { Notification, NotificationReason } from "../../src/realtime.d"
+import { Route } from "../../src/schedule"
 import { initialState } from "../../src/state"
 import { now } from "../../src/util/dateTime"
 
@@ -47,6 +49,33 @@ const notificationWithMatchedVehicle: Notification = {
   routeIdAtCreation: "route1",
 }
 
+const routes: Route[] = [
+  {
+    id: "route1",
+    directionNames: {
+      0: "Outbound",
+      1: "Inbound",
+    },
+    name: "r1",
+  },
+  {
+    id: "route2",
+    directionNames: {
+      0: "Outbound",
+      1: "Inbound",
+    },
+    name: "r2",
+  },
+  {
+    id: "route3",
+    directionNames: {
+      0: "Outbound",
+      1: "Inbound",
+    },
+    name: "r3",
+  },
+]
+
 describe("Notification", () => {
   test("renders empty state", () => {
     const tree = renderer.create(<Notifications />).toJSON()
@@ -61,19 +90,21 @@ describe("Notification", () => {
 
     const tree = renderer
       .create(
-        <NotificationsContext.Provider
-          value={{
-            notifications,
-            showLatestNotification: true,
-            dispatch: jest.fn(),
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <Notifications />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications,
+              showLatestNotification: true,
+              dispatch: jest.fn(),
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <Notifications />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -106,12 +137,14 @@ describe("NotificationCard", () => {
   test("renders notification with matched vehicle", () => {
     const tree = renderer
       .create(
-        <NotificationCard
-          notification={notificationWithMatchedVehicle}
-          currentTime={now()}
-          dispatch={jest.fn()}
-          openVPPForCurrentVehicle={jest.fn()}
-        />
+        <RoutesProvider routes={routes}>
+          <NotificationCard
+            notification={notificationWithMatchedVehicle}
+            currentTime={now()}
+            dispatch={jest.fn()}
+            openVPPForCurrentVehicle={jest.fn()}
+          />
+        </RoutesProvider>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -120,12 +153,14 @@ describe("NotificationCard", () => {
   test("transforms reasons into human-readable titles", () => {
     const n: Notification = { ...notification, reason: "operator_error" }
     const wrapper = mount(
-      <NotificationCard
-        notification={n}
-        currentTime={now()}
-        dispatch={jest.fn()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          currentTime={now()}
+          dispatch={jest.fn()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.html()).toContain("OPERATOR ERROR")
   })
@@ -133,12 +168,14 @@ describe("NotificationCard", () => {
   test("uses custom titles if available", () => {
     const n: Notification = { ...notification, reason: "manpower" }
     const wrapper = mount(
-      <NotificationCard
-        notification={n}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.html()).toContain("NO OPERATOR")
   })
@@ -147,12 +184,14 @@ describe("NotificationCard", () => {
     const n: Notification = { ...notification, reason: "other" }
     const tree = renderer
       .create(
-        <NotificationCard
-          notification={n}
-          dispatch={jest.fn()}
-          currentTime={now()}
-          openVPPForCurrentVehicle={jest.fn()}
-        />
+        <RoutesProvider routes={routes}>
+          <NotificationCard
+            notification={n}
+            dispatch={jest.fn()}
+            currentTime={now()}
+            openVPPForCurrentVehicle={jest.fn()}
+          />
+        </RoutesProvider>
       )
       .toJSON()
     expect(tree).toMatchSnapshot()
@@ -162,16 +201,18 @@ describe("NotificationCard", () => {
     const n: Notification = {
       ...notificationWithMatchedVehicle,
       reason: "accident",
-      routeIds: ["r2", "r3"],
-      routeIdAtCreation: "r1",
+      routeIds: ["route2", "route3"],
+      routeIdAtCreation: "route1",
     }
     const wrapper = mount(
-      <NotificationCard
-        notification={n}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.html()).toContain("r1")
   })
@@ -180,16 +221,18 @@ describe("NotificationCard", () => {
     const n: Notification = {
       ...notification,
       reason: "accident",
-      routeIds: ["r2", "r3"],
+      routeIds: ["route2", "route3"],
       routeIdAtCreation: null,
     }
     const wrapper = mount(
-      <NotificationCard
-        notification={n}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.html()).toContain("r2, r3")
   })
@@ -198,16 +241,18 @@ describe("NotificationCard", () => {
     const n: Notification = {
       ...notificationWithMatchedVehicle,
       reason: "diverted",
-      routeIds: ["r2", "r3"],
-      routeIdAtCreation: "r1",
+      routeIds: ["route2", "route3"],
+      routeIdAtCreation: "route1",
     }
     const wrapper = mount(
-      <NotificationCard
-        notification={n}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.html()).toContain("r2, r3")
   })
@@ -225,24 +270,28 @@ describe("NotificationCard", () => {
   test.each(reasons)("renders notification with reason %s", (reason) => {
     const n: Notification = { ...notification, reason }
     mount(
-      <NotificationCard
-        notification={n}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
   })
 
   test("sets and removes class to animate pop-in", () => {
     jest.useFakeTimers()
     const wrapper = mount(
-      <NotificationCard
-        notification={notification}
-        dispatch={jest.fn()}
-        currentTime={now()}
-        openVPPForCurrentVehicle={jest.fn()}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={notification}
+          dispatch={jest.fn()}
+          currentTime={now()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
     )
     expect(wrapper.find(".m-notifications__card--new")).toHaveLength(1)
     act(() => {
@@ -262,12 +311,14 @@ describe("NotificationCard", () => {
     const openVPPForCurrentVehicle = jest.fn()
 
     const wrapper = mount(
-      <NotificationCard
-        notification={updatedNotification}
-        dispatch={dispatch}
-        currentTime={currentTime}
-        openVPPForCurrentVehicle={openVPPForCurrentVehicle}
-      />
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={updatedNotification}
+          dispatch={dispatch}
+          currentTime={currentTime}
+          openVPPForCurrentVehicle={openVPPForCurrentVehicle}
+        />
+      </RoutesProvider>
     )
     expect(openVPPForCurrentVehicle).not.toHaveBeenCalled()
     expect(dispatch).not.toHaveBeenCalled()
@@ -286,19 +337,21 @@ describe("NotificationCard", () => {
 
     const wrapper = mount(
       <StateDispatchProvider state={initialState} dispatch={jest.fn}>
-        <NotificationsContext.Provider
-          value={{
-            notifications: [updatedNotification],
-            showLatestNotification: true,
-            dispatch: mockNotificationsDispatch,
-            rememberScrollPosition: jest.fn(),
-            scrollPosition: 0,
-            notificationWithOpenSubmenuId: null,
-            setNotificationWithOpenSubmenuId: jest.fn(),
-          }}
-        >
-          <Notifications />
-        </NotificationsContext.Provider>
+        <RoutesProvider routes={routes}>
+          <NotificationsContext.Provider
+            value={{
+              notifications: [updatedNotification],
+              showLatestNotification: true,
+              dispatch: mockNotificationsDispatch,
+              rememberScrollPosition: jest.fn(),
+              scrollPosition: 0,
+              notificationWithOpenSubmenuId: null,
+              setNotificationWithOpenSubmenuId: jest.fn(),
+            }}
+          >
+            <Notifications />
+          </NotificationsContext.Provider>
+        </RoutesProvider>
       </StateDispatchProvider>
     )
 


### PR DESCRIPTION
Ticket: [Ensure that notifications use the same route labels as the route ladders in Skate](https://app.asana.com/0/1148853526253426/1199900940371663/f)

<img width="414" alt="Screen Shot 2021-03-04 at 3 37 09 PM" src="https://user-images.githubusercontent.com/2010157/110029215-2b9c4400-7d02-11eb-8313-c51702dbbc1a.png">
<img width="367" alt="fixed" src="https://user-images.githubusercontent.com/2010157/110030408-add93800-7d03-11eb-9e00-11fe4753186a.png">