### PR TITLE
ci: do checkout before ASDF cache, making .tool-versions present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           POSTGRES_DB: ${{env.DATABASE_NAME}}
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
+      - uses: actions/checkout@v2
       - name: ASDF cache
         uses: actions/cache@v2
         with:
@@ -75,7 +76,6 @@ jobs:
           echo "$ASDF_DIR/bin" >> $GITHUB_PATH
           echo "$ASDF_DIR/shims" >> $GITHUB_PATH
           $ASDF_DIR/bin/asdf reshim
-      - uses: actions/checkout@v2
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v2
@@ -110,6 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
+      - uses: actions/checkout@v2
       - name: ASDF cache
         uses: actions/cache@v2
         with:
@@ -124,7 +125,6 @@ jobs:
           echo "$ASDF_DIR/bin" >> $GITHUB_PATH
           echo "$ASDF_DIR/shims" >> $GITHUB_PATH
           $ASDF_DIR/bin/asdf reshim
-      - uses: actions/checkout@v2
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v2


### PR DESCRIPTION
Thanks for catching this @paulswartz.