### PR TITLE
Save and list presets, close tabs

### DIFF
--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -74,6 +74,7 @@ $color-route-tabs-separator: #9fa2ac;
   align-items: center;
   padding-left: 0.75rem;
   min-width: 0;
+  cursor: default;
 
   .m-ladder-page__tab-title {
     flex-grow: 1;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1313,6 +1313,175 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.2.tgz",
+      "integrity": "sha512-idsS/cqbYudXcVWngc1PuWNmXs416oBy2g/7Q8QAUREt5Z3MUkAL2XJD7xazLJ6esDfqRDi/ZBxk+OPPXitHRw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.16.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+          "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
@@ -1330,6 +1499,26 @@
           "version": "7.15.4",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
           "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -1355,6 +1544,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
       "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
     "@types/babel__core": {
@@ -2022,6 +2217,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -4014,6 +4215,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
       "dev": true
     },
     "dom-serializer": {
@@ -8601,6 +8808,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "make-dir": {
       "version": "3.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@sentry/webpack-plugin": "^1.17.2",
+    "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/enzyme": "^3.10.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",
@@ -50,6 +51,7 @@
     "@types/react-leaflet": "^2.8.2",
     "@types/react-router-dom": "^5.3.2",
     "@types/react-test-renderer": "^17.0.1",
+    "@testing-library/user-event": "^13.5.0",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "enzyme": "^3.11.0",

--- a/assets/src/components/closeButton.tsx
+++ b/assets/src/components/closeButton.tsx
@@ -6,7 +6,13 @@ interface Props {
 }
 
 const CloseButton = ({ onClick }: Props) => (
-  <button className="m-close-button" onClick={onClick}>
+  <button
+    className="m-close-button"
+    onClick={(e) => {
+      e.stopPropagation()
+      onClick()
+    }}
+  >
     {closeIcon()}
   </button>
 )

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -160,10 +160,16 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
 
       <PickerContainer>
         <>
-          <button onClick={() => setCurrentDrawerContent("route_picker")}>
+          <button
+            id="m-ladder-page__routes_picker_button"
+            onClick={() => setCurrentDrawerContent("route_picker")}
+          >
             Routes
           </button>
-          <button onClick={() => setCurrentDrawerContent("presets")}>
+          <button
+            id="m-ladder-page__presets_picker_button"
+            onClick={() => setCurrentDrawerContent("presets")}
+          >
             Presets
           </button>
           {currentDrawerContent === "route_picker" ? (

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -24,6 +24,7 @@ import {
   toggleLadderCrowdingInTab,
   flipLadder,
   toggleLadderCrowding,
+  closeRouteTab,
 } from "../state"
 import CloseButton from "./closeButton"
 import { saveIcon, plusThinIcon } from "../helpers/icon"
@@ -47,9 +48,11 @@ export const findSelectedVehicleOrGhost = (
 const LadderTab = ({
   tab,
   selectTab,
+  closeTab,
 }: {
   tab: RouteTab
   selectTab: () => void
+  closeTab: () => void
 }): ReactElement<HTMLDivElement> => {
   const title = tab.presetName || "Untitled"
   return (
@@ -63,12 +66,7 @@ const LadderTab = ({
       <div className="m-ladder-page__tab-contents">
         <div className="m-ladder-page__tab-title">{title}</div>
         {tab.isCurrentTab ? saveIcon("m-ladder-page__tab-save-icon") : null}
-        <CloseButton
-          onClick={
-            // tslint:disable-next-line: no-empty
-            () => {}
-          }
-        />
+        <CloseButton onClick={() => closeTab()} />
       </div>
     </div>
   )
@@ -187,6 +185,7 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
             <LadderTab
               tab={routeTab}
               selectTab={() => dispatch(selectRouteTab(routeTab.uuid))}
+              closeTab={() => dispatch(closeRouteTab(routeTab.uuid))}
               key={routeTab.uuid}
             />
           ))}

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -1,12 +1,14 @@
-import React, { ReactElement, useContext } from "react"
+import React, { ReactElement, useContext, useState } from "react"
 import RoutesContext from "../contexts/routesContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useTimepoints from "../hooks/useTimepoints"
 import { RouteTab, currentRouteTab } from "../models/routeTab"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
+import PickerContainer from "./pickerContainer"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
 import { ByRouteId, Route, RouteId, TimepointsByRouteId } from "../schedule.d"
 import { Notifications } from "./notifications"
+import Presets from "./presets"
 import RightPanel from "./rightPanel"
 import RouteLadders from "./routeLadders"
 import RoutePicker from "./routePicker"
@@ -25,6 +27,8 @@ import {
 } from "../state"
 import CloseButton from "./closeButton"
 import { saveIcon, plusThinIcon } from "../helpers/icon"
+
+type DrawerContent = "route_picker" | "presets"
 
 export const findRouteById = (
   routes: Route[] | null,
@@ -109,11 +113,13 @@ const LadderPageWithoutTabs = (): ReactElement<HTMLDivElement> => {
   return (
     <div className="m-ladder-page">
       <Notifications />
-      <RoutePicker
-        selectedRouteIds={selectedRouteIds}
-        selectRoute={(routeId) => dispatch(selectRoute(routeId))}
-        deselectRoute={(routeId) => dispatch(deselectRoute(routeId))}
-      />
+      <PickerContainer>
+        <RoutePicker
+          selectedRouteIds={selectedRouteIds}
+          selectRoute={(routeId) => dispatch(selectRoute(routeId))}
+          deselectRoute={(routeId) => dispatch(deselectRoute(routeId))}
+        />
+      </PickerContainer>
 
       <>
         <RouteLadders
@@ -143,6 +149,9 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
   const timepointsByRouteId: TimepointsByRouteId =
     useTimepoints(selectedRouteIds)
 
+  const [currentDrawerContent, setCurrentDrawerContent] =
+    useState<DrawerContent>("route_picker")
+
   const selectedRoutes: Route[] = selectedRouteIds
     .map((routeId) => findRouteById(routes, routeId))
     .filter((route) => route) as Route[]
@@ -150,12 +159,26 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
   return (
     <div className="m-ladder-page">
       <Notifications />
-      <RoutePicker
-        selectedRouteIds={selectedRouteIds}
-        selectRoute={(routeId) => dispatch(selectRouteInTab(routeId))}
-        deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
-      />
 
+      <PickerContainer>
+        <>
+          <button onClick={() => setCurrentDrawerContent("route_picker")}>
+            Routes
+          </button>
+          <button onClick={() => setCurrentDrawerContent("presets")}>
+            Presets
+          </button>
+          {currentDrawerContent === "route_picker" ? (
+            <RoutePicker
+              selectedRouteIds={selectedRouteIds}
+              selectRoute={(routeId) => dispatch(selectRouteInTab(routeId))}
+              deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
+            />
+          ) : (
+            <Presets />
+          )}
+        </>
+      </PickerContainer>
       <div className="m-ladder-page__route-tab-bar">
         {routeTabs
           .filter((routeTab) => routeTab.ordering !== undefined)

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext, useState } from "react"
 import RoutesContext from "../contexts/routesContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useTimepoints from "../hooks/useTimepoints"
-import { RouteTab, currentRouteTab, isNotPreset } from "../models/routeTab"
+import { RouteTab, currentRouteTab, isOpenTab } from "../models/routeTab"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
 import PickerContainer from "./pickerContainer"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
@@ -181,7 +181,7 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
       </PickerContainer>
       <div className="m-ladder-page__route-tab-bar">
         {routeTabs
-          .filter(isNotPreset)
+          .filter(isOpenTab)
           .sort((a, b) => (a.ordering || 0) - (b.ordering || 0))
           .map((routeTab) => (
             <LadderTab

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext, useState } from "react"
 import RoutesContext from "../contexts/routesContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useTimepoints from "../hooks/useTimepoints"
-import { RouteTab, currentRouteTab } from "../models/routeTab"
+import { RouteTab, currentRouteTab, isNotPreset } from "../models/routeTab"
 import { allVehiclesAndGhosts } from "../models/vehiclesByRouteId"
 import PickerContainer from "./pickerContainer"
 import { VehicleId, VehicleOrGhost } from "../realtime.d"
@@ -181,7 +181,7 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
       </PickerContainer>
       <div className="m-ladder-page__route-tab-bar">
         {routeTabs
-          .filter((routeTab) => routeTab.ordering !== undefined)
+          .filter(isNotPreset)
           .sort((a, b) => (a.ordering || 0) - (b.ordering || 0))
           .map((routeTab) => (
             <LadderTab

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -8,7 +8,7 @@ const Presets = () => {
   const presets = routeTabs.filter(isPreset)
 
   return (
-    <div>
+    <div className="m-presets-panel">
       <button
         onClick={() =>
           dispatch(

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -10,7 +10,14 @@ const Presets = () => {
   return (
     <div>
       <button
-        onClick={() => dispatch(createPreset(currentRouteTab(routeTabs)))}
+        onClick={() =>
+          dispatch(
+            createPreset(
+              currentRouteTab(routeTabs).uuid,
+              `Preset ${Math.floor(Math.random() * 10000)}`
+            )
+          )
+        }
       >
         Save as preset
       </button>
@@ -20,7 +27,7 @@ const Presets = () => {
           {presets.map((preset) => (
             <button
               key={preset.uuid}
-              onClick={() => dispatch(instantiatePreset(preset))}
+              onClick={() => dispatch(instantiatePreset(preset.uuid))}
             >
               {preset.presetName}
             </button>

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+
+const Presets = () => (
+  <div>
+    <button>Save as preset</button>
+  </div>
+)
+
+export default Presets

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -1,9 +1,34 @@
-import React from "react"
+import React, { useContext } from "react"
+import { createPreset, instantiatePreset } from "../state"
+import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import { currentRouteTab, isPreset } from "../models/routeTab"
 
-const Presets = () => (
-  <div>
-    <button>Save as preset</button>
-  </div>
-)
+const Presets = () => {
+  const [{ routeTabs }, dispatch] = useContext(StateDispatchContext)
+  const presets = routeTabs.filter(isPreset)
+
+  return (
+    <div>
+      <button
+        onClick={() => dispatch(createPreset(currentRouteTab(routeTabs)))}
+      >
+        Save as preset
+      </button>
+      <div>
+        Existing presets:
+        <ul>
+          {presets.map((preset) => (
+            <button
+              key={preset.uuid}
+              onClick={() => dispatch(instantiatePreset(preset))}
+            >
+              {preset.presetName}
+            </button>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
 
 export default Presets

--- a/assets/src/components/routePicker.tsx
+++ b/assets/src/components/routePicker.tsx
@@ -9,7 +9,6 @@ import {
 import { Route, RouteId } from "../schedule.d"
 import { routeNameOrId } from "../util/route"
 import Loading from "./loading"
-import PickerContainer from "./pickerContainer"
 import {
   GarageFilterData,
   useGarageFilter,
@@ -39,32 +38,30 @@ const RoutePicker = ({
   )
 
   return (
-    <PickerContainer>
-      <div className="m-route-picker">
-        <SelectedRoutesList
-          routes={routes}
+    <div className="m-route-picker">
+      <SelectedRoutesList
+        routes={routes}
+        selectedRouteIds={selectedRouteIds}
+        deselectRoute={deselectRoute}
+      />
+
+      <RouteFilter {...routeFilterData} />
+
+      {featureIsEnabled("presets_workspaces") ? (
+        <GarageFilter {...garageFilterData} />
+      ) : null}
+
+      {routes === null ? (
+        <Loading />
+      ) : (
+        <RoutesList
+          routes={filteredRoutes}
           selectedRouteIds={selectedRouteIds}
+          selectRoute={selectRoute}
           deselectRoute={deselectRoute}
         />
-
-        <RouteFilter {...routeFilterData} />
-
-        {featureIsEnabled("presets_workspaces") ? (
-          <GarageFilter {...garageFilterData} />
-        ) : null}
-
-        {routes === null ? (
-          <Loading />
-        ) : (
-          <RoutesList
-            routes={filteredRoutes}
-            selectedRouteIds={selectedRouteIds}
-            selectRoute={selectRoute}
-            deselectRoute={deselectRoute}
-          />
-        )}
-      </div>
-    </PickerContainer>
+      )}
+    </div>
   )
 }
 

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -10,7 +10,7 @@ export interface RouteTab {
   selectedRouteIds: RouteId[]
   ladderDirections: LadderDirections
   ladderCrowdingToggles: LadderCrowdingToggles
-  ordering: number
+  ordering?: number
 }
 
 export interface RouteTabData {
@@ -32,6 +32,24 @@ export const newRouteTab = (ordering: number): RouteTab => ({
   ordering,
 })
 
+export const newPreset = (sourceTab: RouteTab): RouteTab => ({
+  ...sourceTab,
+  isCurrentTab: false,
+  presetName: `Preset ${Math.floor(Math.random() * 10000)}`,
+  uuid: uuidv4(),
+  ordering: undefined,
+})
+
+export const tabFromPreset = (
+  preset: RouteTab,
+  ordering: number
+): RouteTab => ({
+  ...preset,
+  isCurrentTab: true,
+  uuid: uuidv4(),
+  ordering,
+})
+
 export const currentRouteTab = (routeTabs: RouteTab[]): RouteTab =>
   routeTabs.find((routeTab) => routeTab.isCurrentTab) || newRouteTab(0)
 
@@ -40,11 +58,18 @@ export const parseRouteTabData = (
 ): RouteTab[] => {
   return routeTabsData.map((routeTabData) => ({
     uuid: routeTabData.uuid,
-    ordering: routeTabData.ordering,
-    presetName: routeTabData.preset_name,
+    ordering: nullToUndefined(routeTabData.ordering),
+    presetName: nullToUndefined(routeTabData.preset_name),
     isCurrentTab: routeTabData.is_current_tab || false,
     selectedRouteIds: routeTabData.selected_route_ids,
     ladderDirections: routeTabData.ladder_directions,
     ladderCrowdingToggles: routeTabData.ladder_crowding_toggles,
   }))
 }
+
+export const isPreset = (routeTab: RouteTab): boolean =>
+  routeTab.ordering === undefined
+export const isNotPreset = (routeTab: RouteTab): boolean => !isPreset(routeTab)
+
+const nullToUndefined = <T>(data: T | null): T | undefined =>
+  data === null ? undefined : data

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -60,7 +60,7 @@ export const isPreset = (routeTab: RouteTab): boolean =>
 export const isOpenTab = (routeTab: RouteTab): boolean =>
   routeTab.ordering !== undefined
 
-export const instantiatePresetFromTabs = (
+export const instantiatePresetByUUID = (
   routeTabs: RouteTab[],
   uuid: string
 ): RouteTab[] => {
@@ -99,6 +99,54 @@ export const instantiatePresetFromTabs = (
       }
     })
   }
+}
+
+export const closeTabByUUID = (
+  routeTabs: RouteTab[],
+  uuid: string
+): RouteTab[] => {
+  const tabToClose = routeTabs.find((routeTab) => routeTab.uuid === uuid)
+
+  if (tabToClose === undefined) {
+    throw new Error(`No preset found for UUID ${uuid}`)
+  }
+
+  const newRouteTabs =
+    tabToClose.presetName === undefined
+      ? routeTabs.filter((routeTab) => routeTab.uuid !== uuid)
+      : routeTabs.map((routeTab) => {
+          if (routeTab.uuid === uuid) {
+            return { ...routeTab, ordering: undefined, isCurrentTab: false }
+          } else {
+            return routeTab
+          }
+        })
+
+  if (tabToClose.isCurrentTab) {
+    const nextTabToRight = newRouteTabs
+      .filter(
+        (routeTab) =>
+          routeTab.ordering && routeTab.ordering > (tabToClose.ordering || 0)
+      )
+      .sort((a, b) => a.ordering || 0 - (b.ordering || 0))[0]
+
+    if (nextTabToRight) {
+      nextTabToRight.isCurrentTab = true
+    } else {
+      const nextTabToLeft = newRouteTabs
+        .filter(
+          (routeTab) =>
+            routeTab.ordering && routeTab.ordering < (tabToClose.ordering || 0)
+        )
+        .sort((a, b) => b.ordering || 0 - (a.ordering || 0))[0]
+
+      if (nextTabToLeft) {
+        nextTabToLeft.isCurrentTab = true
+      }
+    }
+  }
+
+  return newRouteTabs
 }
 
 const nullToUndefined = <T>(data: T | null): T | undefined =>

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -111,16 +111,15 @@ export const closeTabByUUID = (
     throw new Error(`No preset found for UUID ${uuid}`)
   }
 
-  const newRouteTabs =
-    tabToClose.presetName === undefined
-      ? routeTabs.filter((routeTab) => routeTab.uuid !== uuid)
-      : routeTabs.map((routeTab) => {
-          if (routeTab.uuid === uuid) {
-            return { ...routeTab, ordering: undefined, isCurrentTab: false }
-          } else {
-            return routeTab
-          }
-        })
+  const newRouteTabs = !isPreset(tabToClose)
+    ? routeTabs.filter((routeTab) => routeTab.uuid !== uuid)
+    : routeTabs.map((routeTab) => {
+        if (routeTab.uuid === uuid) {
+          return { ...routeTab, ordering: undefined, isCurrentTab: false }
+        } else {
+          return routeTab
+        }
+      })
 
   if (tabToClose.isCurrentTab) {
     const nextTabToRight = newRouteTabs

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -60,5 +60,46 @@ export const isPreset = (routeTab: RouteTab): boolean =>
 export const isOpenTab = (routeTab: RouteTab): boolean =>
   routeTab.ordering !== undefined
 
+export const instantiatePresetFromTabs = (
+  routeTabs: RouteTab[],
+  uuid: string
+): RouteTab[] => {
+  const preset = routeTabs.find((routeTab) => routeTab.uuid === uuid)
+
+  if (preset === undefined) {
+    throw new Error(`No preset found for UUID ${uuid}`)
+  } else if (preset.ordering !== undefined) {
+    return routeTabs.map((routeTab) => {
+      if (routeTab.uuid === uuid) {
+        return { ...routeTab, isCurrentTab: true }
+      } else {
+        return { ...routeTab, isCurrentTab: false }
+      }
+    })
+  } else if (currentRouteTab(routeTabs).selectedRouteIds.length === 0) {
+    return routeTabs
+      .filter((routeTab) => routeTab.uuid !== uuid)
+      .map((routeTab) => {
+        if (routeTab.isCurrentTab) {
+          return { ...preset, ordering: routeTab.ordering, isCurrentTab: true }
+        } else {
+          return routeTab
+        }
+      })
+  } else {
+    return routeTabs.map((routeTab) => {
+      if (routeTab.uuid === uuid) {
+        return {
+          ...routeTab,
+          isCurrentTab: true,
+          ordering: highestExistingOrdering(routeTabs) + 1,
+        }
+      } else {
+        return { ...routeTab, isCurrentTab: false }
+      }
+    })
+  }
+}
+
 const nullToUndefined = <T>(data: T | null): T | undefined =>
   data === null ? undefined : data

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -32,23 +32,11 @@ export const newRouteTab = (ordering: number): RouteTab => ({
   ordering,
 })
 
-export const newPreset = (sourceTab: RouteTab): RouteTab => ({
-  ...sourceTab,
-  isCurrentTab: false,
-  presetName: `Preset ${Math.floor(Math.random() * 10000)}`,
-  uuid: uuidv4(),
-  ordering: undefined,
-})
-
-export const tabFromPreset = (
-  preset: RouteTab,
-  ordering: number
-): RouteTab => ({
-  ...preset,
-  isCurrentTab: true,
-  uuid: uuidv4(),
-  ordering,
-})
+export const highestExistingOrdering = (routeTabs: RouteTab[]): number =>
+  Math.max(
+    -1,
+    ...routeTabs.map((existingRouteTab) => existingRouteTab.ordering || 0)
+  )
 
 export const currentRouteTab = (routeTabs: RouteTab[]): RouteTab =>
   routeTabs.find((routeTab) => routeTab.isCurrentTab) || newRouteTab(0)
@@ -68,8 +56,9 @@ export const parseRouteTabData = (
 }
 
 export const isPreset = (routeTab: RouteTab): boolean =>
-  routeTab.ordering === undefined
-export const isNotPreset = (routeTab: RouteTab): boolean => !isPreset(routeTab)
+  routeTab.presetName !== undefined
+export const isOpenTab = (routeTab: RouteTab): boolean =>
+  routeTab.ordering !== undefined
 
 const nullToUndefined = <T>(data: T | null): T | undefined =>
   data === null ? undefined : data

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -27,7 +27,8 @@ import {
   RouteTab,
   newRouteTab,
   highestExistingOrdering,
-  instantiatePresetFromTabs,
+  instantiatePresetByUUID,
+  closeTabByUUID,
 } from "./models/routeTab"
 
 export enum OpenView {
@@ -126,6 +127,16 @@ interface CreateRouteTabAction {
 
 export const createRouteTab = (): CreateRouteTabAction => ({
   type: "CREATE_ROUTE_TAB",
+})
+
+interface CloseRouteTabAction {
+  type: "CLOSE_ROUTE_TAB"
+  payload: { uuid: string }
+}
+
+export const closeRouteTab = (uuid: string): CloseRouteTabAction => ({
+  type: "CLOSE_ROUTE_TAB",
+  payload: { uuid },
 })
 
 interface SelectRouteTabAction {
@@ -473,6 +484,7 @@ export type Action =
   | FlipLadderAction
   | ToggleLadderCrowdingAction
   | CreateRouteTabAction
+  | CloseRouteTabAction
   | SelectRouteTabAction
   | SelectRouteInTabAction
   | DeselectRouteInTabAction
@@ -584,6 +596,11 @@ const routeTabsReducer = (
         ],
         routeTabsUpdated: true,
       }
+    case "CLOSE_ROUTE_TAB":
+      return {
+        newRouteTabs: closeTabByUUID(routeTabs, action.payload.uuid),
+        routeTabsUpdated: true,
+      }
     case "CREATE_PRESET":
       return {
         newRouteTabs: routeTabs.map((existingRouteTab) => {
@@ -600,7 +617,7 @@ const routeTabsReducer = (
       }
     case "INSTANTIATE_PRESET":
       return {
-        newRouteTabs: instantiatePresetFromTabs(routeTabs, action.payload.uuid),
+        newRouteTabs: instantiatePresetByUUID(routeTabs, action.payload.uuid),
         routeTabsUpdated: true,
       }
     case "SELECT_ROUTE_TAB":

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -23,7 +23,12 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "./userSettings"
-import { RouteTab, newRouteTab } from "./models/routeTab"
+import {
+  RouteTab,
+  newRouteTab,
+  newPreset,
+  tabFromPreset,
+} from "./models/routeTab"
 
 export enum OpenView {
   None = 1,
@@ -439,6 +444,28 @@ export const selectVehicleFromNotification = (
   payload: { vehicle },
 })
 
+interface CreatePresetAction {
+  type: "CREATE_PRESET"
+  payload: { sourceTab: RouteTab }
+}
+
+export const createPreset = (sourceTab: RouteTab): CreatePresetAction => ({
+  type: "CREATE_PRESET",
+  payload: { sourceTab },
+})
+
+interface InstantiatePresetAction {
+  type: "INSTANTIATE_PRESET"
+  payload: { preset: RouteTab }
+}
+
+export const instantiatePreset = (
+  preset: RouteTab
+): InstantiatePresetAction => ({
+  type: "INSTANTIATE_PRESET",
+  payload: { preset },
+})
+
 export type Action =
   | SelectRouteAction
   | DeselectRouteAction
@@ -473,6 +500,8 @@ export type Action =
   | ToggleSwingsViewAction
   | ToggleLateViewAction
   | SelectVehicleFromNotificationAction
+  | CreatePresetAction
+  | InstantiatePresetAction
 
 export type Dispatch = ReactDispatch<Action>
 
@@ -544,7 +573,7 @@ const routeTabsReducer = (
     case "CREATE_ROUTE_TAB":
       const highestExistingOrdering = Math.max(
         -1,
-        ...routeTabs.map((existingRouteTab) => existingRouteTab.ordering)
+        ...routeTabs.map((existingRouteTab) => existingRouteTab.ordering || 0)
       )
 
       return {
@@ -556,6 +585,21 @@ const routeTabsReducer = (
             }
           }),
           newRouteTab(highestExistingOrdering + 1),
+        ],
+        routeTabsUpdated: true,
+      }
+    case "CREATE_PRESET":
+      return {
+        newRouteTabs: [...routeTabs, newPreset(action.payload.sourceTab)],
+        routeTabsUpdated: true,
+      }
+    case "INSTANTIATE_PRESET":
+      return {
+        newRouteTabs: [
+          ...routeTabs.map((existingRouteTab) => {
+            return { ...existingRouteTab, isCurrentTab: false }
+          }),
+          tabFromPreset(action.payload.preset, routeTabs.length),
         ],
         routeTabsUpdated: true,
       }

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -27,6 +27,7 @@ import {
   RouteTab,
   newRouteTab,
   highestExistingOrdering,
+  instantiatePresetFromTabs,
 } from "./models/routeTab"
 
 export enum OpenView {
@@ -599,22 +600,7 @@ const routeTabsReducer = (
       }
     case "INSTANTIATE_PRESET":
       return {
-        newRouteTabs: [
-          ...routeTabs.map((existingRouteTab) => {
-            if (existingRouteTab.uuid === action.payload.uuid) {
-              return {
-                ...existingRouteTab,
-                isCurrentTab: true,
-                ordering:
-                  existingRouteTab.ordering !== undefined
-                    ? existingRouteTab.ordering
-                    : highestExistingOrdering(routeTabs) + 1,
-              }
-            } else {
-              return { ...existingRouteTab, isCurrentTab: false }
-            }
-          }),
-        ],
+        newRouteTabs: instantiatePresetFromTabs(routeTabs, action.payload.uuid),
         routeTabsUpdated: true,
       }
     case "SELECT_ROUTE_TAB":

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -99,11 +99,13 @@ exports[`LadderPage renders with route tabs 1`] = `
       </button>
     </div>
     <button
+      id="m-ladder-page__routes_picker_button"
       onClick={[Function]}
     >
       Routes
     </button>
     <button
+      id="m-ladder-page__presets_picker_button"
       onClick={[Function]}
     >
       Presets

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -98,6 +98,16 @@ exports[`LadderPage renders with route tabs 1`] = `
         />
       </button>
     </div>
+    <button
+      onClick={[Function]}
+    >
+      Routes
+    </button>
+    <button
+      onClick={[Function]}
+    >
+      Presets
+    </button>
     <div
       className="m-route-picker"
     >

--- a/assets/tests/components/__snapshots__/presets.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/presets.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Presets renders current presets 1`] = `
+<div
+  className="m-presets-panel"
+>
+  <button
+    onClick={[Function]}
+  >
+    Save as preset
+  </button>
+  <div>
+    Existing presets:
+    <ul>
+      <button
+        onClick={[Function]}
+      >
+        My Preset
+      </button>
+    </ul>
+  </div>
+</div>
+`;

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -2,190 +2,148 @@
 
 exports[`RoutePicker renders a list of routes 1`] = `
 <div
-  className="m-picker-container m-picker-container--narrow visible"
+  className="m-route-picker"
 >
-  <div
-    className="c-drawer-tab"
+  <ul
+    className="m-route-picker__selected-routes"
   >
-    <button
-      className="c-drawer-tab__tab-button"
-      onClick={[Function]}
-    >
-      <span
-        className=""
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "SVG",
-          }
-        }
-      />
-    </button>
-  </div>
-  <div
-    className="m-route-picker"
-  >
-    <ul
-      className="m-route-picker__selected-routes"
-    >
-      <li>
-        <button
-          className="m-route-picker__selected-routes-button"
-          onClick={[Function]}
-        >
-          28
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__selected-routes-button"
-          onClick={[Function]}
-        >
-          39
-        </button>
-      </li>
-    </ul>
-    <div
-      className="m-route-filter"
-    >
-      <div
-        className="m-route-filter__text"
+    <li>
+      <button
+        className="m-route-picker__selected-routes-button"
+        onClick={[Function]}
       >
-        <input
-          className="m-route-filter__input"
-          onChange={[Function]}
-          onKeyDown={[Function]}
-          placeholder="Search routes"
-          type="text"
-          value=""
-        />
-        <button
-          className="m-route-filter__clear"
-          onClick={[Function]}
-        >
-          <span
-            className=""
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </button>
-      </div>
-    </div>
-    <ul
-      className="m-route-picker__route-list"
+        28
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__selected-routes-button"
+        onClick={[Function]}
+      >
+        39
+      </button>
+    </li>
+  </ul>
+  <div
+    className="m-route-filter"
+  >
+    <div
+      className="m-route-filter__text"
     >
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--selected"
-          onClick={[Function]}
-        >
-          28
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--selected"
-          onClick={[Function]}
-        >
-          39
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
-          onClick={[Function]}
-        >
-          71
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
-          onClick={[Function]}
-        >
-          73
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
-          onClick={[Function]}
-        >
-          111
-        </button>
-      </li>
-      <li>
-        <button
-          className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
-          onClick={[Function]}
-        >
-          SL1
-        </button>
-      </li>
-    </ul>
+      <input
+        className="m-route-filter__input"
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Search routes"
+        type="text"
+        value=""
+      />
+      <button
+        className="m-route-filter__clear"
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
   </div>
+  <ul
+    className="m-route-picker__route-list"
+  >
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--selected"
+        onClick={[Function]}
+      >
+        28
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--selected"
+        onClick={[Function]}
+      >
+        39
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
+        onClick={[Function]}
+      >
+        71
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
+        onClick={[Function]}
+      >
+        73
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
+        onClick={[Function]}
+      >
+        111
+      </button>
+    </li>
+    <li>
+      <button
+        className="m-route-picker__route-list-button m-route-picker__route-list-button--unselected"
+        onClick={[Function]}
+      >
+        SL1
+      </button>
+    </li>
+  </ul>
 </div>
 `;
 
 exports[`RoutePicker renders a loading/empty state 1`] = `
 <div
-  className="m-picker-container m-picker-container--narrow visible"
+  className="m-route-picker"
 >
+  <ul
+    className="m-route-picker__selected-routes"
+  />
   <div
-    className="c-drawer-tab"
+    className="m-route-filter"
   >
-    <button
-      className="c-drawer-tab__tab-button"
-      onClick={[Function]}
-    >
-      <span
-        className=""
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "SVG",
-          }
-        }
-      />
-    </button>
-  </div>
-  <div
-    className="m-route-picker"
-  >
-    <ul
-      className="m-route-picker__selected-routes"
-    />
     <div
-      className="m-route-filter"
+      className="m-route-filter__text"
     >
-      <div
-        className="m-route-filter__text"
+      <input
+        className="m-route-filter__input"
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Search routes"
+        type="text"
+        value=""
+      />
+      <button
+        className="m-route-filter__clear"
+        onClick={[Function]}
       >
-        <input
-          className="m-route-filter__input"
-          onChange={[Function]}
-          onKeyDown={[Function]}
-          placeholder="Search routes"
-          type="text"
-          value=""
-        />
-        <button
-          className="m-route-filter__clear"
-          onClick={[Function]}
-        >
-          <span
-            className=""
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
             }
-          />
-        </button>
-      </div>
+          }
+        />
+      </button>
     </div>
-    loading...
   </div>
+  loading...
 </div>
 `;

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -159,6 +159,36 @@ describe("LadderPage", () => {
     expect(mockDispatch).toHaveBeenCalledWith(createRouteTab())
   })
 
+  test("can toggle to presets view in picker and back", () => {
+    ;(featureIsEnabled as jest.Mock).mockImplementationOnce(() => true)
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          ordering: 0,
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+          presetName: "My Preset",
+        }),
+      ],
+    }
+    const wrapper = mount(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <RoutesProvider routes={routes}>
+          <LadderPage />
+        </RoutesProvider>
+      </StateDispatchProvider>
+    )
+
+    wrapper.find("#m-ladder-page__presets_picker_button").simulate("click")
+
+    expect(wrapper.find(".m-presets-panel").length).toBe(1)
+
+    wrapper.find("#m-ladder-page__routes_picker_button").simulate("click")
+
+    expect(wrapper.find(".m-presets-panel").length).toBe(0)
+  })
+
   test("renders with selectedRoutes in different order than routes data", () => {
     const mockState = { ...initialState, selectedRouteIds: ["28", "1"] }
     const tree = renderer

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -21,6 +21,7 @@ import {
   State,
   selectRouteTab,
   createRouteTab,
+  closeRouteTab,
 } from "../../src/state"
 import ghostFactory from "../factories/ghost"
 import routeFactory from "../factories/route"
@@ -131,6 +132,33 @@ describe("LadderPage", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       selectRouteTab(mockState.routeTabs[1].uuid)
+    )
+  })
+
+  test("can close a route tab", () => {
+    ;(featureIsEnabled as jest.Mock).mockImplementationOnce(() => true)
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          ordering: 0,
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+        }),
+      ],
+    }
+    const wrapper = mount(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <RoutesProvider routes={routes}>
+          <LadderPage />
+        </RoutesProvider>
+      </StateDispatchProvider>
+    )
+
+    wrapper.find(".m-ladder-page__tab-contents button").simulate("click")
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      closeRouteTab(mockState.routeTabs[0].uuid)
     )
   })
 

--- a/assets/tests/components/presets.test.tsx
+++ b/assets/tests/components/presets.test.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import renderer from "react-test-renderer"
+import { initialState, createPreset, instantiatePreset } from "../../src/state"
+import Presets from "../../src/components/presets"
+import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import routeTabFactory from "../factories/routeTab"
+
+describe("Presets", () => {
+  test("renders current presets", () => {
+    const mockDispatch = jest.fn()
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          ordering: 0,
+          presetName: "My Preset",
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+        }),
+        routeTabFactory.build({
+          ordering: undefined,
+          isCurrentTab: false,
+          selectedRouteIds: ["28"],
+        }),
+      ],
+    }
+    const tree = renderer
+      .create(
+        <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+          <Presets />
+        </StateDispatchProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("saves current tab as preset", () => {
+    jest.spyOn(Math, "random").mockImplementationOnce(() => {
+      return 0.01
+    })
+    const mockDispatch = jest.fn()
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          uuid: "uuid1",
+          ordering: 0,
+          presetName: undefined,
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+        }),
+      ],
+    }
+
+    const result = render(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <Presets />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Save as preset"))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      createPreset("uuid1", "Preset 100")
+    )
+  })
+
+  test("opens a preset", () => {
+    const mockDispatch = jest.fn()
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          uuid: "uuid1",
+          ordering: 0,
+          presetName: "My Preset",
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+        }),
+      ],
+    }
+
+    const result = render(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <Presets />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("My Preset"))
+
+    expect(mockDispatch).toHaveBeenCalledWith(instantiatePreset("uuid1"))
+  })
+})

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -2,8 +2,31 @@ import {
   currentRouteTab,
   instantiatePresetByUUID,
   closeTabByUUID,
+  highestExistingOrdering,
+  isPreset,
+  isOpenTab,
 } from "../../src/models/routeTab"
 import routeTabFactory from "../factories/routeTab"
+
+describe("highestExistingOrdering", () => {
+  test("returns highest ordering", () => {
+    const routeTab1 = routeTabFactory.build({ ordering: 0 })
+    const routeTab2 = routeTabFactory.build({ ordering: 1 })
+    const routeTab3 = routeTabFactory.build({ ordering: undefined })
+
+    expect(highestExistingOrdering([routeTab1, routeTab2, routeTab3])).toBe(1)
+  })
+
+  test("defaults to 0 when no tabs have ordering", () => {
+    const routeTab = routeTabFactory.build({ ordering: undefined })
+
+    expect(highestExistingOrdering([routeTab])).toBe(0)
+  })
+
+  test("defaults to -1 when no tabs are present", () => {
+    expect(highestExistingOrdering([])).toBe(-1)
+  })
+})
 
 describe("currentRouteTab", () => {
   test("finds route tab flagged as current if present", () => {
@@ -18,6 +41,46 @@ describe("currentRouteTab", () => {
     delete routeTab.uuid
 
     expect(currentRouteTab([])).toMatchObject(routeTab)
+  })
+})
+
+describe("isPreset", () => {
+  test("returns true for a saved preset", () => {
+    const routeTab = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: undefined,
+    })
+
+    expect(isPreset(routeTab)).toBeTruthy()
+  })
+
+  test("returns false for an open tab that is not a saved preset", () => {
+    const routeTab = routeTabFactory.build({
+      presetName: undefined,
+      ordering: 1,
+    })
+
+    expect(isPreset(routeTab)).toBeFalsy()
+  })
+})
+
+describe("isOpenTab", () => {
+  test("returns false for a saved preset that isn't open", () => {
+    const routeTab = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: undefined,
+    })
+
+    expect(isOpenTab(routeTab)).toBeFalsy()
+  })
+
+  test("returns true for an open tab that is not a saved preset", () => {
+    const routeTab = routeTabFactory.build({
+      presetName: undefined,
+      ordering: 1,
+    })
+
+    expect(isOpenTab(routeTab)).toBeTruthy()
   })
 })
 

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -468,6 +468,92 @@ describe("reducer", () => {
     expect(newState).toMatchObject(expectedState)
   })
 
+  test("closeRouteTab", () => {
+    const routeTab1 = routeTabFactory.build({
+      ordering: 0,
+      presetName: undefined,
+      isCurrentTab: true,
+    })
+    const routeTab2 = routeTabFactory.build({
+      uuid: "uuid2",
+      ordering: 1,
+      presetName: undefined,
+      isCurrentTab: false,
+    })
+
+    const newState = reducer(
+      { ...initialState, routeTabs: [routeTab1, routeTab2] },
+      State.closeRouteTab("uuid2")
+    )
+
+    const expectedNewTabs = [routeTab1]
+    const expectedState: State.State = {
+      ...initialState,
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
+    }
+
+    expect(newState).toEqual(expectedState)
+  })
+
+  test("createPreset", () => {
+    const routeTab = routeTabFactory.build({
+      uuid: "uuid",
+      ordering: 0,
+      presetName: undefined,
+      isCurrentTab: true,
+    })
+
+    const newState = reducer(
+      { ...initialState, routeTabs: [routeTab] },
+      State.createPreset("uuid", "My Preset")
+    )
+
+    const expectedNewTabs = [{ ...routeTab, presetName: "My Preset" }]
+    const expectedState: State.State = {
+      ...initialState,
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
+    }
+
+    expect(newState).toEqual(expectedState)
+  })
+
+  test("instantiatePreset", () => {
+    const routeTab1 = routeTabFactory.build({
+      uuid: "uuid1",
+      ordering: 0,
+      presetName: undefined,
+      isCurrentTab: true,
+      selectedRouteIds: ["1"],
+    })
+
+    const routeTab2 = routeTabFactory.build({
+      uuid: "uuid2",
+      ordering: undefined,
+      presetName: "My Preset",
+      isCurrentTab: false,
+      selectedRouteIds: ["39"],
+    })
+
+    const newState = reducer(
+      { ...initialState, routeTabs: [routeTab1, routeTab2] },
+      State.instantiatePreset("uuid2")
+    )
+
+    const expectedNewTabs = [
+      { ...routeTab1, isCurrentTab: false },
+      { ...routeTab2, ordering: 1, isCurrentTab: true },
+    ]
+    const expectedState: State.State = {
+      ...initialState,
+      routeTabs: expectedNewTabs,
+      routeTabsToPush: expectedNewTabs,
+    }
+
+    expect(newState).toEqual(expectedState)
+  })
+
   test("selectRouteTab", () => {
     const routeTab1 = routeTabFactory.build()
     const routeTab2 = routeTabFactory.build({ isCurrentTab: true })

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -49,14 +49,6 @@ defmodule Skate.Settings.RouteTab do
     |> Enum.map(&db_route_tab_to_route_tab(&1))
   end
 
-  @spec create_for_user!(String.t(), t()) :: t()
-  def create_for_user!(username, route_tab) do
-    User.get_or_create(username)
-    |> Ecto.build_assoc(:route_tabs, Map.delete(route_tab, :id))
-    |> DbRouteTab.changeset()
-    |> Repo.insert!()
-  end
-
   @spec db_route_tab_to_route_tab(%DbRouteTab{}) :: t()
   defp db_route_tab_to_route_tab(db_route_tab) do
     %__MODULE__{

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -49,6 +49,14 @@ defmodule Skate.Settings.RouteTab do
     |> Enum.map(&db_route_tab_to_route_tab(&1))
   end
 
+  @spec create_for_user!(String.t(), t()) :: t()
+  def create_for_user!(username, route_tab) do
+    User.get_or_create(username)
+    |> Ecto.build_assoc(:route_tabs, Map.delete(route_tab, :id))
+    |> DbRouteTab.changeset()
+    |> Repo.insert!()
+  end
+
   @spec db_route_tab_to_route_tab(%DbRouteTab{}) :: t()
   defp db_route_tab_to_route_tab(db_route_tab) do
     %__MODULE__{

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -13,16 +13,19 @@ defmodule SkateWeb.RouteTabsController do
 
   @spec format_tabs_for_update([map()]) :: [RouteTab.t()]
   defp format_tabs_for_update(route_tabs) do
-    Enum.map(route_tabs, fn route_tab ->
-      %RouteTab{
-        uuid: Map.get(route_tab, "uuid"),
-        preset_name: Map.get(route_tab, "presetName"),
-        selected_route_ids: Map.get(route_tab, "selectedRouteIds", []),
-        ladder_directions: Map.get(route_tab, "ladderDirections", %{}),
-        ladder_crowding_toggles: Map.get(route_tab, "ladderCrowdingToggles", %{}),
-        ordering: Map.get(route_tab, "ordering"),
-        is_current_tab: Map.get(route_tab, "isCurrentTab")
-      }
-    end)
+    Enum.map(route_tabs, &format_tab/1)
+  end
+
+  @spec format_tab(map()) :: RouteTab.t()
+  defp format_tab(route_tab) do
+    %RouteTab{
+      uuid: Map.get(route_tab, "uuid"),
+      preset_name: Map.get(route_tab, "presetName"),
+      selected_route_ids: Map.get(route_tab, "selectedRouteIds", []),
+      ladder_directions: Map.get(route_tab, "ladderDirections", %{}),
+      ladder_crowding_toggles: Map.get(route_tab, "ladderCrowdingToggles", %{}),
+      ordering: Map.get(route_tab, "ordering"),
+      is_current_tab: Map.get(route_tab, "isCurrentTab")
+    }
   end
 end


### PR DESCRIPTION
Asana tickets: [⚙️Presets panel - list the existing presets + save / open them ](https://app.asana.com/0/1200180014510248/1201367915520953/f) and [⚙️  Implement close tab interaction ](https://app.asana.com/0/1200180014510248/1201448223729774/f)

To the reviewer: there's more documentation in Notion about this feature, just let me know if you'd like links for more background. This functionality is still behind a feature flag so not yet going out to users. Styling and some other parts of the tabs / presets interactions will be in forthcoming PRs.