### PR TITLE
feat: leave garage filter collapsed by default on page load

### DIFF
--- a/assets/src/hooks/useGarageFilter.tsx
+++ b/assets/src/hooks/useGarageFilter.tsx
@@ -59,7 +59,7 @@ export const GarageFilter = ({
   allGarages,
   toggleGarage,
 }: GarageFilterData) => {
-  const [showGaragesFilter, setShowGaragesFilter] = useState<boolean>(true)
+  const [showGaragesFilter, setShowGaragesFilter] = useState<boolean>(false)
   const sortedGarages = allGarages.sort((a, b) => a.localeCompare(b))
 
   return (

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -162,26 +162,7 @@ exports[`RoutePicker renders a list of routes with tabs / presets enabled 1`] = 
         />
       </button>
     </div>
-    <div>
-      <div
-        className="m-garage-filter__garage"
-      >
-        Garage A
-        <button
-          className="m-garage-filter__button"
-          onClick={[Function]}
-        >
-          <span
-            className=""
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
-              }
-            }
-          />
-        </button>
-      </div>
-    </div>
+    <div />
   </div>
   <ul
     className="m-route-picker__selected-routes"

--- a/assets/tests/hooks/useGarageFilter.test.tsx
+++ b/assets/tests/hooks/useGarageFilter.test.tsx
@@ -98,6 +98,11 @@ describe("GarageFilter", () => {
     const garageFilter = mount(<GarageFilter {...mockGarageFilter} />)
 
     garageFilter
+      .find(".m-garage-filter__show-hide-button")
+      .first()
+      .simulate("click")
+
+    garageFilter
       .find(".m-garage-filter__garage > button")
       .first()
       .simulate("click")
@@ -117,13 +122,6 @@ describe("GarageFilter", () => {
 
     const garageFilter = mount(<GarageFilter {...mockGarageFilter} />)
 
-    expect(garageFilter.text().includes("Garage A")).toBeTruthy()
-
-    garageFilter
-      .find(".m-garage-filter__show-hide-button")
-      .first()
-      .simulate("click")
-
     expect(garageFilter.text().includes("Garage A")).toBeFalsy()
 
     garageFilter
@@ -132,5 +130,12 @@ describe("GarageFilter", () => {
       .simulate("click")
 
     expect(garageFilter.text().includes("Garage A")).toBeTruthy()
+
+    garageFilter
+      .find(".m-garage-filter__show-hide-button")
+      .first()
+      .simulate("click")
+
+    expect(garageFilter.text().includes("Garage A")).toBeFalsy()
   })
 })


### PR DESCRIPTION
Asana ticket: [⚙️Make garage filter default to collapsed](https://app.asana.com/0/1200180014510248/1201862941782408/f)

The (now-default) collapsed state is shown here:
![Screen Shot 2022-02-24 at 11 19 00 AM](https://user-images.githubusercontent.com/2010157/155564342-06d5384a-e159-4371-b67d-2984c24a0393.png)
The Asana ticket includes a recording of a weird user interaction that results from the garage filter taking up a lot of vertical space - leaving it collapsed by default makes this less likely, while still hopefully being prominent enough that users see that it's there to expand if they need it.