### PR TITLE
build: GitHub action to deploy to prod (Elastic Beanstalk)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,57 @@
+name: Deploy Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    concurrency: prod
+    env:
+      AWS_REGION: us-east-1
+      ELASTICBEANSTALK_APPLICATION_NAME: skate
+      ELASTICBEANSTALK_ENVIRONMENT_NAME: skate-prod
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - id: metadata
+        uses: mbta/actions/commit-metadata@v1
+      - uses: mbta/actions/build-push-ecr@v1.8
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: '--build-arg SENTRY_ORG --build-arg SENTRY_PROJECT --build-arg SENTRY_AUTH_TOKEN'
+      - id: deployment-package
+        uses: mbta/actions/eb-ecr-dockerrun@v1
+        with:
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - name: Upload static assets to S3
+        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Deploy to EB
+        uses: mbta/beanstalk-deploy@v18
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application-name: ${{ env.ELASTICBEANSTALK_APPLICATION_NAME }}
+          environment-name: ${{ env.ELASTICBEANSTALK_ENVIRONMENT_NAME }}
+          version-label: ${{ steps.metadata.outputs.sha-short }}
+          version-description: ${{ steps.metadata.outputs.commit-message }}
+          region: ${{ env.AWS_REGION }}
+          deployment-package: ${{ steps.deployment-package.outputs.deployment-package }}
+          use-existing-version-if-available: true
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}


### PR DESCRIPTION
Asana ticket: [Add GitHub Action for doing existing skate-prod deploy](https://app.asana.com/0/0/1201796368174144/f)

As part of migrating to ECS we're first going to cut over skate-dev. Up to this point, I've been deploying skate-prod by simply going into the AWS console and deploying the image built by the skate-dev deploy. However, this won't be an option once skate-dev is on ECS (it still builds and pushes to ECR, but those images don't show up as application versions to deploy in Beanstalk without extra steps). This is a stopgap to make sure we don't find ourselves in a position of being unable to deploy skate-prod for a period, or unable without taking complicated extra steps. Later on in the migration process once we move skate-prod over I'll make a new ECS-based deploy workflow for it and delete this one.