### PR TITLE
Extract TabSettings from RouteTab

### DIFF
--- a/lib/skate/settings/db/route_tab.ex
+++ b/lib/skate/settings/db/route_tab.ex
@@ -2,16 +2,14 @@ defmodule Skate.Settings.Db.RouteTab do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Skate.Settings.Db.User
+  alias Skate.Settings.Db.{TabSettings, User}
 
   @type t :: %__MODULE__{}
 
   schema "route_tabs" do
     belongs_to(:user, User)
+    has_one(:tab_settings, TabSettings, on_replace: :update)
     field(:preset_name, :string)
-    field(:selected_route_ids, {:array, :string})
-    field(:ladder_directions, :map)
-    field(:ladder_crowding_toggles, :map)
     field(:ordering, :integer)
     field(:is_current_tab, :boolean)
 
@@ -28,17 +26,13 @@ defmodule Skate.Settings.Db.RouteTab do
       :id,
       :user_id,
       :preset_name,
-      :selected_route_ids,
-      :ladder_directions,
-      :ladder_crowding_toggles,
       :ordering,
       :save_changes_to_tab_id,
       :is_current_tab
     ])
-    |> validate_required([
-      :selected_route_ids,
-      :ladder_directions,
-      :ladder_crowding_toggles
-    ])
+    |> put_assoc(
+      :tab_settings,
+      Map.take(attrs, [:ladder_directions, :ladder_crowding_toggles, :selected_route_ids])
+    )
   end
 end

--- a/lib/skate/settings/db/tab_settings.ex
+++ b/lib/skate/settings/db/tab_settings.ex
@@ -1,0 +1,21 @@
+defmodule Skate.Settings.Db.TabSettings do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Skate.Settings.Db.RouteTab
+
+  @enforce_keys [:selected_route_ids, :ladder_directions, :ladder_crowding_toggles]
+
+  schema "tab_settings" do
+    belongs_to(:route_tab, RouteTab)
+    field(:selected_route_ids, {:array, :string})
+    field(:ladder_directions, :map)
+    field(:ladder_crowding_toggles, :map)
+
+    timestamps()
+  end
+
+  def changeset(tab_settings, attrs \\ %{}) do
+    tab_settings
+    |> cast(attrs, [:selected_route_ids, :ladder_directions, :ladder_crowding_toggles])
+  end
+end

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -42,7 +42,7 @@ defmodule Skate.Settings.RouteTab do
   def update_all_for_user!(username, route_tabs) do
     username
     |> User.get_or_create()
-    |> Repo.preload([:route_tabs])
+    |> Repo.preload(route_tabs: :tab_settings)
     |> DbUser.changeset(%{route_tabs: Enum.map(route_tabs, &Map.from_struct/1)})
     |> Repo.update!()
     |> Map.get(:route_tabs)
@@ -51,14 +51,16 @@ defmodule Skate.Settings.RouteTab do
 
   @spec db_route_tab_to_route_tab(%DbRouteTab{}) :: t()
   defp db_route_tab_to_route_tab(db_route_tab) do
+    tab = Repo.preload(db_route_tab, :tab_settings)
+
     %__MODULE__{
-      id: db_route_tab.id,
-      preset_name: db_route_tab.preset_name,
-      selected_route_ids: db_route_tab.selected_route_ids,
-      ladder_directions: db_route_tab.ladder_directions,
-      ladder_crowding_toggles: db_route_tab.ladder_crowding_toggles,
-      ordering: db_route_tab.ordering,
-      is_current_tab: db_route_tab.is_current_tab
+      id: tab.id,
+      preset_name: tab.preset_name,
+      selected_route_ids: tab.tab_settings.selected_route_ids,
+      ladder_directions: tab.tab_settings.ladder_directions,
+      ladder_crowding_toggles: tab.tab_settings.ladder_crowding_toggles,
+      ordering: tab.ordering,
+      is_current_tab: tab.is_current_tab
     }
   end
 end

--- a/priv/repo/migrations/20211206204239_extract_tab_settings_from_route_tabs.exs
+++ b/priv/repo/migrations/20211206204239_extract_tab_settings_from_route_tabs.exs
@@ -1,0 +1,21 @@
+defmodule Skate.Repo.Migrations.ExtractTabSettingsFromRouteTabs do
+  use Ecto.Migration
+
+  def change do
+    execute("DELETE FROM route_tabs")
+
+    create table(:tab_settings) do
+      add(:selected_route_ids, {:array, :string}, null: false)
+      add(:ladder_directions, :map, null: false)
+      add(:ladder_crowding_toggles, :map, null: false)
+      add(:route_tab_id, references(:route_tabs, on_delete: :delete_all, on_update: :update_all))
+      timestamps()
+    end
+
+    alter table(:route_tabs) do
+      remove(:selected_route_ids)
+      remove(:ladder_directions)
+      remove(:ladder_crowding_toggles)
+    end
+  end
+end

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -3,42 +3,71 @@ defmodule Skate.Settings.RouteTabTest do
   import Skate.Factory
   alias Skate.Settings.RouteTab
 
