### PR TITLE
Fix tabs push

### DIFF
--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -64,17 +64,19 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
   }, [selectedRouteIds, ladderDirections, ladderCrowdingToggles])
 
   useEffect(() => {
-    if (routeTabsToPush && !routeTabsPushInProgress) {
+    if (routeTabsToPush[0] && !routeTabsPushInProgress) {
       dispatch(startingRouteTabsPush())
-      putRouteTabs(routeTabsToPush)
+      putRouteTabs(routeTabsToPush[0])
         .then((response) => {
           if (response.ok) {
             dispatch(routeTabsPushComplete())
           } else {
-            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush))
+            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
           }
         })
-        .catch(() => dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush)))
+        .catch(() =>
+          dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
+        )
     }
   }, [JSON.stringify(routeTabsToPush), routeTabsPushInProgress])
 

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -68,16 +68,16 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
   }, [selectedRouteIds, ladderDirections, ladderCrowdingToggles])
 
   useEffect(() => {
-    if (routeTabsToPush[0] && !routeTabsPushInProgress) {
+    if (routeTabsToPush && !routeTabsPushInProgress) {
       dispatch(startingRouteTabsPush())
-      putRouteTabs(routeTabsToPush[0])
+      putRouteTabs(routeTabsToPush)
         .then((response) => {
           if (response.ok) {
             setRouteTabsPushRetriesLeft(routeTabsPushRetries)
             dispatch(routeTabsPushComplete())
           } else if (routeTabsPushRetriesLeft > 0) {
             setRouteTabsPushRetriesLeft(routeTabsPushRetriesLeft - 1)
-            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
+            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush))
           } else {
             setRouteTabsPushRetriesLeft(routeTabsPushRetries)
             dispatch(routeTabsPushComplete())
@@ -86,7 +86,7 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
         .catch(() => {
           if (routeTabsPushRetriesLeft > 0) {
             setRouteTabsPushRetriesLeft(routeTabsPushRetriesLeft - 1)
-            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
+            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush))
           } else {
             setRouteTabsPushRetriesLeft(routeTabsPushRetries)
             dispatch(routeTabsPushComplete())

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -32,6 +32,8 @@ const LOCALLY_PERSISTED_KEYS: Key[] = [
   ["searchPageState", "savedQueries"],
 ]
 
+const routeTabsPushRetries = 2
+
 const usePersistedStateReducer = (): [State, Dispatch] => {
   const [state, dispatch] = useReducer(reducer, undefined, init)
 
@@ -50,6 +52,8 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
   } = state
 
   const [firstLoadDone, setFirstLoadDone] = useState(false)
+  const [routeTabsPushRetriesLeft, setRouteTabsPushRetriesLeft] =
+    useState(routeTabsPushRetries)
 
   useEffect(() => {
     if (firstLoadDone) {
@@ -69,14 +73,25 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
       putRouteTabs(routeTabsToPush[0])
         .then((response) => {
           if (response.ok) {
+            setRouteTabsPushRetriesLeft(routeTabsPushRetries)
             dispatch(routeTabsPushComplete())
-          } else {
+          } else if (routeTabsPushRetriesLeft > 0) {
+            setRouteTabsPushRetriesLeft(routeTabsPushRetriesLeft - 1)
             dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
+          } else {
+            setRouteTabsPushRetriesLeft(routeTabsPushRetries)
+            dispatch(routeTabsPushComplete())
           }
         })
-        .catch(() =>
-          dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
-        )
+        .catch(() => {
+          if (routeTabsPushRetriesLeft > 0) {
+            setRouteTabsPushRetriesLeft(routeTabsPushRetriesLeft - 1)
+            dispatch(retryRouteTabsPushIfNotOutdated(routeTabsToPush[0]))
+          } else {
+            setRouteTabsPushRetriesLeft(routeTabsPushRetries)
+            dispatch(routeTabsPushComplete())
+          }
+        })
     }
   }, [JSON.stringify(routeTabsToPush), routeTabsPushInProgress])
 

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -826,6 +826,9 @@ const routeTabsPushInProgressReducer = (
   }
 }
 
+/**
+ * @returns tuple of routeTabsToPush, routeTabsToPushNext
+ */
 const routeTabsToPushReducer = (
   routeTabsToPush: RouteTab[] | null,
   routeTabsToPushNext: RouteTab[] | null,

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -72,7 +72,7 @@ export interface State {
   ladderDirections: LadderDirections
   ladderCrowdingToggles: LadderCrowdingToggles
   routeTabs: RouteTab[]
-  routeTabsToPush: RouteTab[] | null
+  routeTabsToPush: RouteTab[][]
   routeTabsPushInProgress: boolean
   selectedShuttleRouteIds: RouteId[]
   selectedShuttleRunIds: RunId[] | "all"
@@ -91,7 +91,7 @@ export const initialState: State = {
   ladderDirections: emptyLadderDirectionsByRouteId,
   ladderCrowdingToggles: emptyLadderCrowdingTogglesByRouteId,
   routeTabs: [],
-  routeTabsToPush: null,
+  routeTabsToPush: [],
   routeTabsPushInProgress: false,
   selectedShuttleRouteIds: [],
   selectedShuttleRunIds: "all",
@@ -825,18 +825,22 @@ const routeTabsPushInProgressReducer = (
 }
 
 const routeTabsToPushReducer = (
-  routeTabsToPush: RouteTab[] | null,
-  newRouteTabs: RouteTab[] | null,
+  routeTabsToPush: RouteTab[][],
+  newRouteTabs: RouteTab[],
   routeTabsUpdated: boolean,
   action: Action
-): RouteTab[] | null => {
+): RouteTab[][] => {
   switch (action.type) {
     case "STARTING_ROUTE_TABS_PUSH":
-      return null
+      return routeTabsToPush.slice(1)
     case "RETRY_ROUTE_TABS_PUSH_IF_NOT_OUTDATED":
-      return routeTabsToPush || action.payload.routeTabsToRetry
+      return routeTabsToPush.length > 0
+        ? routeTabsToPush
+        : [action.payload.routeTabsToRetry]
     default:
-      return routeTabsUpdated ? newRouteTabs : routeTabsToPush
+      return routeTabsUpdated
+        ? [...routeTabsToPush, newRouteTabs]
+        : routeTabsToPush
   }
 }
 
@@ -847,13 +851,13 @@ const routeTabsAndPushReducer = (
     routeTabsPushInProgress,
   }: {
     routeTabs: RouteTab[]
-    routeTabsToPush: RouteTab[] | null
+    routeTabsToPush: RouteTab[][]
     routeTabsPushInProgress: boolean
   },
   action: Action
 ): {
   routeTabs: RouteTab[]
-  routeTabsToPush: RouteTab[] | null
+  routeTabsToPush: RouteTab[][]
   routeTabsPushInProgress: boolean
 } => {
   const { newRouteTabs, routeTabsUpdated } = routeTabsReducer(routeTabs, action)

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -254,7 +254,7 @@ describe("usePersistedStateReducer", () => {
     const [{ routeTabs, routeTabsToPush, routeTabsPushInProgress }] =
       result.current
     expect(routeTabs).toEqual([routeTab])
-    expect(routeTabsToPush).toEqual(null)
+    expect(routeTabsToPush).toEqual([])
     expect(routeTabsPushInProgress).toEqual(false)
   })
 
@@ -275,7 +275,7 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPush).toEqual([state.routeTabs])
     expect(state.routeTabsPushInProgress).toEqual(true)
   })
 
@@ -305,7 +305,7 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPush).toEqual([state.routeTabs])
     expect(state.routeTabsPushInProgress).toEqual(false)
   })
 
@@ -335,7 +335,7 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPush).toEqual([state.routeTabs])
     expect(state.routeTabsPushInProgress).toEqual(false)
   })
 })

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -251,10 +251,17 @@ describe("usePersistedStateReducer", () => {
     const [state] = result.current
     const routeTab = state.routeTabs[0]
     expect(putRouteTabs).toHaveBeenCalledWith([routeTab])
-    const [{ routeTabs, routeTabsToPush, routeTabsPushInProgress }] =
-      result.current
+    const [
+      {
+        routeTabs,
+        routeTabsToPush,
+        routeTabsToPushNext,
+        routeTabsPushInProgress,
+      },
+    ] = result.current
     expect(routeTabs).toEqual([routeTab])
-    expect(routeTabsToPush).toEqual([])
+    expect(routeTabsToPush).toBeNull()
+    expect(routeTabsToPushNext).toBeNull()
     expect(routeTabsPushInProgress).toEqual(false)
   })
 
