### PR TITLE
chore: migration to add route_tabs and user_route_tabs tables

### DIFF
--- a/priv/repo/migrations/20211025154033_create_route_tab.exs
+++ b/priv/repo/migrations/20211025154033_create_route_tab.exs
@@ -1,0 +1,17 @@
+defmodule Skate.Repo.Migrations.CreateRouteTab do
+  use Ecto.Migration
+
+  def change do
+    create table(:route_tabs) do
+      add(:user_id, references(:users, on_delete: :delete_all, on_update: :update_all), null: false)
+      add(:preset_name, :string)
+      add(:selected_route_ids, {:array, :string}, null: false)
+      add(:ladder_directions, :map, null: false)
+      add(:ladder_crowding_toggles, :map, null: false)
+      add(:save_changes_to_tab_id, references(:route_tabs, on_delete: :delete_all, on_update: :update_all))
+      add(:ordering, :integer)
+      add(:is_current_tab, :boolean)
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
Asana ticket: [Create DB schema for presets](https://app.asana.com/0/0/1201189412881320/f)

I'm reasonably certain that this is the schema we I'll want, but I'm going to keep this marked as a draft at first until I have a chance to implement some of the functionality that goes along with it.