### PR TITLE
Remove duplicate late view entries

### DIFF
--- a/assets/src/components/lateView.tsx
+++ b/assets/src/components/lateView.tsx
@@ -12,7 +12,7 @@ import {
   userXIcon,
 } from "../helpers/icon"
 import { useCurrentTimeSeconds } from "../hooks/useCurrentTime"
-import { flatten } from "../helpers/array"
+import { flatten, uniqBy } from "../helpers/array"
 import { isVehicle, isGhost } from "../models/vehicle"
 import { Vehicle, Ghost, VehicleOrGhost } from "../realtime"
 import { ByRouteId } from "../schedule"
@@ -45,7 +45,10 @@ const LateView = (): ReactElement<HTMLElement> => {
     VehiclesByRouteIdContext
   )
 
-  const vehiclesOrGhosts = flatten(Object.values(vehiclesByRouteId))
+  const vehiclesOrGhosts = uniqBy(
+    flatten(Object.values(vehiclesByRouteId)),
+    (vehicleOrGhost) => vehicleOrGhost.runId
+  )
 
   const lateBusThreshold = 60 * 15
   const missingLogonThreshold = 60 * 45
@@ -75,11 +78,6 @@ const LateView = (): ReactElement<HTMLElement> => {
 
   const lateBuses = vehiclesOrGhosts
     .filter(isVehicle)
-    .filter(
-      (vehicle) =>
-        vehicle.routeStatus === "on_route" ||
-        vehicle.routeStatus === "laying_over"
-    )
     .filter((vehicle) => vehicle.scheduleAdherenceSecs >= lateBusThreshold)
     .sort((a, b) => b.scheduleAdherenceSecs - a.scheduleAdherenceSecs)
 

--- a/assets/src/helpers/array.ts
+++ b/assets/src/helpers/array.ts
@@ -20,6 +20,23 @@ export function partition<T>(
 
 export const uniq = <T>(array: T[]): T[] => Array.from(new Set(array)).sort()
 
+export const uniqBy = <T, U>(array: T[], fun: (value: T) => U): T[] => {
+  const [newArray] = array.reduce(
+    ([acc, seen], value) => {
+      const funValue = fun(value)
+
+      if (seen.has(funValue)) {
+        return [acc, seen]
+      } else {
+        return [acc.concat(value), seen.add(funValue)]
+      }
+    },
+    [[] as T[], new Set() as Set<U>]
+  )
+
+  return newArray
+}
+
 export const flatten = <T>(array: T[][]): T[] =>
   array.reduce((previous, current) => previous.concat(current), [])
 

--- a/assets/tests/components/__snapshots__/lateView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/lateView.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
               </span>
             </td>
             <td>
-              N/A
+              run6
             </td>
             <td>
               station
@@ -84,7 +84,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
               </span>
             </td>
             <td>
-              N/A
+              run7
             </td>
             <td>
               somewhere
@@ -169,7 +169,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
                     }
                   }
                 />
-                N/A
+                run5
               </a>
             </td>
             <td />
@@ -205,53 +205,13 @@ exports[`LateView renders missing logons and late buses 1`] = `
                     }
                   }
                 />
-                2
+                run2
               </a>
             </td>
             <td>
               SMITH
                – 
               op2
-            </td>
-          </tr>
-          <tr>
-            <td
-              className="m-late-view__adherence-cell"
-            >
-              -15
-            </td>
-            <td>
-              <span
-                className="m-late-view__route-pill"
-              >
-                route
-              </span>
-            </td>
-            <td>
-              v3-label
-            </td>
-            <td
-              className="m-late-view__run-number-cell m-late-view__run-number-cell--late"
-            >
-              <a
-                className="m-late-view__run-link"
-                onClick={[Function]}
-              >
-                <span
-                  className="m-late-view__run-icon m-late-view__up-right-icon"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "SVG",
-                    }
-                  }
-                />
-                3
-              </a>
-            </td>
-            <td>
-              SMITH
-               – 
-              op3
             </td>
           </tr>
           <tr>
@@ -278,6 +238,46 @@ exports[`LateView renders missing logons and late buses 1`] = `
                 onClick={[Function]}
               >
                 <span
