### PR TITLE
fix: prevent ladders page from overflowing vertical sizing of app

### DIFF
--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -21,6 +21,12 @@ $color-route-tabs-separator: #9fa2ac;
   }
 }
 
+.m-ladder-page__tab-bar-and-ladders {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .m-ladder-page__route-tab-bar {
   display: flex;
   background-color: $color-route-tabs-bg;

--- a/assets/css/_route_ladders.scss
+++ b/assets/css/_route_ladders.scss
@@ -7,7 +7,7 @@
     [m-route-ladder__controls] minmax(auto, max-content)
     [m-ladder] auto
     [m-incoming-box] max-content;
-  height: 100%;
+  flex-grow: 1;
   max-width: 100%;
   overflow-x: auto;
   padding: 1rem;

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -247,38 +247,40 @@ const LadderPageWithTabs = (): ReactElement<HTMLDivElement> => {
           )}
         </>
       </PickerContainer>
-      <div className="m-ladder-page__route-tab-bar">
-        {routeTabs
-          .filter(isOpenTab)
-          .sort((a, b) => (a.ordering || 0) - (b.ordering || 0))
-          .map((routeTab) => (
-            <LadderTab
-              tab={routeTab}
-              selectTab={() => dispatch(selectRouteTab(routeTab.uuid))}
-              closeTab={() => dispatch(closeRouteTab(routeTab.uuid))}
-              showSaveIcon={!isPreset(routeTab) || isEditedPreset(routeTab)}
-              saveTab={() => {
-                dispatch(promptToSaveOrCreatePreset(routeTab))
-              }}
-              key={routeTab.uuid}
-            />
-          ))}
+      <div className="m-ladder-page__tab-bar-and-ladders">
+        <div className="m-ladder-page__route-tab-bar">
+          {routeTabs
+            .filter(isOpenTab)
+            .sort((a, b) => (a.ordering || 0) - (b.ordering || 0))
+            .map((routeTab) => (
+              <LadderTab
+                tab={routeTab}
+                selectTab={() => dispatch(selectRouteTab(routeTab.uuid))}
+                closeTab={() => dispatch(closeRouteTab(routeTab.uuid))}
+                showSaveIcon={!isPreset(routeTab) || isEditedPreset(routeTab)}
+                saveTab={() => {
+                  dispatch(promptToSaveOrCreatePreset(routeTab))
+                }}
+                key={routeTab.uuid}
+              />
+            ))}
 
-        <AddTabButton addTab={() => dispatch(createRouteTab())} />
+          <AddTabButton addTab={() => dispatch(createRouteTab())} />
+        </div>
+
+        <RouteLadders
+          routes={selectedRoutes}
+          timepointsByRouteId={timepointsByRouteId}
+          selectedVehicleId={selectedVehicleOrGhost?.id}
+          deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
+          reverseLadder={(routeId) => dispatch(flipLadderInTab(routeId))}
+          toggleCrowding={(routeId) =>
+            dispatch(toggleLadderCrowdingInTab(routeId))
+          }
+          ladderDirections={ladderDirections}
+          ladderCrowdingToggles={ladderCrowdingToggles}
+        />
       </div>
-
-      <RouteLadders
-        routes={selectedRoutes}
-        timepointsByRouteId={timepointsByRouteId}
-        selectedVehicleId={selectedVehicleOrGhost?.id}
-        deselectRoute={(routeId) => dispatch(deselectRouteInTab(routeId))}
-        reverseLadder={(routeId) => dispatch(flipLadderInTab(routeId))}
-        toggleCrowding={(routeId) =>
-          dispatch(toggleLadderCrowdingInTab(routeId))
-        }
-        ladderDirections={ladderDirections}
-        ladderCrowdingToggles={ladderCrowdingToggles}
-      />
       <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
     </div>
   )

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -291,25 +291,29 @@ exports[`App renders 1`] = `
         </div>
       </div>
       <div
-        className="m-ladder-page__route-tab-bar"
+        className="m-ladder-page__tab-bar-and-ladders"
       >
         <div
-          className="m-ladder-page__add-tab-button"
-          onClick={[Function]}
+          className="m-ladder-page__route-tab-bar"
         >
-          <span
-            className="m-ladder-page__add-tab-icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+          <div
+            className="m-ladder-page__add-tab-button"
+            onClick={[Function]}
+          >
+            <span
+              className="m-ladder-page__add-tab-icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
+        <div
+          className="m-route-ladders"
+        />
       </div>
-      <div
-        className="m-route-ladders"
-      />
     </div>
   </div>
 </div>
@@ -621,25 +625,29 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
         </div>
       </div>
       <div
-        className="m-ladder-page__route-tab-bar"
+        className="m-ladder-page__tab-bar-and-ladders"
       >
         <div
-          className="m-ladder-page__add-tab-button"
-          onClick={[Function]}
+          className="m-ladder-page__route-tab-bar"
         >
-          <span
-            className="m-ladder-page__add-tab-icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+          <div
+            className="m-ladder-page__add-tab-button"
+            onClick={[Function]}
+          >
+            <span
+              className="m-ladder-page__add-tab-icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
+        <div
+          className="m-route-ladders"
+        />
       </div>
-      <div
-        className="m-route-ladders"
-      />
     </div>
   </div>
 </div>

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -291,25 +291,29 @@ exports[`renders 1`] = `
         </div>
       </div>
       <div
