### PR TITLE
Front-end support for route tabs UUID

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1601,6 +1601,11 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
     "@types/yargs": {
       "version": "15.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
@@ -11215,6 +11220,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -13254,10 +13267,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,6 +19,7 @@
     "@rehooks/component-size": "^1.0.3",
     "@sentry/react": "^6.10.0",
     "@tippyjs/react": "^4.2.5",
+    "@types/uuid": "^8.3.4",
     "core-js": "^3.18.2",
     "identity-obj-proxy": "^3.0.0",
     "leaflet": "^1.7.1",
@@ -33,6 +34,7 @@
     "react-leaflet-fullscreen": "^1.0.1",
     "react-router-dom": "^5.2.0",
     "resize-observer-polyfill": "^1.5.1",
+    "uuid": "^8.3.2",
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -163,8 +163,8 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
           .map((routeTab) => (
             <LadderTab
               tab={routeTab}
-              selectTab={() => dispatch(selectRouteTab(routeTab.ordering))}
-              key={routeTab.ordering}
+              selectTab={() => dispatch(selectRouteTab(routeTab.uuid))}
+              key={routeTab.uuid}
             />
           ))}
 

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -1,8 +1,10 @@
 import { RouteId } from "../schedule.d"
 import { LadderDirections } from "./ladderDirection"
 import { LadderCrowdingToggles } from "./ladderCrowdingToggle"