+                  className="m-late-view__run-icon m-late-view__up-right-icon"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "SVG",
+                    }
+                  }
+                />
+                run3
+              </a>
+            </td>
+            <td>
+              SMITH
+               – 
+              op4
+            </td>
+          </tr>
+          <tr>
+            <td
+              className="m-late-view__adherence-cell"
+            >
+              -15
+            </td>
+            <td>
+              <span
+                className="m-late-view__route-pill"
+              >
+                route
+              </span>
+            </td>
+            <td>
+              v5-label
+            </td>
+            <td
+              className="m-late-view__run-number-cell m-late-view__run-number-cell--late"
+            >
+              <a
+                className="m-late-view__run-link"
+                onClick={[Function]}
+              >
+                <span
                   className="m-late-view__run-icon m-late-view__block-waiver-icon"
                   dangerouslySetInnerHTML={
                     Object {
@@ -285,13 +285,13 @@ exports[`LateView renders missing logons and late buses 1`] = `
                     }
                   }
                 />
-                4
+                run4
               </a>
             </td>
             <td>
               SMITH
                – 
-              op4
+              op5
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/lateView.test.tsx
+++ b/assets/tests/components/lateView.test.tsx
@@ -25,35 +25,50 @@ describe("LateView", () => {
   test("renders missing logons and late buses", () => {
     const vehiclesByRouteId = {
       route: [
-        vehicleFactory.build({ routeId: "route", scheduleAdherenceSecs: 0 }),
         vehicleFactory.build({
           routeId: "route",
+          runId: "run1",
+          scheduleAdherenceSecs: 0,
+        }),
+        vehicleFactory.build({
+          routeId: "route",
+          runId: "run2",
+          scheduleAdherenceSecs: 901,
+        }),
+        vehicleFactory.build({
+          routeId: "other_route",
+          runId: "run2",
           scheduleAdherenceSecs: 901,
         }),
         vehicleFactory.build({
           routeId: "route",
+          runId: "run3",
           scheduleAdherenceSecs: 901,
           routeStatus: "laying_over",
         }),
         vehicleFactory.build({
           routeId: "route",
+          runId: "run4",
           scheduleAdherenceSecs: 901,
           blockWaivers: [blockWaiverFactory.build()],
         }),
         ghostFactory.build({
           routeId: "route",
+          runId: "run5",
           scheduledLogonTime: 15299,
           currentPieceFirstRoute: "route",
           currentPieceStartPlace: "garage",
         }),
         ghostFactory.build({
           routeId: "route",
+          runId: "run6",
           scheduledLogonTime: 15301,
           currentPieceFirstRoute: "route",
           currentPieceStartPlace: "station",
         }),
         ghostFactory.build({
           routeId: "route",
+          runId: "run7",
           scheduledLogonTime: 15302,
           currentPieceFirstRoute: "route",
           currentPieceStartPlace: "somewhere",

--- a/assets/tests/helpers/array.test.ts
+++ b/assets/tests/helpers/array.test.ts
@@ -3,6 +3,7 @@ import {
   intersperseString,
   partition,
   uniq,
+  uniqBy,
 } from "../../src/helpers/array"
 
 describe("partition", () => {
@@ -36,6 +37,16 @@ describe("uniq", () => {
 
   test("removes duplicate values even if they're not next to each other", () => {
     expect(uniq(["1", "3", "2", "3", "1", "1"])).toEqual(["1", "2", "3"])
+  })
+})
+
+describe("uniqBy", () => {
+  test("removes values with duplicated function results", () => {
+    expect(uniqBy([4, 6], (n) => n % 2 === 0)).toEqual([4])
+  })
+
+  test("keeps values with distinct function results", () => {
+    expect(uniqBy([4, 5], (n) => n % 2 === 0)).toEqual([4, 5])
   })
 })
 


### PR DESCRIPTION
Asana ticket: [⚙️  Investigate why the same buses appear multiple times in the Late View](https://app.asana.com/0/1200180014510248/1200677474325481/f)

It turns out that a) we weren't doing anything to filter out ghosts that appeared as both on one route and incoming for another and b) just filtering by `route_status` as either `on_route` or `laying_over` still left some gaps / edge cases. I decided to just do the thing we actually _want_ and explicitly filter down to showing at most one entry in the late view per run ID.