### PR TITLE
Correct race condition and possible duplicate orderings in route tabs

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -8,6 +8,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:update": "jest -u",
+    "test:debugger": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "check": "tsc --noEmit && npm run lint:check && npm run format:check",
     "lint": "tslint --fix -p .",
     "lint:check": "tslint -p .",

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -16,7 +16,7 @@ import {
   Timepoint,
   TripId,
 } from "./schedule.d"
-import { RouteTab, parseRouteTabData } from "./models/routeTab"
+import { RouteTab } from "./models/routeTab"
 
 export interface RouteData {
   id: string
@@ -199,19 +199,14 @@ export const putRouteSettings = (routeSettings: RouteSettings): void => {
   })
 }
 
-export const putRouteTabs = (routeTabs: RouteTab[]): Promise<RouteTab[]> =>
-  apiCall({
-    url: "/api/route_tabs",
-    parser: parseRouteTabData,
-    defaultResult: [],
-    fetchArgs: {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        "x-csrf-token": getCsrfToken(),
-      },
-      body: JSON.stringify({ route_tabs: routeTabs }),
+export const putRouteTabs = (routeTabs: RouteTab[]): Promise<Response> =>
+  fetch("/api/route_tabs", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "x-csrf-token": getCsrfToken(),
     },
+    body: JSON.stringify({ route_tabs: routeTabs }),
   })
 
 const getCsrfToken = (): string => appData()?.csrfToken || ""

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -160,11 +160,11 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
         {routeTabs
           .filter((routeTab) => routeTab.ordering !== undefined)
           .sort((a, b) => (a.ordering || 0) - (b.ordering || 0))
-          .map((routeTab, i) => (
+          .map((routeTab) => (
             <LadderTab
               tab={routeTab}
-              selectTab={() => dispatch(selectRouteTab(i))}
-              key={i}
+              selectTab={() => dispatch(selectRouteTab(routeTab.ordering))}
+              key={routeTab.ordering}
             />
           ))}
 

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -5,18 +5,16 @@ import { LadderCrowdingToggles } from "./ladderCrowdingToggle"
 export interface RouteTab {
   isCurrentTab: boolean
   presetName?: string
-  id?: string
   selectedRouteIds: RouteId[]
   ladderDirections: LadderDirections
   ladderCrowdingToggles: LadderCrowdingToggles
-  ordering?: number
+  ordering: number
 }
 
 export interface RouteTabData {
-  id: string
   preset_name?: string
   selected_route_ids: RouteId[]
-  ordering?: number
+  ordering: number
   ladder_directions: LadderDirections
   ladder_crowding_toggles: LadderCrowdingToggles
   is_current_tab?: boolean
@@ -37,7 +35,6 @@ export const parseRouteTabData = (
   routeTabsData: RouteTabData[]
 ): RouteTab[] => {
   return routeTabsData.map((routeTabData) => ({
-    id: routeTabData.id,
     ordering: routeTabData.ordering,
     presetName: routeTabData.preset_name,
     isCurrentTab: routeTabData.is_current_tab || false,

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -537,11 +537,10 @@ describe("putRouteSettings", () => {
 })
 
 describe("putRouteTabs", () => {
-  test("uses PUT and returns updated tabs", (done) => {
+  test("uses PUT", () => {
     mockFetch(200, {
       data: [
         {
-          id: "1",
           preset_name: "some name",
           selected_route_ids: ["1", "28"],
           ordering: 0,
@@ -563,29 +562,12 @@ describe("putRouteTabs", () => {
       }),
     ]
 
-    const result = putRouteTabs(routeTabs)
+    putRouteTabs(routeTabs)
 
     expect(window.fetch).toHaveBeenCalledTimes(1)
     const args = (window.fetch as jest.Mock).mock.calls[0][1]
     expect(args.method).toEqual("PUT")
     expect(args.headers).toHaveProperty("x-csrf-token")
     expect(args.body).toEqual(JSON.stringify({ route_tabs: routeTabs }))
-
-    const expectedRouteTabs = [
-      routeTabFactory.build({
-        id: "1",
-        presetName: "some name",
-        selectedRouteIds: ["1", "28"],
-        ordering: 0,
-        ladderDirections: {},
-        ladderCrowdingToggles: {},
-        isCurrentTab: false,
-      }),
-    ]
-
-    result.then((returnedRouteTabs) => {
-      expect(returnedRouteTabs).toEqual(expectedRouteTabs)
-      done()
-    })
   })
 })

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,10 +1,10 @@
 import { Factory } from "fishery"
 import { RouteTab } from "../../src/models/routeTab"
 
-export default Factory.define<RouteTab>(() => ({
+export default Factory.define<RouteTab>(({ sequence }) => ({
   isCurrentTab: false,
   selectedRouteIds: [],
   ladderDirections: {},
   ladderCrowdingToggles: {},
-  ordering: 0,
+  ordering: sequence,
 }))

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -152,7 +152,6 @@ describe("usePersistedStateReducer", () => {
     expect(state.ladderCrowdingToggles).toEqual({ "83": true })
     expect(state.routeTabs).toEqual([
       routeTabFactory.build({
-        id: "1",
         ordering: 0,
         presetName: "some name",
         isCurrentTab: true,
@@ -237,7 +236,6 @@ describe("usePersistedStateReducer", () => {
 
   test("sends updated route tabs to backend on changes", () => {
     const routeTab = routeTabFactory.build({
-      id: "1",
       isCurrentTab: true,
       selectedRouteIds: [],
       ladderDirections: {},

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -20,7 +20,6 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "../../src/userSettings"
-import { instantPromise } from "../testHelpers/mockHelpers"
 import routeTabFactory from "../factories/routeTab"
 
 // tslint:disable: react-hooks-nesting
@@ -242,8 +241,8 @@ describe("usePersistedStateReducer", () => {
       ladderCrowdingToggles: {},
       ordering: 0,
     })
-    ;(putRouteTabs as jest.Mock).mockImplementationOnce(() =>
-      instantPromise([routeTab])
+    ;(putRouteTabs as jest.Mock).mockImplementationOnce(
+      () => new Promise(() => [routeTab])
     )
     const { result } = renderHook(() => usePersistedStateReducer())
     const [, dispatch] = result.current

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -242,9 +242,12 @@ describe("usePersistedStateReducer", () => {
       ladderCrowdingToggles: {},
       ordering: 0,
     })
-    ;(putRouteTabs as jest.Mock).mockImplementationOnce(
-      () => new Promise(jest.fn())
-    )
+    ;(putRouteTabs as jest.Mock).mockImplementationOnce(() => ({
+      then: (callback: (data: any) => void) => {
+        callback({ ok: true })
+        return { catch: jest.fn() }
+      },
+    }))
     const { result } = renderHook(() => usePersistedStateReducer())
     const [, dispatch] = result.current
 
@@ -260,8 +263,11 @@ describe("usePersistedStateReducer", () => {
         ordering: 0,
       },
     ])
-    const [state] = result.current
-    expect(state.routeTabs).toEqual([routeTab])
+    const [{ routeTabs, routeTabsToPush, routeTabsPushInProgress }] =
+      result.current
+    expect(routeTabs).toEqual([routeTab])
+    expect(routeTabsToPush).toEqual(null)
+    expect(routeTabsPushInProgress).toEqual(false)
   })
 
   test("saves updated route tabs to push later if a push is currently in progress", () => {

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -2,7 +2,7 @@ import { currentRouteTab } from "../../src/models/routeTab"
 import routeTabFactory from "../factories/routeTab"
 
 describe("currentRouteTab", () => {
-  test("finds route tab flagges as current if present", () => {
+  test("finds route tab flagged as current if present", () => {
     const routeTab1 = routeTabFactory.build()
     const routeTab2 = routeTabFactory.build({ isCurrentTab: true })
 
@@ -11,7 +11,7 @@ describe("currentRouteTab", () => {
 
   test("creates new route tab if no current tab found", () => {
     expect(currentRouteTab([])).toEqual(
-      routeTabFactory.build({ isCurrentTab: true })
+      routeTabFactory.build({ isCurrentTab: true, ordering: 0 })
     )
   })
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -447,13 +447,16 @@ describe("reducer", () => {
       State.createRouteTab()
     )
 
+    const expectedNewTabs = [
+      { ...originalRouteTab1 },
+      { ...originalRouteTab2, isCurrentTab: false },
+      routeTabFactory.build({ isCurrentTab: true, ordering: 5 }),
+    ]
+
     const expectedState: State.State = {
       ...initialState,
-      routeTabs: [
-        { ...originalRouteTab1 },
-        { ...originalRouteTab2, isCurrentTab: false },
-        routeTabFactory.build({ isCurrentTab: true, ordering: 5 }),
-      ],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -468,12 +471,14 @@ describe("reducer", () => {
       State.selectRouteTab(routeTab1.ordering)
     )
 
+    const expectedNewTabs = [
+      { ...routeTab1, isCurrentTab: true },
+      { ...routeTab2, isCurrentTab: false },
+    ]
     const expectedState: State.State = {
       ...initialState,
-      routeTabs: [
-        { ...routeTab1, isCurrentTab: true },
-        { ...routeTab2, isCurrentTab: false },
-      ],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -491,9 +496,14 @@ describe("reducer", () => {
       State.selectRouteInTab("1")
     )
 
+    const expectedNewTabs = [
+      { ...routeTab1, selectedRouteIds: ["1"] },
+      routeTab2,
+    ]
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [{ ...routeTab1, selectedRouteIds: ["1"] }, routeTab2],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -512,9 +522,12 @@ describe("reducer", () => {
       State.deselectRouteInTab("1")
     )
 
+    const expectedNewTabs = [{ ...routeTab1, selectedRouteIds: [] }, routeTab2]
+
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [{ ...routeTab1, selectedRouteIds: [] }, routeTab2],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -533,9 +546,14 @@ describe("reducer", () => {
       State.flipLadderInTab("1")
     )
 
+    const expectedNewTabs = [
+      { ...routeTab1, ladderDirections: { "1": 1 } },
+      routeTab2,
+    ]
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [{ ...routeTab1, ladderDirections: { "1": 1 } }, routeTab2],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -554,12 +572,15 @@ describe("reducer", () => {
       State.toggleLadderCrowdingInTab("1")
     )
 
+    const expectedNewTabs = [
+      { ...routeTab1, ladderCrowdingToggles: { "1": true } },
+      routeTab2,
+    ]
+
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [
-        { ...routeTab1, ladderCrowdingToggles: { "1": true } },
-        routeTab2,
-      ],
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
     })
   })
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -429,20 +429,30 @@ describe("reducer", () => {
   })
 
   test("createRouteTab", () => {
+    const originalRouteTab1 = routeTabFactory.build({
+      isCurrentTab: false,
+      ordering: 4,
+    })
+    const originalRouteTab2 = routeTabFactory.build({
+      isCurrentTab: true,
+      ordering: 2,
+    })
+    const originalRouteTabs = [originalRouteTab1, originalRouteTab2]
+
     const newState = reducer(
       {
         ...initialState,
-        routeTabs: [routeTabFactory.build({ isCurrentTab: true })],
+        routeTabs: originalRouteTabs,
       },
       State.createRouteTab()
     )
 
     const expectedState: State.State = {
       ...initialState,
-      routeTabs: [routeTabFactory.build({ isCurrentTab: true })],
-      pendingRouteTabs: [
-        routeTabFactory.build(),
-        routeTabFactory.build({ isCurrentTab: true, ordering: 1 }),
+      routeTabs: [
+        { ...originalRouteTab1 },
+        { ...originalRouteTab2, isCurrentTab: false },
+        routeTabFactory.build({ isCurrentTab: true, ordering: 5 }),
       ],
     }
 
@@ -455,16 +465,15 @@ describe("reducer", () => {
 
     const newState = reducer(
       { ...initialState, routeTabs: [routeTab1, routeTab2] },
-      State.selectRouteTab(0)
+      State.selectRouteTab(routeTab1.ordering)
     )
-
-    const expectedRouteTab1 = routeTabFactory.build({ isCurrentTab: true })
-    const expectedRouteTab2 = routeTabFactory.build()
 
     const expectedState: State.State = {
       ...initialState,
-      routeTabs: [routeTab1, routeTab2],
-      pendingRouteTabs: [expectedRouteTab1, expectedRouteTab2],
+      routeTabs: [
+        { ...routeTab1, isCurrentTab: true },
+        { ...routeTab2, isCurrentTab: false },
+      ],
     }
 
     expect(newState).toEqual(expectedState)
@@ -482,15 +491,9 @@ describe("reducer", () => {
       State.selectRouteInTab("1")
     )
 
-    const expectedRouteTab = routeTabFactory.build({
-      isCurrentTab: true,
-      selectedRouteIds: ["1"],
-    })
-
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [routeTab1, routeTab2],
-      pendingRouteTabs: [expectedRouteTab, routeTab2],
+      routeTabs: [{ ...routeTab1, selectedRouteIds: ["1"] }, routeTab2],
     })
   })
 
@@ -511,11 +514,7 @@ describe("reducer", () => {
 
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [routeTab1, routeTab2],
-      pendingRouteTabs: [
-        routeTabFactory.build({ isCurrentTab: true }),
-        routeTab2,
-      ],
+      routeTabs: [{ ...routeTab1, selectedRouteIds: [] }, routeTab2],
     })
   })
 
@@ -536,15 +535,7 @@ describe("reducer", () => {
 
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [routeTab1, routeTab2],
-      pendingRouteTabs: [
-        routeTabFactory.build({
-          isCurrentTab: true,
-          selectedRouteIds: ["1"],
-          ladderDirections: { "1": 1 },
-        }),
-        routeTab2,
-      ],
+      routeTabs: [{ ...routeTab1, ladderDirections: { "1": 1 } }, routeTab2],
     })
   })
 
@@ -565,13 +556,8 @@ describe("reducer", () => {
 
     expect(newState).toEqual({
       ...initialState,
-      routeTabs: [routeTab1, routeTab2],
-      pendingRouteTabs: [
-        routeTabFactory.build({
-          isCurrentTab: true,
-          selectedRouteIds: ["1"],
-          ladderCrowdingToggles: { "1": true },
-        }),
+      routeTabs: [
+        { ...routeTab1, ladderCrowdingToggles: { "1": true } },
         routeTab2,
       ],
     })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -583,4 +583,58 @@ describe("reducer", () => {
       routeTabsToPush: expectedNewTabs,
     })
   })
+
+  test("startingRouteTabsPush", () => {
+    const newState = reducer(initialState, State.startingRouteTabsPush())
+    expect(newState).toEqual({
+      ...initialState,
+      routeTabsPushInProgress: true,
+    })
+  })
+
+  test("routeTabsPushComplete", () => {
+    const newState = reducer(
+      { ...initialState, routeTabsPushInProgress: true },
+      State.routeTabsPushComplete()
+    )
+    expect(newState).toEqual({
+      ...initialState,
+      routeTabsPushInProgress: false,
+    })
+  })
+
+  test("retryRouteTabsPushIfNotOutdated", () => {
+    const firstPushRouteTabs = [routeTabFactory.build()]
+    const secondPushRouteTabs = [...firstPushRouteTabs, routeTabFactory.build()]
+
+    const stateWithoutQueuedTabs = {
+      ...initialState,
+      routeTabsPushInProgress: true,
+      routeTabs: firstPushRouteTabs,
+    }
+    const stateWithQueuedTabs = {
+      ...stateWithoutQueuedTabs,
+      routeTabsToPush: secondPushRouteTabs,
+      routeTabs: secondPushRouteTabs,
+    }
+
+    const newStateWithoutQueuedTabs = reducer(
+      stateWithoutQueuedTabs,
+      State.retryRouteTabsPushIfNotOutdated(firstPushRouteTabs)
+    )
+    const newStateWithQueuedTabs = reducer(
+      stateWithQueuedTabs,
+      State.retryRouteTabsPushIfNotOutdated(firstPushRouteTabs)
+    )
+
+    expect(newStateWithoutQueuedTabs).toEqual({
+      ...stateWithoutQueuedTabs,
+      routeTabsPushInProgress: false,
+      routeTabsToPush: firstPushRouteTabs,
+    })
+    expect(newStateWithQueuedTabs).toEqual({
+      ...stateWithQueuedTabs,
+      routeTabsPushInProgress: false,
+    })
+  })
 })

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -8,7 +8,6 @@ defmodule Skate.Settings.RouteTab do
   alias Skate.Settings.Db.User, as: DbUser
 
   @type t :: %__MODULE__{
-          id: integer() | nil,
           preset_name: String.t() | nil,
           selected_route_ids: [Route.id()],
           ladder_directions: map(),
@@ -27,8 +26,7 @@ defmodule Skate.Settings.RouteTab do
     :ladder_directions,
     :ladder_crowding_toggles,
     :ordering,
-    :is_current_tab,
-    id: nil
+    :is_current_tab
   ]
 
   @spec get_all_for_user(String.t()) :: [t()]
@@ -54,7 +52,6 @@ defmodule Skate.Settings.RouteTab do
     tab = Repo.preload(db_route_tab, :tab_settings)
 
     %__MODULE__{
-      id: tab.id,
       preset_name: tab.preset_name,
       selected_route_ids: tab.tab_settings.selected_route_ids,
       ladder_directions: tab.tab_settings.ladder_directions,

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -15,7 +15,6 @@ defmodule SkateWeb.RouteTabsController do
   defp format_tabs_for_update(route_tabs) do
     Enum.map(route_tabs, fn route_tab ->
       %RouteTab{
-        id: Map.get(route_tab, "id"),
         preset_name: Map.get(route_tab, "presetName"),
         selected_route_ids: Map.get(route_tab, "selectedRouteIds", []),
         ladder_directions: Map.get(route_tab, "ladderDirections", %{}),

--- a/priv/repo/migrations/20211206204239_extract_tab_settings_from_route_tabs.exs
+++ b/priv/repo/migrations/20211206204239_extract_tab_settings_from_route_tabs.exs
@@ -3,6 +3,7 @@ defmodule Skate.Repo.Migrations.ExtractTabSettingsFromRouteTabs do
 
   def change do
     execute("DELETE FROM route_tabs")
+    create index("route_tabs", [:user_id, :ordering], unique: true)
 
     create table(:tab_settings) do
       add(:selected_route_ids, {:array, :string}, null: false)

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -43,16 +43,14 @@ defmodule Skate.Settings.RouteTabTest do
                }
              ] = RouteTab.update_all_for_user!("charlie", [route_tab])
 
-      [route_tab_from_db] = RouteTab.get_all_for_user("charlie")
-
-      refute is_nil(route_tab_from_db.id)
-
-      assert %RouteTab{
-               preset_name: "some routes",
-               selected_route_ids: ["1", "28"],
-               ladder_directions: %{"28" => "1"},
-               ladder_crowding_toggles: %{"1" => true}
-             } = route_tab_from_db
+      assert [
+               %RouteTab{
+                 preset_name: "some routes",
+                 selected_route_ids: ["1", "28"],
+                 ladder_directions: %{"28" => "1"},
+                 ladder_crowding_toggles: %{"1" => true}
+               }
+             ] = RouteTab.get_all_for_user("charlie")
     end
 
     test "updates an existing tab entry" do
@@ -72,11 +70,8 @@ defmodule Skate.Settings.RouteTabTest do
                  %{persisted_route_tab | preset_name: "some other name"}
                ])
 
-      persisted_route_tab_id = persisted_route_tab.id
-
       assert [
                %RouteTab{
-                 id: ^persisted_route_tab_id,
                  preset_name: "some other name",
                  selected_route_ids: ["1", "28"],
                  ladder_directions: %{"28" => "1"},

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -9,13 +9,24 @@ defmodule SkateWeb.RouteTabsControllerTest do
     test "sets route tabs for logged-in user", %{conn: conn, user: user} do
       conn =
         put(conn, "/api/route_tabs", %{
-          "route_tabs" => [%{"presetName" => "new preset", "selectedRouteIds" => ["1", "28"]}]
+          "route_tabs" => [
+            %{
+              "presetName" => "new preset",
+              "selectedRouteIds" => ["1", "28"],
+              "ordering" => "12345"
+            }
+          ]
         })
 
       response(conn, 200)
 
-      assert [%RouteTab{preset_name: "new preset", selected_route_ids: ["1", "28"]}] =
-               RouteTab.get_all_for_user(user)
+      assert [
+               %RouteTab{
+                 preset_name: "new preset",
+                 selected_route_ids: ["1", "28"],
+                 ordering: 12345
+               }
+             ] = RouteTab.get_all_for_user(user)
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -163,12 +163,11 @@ defmodule Skate.Factory do
 
   def route_tab_factory do
     %Skate.Settings.RouteTab{
-      id: nil,
       preset_name: "preset",
       selected_route_ids: [],
       ladder_directions: %{},
       ladder_crowding_toggles: %{},
-      ordering: nil,
+      ordering: sequence(""),
       is_current_tab: false
     }
   end


### PR DESCRIPTION
This reworks how we sync the route tabs open in a user's browser to the backend DB.

One key aspect is that, after the route tabs have been initialized on page load from the `data-route-tabs` JSON in the HTML, updates only flow from the browser to the backend. When we PUT an update of the route tabs state to the backend, we disregard the server's response, apart from checking its status code. The database IDs of route tabs are as a consequence no longer of interest to the frontend. To put it another way, the definitive route-tabs state is that in the client's browser; we are only interested in saving that state to the backend so that we can use it to initialize future sessions.

That still leaves one race condition possible. Imagine that the route-tabs state in the browser starts out in state S0. The user then adds two tabs, and consequently, the in-browser state goes from S0 to S1 and then to S2. The obvious implementation is to have each change of state fire off a PUT, so that we PUT first S1 and then S2 to the backend in separate requests R1 and R2. But just because we start R1 before R2 doesn't mean that R1 will necessarily complete before R2. If R2 completes first, then R1 overwrites the backend state with S1, a stale state. We add a simple lock-and-queue system to guard against this, ensuring that only one such request can be issued at a time.

There was also a separate bug where tabs might have ended up with a duplicate ordering. I fixed that while I was in here.

Tests to follow, this one is going to take some testing.