### PR TITLE
feat: pre-launch adjustments

### DIFF
--- a/assets/src/components/swingsView.tsx
+++ b/assets/src/components/swingsView.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useState } from "react"
+import React, { ReactElement, useContext } from "react"
 import { useRoutes } from "../contexts/routesContext"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
@@ -8,25 +8,22 @@ import CloseButton from "./closeButton"
 import { flatten, uniq } from "../helpers/array"
 import { ghostIcon, upRightIcon } from "../helpers/icon"
 import { runIdToLabel } from "../helpers/vehicleLabel"
+import useCurrentTime from "../hooks/useCurrentTime"
 import useSwings from "../hooks/useSwings"
 import useVehiclesForRunIds from "../hooks/useVehiclesForRunIds"
 import { ByRunId, VehicleOrGhost } from "../realtime"
 import { ByRouteId, Route, Swing } from "../schedule"
 import { selectVehicle, toggleSwingsView } from "../state"
-import {
-  formattedScheduledTime,
-  now,
-  serviceDaySeconds,
-} from "../util/dateTime"
+import { formattedScheduledTime, serviceDaySeconds } from "../util/dateTime"
 
 const SwingsView = (): ReactElement<HTMLElement> => {
   const [, dispatch] = useContext(StateDispatchContext)
-  const [currentTime] = useState(now())
+  const currentTime = useCurrentTime()
   const swings = useSwings()
 
   const activeSwings = swings
     ? swings.filter((swing) => {
-        return swing.time + 60 > serviceDaySeconds(currentTime)
+        return swing.time + 600 > serviceDaySeconds(currentTime)
       })
     : []
 

--- a/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
@@ -109,7 +109,116 @@ exports[`SwingsView ignores vehicles without run ID 1`] = `
 </div>
 `;
 
-exports[`SwingsView omits past swings 1`] = `
+exports[`SwingsView includes swings less than 10 minutes in the past 1`] = `
+<div
+  className="m-swings-view"
+  id="m-swings-view"
+>
+  <button
+    className="m-close-button"
+    onClick={[Function]}
+  >
+    <span
+      className=""
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "SVG",
+        }
+      }
+    />
+  </button>
+  <div
+    className="m-swings-view__header"
+  >
+    Swings view
+  </div>
+  <div
+    className="m-swings-view__description"
+  >
+    Upcoming swings on your selected routes
+  </div>
+  <div
+    className="m-swings-view__table-container"
+  >
+    <table
+      className="m-swings-view__table"
+    >
+      <thead
+        className="m-swings-view__table-header"
+      >
+        <tr>
+          <th
+            className="m-swings-view__table-header-cell"
+          >
+            Swing On Time
+          </th>
+          <th
+            className="m-swings-view__table-header-cell"
+          >
+            Swing On
+            <div
+              className="run-subheader"
+            >
+              Run
+            </div>
+          </th>
+          <th
+            className="m-swings-view__table-header-cell swing-off"
+          >
+            Swing Off
+            <div
+              className="run-subheader"
+            >
+              Run
+            </div>
+            <div
+              className="route-subheader"
+            >
+              Route
+            </div>
+          </th>
+          <th
+            className="m-swings-view__table-header-cell"
+          >
+            Vehicle No.
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className="m-swings-view__table-row-inactive"
+        >
+          <th
+            className="m-swings-view__table-cell"
+          >
+            4:55 AM
+          </th>
+          <th
+            className="m-swings-view__table-cell"
+          >
+            789
+          </th>
+          <th
+            className="m-swings-view__table-cell swing-off"
+          >
+            456
+            <div
+              className="m-swings-view__route"
+            >
+              Name 1
+            </div>
+          </th>
+          <th
+            className="m-swings-view__table-cell"
+          />
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`SwingsView omits swings more than 10 minutes in the past 1`] = `
 <div
   className="m-swings-view"
   id="m-swings-view"

--- a/assets/tests/components/swingsView.test.tsx
+++ b/assets/tests/components/swingsView.test.tsx
@@ -128,7 +128,7 @@ describe("SwingsView", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("omits past swings", () => {
+  test("omits swings more than 10 minutes in the past", () => {
     ;(useSwings as jest.Mock).mockImplementationOnce((): Swing[] => [
       {
         fromRouteId: "1",
@@ -138,6 +138,29 @@ describe("SwingsView", () => {
         toRunId: "123-789",
         toTripId: "5678",
         time: 1000,
+      },
+    ])
+
+    const tree = renderer
+      .create(
+        <RoutesProvider routes={routes}>
+          <SwingsView />
+        </RoutesProvider>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("includes swings less than 10 minutes in the past", () => {
+    ;(useSwings as jest.Mock).mockImplementationOnce((): Swing[] => [
+      {
+        fromRouteId: "1",
+        fromRunId: "123-456",
+        fromTripId: "1234",
+        toRouteId: "1",
+        toRunId: "123-789",
+        toTripId: "5678",
+        time: 17700,
       },
     ])
 


### PR DESCRIPTION
Asana ticket: [Swings beta: extra time cushion, dynamically remove past swings from list.](https://app.asana.com/0/1200180014510248/1200284850527481/f)

A couple of quick adjustments that came out of our post-standup chat:

* Give 10 minute cushion for showing past swings
* Dynamically remove swings older than cushion