### PR TITLE
feat: make data outage logic only fire if >= 20 buses are present

### DIFF
--- a/lib/realtime/data_status.ex
+++ b/lib/realtime/data_status.ex
@@ -32,7 +32,7 @@ defmodule Realtime.DataStatus do
       } bad_vehicles=#{bad_count}"
     )
 
-    if considered_count >= 10 and bad_count / considered_count >= 0.20 do
+    if considered_count >= 20 and bad_count / considered_count >= 0.20 do
       :outage
     else
       :good

--- a/test/realtime/data_status_test.exs
+++ b/test/realtime/data_status_test.exs
@@ -44,73 +44,74 @@ defmodule Realtime.DataStatusTest do
       Logger.configure(level: :info)
     end
 
-    test "if there are fewer than 10 revenue vehicles, status is good" do
-      bads = List.duplicate(@bad, 9)
+    test "if there are fewer than 20 revenue vehicles, status is good" do
+      bads = List.duplicate(@bad, 19)
       irrelevants = List.duplicate(@irrelevant, 20)
       vehicles = bads ++ irrelevants
 
       log =
         capture_log([level: :info], fn -> assert DataStatus.data_status(vehicles) == :good end)
 
-      assert log =~ "total_vehicles=29"
-      assert log =~ "considered_vehicles=9"
+      assert log =~ "total_vehicles=39"
+      assert log =~ "considered_vehicles=19"
       assert log =~ "good_vehicles=0"
       assert log =~ "good_busloc_vehicles=0"
       assert log =~ "good_swiftly_vehicles=0"
-      assert log =~ "bad_vehicles=9"
+      assert log =~ "bad_vehicles=19"
     end
 
     test "if most vehicles are good, status is good" do
-      goods = List.duplicate(@good, 9)
+      goods = List.duplicate(@good, 17)
 
       log =
         capture_log([level: :info], fn ->
-          assert DataStatus.data_status([@bad | goods]) == :good
+          assert DataStatus.data_status([@bad, @bad, @bad | goods]) == :good
         end)
 
-      assert log =~ "total_vehicles=10"
-      assert log =~ "considered_vehicles=10"
-      assert log =~ "good_vehicles=9"
-      assert log =~ "good_busloc_vehicles=9"
-      assert log =~ "good_swiftly_vehicles=9"
-      assert log =~ "bad_vehicles=1"
+      assert log =~ "total_vehicles=20"
+      assert log =~ "considered_vehicles=20"
+      assert log =~ "good_vehicles=17"
+      assert log =~ "good_busloc_vehicles=17"
+      assert log =~ "good_swiftly_vehicles=17"
+      assert log =~ "bad_vehicles=3"
     end
 
     test "if many vehicles are bad, status is outage" do
-      goods = List.duplicate(@good, 8)
+      goods = List.duplicate(@good, 16)
 
       log =
         capture_log([level: :info], fn ->
-          assert DataStatus.data_status([@bad, @bad | goods]) == :outage
+          assert DataStatus.data_status([@bad, @bad, @bad, @bad | goods]) == :outage
         end)
 
-      assert log =~ "total_vehicles=10"
-      assert log =~ "considered_vehicles=10"
-      assert log =~ "good_vehicles=8"
-      assert log =~ "good_busloc_vehicles=8"
-      assert log =~ "good_swiftly_vehicles=8"
-      assert log =~ "bad_vehicles=2"
+      assert log =~ "total_vehicles=20"
+      assert log =~ "considered_vehicles=20"
+      assert log =~ "good_vehicles=16"
+      assert log =~ "good_busloc_vehicles=16"
+      assert log =~ "good_swiftly_vehicles=16"
+      assert log =~ "bad_vehicles=4"
     end
 
     test "considers vehicles bad if either source is stale or missing" do
-      goods = List.duplicate(@good, 8)
+      goods = List.duplicate(@good, 16)
 
       [
-        {[@swiftly_missing, @swiftly_missing | goods], 10, 8},
-        {[@swiftly_stale, @swiftly_stale | goods], 10, 8},
-        {[@busloc_missing, @busloc_missing | goods], 8, 10},
-        {[@busloc_stale, @busloc_stale | goods], 8, 10}
+        {[@swiftly_missing, @swiftly_missing, @swiftly_missing, @swiftly_missing | goods], 20,
+         16},
+        {[@swiftly_stale, @swiftly_stale, @swiftly_stale, @swiftly_stale | goods], 20, 16},
+        {[@busloc_missing, @busloc_missing, @busloc_missing, @busloc_missing | goods], 16, 20},
+        {[@busloc_stale, @busloc_stale, @busloc_stale, @busloc_stale | goods], 16, 20}
       ]
       |> Enum.each(fn {vehicles, busloc_good, swiftly_good} ->
         log =
           capture_log([level: :info], fn -> assert DataStatus.data_status(vehicles) == :outage end)
 
-        assert log =~ "total_vehicles=10"
-        assert log =~ "considered_vehicles=10"
-        assert log =~ "good_vehicles=8"
+        assert log =~ "total_vehicles=20"
+        assert log =~ "considered_vehicles=20"
+        assert log =~ "good_vehicles=16"
         assert log =~ "good_busloc_vehicles=#{busloc_good}"
         assert log =~ "good_swiftly_vehicles=#{swiftly_good}"
-        assert log =~ "bad_vehicles=2"
+        assert log =~ "bad_vehicles=4"
       end)
     end
 


### PR DESCRIPTION
Ticket: [Investigate and improve the data-outage alert so that there are less false positives](https://app.asana.com/0/1148853526253426/1199922066863534/f)