### PR TITLE
feat: hibernate Schedule.Fetcher process after fetching new data

### DIFF
--- a/lib/schedule/fetcher.ex
+++ b/lib/schedule/fetcher.ex
@@ -89,7 +89,7 @@ defmodule Schedule.Fetcher do
          Map.merge(state, %{
            latest_gtfs_timestamp: gtfs_timestamp,
            latest_hastus_timestamp: hastus_timestamp
-         })}
+         }), :hibernate}
       else
         {:stop, :normal, state}
       end

--- a/test/schedule/fetcher_test.exs
+++ b/test/schedule/fetcher_test.exs
@@ -40,7 +40,8 @@ defmodule Schedule.FetcherTest do
         capture_log(
           [level: :info],
           fn ->
-            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"}} =
+            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"},
+                    :hibernate} =
                      Schedule.Fetcher.do_poll(
                        %{
                          poll_interval_ms: 50,
@@ -202,7 +203,8 @@ defmodule Schedule.FetcherTest do
         capture_log(
           [level: :info],
           fn ->
-            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"}} =
+            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"},
+                    :hibernate} =
                      Schedule.Fetcher.do_poll(
                        %{
                          poll_interval_ms: 50,
@@ -249,7 +251,8 @@ defmodule Schedule.FetcherTest do
         capture_log(
           [level: :info],
           fn ->
-            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"}} =
+            assert {:noreply, %{latest_gtfs_timestamp: "foo", latest_hastus_timestamp: "foo"},
+                    :hibernate} =
                      Schedule.Fetcher.handle_info(
                        :check_gtfs,
                        %{


### PR DESCRIPTION
Asana ticket: [Improve Skate high memory warning](https://app.asana.com/0/1152340551558956/1200080248619320/f)

This simple change causes the `Schedule.Fetcher` process to [hibernate](https://www.erlang.org/doc/man/erlang.html#hibernate-3) after doing a full fetch / parse of new schedule data. This does a full GC pass and cleans up a lot of memory (that probably made it onto the old heap since it takes a while to parse). Since the process only actually needs to execute every few minutes and isn't an interactive / low-latency kind of component, the added time for hibernation should be acceptable. This change will make the high-memory alert condition more meaningful with some other small tweaks.

Below, see a graph of `max(memtot)` as reported by Ehmon on skate-dev before, during, and after parsing a new batch of schedule data:
![Screen Shot 2021-12-15 at 8 34 35 AM](https://user-images.githubusercontent.com/2010157/146196909-b8dcedb7-336d-4e02-9277-096cc331a323.png)