-        className="m-ladder-page__route-tab-bar"
+        className="m-ladder-page__tab-bar-and-ladders"
       >
         <div
-          className="m-ladder-page__add-tab-button"
-          onClick={[Function]}
+          className="m-ladder-page__route-tab-bar"
         >
-          <span
-            className="m-ladder-page__add-tab-icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+          <div
+            className="m-ladder-page__add-tab-button"
+            onClick={[Function]}
+          >
+            <span
+              className="m-ladder-page__add-tab-icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
+        <div
+          className="m-route-ladders"
+        />
       </div>
-      <div
-        className="m-route-ladders"
-      />
     </div>
   </div>
 </div>

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -183,32 +183,99 @@ exports[`LadderPage renders with route tabs 1`] = `
     </div>
   </div>
   <div
-    className="m-ladder-page__route-tab-bar"
+    className="m-ladder-page__tab-bar-and-ladders"
   >
     <div
-      className="m-ladder-page__tab m-ladder-page__tab-current"
-      onClick={[Function]}
+      className="m-ladder-page__route-tab-bar"
     >
       <div
-        className="m-ladder-page__tab-contents"
+        className="m-ladder-page__tab m-ladder-page__tab-current"
+        onClick={[Function]}
       >
         <div
-          className="m-ladder-page__tab-title"
+          className="m-ladder-page__tab-contents"
         >
-          Untitled
-        </div>
-        <div
-          onClick={[Function]}
-        >
-          <span
-            className="m-ladder-page__tab-save-icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "SVG",
+          <div
+            className="m-ladder-page__tab-title"
+          >
+            Untitled
+          </div>
+          <div
+            onClick={[Function]}
+          >
+            <span
+              className="m-ladder-page__tab-save-icon"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
               }
-            }
-          />
+            />
+          </div>
+          <button
+            className="m-close-button"
+            data-testid="close-button"
+            onClick={[Function]}
+          >
+            <span
+              className=""
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
+              }
+            />
+          </button>
         </div>
+      </div>
+      <div
+        className="m-ladder-page__tab"
+        onClick={[Function]}
+      >
+        <div
+          className="m-ladder-page__tab-contents"
+        >
+          <div
+            className="m-ladder-page__tab-title"
+          >
+            Untitled
+          </div>
+          <button
+            className="m-close-button"
+            data-testid="close-button"
+            onClick={[Function]}
+          >
+            <span
+              className=""
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "SVG",
+                }
+              }
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        className="m-ladder-page__add-tab-button"
+        onClick={[Function]}
+      >
+        <span
+          className="m-ladder-page__add-tab-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="m-route-ladders"
+    >
+      <div
+        className="m-route-ladder__header"
+      >
         <button
           className="m-close-button"
           data-testid="close-button"
@@ -223,95 +290,32 @@ exports[`LadderPage renders with route tabs 1`] = `
             }
           />
         </button>
-      </div>
-    </div>
-    <div
-      className="m-ladder-page__tab"
-      onClick={[Function]}
-    >
-      <div
-        className="m-ladder-page__tab-contents"
-      >
         <div
-          className="m-ladder-page__tab-title"
+          className="m-route-ladder__route-name"
         >
-          Untitled
+          1
         </div>
+      </div>
+      <div
+        className="m-route-ladder__controls"
+      >
         <button
-          className="m-close-button"
-          data-testid="close-button"
+          className="m-route-ladder__reverse"
           onClick={[Function]}
         >
           <span
-            className=""
+            className="m-route-ladder__reverse-icon"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "SVG",
               }
             }
           />
+          Reverse
         </button>
       </div>
+      loading...
     </div>
-    <div
-      className="m-ladder-page__add-tab-button"
-      onClick={[Function]}
-    >
-      <span
-        className="m-ladder-page__add-tab-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "SVG",
-          }
-        }
-      />
-    </div>
-  </div>
-  <div
-    className="m-route-ladders"
-  >
-    <div
-      className="m-route-ladder__header"
-    >
-      <button
-        className="m-close-button"
-        data-testid="close-button"
-        onClick={[Function]}
-      >
-        <span
-          className=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
-      </button>
-      <div
-        className="m-route-ladder__route-name"
-      >
-        1
-      </div>
-    </div>
-    <div
-      className="m-route-ladder__controls"
-    >
-      <button
-        className="m-route-ladder__reverse"
-        onClick={[Function]}
-      >
-        <span
-          className="m-route-ladder__reverse-icon"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
-        Reverse
-      </button>
-    </div>
-    loading...
   </div>
 </div>
 `;


### PR DESCRIPTION
Asana ticket: [⚙️Examine Skate viewport weirdness](https://app.asana.com/0/1200180014510248/1201890023661633/f)

We were applying `height: 100%` to the top-level route ladders component, making it as tall as its container, but neglected to update this when we added the tab bar on top. This was causing the route ladders to extend slightly below what was supposed to be the bottom of the page, like so:
![Screen Shot 2022-03-03 at 12 28 50 PM](https://user-images.githubusercontent.com/2010157/156619222-91552056-9711-4513-ad44-0678eee03250.png)
In particular, this was bad because it was causing the horizontal scrollbar to disappear off the bottom of the screen unless you scrolled down a few pixels. With the change, the layout looks much better and the app no longer scrolls vertically:
![Screen Shot 2022-03-03 at 12 29 02 PM](https://user-images.githubusercontent.com/2010157/156619413-5685c787-37f2-4c0a-b4e3-fb15a0345f01.png)
