### PR TITLE
fix: change fake Ueberauth strategy

### DIFF
--- a/lib/skate/ueberauth/strategy/fake.ex
+++ b/lib/skate/ueberauth/strategy/fake.ex
@@ -1,5 +1,5 @@
 defmodule Skate.Ueberauth.Strategy.Fake do
-  use Ueberauth.Strategy
+  use Ueberauth.Strategy, ignores_csrf_attack: true
 
   @impl Ueberauth.Strategy
   def handle_request!(conn) do


### PR DESCRIPTION
Ueberauth was recently updated and the new version requires CSRF
protection, or explicitly setting the ignore_csrf_attack flag. Doing
the latter since this isn't a real strategy.