### PR TITLE
fix: only filter routes by name, not ID

### DIFF
--- a/assets/src/hooks/useRouteFilter.tsx
+++ b/assets/src/hooks/useRouteFilter.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { circleXIcon } from "../helpers/icon"
 import { Route } from "../schedule.d"
 
-type FilterType = "id"
+type FilterType = "name"
 
 export interface RouteFilterData {
   filterType: FilterType
@@ -13,10 +13,9 @@ export interface RouteFilterData {
   clearTextInput: () => void
 }
 
-const isFilterType = (str: string): str is FilterType => str === "id"
+const isFilterType = (str: string): str is FilterType => str === "name"
 
-const byRouteIdOrName = (filterText: string) => (route: Route) =>
-  route.id.toLowerCase().includes(filterText.toLowerCase()) ||
+const byRouteName = (filterText: string) => (route: Route) =>
   route.name.toLowerCase().includes(filterText.toLowerCase())
 
 export const filterRoutes = (
@@ -24,13 +23,13 @@ export const filterRoutes = (
   { filterType, filterText }: { filterType: FilterType; filterText: string }
 ): Route[] => {
   switch (filterType) {
-    case "id":
-      return allRoutes.filter(byRouteIdOrName(filterText))
+    case "name":
+      return allRoutes.filter(byRouteName(filterText))
   }
 }
 
 export const useRouteFilter = (): RouteFilterData => {
-  const initialFilterType: FilterType = "id"
+  const initialFilterType: FilterType = "name"
   const [filterType, setFilterType] = useState(initialFilterType)
   const [filterText, setFilterText] = useState("")
 
@@ -76,7 +75,7 @@ export const RouteFilter = ({
         value={filterType}
         onChange={handleTypeChange}
       >
-        <option value="id">Route ID</option>
+        <option value="name">Route ID</option>
       </select>
       <div className="m-route-filter__text">
         <input

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -223,10 +223,10 @@ exports[`App renders 1`] = `
             <select
               className="m-route-filter__type"
               onChange={[Function]}
-              value="id"
+              value="name"
             >
               <option
-                value="id"
+                value="name"
               >
                 Route ID
               </option>
@@ -505,10 +505,10 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
             <select
               className="m-route-filter__type"
               onChange={[Function]}
-              value="id"
+              value="name"
             >
               <option
-                value="id"
+                value="name"
               >
                 Route ID
               </option>

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -223,10 +223,10 @@ exports[`renders 1`] = `
             <select
               className="m-route-filter__type"
               onChange={[Function]}
-              value="id"
+              value="name"
             >
               <option
-                value="id"
+                value="name"
               >
                 Route ID
               </option>

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -39,10 +39,10 @@ exports[`LadderPage renders the empty state 1`] = `
         <select
           className="m-route-filter__type"
           onChange={[Function]}
-          value="id"
+          value="name"
         >
           <option
-            value="id"
+            value="name"
           >
             Route ID
           </option>
@@ -129,10 +129,10 @@ exports[`LadderPage renders with routes 1`] = `
         <select
           className="m-route-filter__type"
           onChange={[Function]}
-          value="id"
+          value="name"
         >
           <option
-            value="id"
+            value="name"
           >
             Route ID
           </option>
@@ -288,10 +288,10 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         <select
           className="m-route-filter__type"
           onChange={[Function]}
-          value="id"
+          value="name"
         >
           <option
-            value="id"
+            value="name"
           >
             Route ID
           </option>
@@ -488,10 +488,10 @@ exports[`LadderPage renders with timepoints 1`] = `
         <select
           className="m-route-filter__type"
           onChange={[Function]}
-          value="id"
+          value="name"
         >
           <option
-            value="id"
+            value="name"
           >
             Route ID
           </option>
@@ -924,10 +924,10 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
         <select
           className="m-route-filter__type"
           onChange={[Function]}
-          value="id"
+          value="name"
         >
           <option
-            value="id"
+            value="name"
           >
             Route ID
           </option>

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -50,10 +50,10 @@ exports[`RoutePicker renders a list of routes 1`] = `
       <select
         className="m-route-filter__type"
         onChange={[Function]}
-        value="id"
+        value="name"
       >
         <option
-          value="id"
+          value="name"
         >
           Route ID
         </option>
@@ -172,10 +172,10 @@ exports[`RoutePicker renders a loading/empty state 1`] = `
       <select
         className="m-route-filter__type"
         onChange={[Function]}
-        value="id"
+        value="name"
       >
         <option
-          value="id"
+          value="name"
         >
           Route ID
         </option>

--- a/assets/tests/hooks/useRouteFilter.test.tsx
+++ b/assets/tests/hooks/useRouteFilter.test.tsx
@@ -12,10 +12,10 @@ import { Route } from "../../src/schedule.d"
 // tslint:disable: react-hooks-nesting no-empty
 
 describe("useRouteFilter", () => {
-  test("defaults filter type to 'id'", () => {
+  test("defaults filter type to 'name'", () => {
     const { result } = renderHook(() => useRouteFilter())
 
-    expect(result.current.filterType).toBe("id")
+    expect(result.current.filterType).toBe("name")
   })
 
   test("defaults filter text to empty string", () => {
@@ -56,7 +56,7 @@ describe("useRouteFilter", () => {
 })
 
 describe("filterRoutes", () => {
-  test("when filter type is id, filters by route IDs", () => {
+  test("when filter type is name, filters by route name, case insensitively", () => {
     const initialRoutes: Route[] = [
       { id: "3", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "3" },
       { id: "12", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "12" },
@@ -68,53 +68,32 @@ describe("filterRoutes", () => {
       },
     ]
 
-    const filteredRoutes = filterRoutes(initialRoutes, {
-      filterType: "id",
-      filterText: "3",
-    })
-
-    expect(filteredRoutes).toEqual([
-      { id: "3", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "3" },
-      { id: "13", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "13" },
-      {
-        id: "743",
-        directionNames: { 0: "Outbound", 1: "Inbound" },
-        name: "SL3",
-      },
-    ])
-  })
-
-  test("when filter type is id, filters by route name, case insensitively", () => {
-    const initialRoutes: Route[] = [
-      { id: "3", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "3" },
-      { id: "12", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "12" },
-      { id: "13", directionNames: { 0: "Outbound", 1: "Inbound" }, name: "13" },
-      {
-        id: "743",
-        directionNames: { 0: "Outbound", 1: "Inbound" },
-        name: "SL3",
-      },
-    ]
-
-    const filteredRoutes = filterRoutes(initialRoutes, {
-      filterType: "id",
+    const filteredRoutes1 = filterRoutes(initialRoutes, {
+      filterType: "name",
       filterText: "Sl",
     })
 
-    expect(filteredRoutes).toEqual([
+    expect(filteredRoutes1).toEqual([
       {
         id: "743",
         directionNames: { 0: "Outbound", 1: "Inbound" },
         name: "SL3",
       },
     ])
+
+    const filteredRoutes2 = filterRoutes(initialRoutes, {
+      filterType: "name",
+      filterText: "7",
+    })
+
+    expect(filteredRoutes2).toEqual([])
   })
 })
 
 describe("RouteFilter", () => {
   test("changing the filter type updates the route filter", () => {
     const mockRouteFilter: RouteFilterData = {
-      filterType: "id",
+      filterType: "name",
       filterText: "",
       handleTypeChange: jest.fn(),
       handleTextInput: jest.fn(),
@@ -134,7 +113,7 @@ describe("RouteFilter", () => {
 
   test("inputting filter text updates the route filter", () => {
     const mockRouteFilter: RouteFilterData = {
-      filterType: "id",
+      filterType: "name",
       filterText: "",
       handleTypeChange: jest.fn(),
       handleTextInput: jest.fn(),
@@ -154,7 +133,7 @@ describe("RouteFilter", () => {
 
   test("the clear button clears the filter text", () => {
     const mockRouteFilter: RouteFilterData = {
-      filterType: "id",
+      filterType: "name",
       filterText: "",
       handleTypeChange: jest.fn(),
       handleTextInput: jest.fn(),


### PR DESCRIPTION
Asana ticket: [⚙️ CTx / SLx routes show up when searching for their 7xx-series route numbers](https://app.asana.com/0/1200180014510248/1200578295576933/f)