@@ -275,7 +282,8 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual([state.routeTabs])
+    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(true)
   })
 
@@ -305,7 +313,8 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual([state.routeTabs])
+    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
   })
 
@@ -335,7 +344,8 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual([state.routeTabs])
+    expect(state.routeTabsToPush).toEqual(state.routeTabs)
+    expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
   })
 
@@ -369,7 +379,8 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual([])
+    expect(state.routeTabsToPush).toBeNull()
+    expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
     expect(putRouteTabs).toHaveBeenCalledTimes(3)
   })
@@ -402,7 +413,8 @@ describe("usePersistedStateReducer", () => {
         isCurrentTab: true,
       },
     ])
-    expect(state.routeTabsToPush).toEqual([])
+    expect(state.routeTabsToPush).toBeNull()
+    expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
     expect(putRouteTabs).toHaveBeenCalledTimes(3)
   })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -463,7 +463,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toMatchObject(expectedState)
@@ -491,7 +491,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -514,7 +514,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -549,7 +549,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -589,7 +589,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -611,7 +611,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -633,7 +633,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     }
 
     expect(newState).toEqual(expectedState)
@@ -658,7 +658,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -682,7 +682,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -708,7 +708,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -735,7 +735,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: [expectedNewTabs],
+      routeTabsToPush: expectedNewTabs,
     })
   })
 