+  def build_test_tab() do
+    build(:route_tab, %{
+      preset_name: "some routes",
+      selected_route_ids: ["1", "28"],
+      ladder_directions: %{"28" => "1"},
+      ladder_crowding_toggles: %{"1" => true}
+    })
+  end
+
   describe "get_all_for_user/1" do
     test "retrieves route tabs by username" do
-      route_tab =
-        build(:route_tab, %{preset_name: "some routes", selected_route_ids: ["1", "28"]})
+      route_tab = build_test_tab()
 
       RouteTab.update_all_for_user!("user1", [route_tab])
       RouteTab.update_all_for_user!("user2", [route_tab])
 
-      assert [%RouteTab{preset_name: "some routes", selected_route_ids: ["1", "28"]}] =
-               RouteTab.get_all_for_user("user1")
+      assert [
+               %RouteTab{
+                 preset_name: "some routes",
+                 selected_route_ids: ["1", "28"],
+                 ladder_directions: %{"28" => "1"},
+                 ladder_crowding_toggles: %{"1" => true}
+               }
+             ] = RouteTab.get_all_for_user("user1")
     end
   end
 
   describe "update_all_for_user!/2" do
     test "adds a new tab entry" do
-      route_tab =
-        build(:route_tab, %{preset_name: "some routes", selected_route_ids: ["1", "28"]})
+      route_tab = build_test_tab()
 
-      assert [%RouteTab{preset_name: "some routes", selected_route_ids: ["1", "28"]}] =
-               RouteTab.update_all_for_user!("charlie", [route_tab])
+      assert [
+               %RouteTab{
+                 preset_name: "some routes",
+                 selected_route_ids: ["1", "28"],
+                 ladder_directions: %{"28" => "1"},
+                 ladder_crowding_toggles: %{"1" => true}
+               }
+             ] = RouteTab.update_all_for_user!("charlie", [route_tab])
 
       [route_tab_from_db] = RouteTab.get_all_for_user("charlie")
 
       refute is_nil(route_tab_from_db.id)
 
-      assert %RouteTab{preset_name: "some routes", selected_route_ids: ["1", "28"]} =
-               route_tab_from_db
+      assert %RouteTab{
+               preset_name: "some routes",
+               selected_route_ids: ["1", "28"],
+               ladder_directions: %{"28" => "1"},
+               ladder_crowding_toggles: %{"1" => true}
+             } = route_tab_from_db
     end
 
     test "updates an existing tab entry" do
-      route_tab =
-        build(:route_tab, %{preset_name: "some routes", selected_route_ids: ["1", "28"]})
+      route_tab = build_test_tab()
 
       [persisted_route_tab] = RouteTab.update_all_for_user!("charlie", [route_tab])
 
-      assert [%RouteTab{preset_name: "some other name", selected_route_ids: ["1", "28"]}] =
+      assert [
+               %RouteTab{
+                 preset_name: "some other name",
+                 selected_route_ids: ["1", "28"],
+                 ladder_directions: %{"28" => "1"},
+                 ladder_crowding_toggles: %{"1" => true}
+               }
+             ] =
                RouteTab.update_all_for_user!("charlie", [
                  %{persisted_route_tab | preset_name: "some other name"}
                ])
@@ -49,14 +78,15 @@ defmodule Skate.Settings.RouteTabTest do
                %RouteTab{
                  id: ^persisted_route_tab_id,
                  preset_name: "some other name",
-                 selected_route_ids: ["1", "28"]
+                 selected_route_ids: ["1", "28"],
+                 ladder_directions: %{"28" => "1"},
+                 ladder_crowding_toggles: %{"1" => true}
                }
              ] = RouteTab.get_all_for_user("charlie")
     end
 
     test "deletes a removed tab entry" do
-      route_tab =
-        build(:route_tab, %{preset_name: "some routes", selected_route_ids: ["1", "28"]})
+      route_tab = build_test_tab()
 
       [_persisted_route_tab] = RouteTab.update_all_for_user!("charlie", [route_tab])
 


### PR DESCRIPTION
This effectively separates the data in a `RouteTab` from the metadata, moving the data into a new `TabSettings` table. This would be an odd way to do things except that this will make implementing presets much simpler.