+import { v4 as uuidv4 } from "uuid"
 
 export interface RouteTab {
+  uuid: string
   isCurrentTab: boolean
   presetName?: string
   selectedRouteIds: RouteId[]
@@ -12,6 +14,7 @@ export interface RouteTab {
 }
 
 export interface RouteTabData {
+  uuid: string
   preset_name?: string
   selected_route_ids: RouteId[]
   ordering: number
@@ -21,6 +24,7 @@ export interface RouteTabData {
 }
 
 export const newRouteTab = (ordering: number): RouteTab => ({
+  uuid: uuidv4(),
   isCurrentTab: true,
   selectedRouteIds: [],
   ladderDirections: {},
@@ -35,6 +39,7 @@ export const parseRouteTabData = (
   routeTabsData: RouteTabData[]
 ): RouteTab[] => {
   return routeTabsData.map((routeTabData) => ({
+    uuid: routeTabData.uuid,
     ordering: routeTabData.ordering,
     presetName: routeTabData.preset_name,
     isCurrentTab: routeTabData.is_current_tab || false,

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -126,14 +126,14 @@ export const createRouteTab = (): CreateRouteTabAction => ({
 interface SelectRouteTabAction {
   type: "SELECT_ROUTE_TAB"
   payload: {
-    ordering: number
+    uuid: string
   }
 }
 
-export const selectRouteTab = (ordering: number): SelectRouteTabAction => ({
+export const selectRouteTab = (uuid: string): SelectRouteTabAction => ({
   type: "SELECT_ROUTE_TAB",
   payload: {
-    ordering,
+    uuid,
   },
 })
 
@@ -562,7 +562,7 @@ const routeTabsReducer = (
     case "SELECT_ROUTE_TAB":
       return {
         newRouteTabs: routeTabs.map((existingRouteTab) => {
-          if (existingRouteTab.ordering === action.payload.ordering) {
+          if (existingRouteTab.uuid === action.payload.uuid) {
             return { ...existingRouteTab, isCurrentTab: true }
           } else {
             return { ...existingRouteTab, isCurrentTab: false }

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -129,7 +129,9 @@ describe("LadderPage", () => {
       .find(".m-ladder-page__tab:not(.m-ladder-page__tab-current)")
       .simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(selectRouteTab(1))
+    expect(mockDispatch).toHaveBeenCalledWith(
+      selectRouteTab(mockState.routeTabs[1].uuid)
+    )
   })
 
   test("can add a new route tab", () => {

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,7 +1,9 @@
 import { Factory } from "fishery"
 import { RouteTab } from "../../src/models/routeTab"
+import { v4 as uuidv4 } from "uuid"
 
 export default Factory.define<RouteTab>(({ sequence }) => ({
+  uuid: uuidv4(),
   isCurrentTab: false,
   selectedRouteIds: [],
   ladderDirections: {},

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -126,7 +126,7 @@ describe("usePersistedStateReducer", () => {
       }),
       routeTabs: JSON.stringify([
         {
-          id: "1",
+          uuid: "1",
           ordering: 0,
           preset_name: "some name",
           is_current_tab: true,
@@ -152,6 +152,7 @@ describe("usePersistedStateReducer", () => {
     expect(state.ladderCrowdingToggles).toEqual({ "83": true })
     expect(state.routeTabs).toEqual([
       routeTabFactory.build({
+        uuid: "1",
         ordering: 0,
         presetName: "some name",
         isCurrentTab: true,
@@ -235,13 +236,6 @@ describe("usePersistedStateReducer", () => {
   })
 
   test("sends updated route tabs to backend on changes", () => {
-    const routeTab = routeTabFactory.build({
-      isCurrentTab: true,
-      selectedRouteIds: [],
-      ladderDirections: {},
-      ladderCrowdingToggles: {},
-      ordering: 0,
-    })
     ;(putRouteTabs as jest.Mock).mockImplementationOnce(() => ({
       then: (callback: (data: any) => void) => {
         callback({ ok: true })
@@ -254,15 +248,9 @@ describe("usePersistedStateReducer", () => {
     act(() => {
       dispatch(createRouteTab())
     })
-    expect(putRouteTabs).toHaveBeenCalledWith([
-      {
-        isCurrentTab: true,
-        selectedRouteIds: [],
-        ladderDirections: {},
-        ladderCrowdingToggles: {},
-        ordering: 0,
-      },
-    ])
+    const [state] = result.current
+    const routeTab = state.routeTabs[0]
+    expect(putRouteTabs).toHaveBeenCalledWith([routeTab])
     const [{ routeTabs, routeTabsToPush, routeTabsPushInProgress }] =
       result.current
     expect(routeTabs).toEqual([routeTab])
@@ -281,11 +269,11 @@ describe("usePersistedStateReducer", () => {
 
     const [state] = result.current
 
-    expect(state.routeTabs).toEqual([
-      routeTabFactory.build({
+    expect(state.routeTabs).toMatchObject([
+      {
         ordering: 0,
         isCurrentTab: true,
-      }),
+      },
     ])
     expect(state.routeTabsToPush).toEqual(state.routeTabs)
     expect(state.routeTabsPushInProgress).toEqual(true)
@@ -311,11 +299,11 @@ describe("usePersistedStateReducer", () => {
 
     const [state] = result.current
 
-    expect(state.routeTabs).toEqual([
-      routeTabFactory.build({
+    expect(state.routeTabs).toMatchObject([
+      {
         ordering: 0,
         isCurrentTab: true,
-      }),
+      },
     ])
     expect(state.routeTabsToPush).toEqual(state.routeTabs)
     expect(state.routeTabsPushInProgress).toEqual(false)
@@ -341,11 +329,11 @@ describe("usePersistedStateReducer", () => {
 
     const [state] = result.current
 
-    expect(state.routeTabs).toEqual([
-      routeTabFactory.build({
+    expect(state.routeTabs).toMatchObject([
+      {
         ordering: 0,
         isCurrentTab: true,
-      }),
+      },
     ])
     expect(state.routeTabsToPush).toEqual(state.routeTabs)
     expect(state.routeTabsPushInProgress).toEqual(false)

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -10,8 +10,9 @@ describe("currentRouteTab", () => {
   })
 
   test("creates new route tab if no current tab found", () => {
-    expect(currentRouteTab([])).toEqual(
-      routeTabFactory.build({ isCurrentTab: true, ordering: 0 })
-    )
+    const routeTab = routeTabFactory.build({ isCurrentTab: true, ordering: 0 })
+    delete routeTab.uuid
+
+    expect(currentRouteTab([])).toMatchObject(routeTab)
   })
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -474,7 +474,7 @@ describe("reducer", () => {
 
     const newState = reducer(
       { ...initialState, routeTabs: [routeTab1, routeTab2] },
-      State.selectRouteTab(routeTab1.ordering)
+      State.selectRouteTab(routeTab1.uuid)
     )
 
     const expectedNewTabs = [

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -447,10 +447,16 @@ describe("reducer", () => {
       State.createRouteTab()
     )
 
+    const expectedNewTab = routeTabFactory.build({
+      isCurrentTab: true,
+      ordering: 5,
+    })
+    delete expectedNewTab.uuid
+
     const expectedNewTabs = [
       { ...originalRouteTab1 },
       { ...originalRouteTab2, isCurrentTab: false },
-      routeTabFactory.build({ isCurrentTab: true, ordering: 5 }),
+      expectedNewTab,
     ]
 
     const expectedState: State.State = {
@@ -459,7 +465,7 @@ describe("reducer", () => {
       routeTabsToPush: expectedNewTabs,
     }
 
-    expect(newState).toEqual(expectedState)
+    expect(newState).toMatchObject(expectedState)
   })
 
   test("selectRouteTab", () => {


### PR DESCRIPTION
Asana ticket: [⚙️ Get existing tabs and presets work into a good state](https://app.asana.com/0/1200180014510248/1201646081199337/f)

This should be the last major piece of the schema refactor and move to UUIDs.