### PR TITLE
build(deps): remove react-tooltip dependency

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -11440,22 +11440,6 @@
         }
       }
     },
-    "react-tooltip": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.10.tgz",
-      "integrity": "sha512-D7ZLx6/QwpUl0SZRek3IZy/HWpsEEp0v3562tcT8IwZgu8IgV7hY5ZzniTkHyRcuL+IQnljpjj7A7zCgl2+T3w==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-        }
-      }
-    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -30,7 +30,6 @@
     "react-leaflet-control": "^2.1.2",
     "react-leaflet-fullscreen": "^1.0.1",
     "react-router-dom": "^5.2.0",
-    "react-tooltip": "^4.2.10",
     "resize-observer-polyfill": "^1.5.1",
     "whatwg-fetch": "^3.6.2"
   },


### PR DESCRIPTION
We have moved over ti Tippy but it looks like we never actually
cleaned up the dependency on react-tooltip