### PR TITLE
chore: remove old swings API endpoint that doesn't take argument

### DIFF
--- a/lib/skate_web/controllers/swings_controller.ex
+++ b/lib/skate_web/controllers/swings_controller.ex
@@ -1,9 +1,6 @@
 defmodule SkateWeb.SwingsController do
   use SkateWeb, :controller
 
-  alias SkateWeb.AuthManager
-  alias Skate.Settings.RouteTab
-
   def index(conn, %{"route_ids" => route_ids}) do
     swings_fn = Application.get_env(:skate_web, :swings_fn, &Schedule.swings_for_route/3)
     now_fn = Application.get_env(:skate_web, :now_fn, &Util.Time.now/0)
@@ -13,28 +10,6 @@ defmodule SkateWeb.SwingsController do
     swings =
       route_ids
       |> String.split(",")
-      |> Enum.flat_map(fn route_id -> swings_fn.(route_id, now, now) end)
-      |> Enum.uniq_by(fn swing -> {swing.from_run_id, swing.to_run_id} end)
-
-    json(conn, %{data: swings})
-  end
-
-  def index(conn, _params) do
-    username = AuthManager.Plug.current_resource(conn)
-
-    route_ids =
-      username
-      |> RouteTab.get_all_for_user()
-      |> Enum.filter(fn route_tab -> RouteTab.tab_open?(route_tab) end)
-      |> Enum.flat_map(fn route_tab -> route_tab.selected_route_ids end)
-
-    swings_fn = Application.get_env(:skate_web, :swings_fn, &Schedule.swings_for_route/3)
-    now_fn = Application.get_env(:skate_web, :now_fn, &Util.Time.now/0)
-
-    now = now_fn.()
-
-    swings =
-      route_ids
       |> Enum.flat_map(fn route_id -> swings_fn.(route_id, now, now) end)
       |> Enum.uniq_by(fn swing -> {swing.from_run_id, swing.to_run_id} end)
 

--- a/test/skate_web/controllers/swing_controller_test.exs
+++ b/test/skate_web/controllers/swing_controller_test.exs
@@ -48,51 +48,7 @@ defmodule SkateWeb.SwingsControllerTest do
     end
 
     @tag :authenticated
-    test "when logged in, returns all swings for selected routes", %{conn: conn} do
-      conn =
-        conn
-        |> api_headers()
-        |> put("/api/route_tabs", %{
-          "route_tabs" => [
-            %{
-              uuid: Ecto.UUID.generate(),
-              ordering: 0,
-              selectedRouteIds: ["1"],
-              isCurrentTab: true
-            },
-            %{
-              uuid: Ecto.UUID.generate(),
-              ordering: 1,
-              selectedRouteIds: ["2"],
-              isCurrentTab: false
-            },
-            %{
-              uuid: Ecto.UUID.generate(),
-              ordering: nil,
-              selectedRouteIds: ["3"],
-              isCurrentTab: false
-            }
-          ]
-        })
-        |> get("/api/swings")
-
-      assert %{
-               "data" => [
-                 %{
-                   "from_route_id" => "1",
-                   "from_run_id" => "123-456",
-                   "from_trip_id" => "1234",
-                   "time" => 100,
-                   "to_route_id" => "2",
-                   "to_run_id" => "123-789",
-                   "to_trip_id" => "5678"
-                 }
-               ]
-             } = json_response(conn, 200)
-    end
-
-    @tag :authenticated
-    test "when logged in, can provide specific routes as an argument", %{conn: conn} do
+    test "when logged in, returns swings for routes given in argument", %{conn: conn} do
       conn =
         conn
         |> api_headers()


### PR DESCRIPTION
Asana ticket: [⚙️Remove old version of swings API](https://app.asana.com/0/1200180014510248/1201890023661626/f)

Quick followup to #1431 now that that's been released.