### PR TITLE
chore: don't allow SettingsData values to be undefined anymore

### DIFF
--- a/assets/src/userSettings.ts
+++ b/assets/src/userSettings.ts
@@ -46,11 +46,8 @@ export type TripLabelData = "origin" | "destination"
 interface SettingsData {
   ladder_page_vehicle_label: VehicleLabelData
   shuttle_page_vehicle_label: VehicleLabelData
-  vehicle_adherence_colors?: VehicleAdherenceColorsData
-  // We allow minischedules_trip_label to be undefined to handle the
-  // hybrid code problem, we can disallow undefined after the first
-  // deploy of the corresponding backend code.
-  minischedules_trip_label?: TripLabelData
+  vehicle_adherence_colors: VehicleAdherenceColorsData
+  minischedules_trip_label: TripLabelData
 }
 
 const vehicleLabelFromData = (data: VehicleLabelData): VehicleLabelSetting => {

--- a/assets/tests/userSettings.test.ts
+++ b/assets/tests/userSettings.test.ts
@@ -14,6 +14,7 @@ describe("userSettingsFromData", () => {
       ladder_page_vehicle_label: "run_id" as VehicleLabelData,
       shuttle_page_vehicle_label: "run_id" as VehicleLabelData,
       vehicle_adherence_colors: "early_red" as VehicleAdherenceColorsData,
+      minischedules_trip_label: "origin" as TripLabelData,
     }
 
     expect(userSettingsFromData(data).vehicleAdherenceColors).toEqual(
@@ -24,19 +25,13 @@ describe("userSettingsFromData", () => {
       userSettingsFromData({ ...data, vehicle_adherence_colors: "early_blue" })
         .vehicleAdherenceColors
     ).toEqual(VehicleAdherenceColorsSetting.EarlyBlue)
-
-    expect(
-      userSettingsFromData({ ...data, vehicle_adherence_colors: undefined })
-        .vehicleAdherenceColors
-    ).toEqual(VehicleAdherenceColorsSetting.EarlyRed)
   })
-})
 
-describe("userSettingsFromData", () => {
   test("parses minischedulesTripLabel", () => {
     const data = {
       ladder_page_vehicle_label: "run_id" as VehicleLabelData,
       shuttle_page_vehicle_label: "run_id" as VehicleLabelData,
+      vehicle_adherence_colors: "early_red" as VehicleAdherenceColorsData,
       minischedules_trip_label: "origin" as TripLabelData,
     }
 
@@ -46,11 +41,6 @@ describe("userSettingsFromData", () => {
 
     expect(
       userSettingsFromData({ ...data, minischedules_trip_label: "destination" })
-        .minischedulesTripLabel
-    ).toEqual(TripLabelSetting.Destination)
-
-    expect(
-      userSettingsFromData({ ...data, minischedules_trip_label: undefined })
         .minischedulesTripLabel
     ).toEqual(TripLabelSetting.Destination)
   })


### PR DESCRIPTION
Ticket: [Clean up userSettings.ts once deployed to prod](https://app.asana.com/0/1148853526253426/1199999682730453/f)