### PR TITLE
feat: log block waiver keys for future debugging

### DIFF
--- a/lib/realtime/block_waiver_store.ex
+++ b/lib/realtime/block_waiver_store.ex
@@ -5,6 +5,8 @@ defmodule Realtime.BlockWaiverStore do
 
   use GenServer
 
+  require Logger
+
   alias Schedule.Block
   alias Schedule.Gtfs.Service
   alias Realtime.BlockWaiver
@@ -69,6 +71,8 @@ defmodule Realtime.BlockWaiverStore do
         {:set, new_block_waivers_by_block_key},
         %__MODULE__{} = state
       ) do
+    :ok = log_new_block_waivers(new_block_waivers_by_block_key)
+
     # We have this never_set flag to detect if this is the first time this
     # particular instance of BlockWaiverStore has had set called on it.
     # Consider what happens if we don't do this check: the first time
@@ -124,5 +128,16 @@ defmodule Realtime.BlockWaiverStore do
         end
       end
     )
+  end
+
+  @spec log_new_block_waivers(BlockWaiver.block_waivers_by_block_key()) :: :ok
+  defp log_new_block_waivers(block_waivers) do
+    block_keys_with_waivers =
+      block_waivers
+      |> Map.keys()
+      |> Enum.map(fn {block_id, service_id} -> "#{block_id}-#{service_id}" end)
+      |> Enum.join(",")
+
+    Logger.info("block_keys_with_waivers=#{block_keys_with_waivers}")
   end
 end

--- a/test/realtime/block_waiver_store_test.exs
+++ b/test/realtime/block_waiver_store_test.exs
@@ -1,6 +1,8 @@
 defmodule Realtime.BlockWaiverStoreTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Realtime.{BlockWaiver, BlockWaiverStore}
 
   import Test.Support.Helpers
@@ -72,11 +74,28 @@ defmodule Realtime.BlockWaiverStoreTest do
     setup do
       {:ok, server} = BlockWaiverStore.start_link(name: :set)
 
+      log_level = Logger.level()
+
+      on_exit(fn ->
+        Logger.configure(level: log_level)
+      end)
+
+      Logger.configure(level: :info)
+
       {:ok, server: server}
     end
 
-    test "stores the StopTimeUpdates by trip ID", %{server: server} do
-      assert BlockWaiverStore.set(@block_waivers_by_block_key, server) == :ok
+    test "stores the block waivers by block key and logs", %{server: server} do
+      log =
+        capture_log(
+          [level: :info],
+          fn ->
+            assert BlockWaiverStore.set(@block_waivers_by_block_key, server) == :ok
+            Process.sleep(100)
+          end
+        )
+
+      assert log =~ "block_keys_with_waivers=block1-service1"
 
       assert %{block_waivers_by_block_key: @block_waivers_by_block_key} = :sys.get_state(server)
     end


### PR DESCRIPTION
Asana ticket: [🐞 Block waivers not showing up in Skate ](https://app.asana.com/0/1148853526253437/1200899029361209/f)

This doesn't fix the underlying issue (see comments on ticket for things I've looked into so far), but it does provide some logging that should be useful in figuring out what's going on in future scenarios. The `BlockWaiverStore` level is good for logging because it's after the waivers have been ingested via the BusLoc TripUpdates file and reconstructed, but before they're sent to the `Notifications` server and written to the database. That means this information will help us figure out which of those parts of the application is causing the problem.