### PR TITLE
Temporarily disable tabs backend

### DIFF
--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -3,7 +3,6 @@ defmodule SkateWeb.PageController do
   use SkateWeb, :controller
   alias Skate.Settings.RouteSettings
   alias Skate.Settings.UserSettings
-  alias Skate.Settings.RouteTab
   alias SkateWeb.AuthManager
 
   plug(:laboratory_features)
@@ -14,7 +13,7 @@ defmodule SkateWeb.PageController do
 
     user_settings = UserSettings.get_or_create(username)
     route_settings = RouteSettings.get_or_create(username)
-    route_tabs = RouteTab.get_all_for_user(username)
+    route_tabs = []
 
     dispatcher_flag =
       conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_dispatcher_access?()

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -1,27 +1,7 @@
 defmodule SkateWeb.RouteTabsController do
   use SkateWeb, :controller
 
-  alias SkateWeb.AuthManager
-  alias Skate.Settings.RouteTab
-
-  def update(conn, %{"route_tabs" => route_tabs} = _params) do
-    username = AuthManager.Plug.current_resource(conn)
-
-    new_route_tabs = RouteTab.update_all_for_user!(username, format_tabs_for_update(route_tabs))
-    json(conn, %{data: new_route_tabs})
-  end
-
-  @spec format_tabs_for_update([map()]) :: [RouteTab.t()]
-  defp format_tabs_for_update(route_tabs) do
-    Enum.map(route_tabs, fn route_tab ->
-      %RouteTab{
-        preset_name: Map.get(route_tab, "presetName"),
-        selected_route_ids: Map.get(route_tab, "selectedRouteIds", []),
-        ladder_directions: Map.get(route_tab, "ladderDirections", %{}),
-        ladder_crowding_toggles: Map.get(route_tab, "ladderCrowdingToggles", %{}),
-        ordering: Map.get(route_tab, "ordering"),
-        is_current_tab: Map.get(route_tab, "isCurrentTab")
-      }
-    end)
+  def update(conn, %{"route_tabs" => _route_tabs} = _params) do
+    json(conn, %{data: []})
   end
 end

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -39,7 +39,7 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes route tabs in HTML", %{conn: conn, user: user} do
+    test "includes route tabs in HTML, empty for now", %{conn: conn, user: user} do
       Skate.Settings.RouteTab.update_all_for_user!(user, [
         build(:route_tab, %{selected_route_ids: ["1"]})
       ])
@@ -49,7 +49,7 @@ defmodule SkateWeb.PageControllerTest do
       html = html_response(conn, 200)
 
       assert html =~ "data-route-tabs"
-      assert html =~ "selected_route_ids&quot;:[&quot;1&quot;]"
+      assert html =~ "selected_route_ids&quot;:[]"
     end
 
     @tag :authenticated

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -6,7 +6,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
   describe "PUT /api/route_tabs" do
     @tag :authenticated
-    test "sets route tabs for logged-in user", %{conn: conn, user: user} do
+    test "doesn't set route tabs for logged-in user (for now)", %{conn: conn, user: user} do
       conn =
         put(conn, "/api/route_tabs", %{
           "route_tabs" => [
@@ -20,13 +20,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
       response(conn, 200)
 
-      assert [
-               %RouteTab{
-                 preset_name: "new preset",
-                 selected_route_ids: ["1", "28"],
-                 ordering: 12345
-               }
-             ] = RouteTab.get_all_for_user(user)
+      assert [] = RouteTab.get_all_for_user(user)
     end
   end
 end


### PR DESCRIPTION
Asana ticker: [⚙️ Get existing tabs and presets work into a good state ](https://app.asana.com/0/1200180014510248/1201646081199337/f)

Tabs and presets is a feature that is not yet live to our actual users, being developed behind a feature flag. I need to make some slight changes to the data model, mainly using client-generated UUIDs as the primary key. Since nobody is actually using this feature, the easiest way to handle the transitional state during the deploy is to simply make the application no longer use those tables. Once the changes are made and the relevant utility functions are updated I'll undo the changes in this PR.