### PR TITLE
chore: remove unused columns on notifications table

### DIFF
--- a/priv/repo/migrations/20210312200638_remove_unneeded_notifications_columns.exs
+++ b/priv/repo/migrations/20210312200638_remove_unneeded_notifications_columns.exs
@@ -1,0 +1,19 @@
+defmodule Skate.Repo.Migrations.RemoveUnneededNotificationsColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      remove :reason
+      remove :route_ids
+      remove :run_ids
+      remove :trip_ids
+      remove :operator_id
+      remove :operator_name
+      remove :route_id_at_creation
+      remove :block_id
+      remove :service_id
+      remove :start_time
+      remove :end_time
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [Remove block waiver attributes from notifications table](https://app.asana.com/0/1148853526253426/1199546435658878/f)

I have had this running locally and notifications are getting created without any errors. This is just the schema change, the backfiller was already removed in a #1007.