### PR TITLE
build: Upgrade patch versions of languages

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir v1.10.2-otp-22
-erlang 22.3.2
-nodejs 14.18.2
+elixir v1.10.4-otp-22
+erlang 22.3.4.24
+nodejs 14.18.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.10.2-erlang-22.3.2-alpine-3.13.1 as elixir-builder
+FROM hexpm/elixir:1.10.4-erlang-22.3.4-alpine-3.13.1 as elixir-builder
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.10.2" \


### PR DESCRIPTION
No ticket, had trouble building the older version of Erlang on a new machine.

Use the latest 1.10.x version of Elixir, 22.3.x version of Erlang, and
14.x version of Node.