### PR TITLE
Correct minischedule run with mid route swings

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -4,7 +4,7 @@ import { Block, Run } from "./minischedule"
 import { reload } from "./models/browser"
 import { blockFromData, runFromData } from "./models/minischeduleData"
 import { swingsFromData } from "./models/swingsData"
-import { NotificationId, NotificationState } from "./realtime.d"
+import { NotificationId, NotificationState, RunId } from "./realtime.d"
 import { RouteSettings } from "./routeSettings"
 import {
   DirectionName,
@@ -111,16 +111,28 @@ export const fetchTimepointsForRoute = (
     defaultResult: [],
   })
 
-export const fetchMinischeduleRun = (tripId: TripId): Promise<Run | null> =>
-  apiCall({
-    url: `/api/minischedule/run/${tripId}`,
-    parser: nullableParser(runFromData),
-    defaultResult: null,
-  })
+export const fetchScheduleRun = (
+  tripId: TripId,
+  runId: RunId | null
+): Promise<Run | null> => {
+  if (runId) {
+    return apiCall({
+      url: `/api/schedule/run?trip_id=${tripId}&run_id=${runId}`,
+      parser: nullableParser(runFromData),
+      defaultResult: null,
+    })
+  } else {
+    return apiCall({
+      url: `/api/schedule/run?trip_id=${tripId}`,
+      parser: nullableParser(runFromData),
+      defaultResult: null,
+    })
+  }
+}
 
