### PR TITLE
Preset modals

### DIFF
--- a/assets/src/components/closeButton.tsx
+++ b/assets/src/components/closeButton.tsx
@@ -7,6 +7,7 @@ interface Props {
 
 const CloseButton = ({ onClick }: Props) => (
   <button
+    data-testid="close-button"
     className="m-close-button"
     onClick={(e) => {
       e.stopPropagation()

--- a/assets/src/components/inputModals/createPresetModal.tsx
+++ b/assets/src/components/inputModals/createPresetModal.tsx
@@ -1,0 +1,38 @@
+import React, { useContext, useState } from "react"
+import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import { Action, closeInputModal } from "../../state"
+
+const CreatePresetModal = ({
+  createCallback,
+}: {
+  createCallback: (arg0: string, arg1: React.Dispatch<Action>) => void
+}) => {
+  const [, dispatch] = useContext(StateDispatchContext)
+  const [presetName, setPresetName] = useState<string>("")
+  return (
+    <div className="c-modal m-input-modal">
+      <div className="m-input-modal__title">Save open routes as preset</div>
+      <div className="m-input-modal__input">
+        <input
+          placeholder="Name your preset&hellip;"
+          onChange={(event) => {
+            setPresetName(event.currentTarget.value)
+          }}
+        />
+      </div>
+      <div className="m-input-modal__buttons">
+        <button onClick={() => dispatch(closeInputModal())}>Cancel</button>
+        <button
+          onClick={() => {
+            createCallback(presetName, dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default CreatePresetModal

--- a/assets/src/components/inputModals/deletePresetModal.tsx
+++ b/assets/src/components/inputModals/deletePresetModal.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from "react"
+import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import { Action, closeInputModal } from "../../state"
+
+const DeletePresetModal = ({
+  presetName,
+  deleteCallback,
+}: {
+  presetName: string
+  deleteCallback: (arg0: React.Dispatch<Action>) => void
+}) => {
+  const [, dispatch] = useContext(StateDispatchContext)
+  return (
+    <div className="c-modal m-input-modal">
+      <div className="m-input-modal__title">Delete preset?</div>
+      <div className="m-input-modal__text">{presetName}</div>
+      <div className="m-input-modal__buttons">
+        <button onClick={() => dispatch(closeInputModal())}>Cancel</button>
+        <button
+          onClick={() => {
+            deleteCallback(dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DeletePresetModal

--- a/assets/src/components/inputModals/savePresetModal.tsx
+++ b/assets/src/components/inputModals/savePresetModal.tsx
@@ -1,0 +1,31 @@
+import React, { useContext } from "react"
+import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import { Action, closeInputModal } from "../../state"
+
+const SavePresetModal = ({
+  presetName,
+  saveCallback,
+}: {
+  presetName: string
+  saveCallback: (arg0: React.Dispatch<Action>) => void
+}) => {
+  const [, dispatch] = useContext(StateDispatchContext)
+  return (
+    <div className="c-modal m-input-modal">
+      <div className="m-input-modal__title">Overwrite {presetName}</div>
+      <div className="m-input-modal__buttons">
+        <button onClick={() => dispatch(closeInputModal())}>Cancel</button>
+        <button
+          onClick={() => {
+            saveCallback(dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default SavePresetModal

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -31,8 +31,7 @@ import {
   flipLadder,
   toggleLadderCrowding,
   closeRouteTab,
-  createPreset,
-  savePreset,
+  promptToSaveOrCreatePreset,
 } from "../state"
 import CloseButton from "./closeButton"
 import { saveIcon, plusThinIcon } from "../helpers/icon"
@@ -246,11 +245,7 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
               closeTab={() => dispatch(closeRouteTab(routeTab.uuid))}
               showSaveIcon={!isPreset(routeTab) || isEditedPreset(routeTab)}
               saveTab={() => {
-                if (isEditedPreset(routeTab)) {
-                  dispatch(savePreset(routeTab.uuid))
-                } else if (!isPreset(routeTab)) {
-                  dispatch(createPreset(routeTab.uuid, "Preset name"))
-                }
+                dispatch(promptToSaveOrCreatePreset(routeTab))
               }}
               key={routeTab.uuid}
             />

--- a/assets/src/components/modal.tsx
+++ b/assets/src/components/modal.tsx
@@ -7,6 +7,7 @@ import InactiveNotificationModal from "./inactiveNotificationModal"
 import NotificationLoadingModal from "./notificationLoadingModal"
 import CreatePresetModal from "./inputModals/createPresetModal"
 import SavePresetModal from "./inputModals/savePresetModal"
+import DeletePresetModal from "./inputModals/deletePresetModal"
 
 const Modal = (): ReactElement | null => {
   const { connectionStatus } = useContext(SocketContext)
@@ -36,6 +37,13 @@ const Modal = (): ReactElement | null => {
           <SavePresetModal
             presetName={openInputModal.presetName}
             saveCallback={openInputModal.saveCallback}
+          />
+        )
+      case "DELETE_PRESET":
+        return (
+          <DeletePresetModal
+            presetName={openInputModal.presetName}
+            deleteCallback={openInputModal.deleteCallback}
           />
         )
     }

--- a/assets/src/components/modal.tsx
+++ b/assets/src/components/modal.tsx
@@ -5,11 +5,13 @@ import { ConnectionStatus } from "../hooks/useSocket"
 import DisconnectedModal from "./disconnectedModal"
 import InactiveNotificationModal from "./inactiveNotificationModal"
 import NotificationLoadingModal from "./notificationLoadingModal"
+import CreatePresetModal from "./inputModals/createPresetModal"
+import SavePresetModal from "./inputModals/savePresetModal"
 
 const Modal = (): ReactElement | null => {
   const { connectionStatus } = useContext(SocketContext)
   const [state] = useContext(StateDispatchContext)
-  const { selectedNotification, selectedVehicleOrGhost } = state
+  const { selectedNotification, selectedVehicleOrGhost, openInputModal } = state
 
   if (connectionStatus === ConnectionStatus.Disconnected) {
     return <DisconnectedModal />
@@ -21,6 +23,22 @@ const Modal = (): ReactElement | null => {
 
   if (selectedNotification && selectedVehicleOrGhost === undefined) {
     return <NotificationLoadingModal />
+  }
+
+  if (openInputModal) {
+    switch (openInputModal.type) {
+      case "CREATE_PRESET":
+        return (
+          <CreatePresetModal createCallback={openInputModal.createCallback} />
+        )
+      case "SAVE_PRESET":
+        return (
+          <SavePresetModal
+            presetName={openInputModal.presetName}
+            saveCallback={openInputModal.saveCallback}
+          />
+        )
+    }
   }
 
   return null

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -1,5 +1,9 @@
 import React, { useContext } from "react"
-import { instantiatePreset, promptToSaveOrCreatePreset } from "../state"
+import {
+  instantiatePreset,
+  promptToSaveOrCreatePreset,
+  promptToDeletePreset,
+} from "../state"
 import CloseButton from "./closeButton"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { currentRouteTab, isPreset } from "../models/routeTab"
@@ -23,7 +27,7 @@ const Presets = () => {
             </div>
             <CloseButton
               onClick={() => {
-                return
+                dispatch(promptToDeletePreset(preset))
               }}
             />
           </li>

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react"
-import { createPreset, instantiatePreset, savePreset } from "../state"
+import { instantiatePreset, promptToSaveOrCreatePreset } from "../state"
 import CloseButton from "./closeButton"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { currentRouteTab, isPreset, isEditedPreset } from "../models/routeTab"
+import { currentRouteTab, isPreset } from "../models/routeTab"
 import { plusThinIcon } from "../helpers/icon"
 
 const Presets = () => {
@@ -33,18 +33,8 @@ const Presets = () => {
         className="m-presets-panel__save-as-preset-button"
         onClick={() => {
           const currentTab = currentRouteTab(routeTabs)
-
           if (currentTab) {
-            if (isEditedPreset(currentTab)) {
-              dispatch(savePreset(currentTab.uuid))
-            } else if (!isPreset(currentTab)) {
-              dispatch(
-                createPreset(
-                  currentTab.uuid,
-                  `Preset ${Math.floor(Math.random() * 10000)}`
-                )
-              )
-            }
+            dispatch(promptToSaveOrCreatePreset(currentTab))
           }
         }}
       >

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -247,11 +247,14 @@ export const deletePresetByUUID = (
   // Assumes there's at most one edited version of the tab, and if
   // there is an edited version it's currently open. Both true in
   // the current model but something to keep in mind.
-  const existingTabToClose =
-    routeTabs.find(
-      (routeTab) => routeTab.uuid === uuid && routeTab.ordering !== undefined
-    ) || routeTabs.find((routeTab) => routeTab.saveChangesToTabUuid === uuid)
+  const existingTabToClose = routeTabs.find(
+    (routeTab) =>
+      (routeTab.uuid === uuid && routeTab.ordering !== undefined) ||
+      routeTab.saveChangesToTabUuid === uuid
+  )
 
+  // Call closeTabbyUUID to handle marking the correct other tab
+  // as open
   const routeTabsAfterClose = existingTabToClose
     ? closeTabByUUID(routeTabs, existingTabToClose.uuid)
     : routeTabs

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -240,5 +240,27 @@ export const saveEditedPreset = (
     })
 }
 
+export const deletePresetByUUID = (
+  routeTabs: RouteTab[],
+  uuid: string
+): RouteTab[] => {
+  // Assumes there's at most one edited version of the tab, and if
+  // there is an edited version it's currently open. Both true in
+  // the current model but something to keep in mind.
+  const existingTabToClose =
+    routeTabs.find(
+      (routeTab) => routeTab.uuid === uuid && routeTab.ordering !== undefined
+    ) || routeTabs.find((routeTab) => routeTab.saveChangesToTabUuid === uuid)
+
+  const routeTabsAfterClose = existingTabToClose
+    ? closeTabByUUID(routeTabs, existingTabToClose.uuid)
+    : routeTabs
+
+  return routeTabsAfterClose.filter(
+    (routeTab) =>
+      routeTab.uuid !== uuid && routeTab.saveChangesToTabUuid !== uuid
+  )
+}
+
 const nullToUndefined = <T>(data: T | null): T | undefined =>
   data === null ? undefined : data

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -32,6 +32,7 @@ import {
   closeTabByUUID,
   applyRouteTabEdit,
   saveEditedPreset,
+  deletePresetByUUID,
   isEditedPreset,
   isPreset,
 } from "./models/routeTab"
@@ -55,7 +56,8 @@ interface SavePresetModal {
 
 interface DeletePresetModal {
   type: "DELETE_PRESET"
-  deleteCallback: (arg0: string, arg1: React.Dispatch<Action>) => void
+  deleteCallback: (arg1: React.Dispatch<Action>) => void
+  presetName: string
 }
 
 export type OpenInputModal =
@@ -516,6 +518,16 @@ export const savePreset = (uuid: string): SavePresetAction => ({
   payload: { uuid },
 })
 
+interface DeletePresetAction {
+  type: "DELETE_PRESET"
+  payload: { uuid: string }
+}
+
+export const deletePreset = (uuid: string): DeletePresetAction => ({
+  type: "DELETE_PRESET",
+  payload: { uuid },
+})
+
 interface PromptToSaveOrCreatePresetAction {
   type: "PROMPT_TO_SAVE_OR_CREATE_PRESET"
   payload: { routeTab: RouteTab }
@@ -525,6 +537,18 @@ export const promptToSaveOrCreatePreset = (
   routeTab: RouteTab
 ): PromptToSaveOrCreatePresetAction => ({
   type: "PROMPT_TO_SAVE_OR_CREATE_PRESET",
+  payload: { routeTab },
+})
+
+interface PromptToDeletePresetAction {
+  type: "PROMPT_TO_DELETE_PRESET"
+  payload: { routeTab: RouteTab }
+}
+
+export const promptToDeletePreset = (
+  routeTab: RouteTab
+): PromptToDeletePresetAction => ({
+  type: "PROMPT_TO_DELETE_PRESET",
   payload: { routeTab },
 })
 
@@ -574,7 +598,9 @@ export type Action =
   | CreatePresetAction
   | InstantiatePresetAction
   | SavePresetAction
+  | DeletePresetAction
   | PromptToSaveOrCreatePresetAction
+  | PromptToDeletePresetAction
   | CloseInputModalAction
 
 export type Dispatch = ReactDispatch<Action>
@@ -686,6 +712,11 @@ const routeTabsReducer = (
     case "SAVE_PRESET":
       return {
         newRouteTabs: saveEditedPreset(routeTabs, action.payload.uuid),
+        routeTabsUpdated: true,
+      }
+    case "DELETE_PRESET":
+      return {
+        newRouteTabs: deletePresetByUUID(routeTabs, action.payload.uuid),
         routeTabsUpdated: true,
       }
     case "SELECT_ROUTE_TAB":
@@ -982,6 +1013,14 @@ const openInputModalReducer = (
         }
       } else {
         return state
+      }
+    case "PROMPT_TO_DELETE_PRESET":
+      return {
+        type: "DELETE_PRESET",
+        deleteCallback: (dispatch: React.Dispatch<Action>) => {
+          dispatch(deletePreset(action.payload.routeTab.uuid))
+        },
+        presetName: action.payload.routeTab.presetName || "",
       }
     default:
       return state

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -561,10 +561,12 @@ export const closeInputModal = (): CloseInputModalAction => ({
 })
 
 export type Action =
+  // Route ladder management
   | SelectRouteAction
   | DeselectRouteAction
   | FlipLadderAction
   | ToggleLadderCrowdingAction
+  // Route tabs and ladder management in tabs
   | CreateRouteTabAction
   | CloseRouteTabAction
   | SelectRouteTabAction
@@ -572,35 +574,47 @@ export type Action =
   | DeselectRouteInTabAction
   | FlipLadderInTabAction
   | ToggleLadderCrowdingInTabAction
+  // Route tab API push
   | StartingRouteTabsPushAction
   | RouteTabsPushCompleteAction
   | RetryRouteTabsPushIfNotOutdatedAction
+  // Shuttles page
   | SelectShuttleRunAction
   | DeselectShuttleRunAction
   | SelectAllShuttleRunsAction
   | DeselectAllShuttleRunsAction
   | SelectShuttleRouteAction
   | DeselectShuttleRouteAction
+  // Vehicle selection
   | SelectVehicleAction
   | DeselectVehicleAction
+  // Opening / closing picker drawer
   | TogglePickerContainerAction
+  // Notifications
   | OpenNotificationDrawerAction
   | CloseNotificationDrawerAction
   | ToggleNotificationDrawerAction
+  // Settings
   | SetLadderVehicleLabelSettingAction
   | SetShuttleVehicleLabelSettingAction
   | SetVehicleAdherenceColorsSettingAction
+  // Search
   | SearchAction
+  // Notification selection
   | SetNotificationAction
+  | SelectVehicleFromNotificationAction
+  // Views
   | ToggleSwingsViewAction
   | ToggleLateViewAction
-  | SelectVehicleFromNotificationAction
+  // Presets
   | CreatePresetAction
   | InstantiatePresetAction
   | SavePresetAction
   | DeletePresetAction
+  // Preset modals
   | PromptToSaveOrCreatePresetAction
   | PromptToDeletePresetAction
+  // Input modals
   | CloseInputModalAction
 
 export type Dispatch = ReactDispatch<Action>

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -211,6 +211,7 @@ exports[`LadderPage renders with route tabs 1`] = `
         </div>
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -238,6 +239,7 @@ exports[`LadderPage renders with route tabs 1`] = `
         </div>
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -273,6 +275,7 @@ exports[`LadderPage renders with route tabs 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -414,6 +417,7 @@ exports[`LadderPage renders with routes 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -563,6 +567,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -604,6 +609,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -753,6 +759,7 @@ exports[`LadderPage renders with timepoints 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -916,6 +923,7 @@ exports[`LadderPage renders with timepoints 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -1179,6 +1187,7 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -1317,6 +1326,7 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
           >
             <button
               className="m-close-button"
+              data-testid="close-button"
               onClick={[Function]}
             >
               <span

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -34,6 +34,37 @@ exports[`Modal renders create preset modal 1`] = `
 </div>
 `;
 
+exports[`Modal renders delete preset modal 1`] = `
+<div
+  className="c-modal m-input-modal"
+>
+  <div
+    className="m-input-modal__title"
+  >
+    Delete preset?
+  </div>
+  <div
+    className="m-input-modal__text"
+  >
+    My Preset
+  </div>
+  <div
+    className="m-input-modal__buttons"
+  >
+    <button
+      onClick={[Function]}
+    >
+      Cancel
+    </button>
+    <button
+      onClick={[Function]}
+    >
+      Confirm
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Modal renders inactive notification modal when appropriate 1`] = `
 Array [
   <div

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Modal renders create preset modal 1`] = `
+<div
+  className="c-modal m-input-modal"
+>
+  <div
+    className="m-input-modal__title"
+  >
+    Save open routes as preset
+  </div>
+  <div
+    className="m-input-modal__input"
+  >
+    <input
+      onChange={[Function]}
+      placeholder="Name your preset…"
+    />
+  </div>
+  <div
+    className="m-input-modal__buttons"
+  >
+    <button
+      onClick={[Function]}
+    >
+      Cancel
+    </button>
+    <button
+      onClick={[Function]}
+    >
+      Save
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Modal renders inactive notification modal when appropriate 1`] = `
 Array [
   <div
@@ -66,4 +100,31 @@ Array [
     className="c-modal-overlay"
   />,
 ]
+`;
+
+exports[`Modal renders save preset modal 1`] = `
+<div
+  className="c-modal m-input-modal"
+>
+  <div
+    className="m-input-modal__title"
+  >
+    Overwrite 
+    My Preset
+  </div>
+  <div
+    className="m-input-modal__buttons"
+  >
+    <button
+      onClick={[Function]}
+    >
+      Cancel
+    </button>
+    <button
+      onClick={[Function]}
+    >
+      Save
+    </button>
+  </div>
+</div>
 `;

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`NotificationDrawer renders empty state 1`] = `
     </div>
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -69,6 +70,7 @@ exports[`NotificationDrawer renders notifications 1`] = `
     </div>
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span

--- a/assets/tests/components/__snapshots__/presets.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/presets.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Presets renders current presets 1`] = `
       </div>
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -41,6 +42,7 @@ exports[`Presets renders current presets 1`] = `
       </div>
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -98,6 +98,7 @@ Array [
           >
             <button
               className="m-close-button"
+              data-testid="close-button"
               onClick={[Function]}
             >
               <span
@@ -391,6 +392,7 @@ Array [
           >
             <button
               className="m-close-button"
+              data-testid="close-button"
               onClick={[Function]}
             >
               <span

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -7,6 +7,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -53,6 +54,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -449,6 +451,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -778,6 +781,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -1031,6 +1035,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -1199,6 +1204,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -1594,6 +1600,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -1922,6 +1929,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -2385,6 +2393,7 @@ Array [
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span

--- a/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders a route ladder 1`] = `
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span
@@ -172,6 +173,7 @@ exports[`renders a route ladder 1`] = `
   >
     <button
       className="m-close-button"
+      data-testid="close-button"
       onClick={[Function]}
     >
       <span

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -293,6 +293,7 @@ exports[`SearchPage renders a selected vehicle 1`] = `
           >
             <button
               className="m-close-button"
+              data-testid="close-button"
               onClick={[Function]}
             >
               <span

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -505,6 +505,7 @@ exports[`Shuttle Map Page renders a selected shuttle vehicle 1`] = `
           >
             <button
               className="m-close-button"
+              data-testid="close-button"
               onClick={[Function]}
             >
               <span

--- a/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`SwingsView ignores vehicles without run ID (for linking to VPP) 1`] = `
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span
@@ -174,6 +175,7 @@ exports[`SwingsView includes swings less than 15 minutes in the past 1`] = `
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span
@@ -339,6 +341,7 @@ exports[`SwingsView links to both swing-on and swing-off if both are active 1`] 
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span
@@ -530,6 +533,7 @@ exports[`SwingsView omits swings more than 15 minutes in the past 1`] = `
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span
@@ -648,6 +652,7 @@ exports[`SwingsView renders future swings, active and inactive 1`] = `
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span
@@ -933,6 +938,7 @@ exports[`SwingsView renders loading message 1`] = `
 >
   <button
     className="m-close-button"
+    data-testid="close-button"
     onClick={[Function]}
   >
     <span

--- a/assets/tests/components/inputModals/createPresetModal.test.tsx
+++ b/assets/tests/components/inputModals/createPresetModal.test.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import CreatePresetModal from "../../../src/components/inputModals/createPresetModal"
+import { initialState, closeInputModal } from "../../../src/state"
+import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
+
+describe("CreatePresetModal", () => {
+  test("can enter a name and save", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <CreatePresetModal createCallback={mockCallback} />
+      </StateDispatchProvider>
+    )
+
+    userEvent.type(
+      result.getByPlaceholderText("Name your preset", { exact: false }),
+      "My Preset"
+    )
+
+    userEvent.click(result.getByText("Save"))
+
+    expect(mockCallback).toHaveBeenCalledWith("My Preset", mockDispatch)
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+
+  test("can cancel", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <CreatePresetModal createCallback={mockCallback} />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Cancel"))
+
+    expect(mockCallback).not.toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+})

--- a/assets/tests/components/inputModals/deletePresetModal.test.tsx
+++ b/assets/tests/components/inputModals/deletePresetModal.test.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import DeletePresetModal from "../../../src/components/inputModals/deletePresetModal"
+import { initialState, closeInputModal } from "../../../src/state"
+import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
+
+describe("DeletePresetModal", () => {
+  test("can enter a name and save", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <DeletePresetModal
+          presetName="My Preset"
+          deleteCallback={mockCallback}
+        />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Confirm"))
+
+    expect(mockCallback).toHaveBeenCalledWith(mockDispatch)
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+
+  test("can cancel", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <DeletePresetModal
+          presetName="My Preset"
+          deleteCallback={mockCallback}
+        />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Cancel"))
+
+    expect(mockCallback).not.toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+})

--- a/assets/tests/components/inputModals/savePresetModal.test.tsx
+++ b/assets/tests/components/inputModals/savePresetModal.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import SavePresetModal from "../../../src/components/inputModals/savePresetModal"
+import { initialState, closeInputModal } from "../../../src/state"
+import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
+
+describe("SavePresetModal", () => {
+  test("can enter a name and save", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <SavePresetModal presetName="My Preset" saveCallback={mockCallback} />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Save"))
+
+    expect(mockCallback).toHaveBeenCalledWith(mockDispatch)
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+
+  test("can cancel", () => {
+    const mockCallback = jest.fn()
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <SavePresetModal presetName="My Preset" saveCallback={mockCallback} />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByText("Cancel"))
+
+    expect(mockCallback).not.toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+})

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -22,8 +22,7 @@ import {
   selectRouteTab,
   createRouteTab,
   closeRouteTab,
-  createPreset,
-  savePreset,
+  promptToSaveOrCreatePreset,
 } from "../../src/state"
 import ghostFactory from "../factories/ghost"
 import routeFactory from "../factories/route"
@@ -187,7 +186,7 @@ describe("LadderPage", () => {
     wrapper.find(".m-ladder-page__tab-save-icon").simulate("click")
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      createPreset(mockState.routeTabs[0].uuid, "Preset name")
+      promptToSaveOrCreatePreset(mockState.routeTabs[0])
     )
   })
 
@@ -222,7 +221,9 @@ describe("LadderPage", () => {
 
     wrapper.find(".m-ladder-page__tab-save-icon").simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(savePreset("uuid2"))
+    expect(mockDispatch).toHaveBeenCalledWith(
+      promptToSaveOrCreatePreset(mockState.routeTabs[1])
+    )
   })
 
   test("omits save icon for unedited preset", () => {

--- a/assets/tests/components/modal.test.tsx
+++ b/assets/tests/components/modal.test.tsx
@@ -113,4 +113,24 @@ describe("Modal", () => {
     )
     expect(tree).toMatchSnapshot()
   })
+
+  test("renders delete preset modal", () => {
+    const deleteCallback = jest.fn()
+
+    const state: State = {
+      ...initialState,
+      openInputModal: {
+        type: "DELETE_PRESET",
+        presetName: "My Preset",
+        deleteCallback,
+      },
+    }
+
+    const tree = renderer.create(
+      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <Modal />
+      </StateDispatchProvider>
+    )
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/assets/tests/components/modal.test.tsx
+++ b/assets/tests/components/modal.test.tsx
@@ -74,4 +74,43 @@ describe("Modal", () => {
     )
     expect(tree).toMatchSnapshot()
   })
+
+  test("renders create preset modal", () => {
+    const createCallback = jest.fn()
+
+    const state: State = {
+      ...initialState,
+      openInputModal: {
+        type: "CREATE_PRESET",
+        createCallback,
+      },
+    }
+
+    const tree = renderer.create(
+      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <Modal />
+      </StateDispatchProvider>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("renders save preset modal", () => {
+    const saveCallback = jest.fn()
+
+    const state: State = {
+      ...initialState,
+      openInputModal: {
+        type: "SAVE_PRESET",
+        presetName: "My Preset",
+        saveCallback,
+      },
+    }
+
+    const tree = renderer.create(
+      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <Modal />
+      </StateDispatchProvider>
+    )
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/assets/tests/components/presets.test.tsx
+++ b/assets/tests/components/presets.test.tsx
@@ -6,6 +6,7 @@ import {
   initialState,
   instantiatePreset,
   promptToSaveOrCreatePreset,
+  promptToDeletePreset,
 } from "../../src/state"
 import Presets from "../../src/components/presets"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
@@ -135,5 +136,33 @@ describe("Presets", () => {
     userEvent.click(result.getByText("My Preset"))
 
     expect(mockDispatch).toHaveBeenCalledWith(instantiatePreset("uuid1"))
+  })
+
+  test("deletes a preset", () => {
+    const mockDispatch = jest.fn()
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          uuid: "uuid1",
+          ordering: 0,
+          presetName: "My Preset",
+          isCurrentTab: true,
+          selectedRouteIds: ["1"],
+        }),
+      ],
+    }
+
+    const result = render(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <Presets />
+      </StateDispatchProvider>
+    )
+
+    userEvent.click(result.getByTestId("close-button"))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      promptToDeletePreset(mockState.routeTabs[0])
+    )
   })
 })

--- a/assets/tests/components/presets.test.tsx
+++ b/assets/tests/components/presets.test.tsx
@@ -4,9 +4,8 @@ import userEvent from "@testing-library/user-event"
 import renderer from "react-test-renderer"
 import {
   initialState,
-  createPreset,
   instantiatePreset,
-  savePreset,
+  promptToSaveOrCreatePreset,
 } from "../../src/state"
 import Presets from "../../src/components/presets"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
@@ -49,9 +48,6 @@ describe("Presets", () => {
   })
 
   test("saves current tab as preset", () => {
-    jest.spyOn(Math, "random").mockImplementationOnce(() => {
-      return 0.01
-    })
     const mockDispatch = jest.fn()
     const mockState = {
       ...initialState,
@@ -75,7 +71,7 @@ describe("Presets", () => {
     userEvent.click(result.getByText("Save as preset"))
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      createPreset("uuid1", "Preset 100")
+      promptToSaveOrCreatePreset(mockState.routeTabs[0])
     )
   })
 
@@ -110,7 +106,9 @@ describe("Presets", () => {
 
     userEvent.click(result.getByText("Save as preset"))
 
-    expect(mockDispatch).toHaveBeenCalledWith(savePreset("uuid2"))
+    expect(mockDispatch).toHaveBeenCalledWith(
+      promptToSaveOrCreatePreset(mockState.routeTabs[1])
+    )
   })
 
   test("opens a preset", () => {

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`GhostPropertiesPanel renders 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -356,6 +357,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -665,6 +667,7 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`Header renders a header 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -296,6 +297,7 @@ exports[`Header renders for a ghost 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -497,6 +499,7 @@ exports[`Header renders for a late vehicle 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -670,6 +673,7 @@ exports[`Header renders for a shuttle 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -800,6 +804,7 @@ exports[`Header renders for an early vehicle 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -1006,6 +1011,7 @@ exports[`Header renders for an off-course vehicle 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span
@@ -1212,6 +1218,7 @@ exports[`Header renders with route data 1`] = `
     >
       <button
         className="m-close-button"
+        data-testid="close-button"
         onClick={[Function]}
       >
         <span

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -112,6 +112,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -437,6 +438,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -729,6 +731,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -978,6 +981,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -1398,6 +1402,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -1723,6 +1728,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span
@@ -2062,6 +2068,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
       >
         <button
           className="m-close-button"
+          data-testid="close-button"
           onClick={[Function]}
         >
           <span

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -8,6 +8,7 @@ import {
   isOpenTab,
   applyRouteTabEdit,
   saveEditedPreset,
+  deletePresetByUUID,
 } from "../../src/models/routeTab"
 import { v4 as uuidv4 } from "uuid"
 import routeTabFactory from "../factories/routeTab"
@@ -457,5 +458,64 @@ describe("saveEditedPreset", () => {
         new Error("Cannot save tab UUID uuid1: no saveChangesToTabUuid")
       )
     }
+  })
+})
+
+describe("deletePresetByUUID", () => {
+  test("deletes preset", () => {
+    const routeTab1 = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: undefined,
+      isCurrentTab: false,
+    })
+    const routeTab2 = routeTabFactory.build({
+      presetName: "My Other Preset",
+      ordering: 0,
+      isCurrentTab: true,
+    })
+
+    expect(deletePresetByUUID([routeTab1, routeTab2], routeTab1.uuid)).toEqual([
+      routeTab2,
+    ])
+  })
+
+  test("also closes open tab of preset", () => {
+    const routeTab1 = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: 0,
+      isCurrentTab: true,
+    })
+    const routeTab2 = routeTabFactory.build({
+      presetName: "My Other Preset",
+      ordering: 1,
+      isCurrentTab: false,
+    })
+
+    expect(deletePresetByUUID([routeTab1, routeTab2], routeTab1.uuid)).toEqual([
+      { ...routeTab2, isCurrentTab: true },
+    ])
+  })
+
+  test("also closes open, edited tab of preset", () => {
+    const routeTab1 = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: undefined,
+      isCurrentTab: false,
+    })
+    const routeTab2 = routeTabFactory.build({
+      presetName: "My Preset",
+      ordering: 0,
+      isCurrentTab: true,
+      saveChangesToTabUuid: routeTab1.uuid,
+    })
+    const routeTab3 = routeTabFactory.build({
+      presetName: "My Other Preset",
+      ordering: 1,
+      isCurrentTab: false,
+    })
+
+    expect(
+      deletePresetByUUID([routeTab1, routeTab2, routeTab3], routeTab1.uuid)
+    ).toEqual([{ ...routeTab3, isCurrentTab: true }])
   })
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -769,4 +769,79 @@ describe("reducer", () => {
       routeTabsPushInProgress: false,
     })
   })
+
+  test("closeInputModal", () => {
+    const mockCallback = jest.fn() as (arg0: string) => void
+    const stateWithInputModal = {
+      ...initialState,
+      openInputModal: {
+        type: "DELETE_PRESET" as "DELETE_PRESET",
+        deleteCallback: mockCallback,
+      },
+    }
+
+    const newState = reducer(stateWithInputModal, State.closeInputModal())
+
+    expect(newState.openInputModal).toBeNull()
+  })
+
+  test("promptToSaveOrCreatePreset when creating", () => {
+    const mockDispatch = jest.fn()
+    const routeTab = routeTabFactory.build({ presetName: undefined })
+
+    const newState = reducer(
+      initialState,
+      State.promptToSaveOrCreatePreset(routeTab)
+    )
+
+    switch (newState.openInputModal?.type) {
+      case "CREATE_PRESET":
+        newState.openInputModal.createCallback("Preset name", mockDispatch)
+        expect(mockDispatch).toHaveBeenCalledWith(
+          State.createPreset(routeTab.uuid, "Preset name")
+        )
+        return
+      default:
+        fail("did not receive correct openInputModal type")
+    }
+  })
+
+  test("promptToSaveOrCreatePreset when saving", () => {
+    const mockDispatch = jest.fn()
+    const routeTab = routeTabFactory.build({
+      presetName: "My preset",
+      saveChangesToTabUuid: "uuid2",
+    })
+
+    const newState = reducer(
+      initialState,
+      State.promptToSaveOrCreatePreset(routeTab)
+    )
+
+    switch (newState.openInputModal?.type) {
+      case "SAVE_PRESET":
+        newState.openInputModal.saveCallback(mockDispatch)
+        expect(newState.openInputModal.presetName).toBe("My preset")
+        expect(mockDispatch).toHaveBeenCalledWith(
+          State.savePreset(routeTab.uuid)
+        )
+        return
+      default:
+        fail("did not receive correct openInputModal type")
+    }
+  })
+
+  test("promptToSaveOrCreatePreset when there are no changes", () => {
+    const routeTab = routeTabFactory.build({
+      presetName: "My preset",
+      saveChangesToTabUuid: undefined,
+    })
+
+    const newState = reducer(
+      initialState,
+      State.promptToSaveOrCreatePreset(routeTab)
+    )
+
+    expect(newState.openInputModal).toBeNull()
+  })
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -855,7 +855,7 @@ describe("reducer", () => {
     }
   })
 
-  test("promptToSaveOrCreatePreset when there are no changes", () => {
+  test("promptToSaveOrCreatePreset doesn't open a modal when there are no changes", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My preset",
       saveChangesToTabUuid: undefined,


### PR DESCRIPTION
Asana ticket: [⚙️ Implement preset modals](https://app.asana.com/0/1200180014510248/1201286872028647/f)

Note that I'm using React Testing Library over Enzyme as much as possible going forward due to the fact that Enzym's future support prospects seem dubious. On side-effect of this is that one of my tests needed a way to find and click on a `CloseButton` component, and since none of the other methods of selecting elements from RTL really worked I had to use the `data-testid` hatch, thereby changing a ton of snapshots. I don't love this solution but it appears to be the best for now, and as we go and rework the design of Skate and make it conform more to best practices around accessibility, this solution may no longer be needed (since a lot of the RTL selection methods are based on things like ARIA tags).

This PR includes some classes on the relevant components that will be used for styling in the next ticket I'm about to work on.