### PR TITLE
build: use npm rather than nodejs-npm from APK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache --update git
 RUN mix local.hex --force && \
   mix local.rebar --force
 
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update nodejs npm
 
 ARG SENTRY_ORG=$SENTRY_ORG
 ARG SENTRY_PROJECT=$SENTRY_PROJECT


### PR DESCRIPTION
We're now on Alpine 3.14 and it looks like nodejs-npm no longer
exists: https://superuser.com/a/1424979