### PR TITLE
build: upload source maps to Sentry from upload_assets.sh

### DIFF
--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -21,8 +21,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Install sentry-cli
-        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -12,11 +12,6 @@ jobs:
     env:
       ECS_CLUSTER: skate
       ECS_SERVICE: skate-dev-blue
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
@@ -26,13 +21,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-          docker-additional-args: '--build-arg SENTRY_ORG --build-arg SENTRY_PROJECT --build-arg SENTRY_AUTH_TOKEN --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY'
+      - name: Install sentry-cli
+        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -23,8 +23,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Install sentry-cli
-        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:

--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -14,11 +14,6 @@ jobs:
     env:
       ECS_CLUSTER: skate
       ECS_SERVICE: skate-dev
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
@@ -28,13 +23,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-          docker-additional-args: '--build-arg SENTRY_ORG --build-arg SENTRY_PROJECT --build-arg SENTRY_AUTH_TOKEN --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY'
+      - name: Install sentry-cli
+        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-prod-ecs.yml
+++ b/.github/workflows/deploy-prod-ecs.yml
@@ -21,8 +21,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Install sentry-cli
-        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:

--- a/.github/workflows/deploy-prod-ecs.yml
+++ b/.github/workflows/deploy-prod-ecs.yml
@@ -12,11 +12,6 @@ jobs:
     env:
       ECS_CLUSTER: skate
       ECS_SERVICE: skate-prod
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v2
@@ -26,13 +21,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
-          docker-additional-args: '--build-arg SENTRY_ORG --build-arg SENTRY_PROJECT --build-arg SENTRY_AUTH_TOKEN --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY'
+      - name: Install sentry-cli
+        run: npm install @sentry/cli
       - name: Upload static assets to S3
         run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,6 @@ FROM node:14-alpine3.13 as assets-builder
 WORKDIR /root
 ADD . .
 
-# Needed for uploading source maps during front-end build
-ARG SENTRY_ORG=$SENTRY_ORG
-ARG SENTRY_PROJECT=$SENTRY_PROJECT
-ARG SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-ARG AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-
 # Copy in elixir deps required to build node modules for phoenix
 COPY --from=elixir-builder /root/deps ./deps
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1213,20 +1213,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@sentry/cli": {
-      "version": "1.69.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.69.1.tgz",
-      "integrity": "sha512-HxO7vjqSvWfc9L5A/ib3UB1mXKFNiORY9BXwtYTo38jv4ROrKDFz36IzHsD6nPFuv8+6iDVyNlEujK/n9NvRyw==",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.0",
-        "npmlog": "^4.1.2",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "@sentry/core": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.10.0.tgz",
@@ -1284,15 +1270,6 @@
       "requires": {
         "@sentry/types": "6.10.0",
         "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/webpack-plugin": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.17.2.tgz",
-      "integrity": "sha512-1XKNP6FAzB+V58WPCX7DTRLu8BaB/ho11Y2VweqZn10m/MZuqKlHI1PzjJsf4hLoMOZBTt9KdkRi4vjgI6TmPA==",
-      "dev": true,
-      "requires": {
-        "@sentry/cli": "^1.68.0"
       }
     },
     "@sinonjs/commons": {
@@ -9341,39 +9318,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
-    },
     "node-gyp": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
@@ -10909,12 +10853,6 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -10951,12 +10889,6 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "prr": {
       "version": "1.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -38,9 +38,9 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
-    "@sentry/webpack-plugin": "^1.17.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
+    "@testing-library/user-event": "^13.5.0",
     "@types/enzyme": "^3.10.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.24",
@@ -51,7 +51,6 @@
     "@types/react-leaflet": "^2.8.2",
     "@types/react-router-dom": "^5.3.2",
     "@types/react-test-renderer": "^17.0.1",
-    "@testing-library/user-event": "^13.5.0",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "enzyme": "^3.11.0",

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -4,22 +4,12 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const TerserPlugin = require("terser-webpack-plugin")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin")
 const CopyWebpackPlugin = require("copy-webpack-plugin")
-const SentryCliPlugin = require('@sentry/webpack-plugin');
 
 module.exports = (env, options) => {
-  const uploadSourceMapToSentry = options.mode === "production";
-
-  const basePlugins = [
+  const plugins = [
     new MiniCssExtractPlugin({ filename: "../css/app.css" }),
     new CopyWebpackPlugin({ patterns: [{ from: "static/", to: "../" }] })
   ]
-  const plugins = uploadSourceMapToSentry ? 
-    [
-      ...basePlugins, 
-      new SentryCliPlugin({
-        include: '../priv/static/js'
-      })
-    ] : basePlugins
 
   const useMinimization = options.mode === "production";
 

--- a/upload_assets.sh
+++ b/upload_assets.sh
@@ -8,7 +8,6 @@ S3_DIR=s3://mbta-dotcom/$APP
 BUILD_TAG=${1}
 TEMP_DIR=$(mktemp -d)
 STATIC_DIR=$TEMP_DIR/priv/static
-PATH=$(npm bin):$PATH
 
 pushd "$TEMP_DIR" > /dev/null
 sh -c "docker run --rm ${BUILD_TAG} tar -c /home/skate/priv/static" | tar -x --strip-components 2
@@ -28,5 +27,5 @@ aws s3 sync "$STATIC_DIR/fonts" "$S3_DIR/fonts" --size-only --exclude "*" --incl
 aws s3 sync $STATIC_DIR $S3_DIR --size-only
 
 # upload source maps to Sentry
-SENTRY_RELEASE=$(sentry-cli releases propose-version)
-sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps "$STATIC_DIR/js"
+SENTRY_RELEASE=$(npx @sentry/cli releases propose-version)
+npx @sentry/cli releases files "$SENTRY_RELEASE" upload-sourcemaps "$STATIC_DIR/js"

--- a/upload_assets.sh
+++ b/upload_assets.sh
@@ -8,6 +8,7 @@ S3_DIR=s3://mbta-dotcom/$APP
 BUILD_TAG=${1}
 TEMP_DIR=$(mktemp -d)
 STATIC_DIR=$TEMP_DIR/priv/static
+PATH=$(npm bin):$PATH
 
 pushd "$TEMP_DIR" > /dev/null
 sh -c "docker run --rm ${BUILD_TAG} tar -c /home/skate/priv/static" | tar -x --strip-components 2
@@ -25,3 +26,7 @@ aws s3 sync "$STATIC_DIR/fonts" "$S3_DIR/fonts" --size-only --exclude "*" --incl
 
 # sync everything else normally
 aws s3 sync $STATIC_DIR $S3_DIR --size-only
+
+# upload source maps to Sentry
+SENTRY_RELEASE=$(sentry-cli releases propose-version)
+sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps "$STATIC_DIR/js"


### PR DESCRIPTION
Asana ticket: [⚙️ Skate deploy: don't upload Sentry source maps directly from Docker build](https://app.asana.com/0/1152340551558956/1200443690692985/f)

I considered caching the `sentry-cli` install between builds, but a) the step to install it takes only ~7 seconds and b) I wasn't sure what we would use as a cache key (we don't have `.tool-versions` or something like that).

Regarding the choice of installation method, NPM in included on the [list of packages](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md) that come with the `ubuntu-latest` environment for GitHub Actions. There are [other options](https://docs.sentry.io/product/cli/installation/) but this seemed preferable alternatives like the `curl ... | bash` pattern.

I have tested deploying this branch to dev, looking at the GitHub Actions output, and looking in the Sentry UI to confirm that source maps had been uploaded.