### PR TITLE
fix: include vehicles from all tabs in VehiclesByRouteIdProvider

### DIFF
--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -23,7 +23,7 @@ import LateView from "./lateView"
 import { OpenView } from "../state"
 import featureIsEnabled from "../laboratoryFeatures"
 import { isOpenTab } from "../models/routeTab"
-import { flatten } from "../helpers/array"
+import { flatten, uniq } from "../helpers/array"
 
 const AppRoutes = () => {
   useAppcues()
@@ -39,8 +39,12 @@ const AppRoutes = () => {
     openView === OpenView.Late || location.pathname === "/"
 
   const routesForVehicles = featureIsEnabled("presets_workspaces")
-    ? flatten(
-        routeTabs.filter(isOpenTab).map((routeTab) => routeTab.selectedRouteIds)
+    ? uniq(
+        flatten(
+          routeTabs
+            .filter(isOpenTab)
+            .map((routeTab) => routeTab.selectedRouteIds)
+        )
       )
     : selectedRouteIds
 

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -22,7 +22,8 @@ import TabBar from "./tabBar"
 import LateView from "./lateView"
 import { OpenView } from "../state"
 import featureIsEnabled from "../laboratoryFeatures"
-import { currentRouteTab } from "../models/routeTab"
+import { isOpenTab } from "../models/routeTab"
+import { flatten } from "../helpers/array"
 
 const AppRoutes = () => {
   useAppcues()
@@ -38,7 +39,9 @@ const AppRoutes = () => {
     openView === OpenView.Late || location.pathname === "/"
 
   const routesForVehicles = featureIsEnabled("presets_workspaces")
-    ? currentRouteTab(routeTabs)?.selectedRouteIds || []
+    ? flatten(
+        routeTabs.filter(isOpenTab).map((routeTab) => routeTab.selectedRouteIds)
+      )
     : selectedRouteIds
 
   const vehiclesByRouteId: ByRouteId<VehicleOrGhost[]> = useVehicles(

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -51,10 +51,10 @@ describe("App", () => {
       routeTabs: [
         routeTabFactory.build({
           ordering: 0,
-          selectedRouteIds: ["1"],
+          selectedRouteIds: ["1", "15"],
           isCurrentTab: true,
         }),
-        routeTabFactory.build({ ordering: 1, selectedRouteIds: ["15"] }),
+        routeTabFactory.build({ ordering: 1, selectedRouteIds: ["15", "22"] }),
       ],
     }
     const mockDispatch = jest.fn()
@@ -66,6 +66,6 @@ describe("App", () => {
 
     const routeIds = (useVehicles as jest.Mock).mock.calls[0][1]
 
-    expect(routeIds).toEqual(["1", "15"])
+    expect(routeIds).toEqual(["1", "15", "22"])
   })
 })

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -2,13 +2,21 @@ import { mount } from "enzyme"
 import React from "react"
 import renderer from "react-test-renderer"
 import App from "../../src/components/app"
+import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { SocketProvider } from "../../src/contexts/socketContext"
 import useDataStatus from "../../src/hooks/useDataStatus"
 import { ConnectionStatus } from "../../src/hooks/useSocket"
+import { initialState } from "../../src/state"
+import routeTabFactory from "../factories/routeTab"
+import useVehicles from "../../src/hooks/useVehicles"
 
 jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
   default: jest.fn(() => "good"),
+}))
+jest.mock("../../src/hooks/useVehicles", () => ({
+  __esModule: true,
+  default: jest.fn(),
 }))
 
 describe("App", () => {
@@ -35,5 +43,29 @@ describe("App", () => {
     ;(useDataStatus as jest.Mock).mockImplementation(() => "outage")
     const tree = renderer.create(<App />).toJSON()
     expect(tree).toMatchSnapshot()
+  })
+
+  test("pulls in vehicles / ghosts for routes in all open tabs", () => {
+    const mockState = {
+      ...initialState,
+      routeTabs: [
+        routeTabFactory.build({
+          ordering: 0,
+          selectedRouteIds: ["1"],
+          isCurrentTab: true,
+        }),
+        routeTabFactory.build({ ordering: 1, selectedRouteIds: ["15"] }),
+      ],
+    }
+    const mockDispatch = jest.fn()
+    renderer.create(
+      <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
+        <App />
+      </StateDispatchProvider>
+    )
+
+    const routeIds = (useVehicles as jest.Mock).mock.calls[0][1]
+
+    expect(routeIds).toEqual(["1", "15"])
   })
 })


### PR DESCRIPTION
Asana ticket: [⚙️ Late view - base routes on tabs](https://app.asana.com/0/1200180014510248/1201880022483803/f)

The Late View uses the contents of the `VehiclesByRouteIdContext`, and Late View users want to be able to monitor routes across all of their open tabs simultaneously. This will somewhat increase the amount of network traffic coming across the WebSocket relative to only subscribing to the current tab's worth of routes, but since the data on each individual vehicle is relatively small and only updates every few seconds, I don't think this is a huge problem. Also, having this data already loaded makes switching back and forth between tabs slightly more instantaneous.