### PR TITLE
Use updated Webpack option

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,7 @@ config :skate, SkateWeb.Endpoint,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch-stdin",
+      "--watch-options-stdin",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]


### PR DESCRIPTION
The recent update of Webpack caused it to break, but only in dev, due to one option being renamed.