### PR TITLE
feat: process to migrate route_settings to route_tabs

### DIFF
--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -28,6 +28,7 @@ defmodule Skate.Settings.Db.User do
       :username
     ])
     |> cast_assoc(:route_tabs, with: &DbRouteTab.changeset/2)
+    |> cast_assoc(:route_settings, with: &DbRouteSettings.changeset/2)
     |> validate_required([
       :username
     ])

--- a/lib/skate/settings/route_settings_migrator.ex
+++ b/lib/skate/settings/route_settings_migrator.ex
@@ -24,6 +24,7 @@ defmodule Skate.Settings.RouteSettingsMigrator do
       from(u in DbUser)
       |> Repo.all()
       |> Repo.preload([:route_settings, :route_tabs])
+      |> Enum.filter(fn db_user -> !is_nil(db_user.route_settings) end)
       |> Enum.filter(fn db_user ->
         route_settings_time =
           db_user.route_settings.updated_at || db_user.route_settings.inserted_at
@@ -42,6 +43,8 @@ defmodule Skate.Settings.RouteSettingsMigrator do
           route_tabs: [
             %{
               uuid: Ecto.UUID.generate(),
+              ordering: 0,
+              is_current_tab: true,
               selected_route_ids: route_settings.selected_route_ids,
               ladder_directions: route_settings.ladder_directions,
               ladder_crowding_toggles: route_settings.ladder_crowding_toggles
@@ -64,6 +67,7 @@ defmodule Skate.Settings.RouteSettingsMigrator do
       from(u in DbUser)
       |> Repo.all()
       |> Repo.preload([:route_settings, :route_tabs])
+      |> Enum.filter(fn db_user -> !is_nil(db_user.route_settings) end)
       |> Enum.filter(fn db_user ->
         route_settings_time =
           db_user.route_settings.updated_at || db_user.route_settings.inserted_at

--- a/lib/skate/settings/route_settings_migrator.ex
+++ b/lib/skate/settings/route_settings_migrator.ex
@@ -34,7 +34,8 @@ defmodule Skate.Settings.RouteSettingsMigrator do
           |> Enum.map(fn route_tab -> route_tab.updated_at || route_tab.inserted_at end)
           |> Enum.max(fn -> nil end)
 
-        is_nil(route_tabs_time) || route_settings_time >= route_tabs_time
+        is_nil(route_tabs_time) ||
+          NaiveDateTime.compare(route_settings_time, route_tabs_time) in [:gt, :eq]
       end)
       |> Enum.map(fn db_user ->
         route_settings = db_user.route_settings
@@ -77,7 +78,8 @@ defmodule Skate.Settings.RouteSettingsMigrator do
           |> Enum.map(fn route_tab -> route_tab.updated_at || route_tab.inserted_at end)
           |> Enum.max(fn -> nil end)
 
-        !is_nil(route_tabs_time) && route_tabs_time >= route_settings_time
+        !is_nil(route_tabs_time) &&
+          NaiveDateTime.compare(route_tabs_time, route_settings_time) in [:gt, :eq]
       end)
       |> Enum.map(fn db_user ->
         ordered_open_route_tabs =

--- a/lib/skate/settings/route_settings_migrator.ex
+++ b/lib/skate/settings/route_settings_migrator.ex
@@ -1,0 +1,128 @@
+defmodule Skate.Settings.RouteSettingsMigrator do
+  use GenServer, restart: :transient
+  require Logger
+  import Ecto.Query
+
+  alias Skate.Repo
+  alias Skate.Settings.Db.User, as: DbUser
+
+  @type direction :: :route_settings_to_route_tabs | :route_tabs_to_route_settings
+
+  @impl true
+  def init(opts) do
+    {:ok, nil, {:continue, opts[:direction]}}
+  end
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name] || __MODULE__)
+  end
+
+  @impl true
+  def handle_continue(:route_settings_to_route_tabs, _state) do
+    changesets =
+      from(u in DbUser)
+      |> Repo.all()
+      |> Repo.preload([:route_settings, :route_tabs])
+      |> Enum.filter(fn db_user ->
+        route_settings_time =
+          db_user.route_settings.updated_at || db_user.route_settings.inserted_at
+
+        route_tabs_time =
+          db_user.route_tabs
+          |> Enum.map(fn route_tab -> route_tab.updated_at || route_tab.inserted_at end)
+          |> Enum.max(fn -> nil end)
+
+        is_nil(route_tabs_time) || route_settings_time >= route_tabs_time
+      end)
+      |> Enum.map(fn db_user ->
+        route_settings = db_user.route_settings
+
+        DbUser.changeset(db_user, %{
+          route_tabs: [
+            %{
+              uuid: Ecto.UUID.generate(),
+              selected_route_ids: route_settings.selected_route_ids,
+              ladder_directions: route_settings.ladder_directions,
+              ladder_crowding_toggles: route_settings.ladder_crowding_toggles
+            }
+          ]
+        })
+      end)
+
+    Enum.each(changesets, fn changeset -> Repo.update!(changeset) end)
+
+    Logger.info(
+      "#{__MODULE__} migrated #{Enum.count(changesets)} user(s) from route_settings to route_tabs"
+    )
+
+    {:stop, :normal, nil}
+  end
+
+  def handle_continue(:route_tabs_to_route_settings, _state) do
+    changesets =
+      from(u in DbUser)
+      |> Repo.all()
+      |> Repo.preload([:route_settings, :route_tabs])
+      |> Enum.filter(fn db_user ->
+        route_settings_time =
+          db_user.route_settings.updated_at || db_user.route_settings.inserted_at
+
+        route_tabs_time =
+          db_user.route_tabs
+          |> Enum.map(fn route_tab -> route_tab.updated_at || route_tab.inserted_at end)
+          |> Enum.max(fn -> nil end)
+
+        !is_nil(route_tabs_time) && route_tabs_time >= route_settings_time
+      end)
+      |> Enum.map(fn db_user ->
+        ordered_open_route_tabs =
+          db_user.route_tabs
+          |> Enum.filter(&(!is_nil(&1.ordering)))
+          |> Enum.sort_by(& &1.ordering)
+
+        selected_route_ids =
+          ordered_open_route_tabs
+          |> Enum.map(& &1.selected_route_ids)
+          |> List.flatten()
+          |> Enum.uniq_by(& &1)
+
+        ladder_directions =
+          ordered_open_route_tabs
+          |> Enum.map(& &1.ladder_directions)
+          |> Enum.reduce(%{}, fn ladder_directions, acc ->
+            Map.merge(acc, ladder_directions || %{})
+          end)
+
+        ladder_crowding_toggles =
+          ordered_open_route_tabs
+          |> Enum.map(& &1.ladder_crowding_toggles)
+          |> Enum.reduce(%{}, fn ladder_crowding_toggles, acc ->
+            Map.merge(acc, ladder_crowding_toggles || %{})
+          end)
+
+        DbUser.changeset(db_user, %{
+          route_settings: %{
+            user_id: db_user.id,
+            selected_route_ids: selected_route_ids,
+            ladder_directions: ladder_directions,
+            ladder_crowding_toggles: ladder_crowding_toggles
+          }
+        })
+      end)
+
+    Enum.each(changesets, fn changeset -> Repo.update!(changeset) end)
+
+    Logger.info(
+      "#{__MODULE__} migrated #{Enum.count(changesets)} user(s) from route_tabs to route_settings"
+    )
+
+    {:stop, :normal, nil}
+  end
+
+  def handle_continue(direction, _state) do
+    Logger.error("#{__MODULE__} invalid direction for migration: #{inspect(direction)}")
+
+    {:stop, :invalid_direction, nil}
+  end
+end

--- a/lib/skate_web/controllers/route_settings_controller.ex
+++ b/lib/skate_web/controllers/route_settings_controller.ex
@@ -21,6 +21,6 @@ defmodule SkateWeb.RouteSettingsController do
 
     settings
     |> Map.take(Map.keys(translations))
-    |> Enum.map(fn {key, value} -> {Map.fetch!(translations, key), value} end)
+    |> Map.new(fn {key, value} -> {Map.fetch!(translations, key), value} end)
   end
 end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -260,7 +260,7 @@ defmodule Notifications.NotificationServerTest do
       end)
 
       RouteSettings.get_or_create("fake_uid")
-      RouteSettings.set("fake_uid", [{:selected_route_ids, ["39"]}])
+      RouteSettings.set("fake_uid", %{selected_route_ids: ["39"]})
     end
 
     test "broadcasts, saves, and logs nothing if no new block waivers are received" do
@@ -329,7 +329,7 @@ defmodule Notifications.NotificationServerTest do
     test "doesn't send notifications to a user not looking at the route in question" do
       Repo.delete_all(from(DbUser))
       RouteSettings.get_or_create("fake_uid")
-      RouteSettings.set("fake_uid", [{:selected_route_ids, ["1,83,77"]}])
+      RouteSettings.set("fake_uid", %{selected_route_ids: ["1", "83", "77"]})
 
       set_log_level(:info)
 
@@ -416,7 +416,7 @@ defmodule Notifications.NotificationServerTest do
         uid = "fake_uid#{i}"
         route_id = Enum.at(@chelsea_bridge_route_ids, i)
         RouteSettings.get_or_create(uid)
-        RouteSettings.set(uid, [{:selected_route_ids, ["#{route_id}"]}])
+        RouteSettings.set(uid, %{selected_route_ids: [route_id]})
       end
 
       start_time = DateTime.utc_now() |> DateTime.to_unix()
@@ -452,7 +452,7 @@ defmodule Notifications.NotificationServerTest do
         uid = "fake_uid#{i}"
         route_id = Enum.at(@chelsea_bridge_route_ids, i)
         RouteSettings.get_or_create(uid)
-        RouteSettings.set(uid, [{:selected_route_ids, ["#{route_id}"]}])
+        RouteSettings.set(uid, %{selected_route_ids: [route_id]})
       end
 
       NotificationServer.subscribe("fake_uid0", server)
@@ -493,7 +493,7 @@ defmodule Notifications.NotificationServerTest do
 
       Repo.delete_all(from(DbUser))
       RouteSettings.get_or_create("fake_uid")
-      RouteSettings.set("fake_uid", [{:selected_route_ids, ["1,83,77"]}])
+      RouteSettings.set("fake_uid", %{selected_route_ids: ["1", "83", "77"]})
 
       set_log_level(:info)
 
@@ -532,7 +532,7 @@ defmodule Notifications.NotificationServerTest do
         uid = "fake_uid#{i}"
         route_id = Enum.at(@chelsea_bridge_route_ids, i)
         RouteSettings.get_or_create(uid)
-        RouteSettings.set(uid, [{:selected_route_ids, ["#{route_id}"]}])
+        RouteSettings.set(uid, %{selected_route_ids: [route_id]})
       end
 
       NotificationServer.subscribe("fake_uid0", server)

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -21,9 +21,9 @@ defmodule Notifications.NotificationTest do
       RouteSettings.get_or_create("user2")
       RouteSettings.get_or_create("user3")
 
-      RouteSettings.set("user1", selected_route_ids: ["4", "1"])
-      RouteSettings.set("user2", selected_route_ids: ["2"])
-      RouteSettings.set("user3", selected_route_ids: ["4", "5", "6", "7"])
+      RouteSettings.set("user1", %{selected_route_ids: ["4", "1"]})
+      RouteSettings.set("user2", %{selected_route_ids: ["2"]})
+      RouteSettings.set("user3", %{selected_route_ids: ["4", "5", "6", "7"]})
 
       notification_values = %{
         created_at: 12345,
@@ -61,8 +61,8 @@ defmodule Notifications.NotificationTest do
 
       RouteSettings.get_or_create("user1")
       RouteSettings.get_or_create("user2")
-      RouteSettings.set("user1", selected_route_ids: ["1", "2", "112"])
-      RouteSettings.set("user2", selected_route_ids: ["1", "3", "743"])
+      RouteSettings.set("user1", %{selected_route_ids: ["1", "2", "112"]})
+      RouteSettings.set("user2", %{selected_route_ids: ["1", "3", "743"]})
 
       route_1_unexpired =
         Notification.get_or_create_from_block_waiver(%{

--- a/test/skate/settings/route_settings_migrator_test.exs
+++ b/test/skate/settings/route_settings_migrator_test.exs
@@ -30,11 +30,11 @@ defmodule Skate.Settings.RouteSettingsMigratorTest do
       _user = RouteSettings.get_or_create("charlie")
 
       :ok =
-        RouteSettings.set("charlie", [
-          {:selected_route_ids, ["1", "77"]},
-          {:ladder_directions, %{"77" => 1}},
-          {:ladder_crowding_toggles, %{"1" => true}}
-        ])
+        RouteSettings.set("charlie", %{
+          selected_route_ids: ["1", "77"],
+          ladder_directions: %{"77" => 1},
+          ladder_crowding_toggles: %{"1" => true}
+        })
 
       log =
         capture_log([level: :info], fn ->
@@ -60,7 +60,7 @@ defmodule Skate.Settings.RouteSettingsMigratorTest do
 
     test "doesn't migrate for users who have route_tabs more recent than route_settings" do
       _user = RouteSettings.get_or_create("charlie")
-      :ok = RouteSettings.set("charlie", [{:selected_route_ids, ["1", "77"]}])
+      :ok = RouteSettings.set("charlie", %{selected_route_ids: ["1", "77"]})
 
       from(rs in DbRouteSettings)
       |> Repo.update_all(set: [updated_at: DateTime.utc_now() |> DateTime.add(-60, :second)])
@@ -121,7 +121,7 @@ defmodule Skate.Settings.RouteSettingsMigratorTest do
 
     test "doesn't migrate for users who have route_settings more recent than route_tabs" do
       _user = RouteSettings.get_or_create("charlie")
-      :ok = RouteSettings.set("charlie", [{:selected_route_ids, ["1", "77"]}])
+      :ok = RouteSettings.set("charlie", %{selected_route_ids: ["1", "77"]})
 
       _route_tabs =
         RouteTab.update_all_for_user!("charlie", [

--- a/test/skate/settings/route_settings_migrator_test.exs
+++ b/test/skate/settings/route_settings_migrator_test.exs
@@ -47,6 +47,8 @@ defmodule Skate.Settings.RouteSettingsMigratorTest do
 
       assert [
                %{
+                 ordering: 0,
+                 is_current_tab: true,
                  selected_route_ids: ["1", "77"],
                  ladder_directions: %{"77" => 1},
                  ladder_crowding_toggles: %{"1" => true}

--- a/test/skate/settings/route_settings_migrator_test.exs
+++ b/test/skate/settings/route_settings_migrator_test.exs
@@ -1,0 +1,157 @@
+defmodule Skate.Settings.RouteSettingsMigratorTest do
+  use Skate.DataCase
+  import Skate.Factory
+  import ExUnit.CaptureLog
+  import Ecto.Query
+  import Test.Support.Helpers
+
+  alias Skate.Settings.RouteSettings
+  alias Skate.Settings.RouteTab
+  alias Skate.Settings.Db.RouteSettings, as: DbRouteSettings
+  alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+
+  describe "init/1" do
+    test "passes through direction option" do
+      assert {:ok, nil, {:continue, :route_tabs_to_route_settings}} =
+               Skate.Settings.RouteSettingsMigrator.init(direction: :route_tabs_to_route_settings)
+    end
+  end
+
+  describe "start_link/1" do
+    test "starts GenServer" do
+      assert {:ok, _pid} = Skate.Settings.RouteSettingsMigrator.start_link()
+    end
+  end
+
+  describe "handle_continue/2" do
+    test "migrates from route_settings to route_tabs" do
+      set_log_level(:info)
+
+      _user = RouteSettings.get_or_create("charlie")
+
+      :ok =
+        RouteSettings.set("charlie", [
+          {:selected_route_ids, ["1", "77"]},
+          {:ladder_directions, %{"77" => 1}},
+          {:ladder_crowding_toggles, %{"1" => true}}
+        ])
+
+      log =
+        capture_log([level: :info], fn ->
+          {:stop, :normal, nil} =
+            Skate.Settings.RouteSettingsMigrator.handle_continue(
+              :route_settings_to_route_tabs,
+              nil
+            )
+        end)
+
+      assert [
+               %{
+                 selected_route_ids: ["1", "77"],
+                 ladder_directions: %{"77" => 1},
+                 ladder_crowding_toggles: %{"1" => true}
+               }
+             ] = RouteTab.get_all_for_user("charlie")
+
+      assert log =~ "migrated 1 user(s) from route_settings to route_tabs"
+    end
+
+    test "doesn't migrate for users who have route_tabs more recent than route_settings" do
+      _user = RouteSettings.get_or_create("charlie")
+      :ok = RouteSettings.set("charlie", [{:selected_route_ids, ["1", "77"]}])
+
+      from(rs in DbRouteSettings)
+      |> Repo.update_all(set: [updated_at: DateTime.utc_now() |> DateTime.add(-60, :second)])
+
+      _route_tabs =
+        RouteTab.update_all_for_user!("charlie", [
+          build(:route_tab, %{selected_route_ids: ["28", "39"]})
+        ])
+
+      {:stop, :normal, nil} =
+        Skate.Settings.RouteSettingsMigrator.handle_continue(:route_settings_to_route_tabs, nil)
+
+      assert [%{selected_route_ids: ["28", "39"]}] = RouteTab.get_all_for_user("charlie")
+    end
+
+    test "migrates from route_tabs to route_settings" do
+      set_log_level(:info)
+
+      _user = RouteSettings.get_or_create("charlie")
+
+      _route_tabs =
+        RouteTab.update_all_for_user!("charlie", [
+          build(:route_tab, %{
+            ordering: 0,
+            selected_route_ids: ["1", "22"],
+            ladder_directions: %{"22" => 1},
+            ladder_crowding_toggles: %{"22" => true}
+          }),
+          build(:route_tab, %{
+            ordering: 1,
+            selected_route_ids: ["22", "66"],
+            ladder_directions: %{"22" => 0},
+            ladder_crowding_toggles: %{"22" => false}
+          }),
+          build(:route_tab, %{
+            ordering: nil,
+            selected_route_ids: ["71", "73"]
+          })
+        ])
+
+      log =
+        capture_log([level: :info], fn ->
+          {:stop, :normal, nil} =
+            Skate.Settings.RouteSettingsMigrator.handle_continue(
+              :route_tabs_to_route_settings,
+              nil
+            )
+        end)
+
+      assert %RouteSettings{
+               selected_route_ids: ["1", "22", "66"],
+               ladder_directions: %{"22" => 0},
+               ladder_crowding_toggles: %{"22" => false}
+             } = RouteSettings.get_or_create("charlie")
+
+      assert log =~ "migrated 1 user(s) from route_tabs to route_settings"
+    end
+
+    test "doesn't migrate for users who have route_settings more recent than route_tabs" do
+      _user = RouteSettings.get_or_create("charlie")
+      :ok = RouteSettings.set("charlie", [{:selected_route_ids, ["1", "77"]}])
+
+      _route_tabs =
+        RouteTab.update_all_for_user!("charlie", [
+          build(:route_tab, %{
+            ordering: 0,
+            selected_route_ids: ["22", "66"],
+            ladder_directions: %{"22" => 0},
+            ladder_crowding_toggles: %{"22" => false}
+          })
+        ])
+
+      from(rt in DbRouteTab)
+      |> Repo.update_all(set: [updated_at: DateTime.utc_now() |> DateTime.add(-60, :second)])
+
+      {:stop, :normal, nil} =
+        Skate.Settings.RouteSettingsMigrator.handle_continue(:route_tabs_to_route_settings, nil)
+
+      assert %RouteSettings{
+               selected_route_ids: ["1", "77"],
+               ladder_directions: %{},
+               ladder_crowding_toggles: %{}
+             } = RouteSettings.get_or_create("charlie")
+    end
+
+    test "logs error when unrecognized direction is provided" do
+      log =
+        capture_log([level: :error], fn ->
+          assert {:stop, :invalid_direction, nil} =
+                   Skate.Settings.RouteSettingsMigrator.handle_continue(:foo, nil)
+        end)
+
+      assert log =~ "Skate.Settings.RouteSettingsMigrator invalid direction for migration: :foo"
+    end
+  end
+end

--- a/test/skate/settings/route_settings_test.exs
+++ b/test/skate/settings/route_settings_test.exs
@@ -67,11 +67,11 @@ defmodule Skate.Settings.RouteSettingsTest do
 
       RouteSettings.set(
         "charlie",
-        [
-          {:selected_route_ids, ["12", "34", "56"]},
-          {:ladder_directions, %{"39" => 1, "77" => 0}},
-          {:ladder_crowding_toggles, %{"741" => true}}
-        ]
+        %{
+          selected_route_ids: ["12", "34", "56"],
+          ladder_directions: %{"39" => 1, "77" => 0},
+          ladder_crowding_toggles: %{"741" => true}
+        }
       )
 
       [sole_record] = Skate.Repo.all(DbRouteSettings)

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -17,11 +17,11 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
     } do
       user = User.get_or_create(username)
       RouteSettings.get_or_create(username)
-      RouteSettings.set(username, selected_route_ids: ["1", "2"])
+      RouteSettings.set(username, %{selected_route_ids: ["1", "2"]})
 
       User.get_or_create("otherguy")
       RouteSettings.get_or_create("otherguy")
-      RouteSettings.set("otherguy", selected_route_ids: ["1", "2"])
+      RouteSettings.set("otherguy", %{selected_route_ids: ["1", "2"]})
 
       user_notification1 =
         Notification.get_or_create_from_block_waiver(%{


### PR DESCRIPTION
Asana ticket: [⚙️ Migrate user settings for tabs + presets](https://app.asana.com/0/1200180014510248/1201481603842987/f)

Note that this doesn't actually enable the process in the supervision tree, that will be in the PR to roll tabs and presets out.

The logic ended up being complicated enough that I opted for this GenServer rather than a real Ecto migration, not to mention the fact that it's not _truly_ reversible so putting it in a migration with an `up` and `down` function would have been slightly disingenuous. This means we have to take care to look at `inserted_at` and `updated_at` values to make sure we're not blowing away subsequent changes by users, given that we don't have the tracking in the `schema_migrations` table to check whether or not the migration has run yet.