### PR TITLE
fix: don't rely on branch for build-push-ecr

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: metadata
         uses: mbta/actions/commit-metadata@v1
-      - uses: mbta/actions/build-push-ecr@pwd-add-docker-args-to-build-push-ecr
+      - uses: mbta/actions/build-push-ecr@v1.8
         id: build-push
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Small change that I forgot to actually open a PR for last week.