### PR TITLE
feat: log time spent sending data message from Schedule.Fetcher

### DIFF
--- a/lib/schedule/fetcher.ex
+++ b/lib/schedule/fetcher.ex
@@ -70,7 +70,14 @@ defmodule Schedule.Fetcher do
            ) do
       schedule_state = {:loaded, data}
 
+      update_start_time = Time.utc_now()
       :ok = state[:updater_function].(schedule_state)
+
+      Logger.info(
+        "#{__MODULE__}: Sent updated schedule data to receiving process, time_in_ms=#{
+          Time.diff(Time.utc_now(), update_start_time, :millisecond)
+        }"
+      )
 
       Logger.info(
         "#{__MODULE__}: Successfully loaded schedule data, time_in_ms=#{

--- a/test/schedule/fetcher_test.exs
+++ b/test/schedule/fetcher_test.exs
@@ -57,6 +57,7 @@ defmodule Schedule.FetcherTest do
           end
         )
 
+      assert log =~ ~r/Sent updated schedule data to receiving process, time_in_ms=\d+/
       assert log =~ "Successfully loaded schedule data"
     end
 
@@ -219,6 +220,7 @@ defmodule Schedule.FetcherTest do
           end
         )
 
+      assert log =~ ~r/Sent updated schedule data to receiving process, time_in_ms=\d+/
       assert log =~ "Successfully loaded schedule data"
       assert log =~ "Saving gtfs cache"
     end
@@ -266,6 +268,7 @@ defmodule Schedule.FetcherTest do
           end
         )
 
+      assert log =~ ~r/Sent updated schedule data to receiving process, time_in_ms=\d+/
       assert log =~ "Successfully loaded schedule data"
     end
   end


### PR DESCRIPTION
Asana ticker: [⚙️ Log time spent in GenServer.call from Schedule.Fetcher to Schedule](https://app.asana.com/0/1200180014510248/1201523184137409/f)

I also did other experimenting but none of it was really fruitful in terms of improving performance - see my comment on the Asana ticket.

Note that we're still only doing the schedule fetch on app startup, so we'll only see this logging when a new instance starts up.