-export const fetchMinischeduleBlock = (tripId: TripId): Promise<Block | null> =>
+export const fetchScheduleBlock = (tripId: TripId): Promise<Block | null> =>
   apiCall({
-    url: `/api/minischedule/block/${tripId}`,
+    url: `/api/schedule/block?trip_id=${tripId}`,
     parser: nullableParser(blockFromData),
     defaultResult: null,
   })

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -53,7 +53,10 @@ export interface Props {
 }
 
 export const MinischeduleRun = ({ vehicleOrGhost }: Props): ReactElement => {
-  const run: Run | null | undefined = useMinischeduleRun(vehicleOrGhost.tripId!)
+  const run: Run | null | undefined = useMinischeduleRun(
+    vehicleOrGhost.tripId!,
+    vehicleOrGhost.runId!
+  )
   return (
     <Minischedule runOrBlock={run} vehicleOrGhost={vehicleOrGhost} view="run" />
   )

--- a/assets/src/hooks/useMinischedule.ts
+++ b/assets/src/hooks/useMinischedule.ts
@@ -1,16 +1,20 @@
 import { useEffect, useState } from "react"
-import { fetchMinischeduleBlock, fetchMinischeduleRun } from "../api"
+import { fetchScheduleBlock, fetchScheduleRun } from "../api"
 import { Block, Run } from "../minischedule"
 import { TripId } from "../schedule"
+import { RunId } from "../realtime"
 
 /**
  * undefined means loading
  * null means loaded, but there was no run found
  */
-export const useMinischeduleRun = (tripId: TripId): Run | null | undefined => {
+export const useMinischeduleRun = (
+  tripId: TripId,
+  runId: RunId
+): Run | null | undefined => {
   const [run, setRun] = useState<Run | null | undefined>(undefined)
   useEffect(() => {
-    fetchMinischeduleRun(tripId).then(setRun)
+    fetchScheduleRun(tripId, runId).then(setRun)
   }, [tripId])
   return run
 }
@@ -24,7 +28,7 @@ export const useMinischeduleRuns = (
 ): (Run | null)[] | undefined => {
   const [runs, setRuns] = useState<(Run | null)[] | undefined>(undefined)
   useEffect(() => {
-    Promise.all(tripIds.map((tripId) => fetchMinischeduleRun(tripId))).then(
+    Promise.all(tripIds.map((tripId) => fetchScheduleRun(tripId, null))).then(
       setRuns
     )
   }, [JSON.stringify(tripIds)])
@@ -40,7 +44,7 @@ export const useMinischeduleBlock = (
 ): Block | null | undefined => {
   const [block, setBlock] = useState<Block | null | undefined>(undefined)
   useEffect(() => {
-    fetchMinischeduleBlock(tripId).then(setBlock)
+    fetchScheduleBlock(tripId).then(setBlock)
   }, [tripId])
   return block
 }

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -1,7 +1,7 @@
 import {
   apiCall,
-  fetchMinischeduleBlock,
-  fetchMinischeduleRun,
+  fetchScheduleBlock,
+  fetchScheduleRun,
   fetchNearestIntersection,
   fetchRoutes,
   fetchShapeForRoute,
@@ -325,7 +325,7 @@ describe("fetchTimepointsForRoute", () => {
   })
 })
 
-describe("minischedulesRun", () => {
+describe("fetchScheduleRun", () => {
   test("fetches a run with a break", (done) => {
     mockFetch(200, {
       data: {
@@ -340,7 +340,7 @@ describe("minischedulesRun", () => {
       },
     })
 
-    fetchMinischeduleRun("trip").then((result) => {
+    fetchScheduleRun("trip", "run").then((result) => {
       expect(result).toEqual({
         id: "run",
         activities: [
@@ -357,14 +357,14 @@ describe("minischedulesRun", () => {
 
   test("can return null", (done) => {
     mockFetch(200, { data: null })
-    fetchMinischeduleRun("trip").then((result) => {
+    fetchScheduleRun("trip", "run").then((result) => {
       expect(result).toEqual(null)
       done()
     })
   })
 })
 
-describe("minischedulesBlock", () => {
+describe("fetchScheduleBlock", () => {
   test("fetches a block with a piece", (done) => {
     mockFetch(200, {
       data: {
@@ -404,7 +404,7 @@ describe("minischedulesBlock", () => {
       },
     })
 
-    fetchMinischeduleBlock("trip").then((result) => {
+    fetchScheduleBlock("trip").then((result) => {
       expect(result).toEqual({
         id: "block",
         pieces: [
@@ -446,7 +446,7 @@ describe("minischedulesBlock", () => {
 
   test("can return null", (done) => {
     mockFetch(200, { data: null })
-    fetchMinischeduleBlock("trip").then((result) => {
+    fetchScheduleBlock("trip").then((result) => {
       expect(result).toEqual(null)
       done()
     })

--- a/assets/tests/hooks/useMinischedule.test.ts
+++ b/assets/tests/hooks/useMinischedule.test.ts
@@ -13,36 +13,34 @@ import { TripId } from "../../src/schedule"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  fetchMinischeduleRun: jest.fn(() => neverPromise()),
-  fetchMinischeduleBlock: jest.fn(() => neverPromise()),
+  fetchScheduleRun: jest.fn(() => neverPromise()),
+  fetchScheduleBlock: jest.fn(() => neverPromise()),
 }))
 
 describe("useMinischeduleRun", () => {
   test("returns undefined while loading", () => {
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { result } = renderHook(() => {
-      return useMinischeduleRun("trip")
+      return useMinischeduleRun("trip", "run")
     })
-    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
+    expect(mockFetchScheduleRun).toHaveBeenCalledTimes(1)
     expect(result.current).toEqual(undefined)
   })
 
   test("returns a run", () => {
     const run: Run = "run" as any as Run
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
-    mockFetchMinischeduleRun.mockImplementationOnce(() => instantPromise(run))
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
+    mockFetchScheduleRun.mockImplementationOnce(() => instantPromise(run))
     const { result } = renderHook(() => {
-      return useMinischeduleRun("trip")
+      return useMinischeduleRun("trip", "run")
     })
     expect(result.current).toEqual(run)
   })
 
   test("doesn't refetch on every render", () => {
-    const mockFetchShuttles: jest.Mock = Api.fetchMinischeduleRun as jest.Mock
+    const mockFetchShuttles: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { rerender } = renderHook(() => {
-      return useMinischeduleRun("trip")
+      return useMinischeduleRun("trip", "run")
     })
     rerender()
     expect(mockFetchShuttles).toHaveBeenCalledTimes(1)
@@ -51,21 +49,19 @@ describe("useMinischeduleRun", () => {
 
 describe("useMinischeduleRuns", () => {
   test("returns undefined while loading", () => {
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { result } = renderHook(() => {
       return useMinischeduleRuns(["trip"])
     })
-    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
+    expect(mockFetchScheduleRun).toHaveBeenCalledTimes(1)
     expect(result.current).toEqual(undefined)
   })
 
   test("returns runs", async () => {
     const run1: Run = "run1" as any as Run
     const run2: Run = "run2" as any as Run
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
-    mockFetchMinischeduleRun
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
+    mockFetchScheduleRun
       .mockImplementationOnce(() => instantPromise(run1))
       .mockImplementationOnce(() => instantPromise(run2))
     const { result, waitForNextUpdate } = renderHook(() => {
@@ -77,18 +73,16 @@ describe("useMinischeduleRuns", () => {
   })
 
   test("doesn't refetch on every render", () => {
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { rerender } = renderHook(() => {
       return useMinischeduleRuns(["trip"])
     })
     rerender()
-    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(1)
+    expect(mockFetchScheduleRun).toHaveBeenCalledTimes(1)
   })
 
   test("does refetch when trip IDs changed", () => {
-    const mockFetchMinischeduleRun: jest.Mock =
-      Api.fetchMinischeduleRun as jest.Mock
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { rerender } = renderHook(
       (tripIds: TripId[]) => {
         return useMinischeduleRuns(tripIds)
@@ -96,28 +90,26 @@ describe("useMinischeduleRuns", () => {
       { initialProps: ["trip1"] }
     )
     rerender(["trip2"])
-    expect(mockFetchMinischeduleRun).toHaveBeenCalledTimes(2)
+    expect(mockFetchScheduleRun).toHaveBeenCalledTimes(2)
   })
 })
 
 describe("useMinischeduleBlock", () => {
   test("returns undefined while loading", () => {
-    const mockFetchMinischeduleBlock: jest.Mock =
-      Api.fetchMinischeduleBlock as jest.Mock
+    const mockFetchScheduleBlock: jest.Mock =
+      Api.fetchScheduleBlock as jest.Mock
     const { result } = renderHook(() => {
       return useMinischeduleBlock("trip")
     })
-    expect(mockFetchMinischeduleBlock).toHaveBeenCalledTimes(1)
+    expect(mockFetchScheduleBlock).toHaveBeenCalledTimes(1)
     expect(result.current).toEqual(undefined)
   })
 
   test("returns a block", () => {
     const block: Block = "block" as any as Block
-    const mockFetchMinischeduleBlock: jest.Mock =
-      Api.fetchMinischeduleBlock as jest.Mock
-    mockFetchMinischeduleBlock.mockImplementationOnce(() =>
-      instantPromise(block)
-    )
+    const mockFetchScheduleBlock: jest.Mock =
+      Api.fetchScheduleBlock as jest.Mock
+    mockFetchScheduleBlock.mockImplementationOnce(() => instantPromise(block))
     const { result } = renderHook(() => {
       return useMinischeduleBlock("trip")
     })
@@ -125,7 +117,7 @@ describe("useMinischeduleBlock", () => {
   })
 
   test("doesn't refetch on every render", () => {
-    const mockFetchShuttles: jest.Mock = Api.fetchMinischeduleBlock as jest.Mock
+    const mockFetchShuttles: jest.Mock = Api.fetchScheduleBlock as jest.Mock
     const { rerender } = renderHook(() => {
       return useMinischeduleBlock("trip")
     })


### PR DESCRIPTION
Asana ticket: [⚙️ Minischedules showing incorrect run with mid-route swing](https://app.asana.com/0/1200180014510248/1200317928103334/f)

This includes both the back-end and front-end changes, but I'll rebase onto master once I merge #1267, making this only the front-end changes. The other PR should be reviewed first.