### PR TITLE
use ADRs, document switch to :persistent_term

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+documentation/adr

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 elixir v1.10.2-otp-22
 erlang 22.3.2
 nodejs 14.18.2
+adr-tools 3.0.0

--- a/documentation/adr/0001-record-architecture-decisions.md
+++ b/documentation/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2022-01-26
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/documentation/adr/0002-use-persistent-term-to-store-schedule-state.md
+++ b/documentation/adr/0002-use-persistent-term-to-store-schedule-state.md
@@ -1,0 +1,37 @@
+# 2. Use :persistent_term to store schedule state
+
+Date: 2022-01-26
+
+## Status
+
+Accepted
+
+## Context
+
+Asana: https://app.asana.com/0/116562505129567/1201514090100824
+
+The `Schedule.Fetcher` GenServer makes a call to the `Schedule GenServer` (which a
+lot of Skate calls) when it has new state to provide. Usually this works
+smoothly, but sometimes it causes us to log `GenServer Schedule.Fetcher
+terminating` followed by a longer message `** (stop) exited in:
+GenServer.call(Schedule, [...state])`. This is then followed by some logging on
+the `Schedule` side, with a bunch of warnings like `module=Elixir.Schedule
+function=trip error=timeout` in the couple of minutes after the other error.
+
+It is not purely a deadlock, but it causes a degradation of performance.
+
+## Decision
+
+Instead of storing the state in the `Schedule` GenServer, we will use the
+[:persistent_term](https://www.erlang.org/doc/man/persistent_term.html) module
+to store the data without additional copying. See
+https://github.com/mbta/skate/pull/1379 for the original PR.
+
+We investigated using Mnesia in https://github.com/mbta/skate/pull/1368, but
+this had additional performance issues as well as being a much larger refactor.
+
+## Consequences
+
+- Updates to the state in `:persistent_term` can take several seconds
+- Additional memory needs to be given to the literal allocator, which
+  `:persistent_term` uses to store data


### PR DESCRIPTION
Offering this as a proposal to document internal engineering choices, for our use as well as to help onboard future engineers/PMs.