### PR TITLE
fix: don't crash if we can't access instance id

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,5 +1,5 @@
 #!/bin/sh
-INSTANCE_ID=$(curl --max-time 5 -s http://169.254.169.254/latest/meta-data/instance-id)
+INSTANCE_ID=$(curl --max-time 5 -s http://169.254.169.254/latest/meta-data/instance-id || true)
 if [ -n "${INSTANCE_ID}" ]; then
     export RELEASE_NODE=skate-${INSTANCE_ID}
 fi


### PR DESCRIPTION
If `curl` fails, ignore it with `true` which will give an empty instance ID.