### PR TITLE
refactor: Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,11 @@
+name: Docker
+
+on: [push]
+
+jobs:
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,23 @@ ENV ELIXIR_VERSION="v1.10.2" \
   MIX_ENV=prod
 
 WORKDIR /root
-ADD . .
-
 # Install git so we can install dependencies from GitHub
 RUN apk add --no-cache --update git
 
-# Install Hex+Rebar+deps
+# Install Hex+Rebar
 RUN mix local.hex --force && \
-  mix local.rebar --force && \
-  mix do deps.get --only prod
+  mix local.rebar --force
+
+COPY mix.exs mix.exs
+COPY mix.lock mix.lock
+COPY config/config.exs config/
+COPY config/prod.exs config/
+
+RUN mix do deps.get --only $MIX_ENV && mix deps.compile
 
 FROM node:14-alpine3.13 as assets-builder
 
 WORKDIR /root
-ADD . .
 
 # Needed for uploading source maps during front-end build
 ARG SENTRY_ORG=$SENTRY_ORG
@@ -31,7 +34,13 @@ ARG AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 # Copy in elixir deps required to build node modules for phoenix
 COPY --from=elixir-builder /root/deps ./deps
 
+COPY assets/package.json assets/
+COPY assets/package-lock.json assets/
+
 RUN npm --prefix assets ci
+
+COPY assets/ assets/
+
 RUN npm --prefix assets run deploy
 
 FROM elixir-builder as app-builder
@@ -40,10 +49,20 @@ ENV LANG="C.UTF-8" MIX_ENV=prod
 
 WORKDIR /root
 
+COPY lib lib
+COPY data data
+
+RUN mix do compile --force
+
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static
 
-RUN mix do compile --force, phx.digest, release
+RUN mix phx.digest
+
+COPY rel rel
+COPY config/releases.exs config/
+
+RUN mix release
 
 FROM alpine:3.13.6
 


### PR DESCRIPTION
Only `COPY` files as needed, to better use the cache.

Not really needed, but it was helpful for me as I was iterating on the Dockerfile to track down #1391.