### PR TITLE
feat: re-enable route tabs backend, with UUID support

### DIFF
--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -3,6 +3,7 @@ defmodule SkateWeb.PageController do
   use SkateWeb, :controller
   alias Skate.Settings.RouteSettings
   alias Skate.Settings.UserSettings
+  alias Skate.Settings.RouteTab
   alias SkateWeb.AuthManager
 
   plug(:laboratory_features)
@@ -13,7 +14,7 @@ defmodule SkateWeb.PageController do
 
     user_settings = UserSettings.get_or_create(username)
     route_settings = RouteSettings.get_or_create(username)
-    route_tabs = []
+    route_tabs = RouteTab.get_all_for_user(username)
 
     dispatcher_flag =
       conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_dispatcher_access?()

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -1,7 +1,28 @@
 defmodule SkateWeb.RouteTabsController do
   use SkateWeb, :controller
 
-  def update(conn, %{"route_tabs" => _route_tabs} = _params) do
-    json(conn, %{data: []})
+  alias SkateWeb.AuthManager
+  alias Skate.Settings.RouteTab
+
+  def update(conn, %{"route_tabs" => route_tabs} = _params) do
+    username = AuthManager.Plug.current_resource(conn)
+
+    new_route_tabs = RouteTab.update_all_for_user!(username, format_tabs_for_update(route_tabs))
+    json(conn, %{data: new_route_tabs})
+  end
+
+  @spec format_tabs_for_update([map()]) :: [RouteTab.t()]
+  defp format_tabs_for_update(route_tabs) do
+    Enum.map(route_tabs, fn route_tab ->
+      %RouteTab{
+        uuid: Map.get(route_tab, "uuid"),
+        preset_name: Map.get(route_tab, "presetName"),
+        selected_route_ids: Map.get(route_tab, "selectedRouteIds", []),
+        ladder_directions: Map.get(route_tab, "ladderDirections", %{}),
+        ladder_crowding_toggles: Map.get(route_tab, "ladderCrowdingToggles", %{}),
+        ordering: Map.get(route_tab, "ordering"),
+        is_current_tab: Map.get(route_tab, "isCurrentTab")
+      }
+    end)
   end
 end

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -39,7 +39,7 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes route tabs in HTML, empty for now", %{conn: conn, user: user} do
+    test "includes route tabs in HTML", %{conn: conn, user: user} do
       Skate.Settings.RouteTab.update_all_for_user!(user, [
         build(:route_tab, %{selected_route_ids: ["1"]})
       ])
@@ -49,7 +49,7 @@ defmodule SkateWeb.PageControllerTest do
       html = html_response(conn, 200)
 
       assert html =~ "data-route-tabs"
-      assert html =~ "selected_route_ids&quot;:[]"
+      assert html =~ "selected_route_ids&quot;:[&quot;1&quot;]"
     end
 
     @tag :authenticated

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -6,11 +6,12 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
   describe "PUT /api/route_tabs" do
     @tag :authenticated
-    test "doesn't set route tabs for logged-in user (for now)", %{conn: conn, user: user} do
+    test "sets route tabs for logged-in user", %{conn: conn, user: user} do
       conn =
         put(conn, "/api/route_tabs", %{
           "route_tabs" => [
             %{
+              "uuid" => Ecto.UUID.generate(),
               "presetName" => "new preset",
               "selectedRouteIds" => ["1", "28"],
               "ordering" => "12345"
@@ -20,7 +21,13 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
       response(conn, 200)
 
-      assert [] = RouteTab.get_all_for_user(user)
+      assert [
+               %RouteTab{
+                 preset_name: "new preset",
+                 selected_route_ids: ["1", "28"],
+                 ordering: 12345
+               }
+             ] = RouteTab.get_all_for_user(user)
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [⚙️ Get existing tabs and presets work into a good state ](https://app.asana.com/0/1200180014510248/1201646081199337/f)

Now re-enabling the page controller and API functionality that uses route tabs. This will have to be deployed _after_ the migration that updates the schema itself. Another PR with updates to the front-end functionality is following directly behind this one.