### PR TITLE
Foundational work for presets and tabs

### DIFF
--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -16,3 +16,12 @@
     width: calc(100% - #{$tab-bar-width});
   }
 }
+
+.m-ladder-page__route-tab-bar {
+  display: flex;
+  align-content: flex-start;
+}
+
+.m-ladder-page__tab-current {
+  color: $color-component-red;
+}

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -21,11 +21,13 @@ import ShuttleMapPage from "./shuttleMapPage"
 import TabBar from "./tabBar"
 import LateView from "./lateView"
 import { OpenView } from "../state"
+import featureIsEnabled from "../laboratoryFeatures"
+import { currentRouteTab } from "../models/routeTab"
 
 const AppRoutes = () => {
   useAppcues()
 
-  const [{ pickerContainerIsVisible, openView, selectedRouteIds }] =
+  const [{ pickerContainerIsVisible, openView, selectedRouteIds, routeTabs }] =
     useContext(StateDispatchContext)
 
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
@@ -35,9 +37,13 @@ const AppRoutes = () => {
   const vehiclesByRouteIdNeeded =
     openView === OpenView.Late || location.pathname === "/"
 
+  const routesForVehicles = featureIsEnabled("presets_workspaces")
+    ? currentRouteTab(routeTabs).selectedRouteIds
+    : selectedRouteIds
+
   const vehiclesByRouteId: ByRouteId<VehicleOrGhost[]> = useVehicles(
     socket,
-    vehiclesByRouteIdNeeded ? selectedRouteIds : []
+    vehiclesByRouteIdNeeded ? routesForVehicles : []
   )
 
   return (

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -58,13 +58,13 @@ const LadderTab = ({
   )
 }
 
-const AddLadderButton = ({
-  addLadder,
+const AddTabButton = ({
+  addTab,
 }: {
-  addLadder: () => void
+  addTab: () => void
 }): ReactElement<HTMLDivElement> => {
   return (
-    <div className="m-ladder-page__add-tab-button" onClick={addLadder}>
+    <div className="m-ladder-page__add-tab-button" onClick={addTab}>
       +
     </div>
   )
@@ -153,7 +153,7 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
           />
         ))}
 
-        <AddLadderButton addLadder={() => dispatch(createRouteTab())} />
+        <AddTabButton addTab={() => dispatch(createRouteTab())} />
       </div>
 
       <RouteLadders

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useContext } from "react"
 import RoutesContext from "../contexts/routesContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useTimepoints from "../hooks/useTimepoints"
+import { RouteTab, currentRouteTab } from "../models/routeTab"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { ByRouteId, Route, RouteId, TimepointsByRouteId } from "../schedule.d"
@@ -9,6 +10,19 @@ import { Notifications } from "./notifications"
 import RightPanel from "./rightPanel"
 import RouteLadders from "./routeLadders"
 import RoutePicker from "./routePicker"
+import featureIsEnabled from "../laboratoryFeatures"
+import {
+  createRouteTab,
+  selectRouteTab,
+  selectRoute,
+  deselectRoute,
+  selectRouteInTab,
+  deselectRouteInTab,
+  flipLadderInTab,
+  toggleLadderCrowdingInTab,
+  flipLadder,
+  toggleLadderCrowding,
+} from "../state"
 
 export const findRouteById = (
   routes: Route[] | null,
@@ -24,9 +38,53 @@ export const findSelectedVehicleOrGhost = (
   )
 }
 
-const LadderPage = (): ReactElement<HTMLDivElement> => {
-  const [state] = useContext(StateDispatchContext)
-  const { selectedRouteIds, selectedVehicleOrGhost } = state
+const LadderTab = ({
+  tab,
+  selectTab,
+}: {
+  tab: RouteTab
+  selectTab: () => void
+}): ReactElement<HTMLDivElement> => {
+  const title = tab.presetName || "Untitled"
+  return (
+    <div
+      className={
+        tab.isCurrentTab ? "m-ladder-page__tab-current" : "m-ladder-page__tab"
+      }
+      onClick={() => selectTab()}
+    >
+      {title}
+    </div>
+  )
+}
+
+const AddLadderButton = ({
+  addLadder,
+}: {
+  addLadder: () => void
+}): ReactElement<HTMLDivElement> => {
+  return (
+    <div className="m-ladder-page__add-tab-button" onClick={addLadder}>
+      +
+    </div>
+  )
+}
+
+const LadderPage = (): ReactElement<HTMLDivElement> =>
+  featureIsEnabled("presets_workspaces") ? (
+    <LadderPageWithTabs />
+  ) : (
+    <LadderPageWithoutTabs />
+  )
+
+const LadderPageWithoutTabs = (): ReactElement<HTMLDivElement> => {
+  const [state, dispatch] = useContext(StateDispatchContext)
+  const {
+    selectedRouteIds,
+    ladderDirections,
+    ladderCrowdingToggles,
+    selectedVehicleOrGhost,
+  } = state
 
   const routes: Route[] | null = useContext(RoutesContext)
   const timepointsByRouteId: TimepointsByRouteId =
@@ -39,16 +97,78 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
   return (
     <div className="m-ladder-page">
       <Notifications />
-      <RoutePicker selectedRouteIds={selectedRouteIds} />
+      <RoutePicker
+        selectedRouteIds={selectedRouteIds}
+        selectRoute={(routeId) => dispatch(selectRoute(routeId))}
+        deselectRoute={(routeId) => dispatch(deselectRoute(routeId))}
+      />
 
       <>
         <RouteLadders
           routes={selectedRoutes}
           timepointsByRouteId={timepointsByRouteId}
           selectedVehicleId={selectedVehicleOrGhost?.id}
+          deselectRoute={(routeId) => dispatch(deselectRoute(routeId))}
+          reverseLadder={(routeId) => dispatch(flipLadder(routeId))}
+          toggleCrowding={(routeId) => dispatch(toggleLadderCrowding(routeId))}
+          ladderDirections={ladderDirections}
+          ladderCrowdingToggles={ladderCrowdingToggles}
         />
         <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
       </>
+    </div>
+  )
+}
+
+const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
+  const [state, dispatch] = useContext(StateDispatchContext)
+  const { routeTabs, selectedVehicleOrGhost } = state
+
+  const { selectedRouteIds, ladderDirections, ladderCrowdingToggles } =
+    currentRouteTab(routeTabs)
+
+  const routes: Route[] | null = useContext(RoutesContext)
+  const timepointsByRouteId: TimepointsByRouteId =
+    useTimepoints(selectedRouteIds)
+
+  const selectedRoutes: Route[] = selectedRouteIds
+    .map((routeId) => findRouteById(routes, routeId))
+    .filter((route) => route) as Route[]
+
+  return (
+    <div className="m-ladder-page">
+      <Notifications />
+      <RoutePicker
+        selectedRouteIds={selectedRouteIds}
+        selectRoute={(routeId) => dispatch(selectRouteInTab(routeId))}
+        deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
+      />
+
+      <div className="m-ladder-page__route-tab-bar">
+        {routeTabs.map((routeTab, i) => (
+          <LadderTab
+            tab={routeTab}
+            selectTab={() => dispatch(selectRouteTab(i))}
+            key={i}
+          />
+        ))}
+
+        <AddLadderButton addLadder={() => dispatch(createRouteTab())} />
+      </div>
+
+      <RouteLadders
+        routes={selectedRoutes}
+        timepointsByRouteId={timepointsByRouteId}
+        selectedVehicleId={selectedVehicleOrGhost?.id}
+        deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
+        reverseLadder={(routeId) => dispatch(flipLadderInTab(routeId))}
+        toggleCrowding={(routeId) =>
+          dispatch(toggleLadderCrowdingInTab(routeId))
+        }
+        ladderDirections={ladderDirections}
+        ladderCrowdingToggles={ladderCrowdingToggles}
+      />
+      <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
     </div>
   )
 }

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -1,13 +1,14 @@
-import React, { useContext } from "react"
-import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import React from "react"
 import { crowdingIcon, reverseIcon, reverseIconReversed } from "../helpers/icon"
 import {
   getLadderCrowdingToggleForRoute,
   LadderCrowdingToggle,
+  LadderCrowdingToggles,
 } from "../models/ladderCrowdingToggle"
 import {
   getLadderDirectionForRoute,
   LadderDirection,
+  LadderDirections,
 } from "../models/ladderDirection"
 import { isVehicle } from "../models/vehicle"
 import {
@@ -16,7 +17,6 @@ import {
 } from "../models/vehiclesByPosition"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { LoadableTimepoints, Route, RouteId } from "../schedule.d"
-import { deselectRoute, flipLadder, toggleLadderCrowding } from "../state"
 import CloseButton from "./closeButton"
 import IncomingBox from "./incomingBox"
 import Ladder from "./ladder"
@@ -27,14 +27,23 @@ interface Props {
   timepoints: LoadableTimepoints
   vehiclesAndGhosts?: VehicleOrGhost[]
   selectedVehicleId: VehicleId | undefined
+  deselectRoute: (routeId: RouteId) => void
+  reverseLadder: (routeId: RouteId) => void
+  toggleCrowding: (routeId: RouteId) => void
+  ladderDirections: LadderDirections
+  ladderCrowdingToggles: LadderCrowdingToggles
 }
 
-const Header = ({ route }: { route: Route }) => {
-  const [, dispatch] = useContext(StateDispatchContext)
-
+const Header = ({
+  route,
+  deselectRoute,
+}: {
+  route: Route
+  deselectRoute: (routeId: RouteId) => void
+}) => {
   return (
     <div className="m-route-ladder__header">
-      <CloseButton onClick={() => dispatch(deselectRoute(route.id))} />
+      <CloseButton onClick={() => deselectRoute(route.id)} />
 
       <div className="m-route-ladder__route-name">{route.name}</div>
     </div>
@@ -112,21 +121,18 @@ const RouteLadder = ({
   timepoints,
   vehiclesAndGhosts,
   selectedVehicleId,
+  deselectRoute,
+  reverseLadder,
+  toggleCrowding,
+  ladderDirections,
+  ladderCrowdingToggles,
 }: Props) => {
-  const [{ ladderDirections, ladderCrowdingToggles }, dispatch] =
-    useContext(StateDispatchContext)
   const ladderDirection = getLadderDirectionForRoute(ladderDirections, route.id)
-  const reverseLadder = () => {
-    dispatch(flipLadder(route.id))
-  }
 
   const ladderCrowdingToggle = getLadderCrowdingToggleForRoute(
     ladderCrowdingToggles,
     route.id
   )
-  const toggleCrowding = () => {
-    dispatch(toggleLadderCrowding(route.id))
-  }
 
   const byPosition: VehiclesByPosition = groupByPosition(
     vehiclesAndGhosts?.filter((vehicleOrGhost) => {
@@ -145,13 +151,13 @@ const RouteLadder = ({
 
   return (
     <>
-      <Header route={route} />
+      <Header route={route} deselectRoute={deselectRoute} />
       <Controls
         displayCrowdingToggleIcon={displayCrowding}
         ladderDirection={ladderDirection}
         ladderCrowdingToggle={ladderCrowdingToggle}
-        reverseLadder={reverseLadder}
-        toggleCrowding={toggleCrowding}
+        reverseLadder={() => reverseLadder(route.id)}
+        toggleCrowding={() => toggleCrowding(route.id)}
       />
 
       {timepoints ? (

--- a/assets/src/components/routeLadders.tsx
+++ b/assets/src/components/routeLadders.tsx
@@ -1,19 +1,31 @@
 import React, { useContext } from "react"
 import { VehiclesByRouteIdContext } from "../contexts/vehiclesByRouteIdContext"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
-import { ByRouteId, Route, TimepointsByRouteId } from "../schedule.d"
+import { ByRouteId, Route, TimepointsByRouteId, RouteId } from "../schedule.d"
 import RouteLadder from "./routeLadder"
+import { LadderDirections } from "../models/ladderDirection"
+import { LadderCrowdingToggles } from "../models/ladderCrowdingToggle"
 
 interface Props {
   routes: Route[]
   timepointsByRouteId: TimepointsByRouteId
   selectedVehicleId: VehicleId | undefined
+  deselectRoute: (routeId: RouteId) => void
+  reverseLadder: (routeId: RouteId) => void
+  toggleCrowding: (routeId: RouteId) => void
+  ladderDirections: LadderDirections
+  ladderCrowdingToggles: LadderCrowdingToggles
 }
 
 const RouteLadders = ({
   routes,
   timepointsByRouteId,
   selectedVehicleId,
+  deselectRoute,
+  reverseLadder,
+  toggleCrowding,
+  ladderDirections,
+  ladderCrowdingToggles,
 }: Props) => {
   const vehiclesByRouteId: ByRouteId<VehicleOrGhost[]> = useContext(
     VehiclesByRouteIdContext
@@ -28,6 +40,11 @@ const RouteLadders = ({
           timepoints={timepointsByRouteId[route.id]}
           vehiclesAndGhosts={vehiclesByRouteId[route.id]}
           selectedVehicleId={selectedVehicleId}
+          deselectRoute={deselectRoute}
+          reverseLadder={reverseLadder}
+          toggleCrowding={toggleCrowding}
+          ladderDirections={ladderDirections}
+          ladderCrowdingToggles={ladderCrowdingToggles}
         />
       ))}
     </div>

--- a/assets/src/components/routePicker.tsx
+++ b/assets/src/components/routePicker.tsx
@@ -1,6 +1,5 @@
-import React, { Dispatch, useContext } from "react"
+import React, { useContext } from "react"
 import RoutesContext from "../contexts/routesContext"
-import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import {
   filterRoutes,
   RouteFilter,
@@ -8,7 +7,6 @@ import {
   useRouteFilter,
 } from "../hooks/useRouteFilter"
 import { Route, RouteId } from "../schedule.d"
-import { deselectRoute, DeselectRouteAction, selectRoute } from "../state"
 import { routeNameOrId } from "../util/route"
 import Loading from "./loading"
 import PickerContainer from "./pickerContainer"
@@ -22,9 +20,15 @@ import featureIsEnabled from "../laboratoryFeatures"
 
 interface Props {
   selectedRouteIds: RouteId[]
+  selectRoute: (routeId: RouteId) => void
+  deselectRoute: (routeId: RouteId) => void
 }
 
-const RoutePicker = ({ selectedRouteIds }: Props) => {
+const RoutePicker = ({
+  selectedRouteIds,
+  selectRoute,
+  deselectRoute,
+}: Props) => {
   const routes = useContext(RoutesContext)
   const routeFilterData: RouteFilterData = useRouteFilter()
   const garageFilterData: GarageFilterData = useGarageFilter(routes)
@@ -40,6 +44,7 @@ const RoutePicker = ({ selectedRouteIds }: Props) => {
         <SelectedRoutesList
           routes={routes}
           selectedRouteIds={selectedRouteIds}
+          deselectRoute={deselectRoute}
         />
 
         <RouteFilter {...routeFilterData} />
@@ -54,6 +59,8 @@ const RoutePicker = ({ selectedRouteIds }: Props) => {
           <RoutesList
             routes={filteredRoutes}
             selectedRouteIds={selectedRouteIds}
+            selectRoute={selectRoute}
+            deselectRoute={deselectRoute}
           />
         )}
       </div>
@@ -64,12 +71,12 @@ const RoutePicker = ({ selectedRouteIds }: Props) => {
 const SelectedRoutesList = ({
   routes,
   selectedRouteIds,
+  deselectRoute,
 }: {
   routes: Route[] | null
   selectedRouteIds: RouteId[]
+  deselectRoute: (routeId: RouteId) => void
 }) => {
-  const [, dispatch] = useContext(StateDispatchContext)
-
   return (
     <ul className="m-route-picker__selected-routes">
       {selectedRouteIds.map((routeId) => (
@@ -77,7 +84,7 @@ const SelectedRoutesList = ({
           key={routeId}
           routeId={routeId}
           routes={routes}
-          dispatch={dispatch}
+          deselectRoute={deselectRoute}
         />
       ))}
     </ul>
@@ -87,17 +94,17 @@ const SelectedRoutesList = ({
 const SelectedRouteButton = ({
   routeId,
   routes,
-  dispatch,
+  deselectRoute,
 }: {
   routeId: RouteId
   routes: Route[] | null
-  dispatch: Dispatch<DeselectRouteAction>
+  deselectRoute: (routeId: RouteId) => void
 }) => {
   return (
     <li>
       <button
         className="m-route-picker__selected-routes-button"
-        onClick={() => dispatch(deselectRoute(routeId))}
+        onClick={() => deselectRoute(routeId)}
       >
         {routeNameOrId(routeId, routes)}
       </button>
@@ -108,9 +115,13 @@ const SelectedRouteButton = ({
 const RoutesList = ({
   routes,
   selectedRouteIds,
+  selectRoute,
+  deselectRoute,
 }: {
   routes: Route[]
   selectedRouteIds: RouteId[]
+  selectRoute: (routeId: RouteId) => void
+  deselectRoute: (routeId: RouteId) => void
 }) => (
   <ul className="m-route-picker__route-list">
     {routes.map((route) => (
@@ -118,6 +129,8 @@ const RoutesList = ({
         <RouteListButton
           route={route}
           isSelected={selectedRouteIds.includes(route.id)}
+          selectRoute={selectRoute}
+          deselectRoute={deselectRoute}
         />
       </li>
     ))}
@@ -127,17 +140,20 @@ const RoutesList = ({
 const RouteListButton = ({
   route,
   isSelected,
+  selectRoute,
+  deselectRoute,
 }: {
   route: Route
   isSelected: boolean
+  selectRoute: (routeId: RouteId) => void
+  deselectRoute: (routeId: RouteId) => void
 }) => {
-  const [, dispatch] = useContext(StateDispatchContext)
   const selectedClass = isSelected
     ? "m-route-picker__route-list-button--selected"
     : "m-route-picker__route-list-button--unselected"
   const clickHandler = isSelected
-    ? () => dispatch(deselectRoute(route.id))
-    : () => dispatch(selectRoute(route.id))
+    ? () => deselectRoute(route.id)
+    : () => selectRoute(route.id)
 
   return (
     <button

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -1,0 +1,9 @@
+import { RouteId } from "../schedule.d"
+import { LadderDirections } from "./ladderDirection"
+import { LadderCrowdingToggles } from "./ladderCrowdingToggle"
+
+export interface RouteTab {
+  selectedRouteIds: RouteId[]
+  ladderDirections: LadderDirections
+  ladderCrowdingToggles: LadderCrowdingToggles
+}

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -18,12 +18,5 @@ export const newRouteTab = (): RouteTab => ({
   ladderCrowdingToggles: {},
 })
 
-export const currentRouteTab = (routeTabs: RouteTab[]): RouteTab => {
-  const currentTab = routeTabs.find((routeTab) => routeTab.isCurrentTab)
-
-  if (currentTab === undefined) {
-    return newRouteTab()
-  } else {
-    return currentTab
-  }
-}
+export const currentRouteTab = (routeTabs: RouteTab[]): RouteTab =>
+  routeTabs.find((routeTab) => routeTab.isCurrentTab) || newRouteTab()

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -3,7 +3,27 @@ import { LadderDirections } from "./ladderDirection"
 import { LadderCrowdingToggles } from "./ladderCrowdingToggle"
 
 export interface RouteTab {
+  isCurrentTab: boolean
+  presetName?: string
+  id?: string
   selectedRouteIds: RouteId[]
   ladderDirections: LadderDirections
   ladderCrowdingToggles: LadderCrowdingToggles
+}
+
+export const newRouteTab = (): RouteTab => ({
+  isCurrentTab: true,
+  selectedRouteIds: [],
+  ladderDirections: {},
+  ladderCrowdingToggles: {},
+})
+
+export const currentRouteTab = (routeTabs: RouteTab[]): RouteTab => {
+  const currentTab = routeTabs.find((routeTab) => routeTab.isCurrentTab)
+
+  if (currentTab === undefined) {
+    return newRouteTab()
+  } else {
+    return currentTab
+  }
 }

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -23,6 +23,7 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "./userSettings"
+import { RouteTab } from "./models/routeTab"
 
 export enum OpenView {
   None = 1,
@@ -36,6 +37,7 @@ export interface State {
   selectedRouteIds: RouteId[]
   ladderDirections: LadderDirections
   ladderCrowdingToggles: LadderCrowdingToggles
+  routeTabs: RouteTab[]
   selectedShuttleRouteIds: RouteId[]
   selectedShuttleRunIds: RunId[] | "all"
   selectedVehicleOrGhost?: VehicleOrGhost | null
@@ -51,6 +53,7 @@ export const initialState: State = {
   selectedRouteIds: [],
   ladderDirections: emptyLadderDirectionsByRouteId,
   ladderCrowdingToggles: emptyLadderCrowdingTogglesByRouteId,
+  routeTabs: [],
   selectedShuttleRouteIds: [],
   selectedShuttleRunIds: "all",
   selectedVehicleOrGhost: undefined,
@@ -549,6 +552,7 @@ export const reducer = (state: State, action: Action): State => ({
     state.ladderCrowdingToggles,
     action
   ),
+  routeTabs: [],
   selectedShuttleRouteIds: selectedShuttleRouteIdsReducer(
     state.selectedShuttleRouteIds,
     action

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -23,7 +23,7 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "./userSettings"
-import { RouteTab } from "./models/routeTab"
+import { RouteTab, newRouteTab } from "./models/routeTab"
 
 export enum OpenView {
   None = 1,
@@ -108,6 +108,80 @@ export const toggleLadderCrowding = (
   routeId: RouteId
 ): ToggleLadderCrowdingAction => ({
   type: "TOGGLE_LADDER_CROWDING",
+  payload: { routeId },
+})
+
+interface CreateRouteTabAction {
+  type: "CREATE_ROUTE_TAB"
+}
+
+export const createRouteTab = (): CreateRouteTabAction => ({
+  type: "CREATE_ROUTE_TAB",
+})
+
+interface SelectRouteTabAction {
+  type: "SELECT_ROUTE_TAB"
+  payload: {
+    index: number
+  }
+}
+
+export const selectRouteTab = (index: number): SelectRouteTabAction => ({
+  type: "SELECT_ROUTE_TAB",
+  payload: {
+    index,
+  },
+})
+
+interface SelectRouteInTabAction {
+  type: "SELECT_ROUTE_IN_TAB"
+  payload: {
+    routeId: RouteId
+  }
+}
+
+export const selectRouteInTab = (routeId: RouteId): SelectRouteInTabAction => ({
+  type: "SELECT_ROUTE_IN_TAB",
+  payload: { routeId },
+})
+
+export interface DeselectRouteInTabAction {
+  type: "DESELECT_ROUTE_IN_TAB"
+  payload: {
+    routeId: RouteId
+  }
+}
+
+export const deselectRouteInTab = (
+  routeId: RouteId
+): DeselectRouteInTabAction => ({
+  type: "DESELECT_ROUTE_IN_TAB",
+  payload: { routeId },
+})
+
+export interface FlipLadderInTabAction {
+  type: "FLIP_LADDER_IN_TAB"
+  payload: {
+    routeId: RouteId
+  }
+}
+
+export const flipLadderInTab = (routeId: RouteId): FlipLadderInTabAction => ({
+  type: "FLIP_LADDER_IN_TAB",
+  payload: { routeId },
+})
+
+export interface ToggleLadderCrowdingInTabAction {
+  type: "TOGGLE_LADDER_CROWDING_IN_TAB"
+  payload: {
+    routeId: RouteId
+  }
+}
+
+export const toggleLadderCrowdingInTab = (
+  routeId: RouteId
+): ToggleLadderCrowdingInTabAction => ({
+  type: "TOGGLE_LADDER_CROWDING_IN_TAB",
   payload: { routeId },
 })
 
@@ -338,6 +412,12 @@ export type Action =
   | DeselectRouteAction
   | FlipLadderAction
   | ToggleLadderCrowdingAction
+  | CreateRouteTabAction
+  | SelectRouteTabAction
+  | SelectRouteInTabAction
+  | DeselectRouteInTabAction
+  | FlipLadderInTabAction
+  | ToggleLadderCrowdingInTabAction
   | SelectShuttleRunAction
   | DeselectShuttleRunAction
   | SelectAllShuttleRunsAction
@@ -413,6 +493,65 @@ const ladderCrowdingTogglesReducer = (
     case "TOGGLE_LADDER_CROWDING":
       const routeId = action.payload.routeId
       return toggleLadderCrowdingForRoute(state, routeId)
+    default:
+      return state
+  }
+}
+
+const routeTabsReducer = (state: RouteTab[], action: Action): RouteTab[] => {
+  const selectedTab = state.find((routeTab) => routeTab.isCurrentTab)
+
+  switch (action.type) {
+    case "CREATE_ROUTE_TAB":
+      return [
+        ...state.map((existingRouteTab) => {
+          return { ...existingRouteTab, isCurrentTab: false }
+        }),
+        newRouteTab(),
+      ]
+    case "SELECT_ROUTE_TAB":
+      const routeTabs = state.map((existingRouteTab) => {
+        return { ...existingRouteTab, isCurrentTab: false }
+      })
+
+      routeTabs[action.payload.index].isCurrentTab = true
+
+      return routeTabs
+    case "SELECT_ROUTE_IN_TAB":
+      if (selectedTab) {
+        selectedTab.selectedRouteIds = [
+          ...selectedTab.selectedRouteIds,
+          action.payload.routeId,
+        ]
+      }
+
+      return state
+    case "DESELECT_ROUTE_IN_TAB":
+      if (selectedTab) {
+        selectedTab.selectedRouteIds = selectedTab.selectedRouteIds.filter(
+          (routeId) => routeId !== action.payload.routeId
+        )
+      }
+
+      return state
+    case "FLIP_LADDER_IN_TAB":
+      if (selectedTab) {
+        selectedTab.ladderDirections = flipLadderDirectionForRoute(
+          selectedTab.ladderDirections,
+          action.payload.routeId
+        )
+      }
+
+      return state
+    case "TOGGLE_LADDER_CROWDING_IN_TAB":
+      if (selectedTab) {
+        selectedTab.ladderCrowdingToggles = toggleLadderCrowdingForRoute(
+          selectedTab.ladderCrowdingToggles,
+          action.payload.routeId
+        )
+      }
+
+      return state
     default:
       return state
   }
@@ -552,7 +691,7 @@ export const reducer = (state: State, action: Action): State => ({
     state.ladderCrowdingToggles,
     action
   ),
-  routeTabs: [],
+  routeTabs: routeTabsReducer(state.routeTabs, action),
   selectedShuttleRouteIds: selectedShuttleRouteIdsReducer(
     state.selectedShuttleRouteIds,
     action

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -81,6 +81,173 @@ exports[`LadderPage renders the empty state 1`] = `
 </div>
 `;
 
+exports[`LadderPage renders with route tabs 1`] = `
+<div
+  className="m-ladder-page"
+>
+  <div
+    className="m-notifications"
+  />
+  <div
+    className="m-picker-container m-picker-container--narrow visible"
+  >
+    <div
+      className="c-drawer-tab"
+    >
+      <button
+        className="c-drawer-tab__tab-button"
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="m-route-picker"
+    >
+      <ul
+        className="m-route-picker__selected-routes"
+      >
+        <li>
+          <button
+            className="m-route-picker__selected-routes-button"
+            onClick={[Function]}
+          >
+            1
+          </button>
+        </li>
+      </ul>
+      <div
+        className="m-route-filter"
+      >
+        <select
+          className="m-route-filter__type"
+          onChange={[Function]}
+          value="name"
+        >
+          <option
+            value="name"
+          >
+            Route ID
+          </option>
+        </select>
+        <div
+          className="m-route-filter__text"
+        >
+          <input
+            className="m-route-filter__input"
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            type="text"
+            value=""
+          />
+          <button
+            className="m-route-filter__clear"
+            onClick={[Function]}
+          >
+            <span
+              className=""
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
+              }
+            />
+          </button>
+        </div>
+      </div>
+      <ul
+        className="m-route-picker__route-list"
+      >
+        <li>
+          <button
+            className="m-route-picker__route-list-button m-route-picker__route-list-button--selected"
+            onClick={[Function]}
+          >
+            1
+          </button>
+        </li>
+        <li>
+          <button
+            className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
+            onClick={[Function]}
+          >
+            28
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="m-ladder-page__route-tab-bar"
+  >
+    <div
+      className="m-ladder-page__tab-current"
+      onClick={[Function]}
+    >
+      Untitled
+    </div>
+    <div
+      className="m-ladder-page__add-tab-button"
+      onClick={[Function]}
+    >
+      +
+    </div>
+  </div>
+  <div
+    className="m-route-ladders"
+  >
+    <div
+      className="m-route-ladder__header"
+    >
+      <button
+        className="m-close-button"
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+      <div
+        className="m-route-ladder__route-name"
+      >
+        1
+      </div>
+    </div>
+    <div
+      className="m-route-ladder__controls"
+    >
+      <button
+        className="m-route-ladder__reverse"
+        onClick={[Function]}
+      >
+        <span
+          className="m-route-ladder__reverse-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+        Reverse
+      </button>
+    </div>
+    loading...
+  </div>
+</div>
+`;
+
 exports[`LadderPage renders with routes 1`] = `
 <div
   className="m-ladder-page"

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -19,6 +19,8 @@ import { ByRouteId, Route, TimepointsByRouteId } from "../../src/schedule.d"
 import { initialState, State } from "../../src/state"
 import ghostFactory from "../factories/ghost"
 import routeFactory from "../factories/route"
+import routeTabFactory from "../factories/routeTab"
+import featureIsEnabled from "../../src/laboratoryFeatures"
 
 jest.mock("../../src/hooks/useTimepoints", () => ({
   __esModule: true,
@@ -32,6 +34,10 @@ jest.mock("../../src/hooks/useVehicleForNotification", () => ({
   __esModule: true,
   default: jest.fn(() => undefined),
 }))
+jest.mock("../../src/laboratoryFeatures", () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}))
 
 const mockDispatch = jest.fn()
 
@@ -43,6 +49,26 @@ describe("LadderPage", () => {
 
   test("renders with routes", () => {
     const mockState = { ...initialState, selectedRouteIds: ["1"] }
+    const tree = renderer
+      .create(
+        <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+          <RoutesProvider routes={routes}>
+            <LadderPage />
+          </RoutesProvider>
+        </StateDispatchProvider>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders with route tabs", () => {
+    ;(featureIsEnabled as jest.Mock).mockImplementationOnce(() => true)
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({ isCurrentTab: true, selectedRouteIds: ["1"] }),
+      ],
+    }
     const tree = renderer
       .create(
         <StateDispatchProvider state={mockState} dispatch={mockDispatch}>

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -12,14 +12,7 @@ import {
   VehicleOrGhost,
 } from "../../src/realtime.d"
 import { Route } from "../../src/schedule.d"
-import {
-  deselectRoute,
-  flipLadder,
-  initialState,
-  selectVehicle,
-  State,
-  toggleLadderCrowding,
-} from "../../src/state"
+import { initialState, selectVehicle } from "../../src/state"
 import ghostFactory from "../factories/ghost"
 import routeFactory from "../factories/route"
 
@@ -167,6 +160,14 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={undefined}
           selectedVehicleId={undefined}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -211,6 +212,14 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={(vehicles as VehicleOrGhost[]).concat([ghost])}
           selectedVehicleId={undefined}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -238,6 +247,14 @@ describe("routeLadder", () => {
             routeStatus: "pulling_out" as RouteStatus,
           }))}
           selectedVehicleId={undefined}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -268,6 +285,14 @@ describe("routeLadder", () => {
             { ...v1, routeStatus: "laying_over" },
             { ...v2, routeStatus: "laying_over" },
           ]}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -276,12 +301,7 @@ describe("routeLadder", () => {
   })
 
   test("renders a route ladder with crowding instead of vehicles", () => {
-    const mockDispatch = jest.fn()
     const ladderCrowdingToggles: LadderCrowdingToggles = { "28": true }
-    const state: State = {
-      ...initialState,
-      ladderCrowdingToggles,
-    }
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -296,28 +316,34 @@ describe("routeLadder", () => {
     const [v1, v2] = vehicles
     const tree = renderer
       .create(
-        <StateDispatchProvider state={state} dispatch={mockDispatch}>
-          <RouteLadder
-            route={route}
-            selectedVehicleId={undefined}
-            timepoints={timepoints}
-            vehiclesAndGhosts={[
-              {
-                ...v1,
-                crowding: {
-                  occupancyStatus: "FEW_SEATS_AVAILABLE",
-                  occupancyPercentage: 0.78,
-                  load: 14,
-                  capacity: 18,
-                },
+        <RouteLadder
+          route={route}
+          selectedVehicleId={undefined}
+          timepoints={timepoints}
+          vehiclesAndGhosts={[
+            {
+              ...v1,
+              crowding: {
+                occupancyStatus: "FEW_SEATS_AVAILABLE",
+                occupancyPercentage: 0.78,
+                load: 14,
+                capacity: 18,
               },
-              {
-                ...v2,
-                crowding: null,
-              },
-            ]}
-          />
-        </StateDispatchProvider>
+            },
+            {
+              ...v2,
+              crowding: null,
+            },
+          ]}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={ladderCrowdingToggles}
+        />
       )
       .toJSON()
 
@@ -353,6 +379,14 @@ describe("routeLadder", () => {
               isRevenue: false,
             },
           ]}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -361,12 +395,7 @@ describe("routeLadder", () => {
   })
 
   test("displays no crowding data for a bus coming off a route with no crowding data onto a route with crowding data", () => {
-    const mockDispatch = jest.fn()
     const ladderCrowdingToggles: LadderCrowdingToggles = { "28": true }
-    const state: State = {
-      ...initialState,
-      ladderCrowdingToggles,
-    }
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -381,29 +410,35 @@ describe("routeLadder", () => {
     const [v1, v2] = vehicles
     const tree = renderer
       .create(
-        <StateDispatchProvider state={state} dispatch={mockDispatch}>
-          <RouteLadder
-            route={route}
-            selectedVehicleId={undefined}
-            timepoints={timepoints}
-            vehiclesAndGhosts={[
-              {
-                ...v1,
-                crowding: {
-                  occupancyStatus: "FEW_SEATS_AVAILABLE",
-                  occupancyPercentage: 0.78,
-                  load: 14,
-                  capacity: 18,
-                },
+        <RouteLadder
+          route={route}
+          selectedVehicleId={undefined}
+          timepoints={timepoints}
+          vehiclesAndGhosts={[
+            {
+              ...v1,
+              crowding: {
+                occupancyStatus: "FEW_SEATS_AVAILABLE",
+                occupancyPercentage: 0.78,
+                load: 14,
+                capacity: 18,
               },
-              {
-                ...v2,
-                routeId: "741",
-                crowding: null,
-              },
-            ]}
-          />
-        </StateDispatchProvider>
+            },
+            {
+              ...v2,
+              routeId: "741",
+              crowding: null,
+            },
+          ]}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={ladderCrowdingToggles}
+        />
       )
       .toJSON()
 
@@ -411,12 +446,7 @@ describe("routeLadder", () => {
   })
 
   test("doesn't display crowding data for a vehicle coming off a route with crowding data onto a route with none", () => {
-    const mockDispatch = jest.fn()
     const ladderCrowdingToggles: LadderCrowdingToggles = { "28": true }
-    const state: State = {
-      ...initialState,
-      ladderCrowdingToggles,
-    }
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -431,29 +461,35 @@ describe("routeLadder", () => {
     const [v1, v2] = vehicles
     const tree = renderer
       .create(
-        <StateDispatchProvider state={state} dispatch={mockDispatch}>
-          <RouteLadder
-            route={route}
-            selectedVehicleId={undefined}
-            timepoints={timepoints}
-            vehiclesAndGhosts={[
-              {
-                ...v1,
-                crowding: null,
+        <RouteLadder
+          route={route}
+          selectedVehicleId={undefined}
+          timepoints={timepoints}
+          vehiclesAndGhosts={[
+            {
+              ...v1,
+              crowding: null,
+            },
+            {
+              ...v2,
+              routeId: "741",
+              crowding: {
+                occupancyStatus: "FEW_SEATS_AVAILABLE",
+                occupancyPercentage: 0.78,
+                load: 14,
+                capacity: 18,
               },
-              {
-                ...v2,
-                routeId: "741",
-                crowding: {
-                  occupancyStatus: "FEW_SEATS_AVAILABLE",
-                  occupancyPercentage: 0.78,
-                  load: 14,
-                  capacity: 18,
-                },
-              },
-            ]}
-          />
-        </StateDispatchProvider>
+            },
+          ]}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={ladderCrowdingToggles}
+        />
       )
       .toJSON()
 
@@ -474,6 +510,14 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={undefined}
           selectedVehicleId={undefined}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       )
       .toJSON()
@@ -482,7 +526,7 @@ describe("routeLadder", () => {
   })
 
   test("clicking the close button deselects that route", () => {
-    const mockDispatch = jest.fn()
+    const mockDeselect = jest.fn()
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -494,22 +538,27 @@ describe("routeLadder", () => {
     ]
 
     const wrapper = mount(
-      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={undefined}
-          selectedVehicleId={undefined}
-        />
-      </StateDispatchProvider>
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={undefined}
+        selectedVehicleId={undefined}
+        deselectRoute={mockDeselect}
+        // tslint:disable-next-line: no-empty
+        reverseLadder={() => {}}
+        // tslint:disable-next-line: no-empty
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+      />
     )
     wrapper.find(".m-route-ladder__header .m-close-button").simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(deselectRoute("28"))
+    expect(mockDeselect).toHaveBeenCalledWith("28")
   })
 
   test("clicking the reverse button reverses the order of the timepoints", () => {
-    const mockDispatch = jest.fn()
+    const mockReverse = jest.fn()
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -521,24 +570,29 @@ describe("routeLadder", () => {
     ]
 
     const wrapper = mount(
-      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={undefined}
-          selectedVehicleId={undefined}
-        />
-      </StateDispatchProvider>
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={undefined}
+        selectedVehicleId={undefined}
+        // tslint:disable-next-line: no-empty
+        deselectRoute={() => {}}
+        reverseLadder={mockReverse}
+        // tslint:disable-next-line: no-empty
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+      />
     )
     act(() => {
       wrapper.find(".m-route-ladder__reverse").simulate("click")
     })
 
-    expect(mockDispatch).toHaveBeenCalledWith(flipLadder("28"))
+    expect(mockReverse).toHaveBeenCalledWith("28")
   })
 
   test("clicking the crowding toggle toggles crowding", () => {
-    const mockDispatch = jest.fn()
+    const mockToggle = jest.fn()
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -552,30 +606,35 @@ describe("routeLadder", () => {
     const [v1] = vehicles
 
     const wrapper = mount(
-      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            {
-              ...v1,
-              crowding: {
-                occupancyStatus: "EMPTY",
-                load: 0,
-                capacity: 18,
-                occupancyPercentage: 0,
-              },
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          {
+            ...v1,
+            crowding: {
+              occupancyStatus: "EMPTY",
+              load: 0,
+              capacity: 18,
+              occupancyPercentage: 0,
             },
-          ]}
-          selectedVehicleId={undefined}
-        />
-      </StateDispatchProvider>
+          },
+        ]}
+        selectedVehicleId={undefined}
+        // tslint:disable-next-line: no-empty
+        deselectRoute={() => {}}
+        // tslint:disable-next-line: no-empty
+        reverseLadder={() => {}}
+        toggleCrowding={mockToggle}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+      />
     )
     act(() => {
       wrapper.find(".m-route-ladder__crowding-toggle--show").simulate("click")
     })
 
-    expect(mockDispatch).toHaveBeenCalledWith(toggleLadderCrowding("28"))
+    expect(mockToggle).toHaveBeenCalledWith("28")
   })
 
   test("clicking an incoming vehicle selects that vehicle", () => {
@@ -641,6 +700,14 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={[vehicle]}
           selectedVehicleId={undefined}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          reverseLadder={() => {}}
+          // tslint:disable-next-line: no-empty
+          toggleCrowding={() => {}}
+          ladderDirections={{}}
+          ladderCrowdingToggles={{}}
         />
       </StateDispatchProvider>
     )

--- a/assets/tests/components/routeLadders.test.tsx
+++ b/assets/tests/components/routeLadders.test.tsx
@@ -30,6 +30,14 @@ test("renders a route ladder", () => {
         routes={routes}
         timepointsByRouteId={timepointsByRouteId}
         selectedVehicleId={undefined}
+        // tslint:disable-next-line: no-empty
+        deselectRoute={() => {}}
+        // tslint:disable-next-line: no-empty
+        reverseLadder={() => {}}
+        // tslint:disable-next-line: no-empty
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
       />
     )
     .toJSON()

--- a/assets/tests/components/routeLadders.test.tsx
+++ b/assets/tests/components/routeLadders.test.tsx
@@ -30,12 +30,9 @@ test("renders a route ladder", () => {
         routes={routes}
         timepointsByRouteId={timepointsByRouteId}
         selectedVehicleId={undefined}
-        // tslint:disable-next-line: no-empty
-        deselectRoute={() => {}}
-        // tslint:disable-next-line: no-empty
-        reverseLadder={() => {}}
-        // tslint:disable-next-line: no-empty
-        toggleCrowding={() => {}}
+        deselectRoute={jest.fn()}
+        reverseLadder={jest.fn()}
+        toggleCrowding={jest.fn()}
         ladderDirections={{}}
         ladderCrowdingToggles={{}}
       />

--- a/assets/tests/components/routePicker.test.tsx
+++ b/assets/tests/components/routePicker.test.tsx
@@ -4,9 +4,7 @@ import renderer from "react-test-renderer"
 import routeFactory from "../factories/route"
 import RoutePicker from "../../src/components/routePicker"
 import { RoutesProvider } from "../../src/contexts/routesContext"
-import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { Route, RouteId } from "../../src/schedule.d"
-import { deselectRoute, initialState, selectRoute } from "../../src/state"
 
 describe("RoutePicker", () => {
   test("renders a list of routes", () => {
@@ -24,7 +22,13 @@ describe("RoutePicker", () => {
     const tree = renderer
       .create(
         <RoutesProvider routes={routes}>
-          <RoutePicker selectedRouteIds={selectedRouteIds} />
+          <RoutePicker
+            selectedRouteIds={selectedRouteIds}
+            // tslint:disable-next-line: no-empty
+            selectRoute={() => {}}
+            // tslint:disable-next-line: no-empty
+            deselectRoute={() => {}}
+          />
         </RoutesProvider>
       )
       .toJSON()
@@ -33,21 +37,34 @@ describe("RoutePicker", () => {
   })
 
   test("renders a loading/empty state", () => {
-    const tree = renderer.create(<RoutePicker selectedRouteIds={[]} />).toJSON()
+    const tree = renderer
+      .create(
+        <RoutePicker
+          selectedRouteIds={[]}
+          // tslint:disable-next-line: no-empty
+          selectRoute={() => {}}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+        />
+      )
+      .toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
   test("clicking a route selects it", () => {
-    const mockDispatch = jest.fn()
+    const mockSelect = jest.fn()
 
     const routes = [routeFactory.build({ id: "id", name: "id" })]
 
     const routePicker = mount(
       <RoutesProvider routes={routes}>
-        <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-          <RoutePicker selectedRouteIds={[]} />
-        </StateDispatchProvider>
+        <RoutePicker
+          selectedRouteIds={[]}
+          selectRoute={mockSelect}
+          // tslint:disable-next-line: no-empty
+          deselectRoute={() => {}}
+        />
       </RoutesProvider>
     )
 
@@ -56,19 +73,22 @@ describe("RoutePicker", () => {
       .first()
       .simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(selectRoute("id"))
+    expect(mockSelect).toHaveBeenCalledWith("id")
   })
 
   test("clicking a selected route deselects it", () => {
-    const mockDispatch = jest.fn()
+    const mockDeselect = jest.fn()
 
     const routes = [routeFactory.build({ id: "id", name: "id" })]
 
     const routePicker = mount(
       <RoutesProvider routes={routes}>
-        <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-          <RoutePicker selectedRouteIds={["id"]} />
-        </StateDispatchProvider>
+        <RoutePicker
+          selectedRouteIds={["id"]}
+          // tslint:disable-next-line: no-empty
+          selectRoute={() => {}}
+          deselectRoute={mockDeselect}
+        />
       </RoutesProvider>
     )
 
@@ -77,16 +97,19 @@ describe("RoutePicker", () => {
       .first()
       .simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(deselectRoute("id"))
+    expect(mockDeselect).toHaveBeenCalledWith("id")
   })
 
   test("clicking in the list of selected routes deselects a route", () => {
-    const mockDispatch = jest.fn()
+    const mockDeselect = jest.fn()
 
     const routePicker = mount(
-      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-        <RoutePicker selectedRouteIds={["id"]} />
-      </StateDispatchProvider>
+      <RoutePicker
+        selectedRouteIds={["id"]}
+        // tslint:disable-next-line: no-empty
+        selectRoute={() => {}}
+        deselectRoute={mockDeselect}
+      />
     )
 
     routePicker
@@ -94,6 +117,6 @@ describe("RoutePicker", () => {
       .first()
       .simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(deselectRoute("id"))
+    expect(mockDeselect).toHaveBeenCalledWith("id")
   })
 })

--- a/assets/tests/components/routePicker.test.tsx
+++ b/assets/tests/components/routePicker.test.tsx
@@ -24,10 +24,8 @@ describe("RoutePicker", () => {
         <RoutesProvider routes={routes}>
           <RoutePicker
             selectedRouteIds={selectedRouteIds}
-            // tslint:disable-next-line: no-empty
-            selectRoute={() => {}}
-            // tslint:disable-next-line: no-empty
-            deselectRoute={() => {}}
+            selectRoute={jest.fn()}
+            deselectRoute={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -41,10 +39,8 @@ describe("RoutePicker", () => {
       .create(
         <RoutePicker
           selectedRouteIds={[]}
-          // tslint:disable-next-line: no-empty
-          selectRoute={() => {}}
-          // tslint:disable-next-line: no-empty
-          deselectRoute={() => {}}
+          selectRoute={jest.fn()}
+          deselectRoute={jest.fn()}
         />
       )
       .toJSON()
@@ -62,8 +58,7 @@ describe("RoutePicker", () => {
         <RoutePicker
           selectedRouteIds={[]}
           selectRoute={mockSelect}
-          // tslint:disable-next-line: no-empty
-          deselectRoute={() => {}}
+          deselectRoute={jest.fn()}
         />
       </RoutesProvider>
     )
@@ -85,8 +80,7 @@ describe("RoutePicker", () => {
       <RoutesProvider routes={routes}>
         <RoutePicker
           selectedRouteIds={["id"]}
-          // tslint:disable-next-line: no-empty
-          selectRoute={() => {}}
+          selectRoute={jest.fn()}
           deselectRoute={mockDeselect}
         />
       </RoutesProvider>
@@ -106,8 +100,7 @@ describe("RoutePicker", () => {
     const routePicker = mount(
       <RoutePicker
         selectedRouteIds={["id"]}
-        // tslint:disable-next-line: no-empty
-        selectRoute={() => {}}
+        selectRoute={jest.fn()}
         deselectRoute={mockDeselect}
       />
     )

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,0 +1,9 @@
+import { Factory } from "fishery"
+import { RouteTab } from "../../src/models/routeTab"
+
+export default Factory.define<RouteTab>(() => ({
+  isCurrentTab: false,
+  selectedRouteIds: [],
+  ladderDirections: {},
+  ladderCrowdingToggles: {},
+}))

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -1,0 +1,17 @@
+import { currentRouteTab } from "../../src/models/routeTab"
+import routeTabFactory from "../factories/routeTab"
+
+describe("currentRouteTab", () => {
+  test("finds route tab flagges as current if present", () => {
+    const routeTab1 = routeTabFactory.build()
+    const routeTab2 = routeTabFactory.build({ isCurrentTab: true })
+
+    expect(currentRouteTab([routeTab1, routeTab2])).toBe(routeTab2)
+  })
+
+  test("creates new route tab if no current tab found", () => {
+    expect(currentRouteTab([])).toEqual(
+      routeTabFactory.build({ isCurrentTab: true })
+    )
+  })
+})

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/userSettings"
 
 import vehicleFactory from "./factories/vehicle"
+import routeTabFactory from "./factories/routeTab"
 
 const initialState = State.initialState
 const reducer = State.reducer
@@ -425,5 +426,134 @@ describe("reducer", () => {
     )
 
     expect(newState).toEqual(initialState)
+  })
+
+  test("createRouteTab", () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        routeTabs: [routeTabFactory.build({ isCurrentTab: true })],
+      },
+      State.createRouteTab()
+    )
+
+    const expectedState: State.State = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build(),
+        routeTabFactory.build({ isCurrentTab: true }),
+      ],
+    }
+
+    expect(newState).toEqual(expectedState)
+  })
+
+  test("selectRouteTab", () => {
+    const routeTab1 = routeTabFactory.build()
+    const routeTab2 = routeTabFactory.build({ isCurrentTab: true })
+
+    const newState = reducer(
+      { ...initialState, routeTabs: [routeTab1, routeTab2] },
+      State.selectRouteTab(0)
+    )
+
+    const expectedRouteTab1 = routeTabFactory.build({ isCurrentTab: true })
+    const expectedRouteTab2 = routeTabFactory.build()
+
+    const expectedState: State.State = {
+      ...initialState,
+      routeTabs: [expectedRouteTab1, expectedRouteTab2],
+    }
+
+    expect(newState).toEqual(expectedState)
+  })
+
+  test("selectRouteInTab", () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        routeTabs: [routeTabFactory.build({ isCurrentTab: true })],
+      },
+      State.selectRouteInTab("1")
+    )
+
+    const expectedRouteTab = routeTabFactory.build({
+      isCurrentTab: true,
+      selectedRouteIds: ["1"],
+    })
+
+    expect(newState).toEqual({ ...initialState, routeTabs: [expectedRouteTab] })
+  })
+
+  test("deselectRouteInTab", () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        routeTabs: [
+          routeTabFactory.build({
+            isCurrentTab: true,
+            selectedRouteIds: ["1"],
+          }),
+        ],
+      },
+      State.deselectRouteInTab("1")
+    )
+
+    expect(newState).toEqual({
+      ...initialState,
+      routeTabs: [routeTabFactory.build({ isCurrentTab: true })],
+    })
+  })
+
+  test("flipLadderInTab", () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        routeTabs: [
+          routeTabFactory.build({
+            isCurrentTab: true,
+            selectedRouteIds: ["1"],
+          }),
+        ],
+      },
+      State.flipLadderInTab("1")
+    )
+
+    expect(newState).toEqual({
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+          ladderDirections: { "1": 1 },
+        }),
+      ],
+    })
+  })
+
+  test("toggleLadderCrowdingInTab", () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        routeTabs: [
+          routeTabFactory.build({
+            isCurrentTab: true,
+            selectedRouteIds: ["1"],
+          }),
+        ],
+      },
+      State.toggleLadderCrowdingInTab("1")
+    )
+
+    expect(newState).toEqual({
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+          ladderCrowdingToggles: { "1": true },
+        }),
+      ],
+    })
   })
 })

--- a/lib/skate/settings/db/route_tab.ex
+++ b/lib/skate/settings/db/route_tab.ex
@@ -1,0 +1,41 @@
+defmodule Skate.Settings.Db.RouteTab do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Skate.Settings.Db.User
+
+  @type t :: %__MODULE__{}
+
+  schema "route_tabs" do
+    belongs_to(:user, User)
+    field(:preset_name, :string)
+    field(:selected_route_ids, {:array, :string})
+    field(:ladder_directions, :map)
+    field(:ladder_crowding_toggles, :map)
+
+    belongs_to(:save_changes_to_tab, Skate.Settings.Db.RouteTab,
+      foreign_key: :save_changes_to_tab_id
+    )
+
+    timestamps()
+  end
+
+  def changeset(route_tab, attrs \\ %{}) do
+    route_tab
+    |> cast(attrs, [
+      :id,
+      :user_id,
+      :preset_name,
+      :selected_route_ids,
+      :ladder_directions,
+      :ladder_crowding_toggles,
+      :save_changes_to_tab_id
+    ])
+    |> validate_required([
+      :user_id,
+      :selected_route_ids,
+      :ladder_directions,
+      :ladder_crowding_toggles
+    ])
+  end
+end

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -1,0 +1,73 @@
+defmodule Skate.Settings.RouteTab do
+  import Ecto.Query
+
+  alias Skate.Repo
+  alias Schedule.Route
+  alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+  alias Skate.Settings.User
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          preset_name: String.t() | nil,
+          selected_route_ids: [Route.id()],
+          ladder_directions: map(),
+          ladder_crowding_toggles: map()
+        }
+
+  @enforce_keys [:selected_route_ids, :ladder_directions, :ladder_crowding_toggles]
+
+  @derive Jason.Encoder
+
+  defstruct [
+    :preset_name,
+    :selected_route_ids,
+    :ladder_directions,
+    :ladder_crowding_toggles,
+    id: nil
+  ]
+
+  @spec create(String.t()) :: t()
+  def create(username) do
+    user = User.get_or_create(username)
+
+    route_tab =
+      Repo.insert!(
+        DbRouteTab.changeset(%DbRouteTab{}, %{
+          user_id: user.id,
+          selected_route_ids: [],
+          ladder_directions: %{},
+          ladder_crowding_toggles: %{}
+        }),
+        returning: true
+      )
+
+    %__MODULE__{
+      id: route_tab.id,
+      selected_route_ids: route_tab.selected_route_ids,
+      ladder_directions: route_tab.ladder_directions,
+      ladder_crowding_toggles: route_tab.ladder_crowding_toggles
+    }
+  end
+
+  @spec get_all_for_user(String.t()) :: [t()]
+  def get_all_for_user(username) do
+    from(rt in DbRouteTab, join: u in assoc(rt, :user), where: u.username == ^username)
+    |> Repo.all()
+    |> Enum.map(fn db_route_tab ->
+      %__MODULE__{
+        id: db_route_tab.id,
+        selected_route_ids: db_route_tab.selected_route_ids,
+        ladder_directions: db_route_tab.ladder_directions,
+        ladder_crowding_toggles: db_route_tab.ladder_crowding_toggles
+      }
+    end)
+  end
+
+  @spec set(t(), map()) :: t()
+  def set(route_tab, attrs) do
+    DbRouteTab
+    |> Repo.get(route_tab.id)
+    |> DbRouteTab.changeset(attrs)
+    |> Repo.update!()
+  end
+end

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -3,6 +3,7 @@ defmodule SkateWeb.PageController do
   use SkateWeb, :controller
   alias Skate.Settings.RouteSettings
   alias Skate.Settings.UserSettings
+  alias Skate.Settings.RouteTab
   alias SkateWeb.AuthManager
 
   plug(:laboratory_features)
@@ -13,6 +14,7 @@ defmodule SkateWeb.PageController do
 
     user_settings = UserSettings.get_or_create(username)
     route_settings = RouteSettings.get_or_create(username)
+    route_tabs = RouteTab.get_all_for_user(username)
 
     dispatcher_flag =
       conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_dispatcher_access?()
@@ -22,6 +24,7 @@ defmodule SkateWeb.PageController do
     |> assign(:csrf_token, Plug.CSRFProtection.get_csrf_token())
     |> assign(:user_settings, user_settings)
     |> assign(:route_settings, route_settings)
+    |> assign(:route_tabs, route_tabs)
     |> assign(:dispatcher_flag, dispatcher_flag)
     |> render("index.html")
   end

--- a/lib/skate_web/templates/page/index.html.eex
+++ b/lib/skate_web/templates/page/index.html.eex
@@ -3,6 +3,7 @@
   data-csrf-token="<%= @csrf_token %>"
   data-user-settings="<%= Jason.encode!(@user_settings) %>"
   data-route-settings="<%= Jason.encode!(@route_settings) %>"
+  data-route-tabs="<%= Jason.encode!(@route_tabs) %>"
   data-laboratory-features="<%= Jason.encode!(@laboratory_features) %>"
   data-dispatcher-flag="<%= Jason.encode!(@dispatcher_flag) %>"
 ></div>

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -1,0 +1,53 @@
+defmodule Skate.Settings.RouteTabTest do
+  use Skate.DataCase
+  alias Skate.Settings.RouteTab
+  alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+  alias Skate.Settings.Db.User, as: DbUser
+
+  describe "create/1" do
+    test "creates and returns new record" do
+      route_tab = RouteTab.create("charlie")
+
+      assert %RouteTab{
+               preset_name: nil,
+               ladder_crowding_toggles: %{},
+               ladder_directions: %{},
+               selected_route_ids: []
+             } = route_tab
+
+      n_route_tabs = Skate.Repo.aggregate(DbRouteTab, :count)
+      assert n_route_tabs == 1
+      [sole_record] = Skate.Repo.all(DbRouteTab)
+
+      assert %{
+               preset_name: nil,
+               ladder_crowding_toggles: %{},
+               ladder_directions: %{},
+               selected_route_ids: []
+             } = sole_record
+
+      [sole_user] = Skate.Repo.all(DbUser)
+      assert %{username: "charlie"} = sole_user
+      assert sole_user.id == sole_record.user_id
+    end
+  end
+
+  describe "get_all_for_user/1" do
+    test "retrieves route tabs by username" do
+      RouteTab.create("user1")
+      RouteTab.create("user2")
+
+      assert [%RouteTab{}] = RouteTab.get_all_for_user("user1")
+    end
+  end
+
+  describe "set/2" do
+    test "updates existing route_tab" do
+      route_tab = RouteTab.create("charlie")
+
+      new_route_tab = RouteTab.set(route_tab, %{selected_route_ids: ["1"]})
+
+      assert %{selected_route_ids: ["1"]} = new_route_tab
+    end
+  end
+end

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -38,6 +38,20 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
+    test "includes route tabs in HTML", %{conn: conn, user: user} do
+      user
+      |> Skate.Settings.RouteTab.create()
+      |> Skate.Settings.RouteTab.set(%{selected_route_ids: ["1"]})
+
+      conn = get(conn, "/")
+
+      html = html_response(conn, 200)
+
+      assert html =~ "data-route-tabs"
+      assert html =~ "selected_route_ids&quot;:[&quot;1&quot;]"
+    end
+
+    @tag :authenticated
     test "/settings returns 200", %{conn: conn} do
       conn = get(conn, "/settings")
 


### PR DESCRIPTION
Asana ticket: [⚙️ Live prototype: Implement logic + interactions for Presets tab ](https://app.asana.com/0/1200180014510248/1201087271304728/f)

This PR contains a few somewhat-disparate pieces of groundwork for presets and tabs, and the commits should probably be reviewed separately. ~~One of them is a database migration, but since the code that references these database fields isn't written yet, I feel okay not separating it out into its own PR.~~ Never mind, there are uses of the new tables. I have reopened #1311 as a separate PR. Probably the meatiest commit is the last one, which adds the basics of tab interactions to the front-end. Future PRs will sync this up with the tab data on the back-end, allow saving as presets, etc.