### PR TITLE
build: remove codecov upload step

### DIFF
--- a/semaphore/test.sh
+++ b/semaphore/test.sh
@@ -7,5 +7,4 @@ export MIX_ENV=test
 mix ecto.create &&
 mix ecto.migrate &&
 mix coveralls.json &&
-pushd assets && npm test && popd &&
-bash <(curl -s https://codecov.io/bash)
+pushd assets && npm test && popd


### PR DESCRIPTION
Codecov is going away soon (read: this weekend), so we should remove the step that does the upload. I'll also go in and disable it as a required step to merge.