@@ -769,7 +769,7 @@ describe("reducer", () => {
     }
     const stateWithQueuedTabs = {
       ...stateWithoutQueuedTabs,
-      routeTabsToPush: [secondPushRouteTabs],
+      routeTabsToPush: secondPushRouteTabs,
       routeTabs: secondPushRouteTabs,
     }
 
@@ -785,7 +785,7 @@ describe("reducer", () => {
     expect(newStateWithoutQueuedTabs).toEqual({
       ...stateWithoutQueuedTabs,
       routeTabsPushInProgress: false,
-      routeTabsToPush: [firstPushRouteTabs],
+      routeTabsToPush: firstPushRouteTabs,
     })
     expect(newStateWithQueuedTabs).toEqual({
       ...stateWithQueuedTabs,

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -463,7 +463,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toMatchObject(expectedState)
@@ -491,7 +491,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -514,7 +514,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -549,7 +549,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -589,7 +589,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -611,7 +611,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -633,7 +633,7 @@ describe("reducer", () => {
     const expectedState: State.State = {
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     }
 
     expect(newState).toEqual(expectedState)
@@ -658,7 +658,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     })
   })
 
@@ -682,7 +682,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     })
   })
 
@@ -708,7 +708,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     })
   })
 
@@ -735,7 +735,7 @@ describe("reducer", () => {
     expect(newState).toEqual({
       ...initialState,
       routeTabs: expectedNewTabs,
-      routeTabsToPush: expectedNewTabs,
+      routeTabsToPush: [expectedNewTabs],
     })
   })
 
@@ -769,7 +769,7 @@ describe("reducer", () => {
     }
     const stateWithQueuedTabs = {
       ...stateWithoutQueuedTabs,
-      routeTabsToPush: secondPushRouteTabs,
+      routeTabsToPush: [secondPushRouteTabs],
       routeTabs: secondPushRouteTabs,
     }
 
@@ -785,7 +785,7 @@ describe("reducer", () => {
     expect(newStateWithoutQueuedTabs).toEqual({
       ...stateWithoutQueuedTabs,
       routeTabsPushInProgress: false,
-      routeTabsToPush: firstPushRouteTabs,
+      routeTabsToPush: [firstPushRouteTabs],
     })
     expect(newStateWithQueuedTabs).toEqual({
       ...stateWithQueuedTabs,


### PR DESCRIPTION
Asana ticket: [⚙️ Fix behavior of route tabs push with multiple updates](https://app.asana.com/0/1200180014510248/1201725368292425/f)

The ticket contains a detailed description of the exact bug observed. Basically, due to the order in which hooks were rerendered and promises were resolved, it was possible to have the `usePersistedStateReducer` hook send the `startingRouteTabsPush` action while not having the most recent copy of the route tabs to push, thereby removing the more-recent route tabs data without actually pushing it to the server. This replaces it with a simple FIFO queue, which potentially results in more server requests than are strictly necessary, but which avoids the bad race condition case.

In addition, I limited the retry logic to retrying at most two times, to prevent the application from thrashing and continually retrying if the backend is down or something. In the future I would like to do better surfacing of errors to the user, as well as having an actual delay / backoff when retrying. Some of that relies on design work though and we'd also like to find a pattern that works more generally for Skate features that involve write operations.