### PR TITLE
fix: run data status check every 30s, even if no updates come in

### DIFF
--- a/lib/concentrate/consumer/vehicle_positions.ex
+++ b/lib/concentrate/consumer/vehicle_positions.ex
@@ -6,7 +6,7 @@ defmodule Concentrate.Consumer.VehiclePositions do
   use GenStage
 
   alias Concentrate.{Merge, VehiclePosition}
-  alias Realtime.{DataStatus, DataStatusPubSub, Vehicles, Server, Vehicle}
+  alias Realtime.{Vehicles, Server, Vehicle}
 
   def start_link(opts) do
     GenStage.start_link(__MODULE__, opts)
@@ -31,14 +31,10 @@ defmodule Concentrate.Consumer.VehiclePositions do
       |> vehicle_positions_from_groups()
       |> Enum.map(&Vehicle.from_vehicle_position/1)
 
-    data_status_fn = Application.get_env(:skate, :data_status_fn) || (&DataStatus.data_status/1)
-    data_status = data_status_fn.(all_vehicles)
-
     by_route = Vehicles.group_by_route(all_vehicles)
     shuttles = Enum.filter(all_vehicles, & &1.is_shuttle)
 
     _ = Server.update({by_route, shuttles})
-    _ = DataStatusPubSub.update(data_status)
 
     {:noreply, [], state}
   end

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -189,7 +189,7 @@ defmodule Realtime.Server do
       |> lookup()
       |> Enum.filter(fn vehicle_or_ghost -> match?(%Vehicle{}, vehicle_or_ghost) end)
 
-    data_status_fn = Application.get_env(:skate, :data_status_fn) || (&DataStatus.data_status/1)
+    data_status_fn = Application.get_env(:skate, :data_status_fn, &DataStatus.data_status/1)
     data_status = data_status_fn.(all_vehicles)
     _ = DataStatusPubSub.update(data_status)
 

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -16,13 +16,13 @@ defmodule Realtime.ServerTest do
              operator_name: "FRANCIS"
            )
 
-  @inactive_block build(:vehicle,
-                    route_id: "1",
-                    block_is_active: false,
-                    id: "v2",
-                    label: "v2-label",
-                    run_id: "456-7890"
-                  )
+  @vehicle_on_inactive_block build(:vehicle,
+                               route_id: "1",
+                               block_is_active: false,
+                               id: "v2",
+                               label: "v2-label",
+                               run_id: "456-7890"
+                             )
 
   @ghost build(:ghost)
 
@@ -122,7 +122,7 @@ defmodule Realtime.ServerTest do
     test "vehicles on inactive blocks are removed", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({%{"1" => [@inactive_block]}, []}, server_pid)
+      Server.update({%{"1" => [@vehicle_on_inactive_block]}, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -195,11 +195,11 @@ defmodule Realtime.ServerTest do
     test "vehicles on inactive blocks are included", %{server_pid: pid} do
       Server.subscribe_to_search("v2-label", :vehicle, pid)
 
-      Server.update({%{"1" => [@inactive_block]}, []}, pid)
+      Server.update({%{"1" => [@vehicle_on_inactive_block]}, []}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
 
-      assert Server.lookup(lookup_args) == [@inactive_block]
+      assert Server.lookup(lookup_args) == [@vehicle_on_inactive_block]
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -33,4 +33,23 @@ defmodule Skate.Factory do
       end_of_trip_type: :another_trip
     }
   end
+
+  def ghost_factory do
+    %Realtime.Ghost{
+      id: "ghost-trip",
+      direction_id: 0,
+      route_id: "1",
+      trip_id: "t2",
+      headsign: "headsign",
+      block_id: "block",
+      run_id: "123-9049",
+      via_variant: "X",
+      layover_departure_time: nil,
+      scheduled_timepoint_status: %{
+        timepoint_id: "t2",
+        fraction_until_timepoint: 0.5
+      },
+      route_status: :on_route
+    }
+  end
 end


### PR DESCRIPTION
Asana Ticket: [Make data outage logic independent of new data coming in](https://app.asana.com/0/1148853526253426/1200062807015666/f)

I considered making this a completely independent GenServer that references the ETS table, but because the actual name of the ETS table is only accessible by calling the `Realtime.Server` process to begin with, I decided to just keep it in there.