### PR TITLE
fix: restore line dropped in rebase

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -231,7 +231,8 @@ defmodule Notifications.Notification do
 
     Skate.Repo.insert_all(
       DbNotificationUser,
-      notification_user_maps
+      notification_user_maps,
+      on_conflict: :nothing
     )
   end
 


### PR DESCRIPTION
Asana ticket: followup from [⚙️ Deliver notifications based on tabs they have open](https://app.asana.com/0/1200180014510248/1201699907939374/f)

Context: I did a rebase and accidentally dropped this (important) line from the original PR before merging. I went through and made sure that the other changes made it in properly.