### PR TITLE
Keyboard shortcuts for presets modals

### DIFF
--- a/assets/css/_input_modal.scss
+++ b/assets/css/_input_modal.scss
@@ -13,6 +13,13 @@
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.25);
   border-radius: 0.25rem;
   line-height: 1.125rem;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
 }
 
 .m-input-modal__overlay {

--- a/assets/src/components/inputModal.tsx
+++ b/assets/src/components/inputModal.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from "react"
+import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import { closeInputModal } from "../state"
+
+const InputModal = ({
+  children,
+}: {
+  children: JSX.Element | JSX.Element[]
+}) => {
+  const [, dispatch] = useContext(StateDispatchContext)
+  return (
+    <>
+      <div
+        className="m-input-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            dispatch(closeInputModal())
+          }
+        }}
+      >
+        {children}
+      </div>
+      <div className="m-input-modal__overlay" />
+    </>
+  )
+}
+
+export default InputModal

--- a/assets/src/components/inputModals/createPresetModal.tsx
+++ b/assets/src/components/inputModals/createPresetModal.tsx
@@ -18,7 +18,14 @@ const CreatePresetModal = ({
   const [presetName, setPresetName] = useState<string>("")
   return (
     <>
-      <div className="m-input-modal">
+      <div
+        className="m-input-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            dispatch(closeInputModal())
+          }
+        }}
+      >
         <form
           onSubmit={(event) => {
             event.preventDefault()

--- a/assets/src/components/inputModals/createPresetModal.tsx
+++ b/assets/src/components/inputModals/createPresetModal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react"
+import InputModal from "../inputModal"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { Action, closeInputModal } from "../../state"
 import { findPresetByName } from "../../models/routeTab"
@@ -17,65 +18,51 @@ const CreatePresetModal = ({
   const [{ routeTabs }, dispatch] = useContext(StateDispatchContext)
   const [presetName, setPresetName] = useState<string>("")
   return (
-    <>
-      <div
-        className="m-input-modal"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
+    <InputModal>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          const existingPreset = findPresetByName(routeTabs, presetName)
+          if (existingPreset) {
+            confirmOverwriteCallback(presetName, existingPreset.uuid, dispatch)
+          } else {
+            createCallback(presetName, dispatch)
             dispatch(closeInputModal())
           }
         }}
       >
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            const existingPreset = findPresetByName(routeTabs, presetName)
-            if (existingPreset) {
-              confirmOverwriteCallback(
-                presetName,
-                existingPreset.uuid,
-                dispatch
-              )
-            } else {
-              createCallback(presetName, dispatch)
-              dispatch(closeInputModal())
+        <div className="m-input-modal__title">Save open routes as preset</div>
+        <div className="m-input-modal__input">
+          <input
+            autoFocus={true}
+            placeholder="Name your preset&hellip;"
+            required={true}
+            onChange={(event) => {
+              setPresetName(event.currentTarget.value)
+            }}
+          />
+        </div>
+        <div className="m-input-modal__buttons">
+          <button
+            type="button"
+            className="m-input-modal__button"
+            onClick={() => dispatch(closeInputModal())}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={presetName.length === 0}
+            className={
+              "m-input-modal__button" +
+              (presetName.length === 0 ? "-disabled" : "-confirm")
             }
-          }}
-        >
-          <div className="m-input-modal__title">Save open routes as preset</div>
-          <div className="m-input-modal__input">
-            <input
-              autoFocus={true}
-              placeholder="Name your preset&hellip;"
-              required={true}
-              onChange={(event) => {
-                setPresetName(event.currentTarget.value)
-              }}
-            />
-          </div>
-          <div className="m-input-modal__buttons">
-            <button
-              type="button"
-              className="m-input-modal__button"
-              onClick={() => dispatch(closeInputModal())}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={presetName.length === 0}
-              className={
-                "m-input-modal__button" +
-                (presetName.length === 0 ? "-disabled" : "-confirm")
-              }
-            >
-              Save
-            </button>
-          </div>
-        </form>
-      </div>
-      <div className="m-input-modal__overlay" />
-    </>
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </InputModal>
   )
 }
 

--- a/assets/src/components/inputModals/createPresetModal.tsx
+++ b/assets/src/components/inputModals/createPresetModal.tsx
@@ -19,46 +19,53 @@ const CreatePresetModal = ({
   return (
     <>
       <div className="m-input-modal">
-        <div className="m-input-modal__title">Save open routes as preset</div>
-        <div className="m-input-modal__input">
-          <input
-            autoFocus={true}
-            placeholder="Name your preset&hellip;"
-            onChange={(event) => {
-              setPresetName(event.currentTarget.value)
-            }}
-          />
-        </div>
-        <div className="m-input-modal__buttons">
-          <button
-            className="m-input-modal__button"
-            onClick={() => dispatch(closeInputModal())}
-          >
-            Cancel
-          </button>
-          <button
-            disabled={presetName.length === 0}
-            className={
-              "m-input-modal__button" +
-              (presetName.length === 0 ? "-disabled" : "-confirm")
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            const existingPreset = findPresetByName(routeTabs, presetName)
+            if (existingPreset) {
+              confirmOverwriteCallback(
+                presetName,
+                existingPreset.uuid,
+                dispatch
+              )
+            } else {
+              createCallback(presetName, dispatch)
+              dispatch(closeInputModal())
             }
-            onClick={() => {
-              const existingPreset = findPresetByName(routeTabs, presetName)
-              if (existingPreset) {
-                confirmOverwriteCallback(
-                  presetName,
-                  existingPreset.uuid,
-                  dispatch
-                )
-              } else {
-                createCallback(presetName, dispatch)
-                dispatch(closeInputModal())
+          }}
+        >
+          <div className="m-input-modal__title">Save open routes as preset</div>
+          <div className="m-input-modal__input">
+            <input
+              autoFocus={true}
+              placeholder="Name your preset&hellip;"
+              required={true}
+              onChange={(event) => {
+                setPresetName(event.currentTarget.value)
+              }}
+            />
+          </div>
+          <div className="m-input-modal__buttons">
+            <button
+              type="button"
+              className="m-input-modal__button"
+              onClick={() => dispatch(closeInputModal())}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={presetName.length === 0}
+              className={
+                "m-input-modal__button" +
+                (presetName.length === 0 ? "-disabled" : "-confirm")
               }
-            }}
-          >
-            Save
-          </button>
-        </div>
+            >
+              Save
+            </button>
+          </div>
+        </form>
       </div>
       <div className="m-input-modal__overlay" />
     </>

--- a/assets/src/components/inputModals/deletePresetModal.tsx
+++ b/assets/src/components/inputModals/deletePresetModal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react"
+import InputModal from "../inputModal"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { Action, closeInputModal } from "../../state"
 
@@ -11,44 +12,34 @@ const DeletePresetModal = ({
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
   return (
-    <>
-      <div
-        className="m-input-modal"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            dispatch(closeInputModal())
-          }
-        }}
-      >
-        <div className="m-input-modal__title">Delete preset?</div>
-        <div className="m-input-modal__text">
-          <span className="m-input-modal__name-text">{presetName}</span>
-        </div>
-        <div className="m-input-modal__buttons">
-          <button
-            className="m-input-modal__button"
-            onClick={() => dispatch(closeInputModal())}
-          >
-            Cancel
-          </button>
-          <button
-            autoFocus={true}
-            className="m-input-modal__button-danger"
-            onClick={() => {
-              if (window.FS) {
-                window.FS.event("Preset deleted")
-              }
-
-              deleteCallback(dispatch)
-              dispatch(closeInputModal())
-            }}
-          >
-            Confirm
-          </button>
-        </div>
+    <InputModal>
+      <div className="m-input-modal__title">Delete preset?</div>
+      <div className="m-input-modal__text">
+        <span className="m-input-modal__name-text">{presetName}</span>
       </div>
-      <div className="m-input-modal__overlay" />
-    </>
+      <div className="m-input-modal__buttons">
+        <button
+          className="m-input-modal__button"
+          onClick={() => dispatch(closeInputModal())}
+        >
+          Cancel
+        </button>
+        <button
+          autoFocus={true}
+          className="m-input-modal__button-danger"
+          onClick={() => {
+            if (window.FS) {
+              window.FS.event("Preset deleted")
+            }
+
+            deleteCallback(dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Confirm
+        </button>
+      </div>
+    </InputModal>
   )
 }
 

--- a/assets/src/components/inputModals/deletePresetModal.tsx
+++ b/assets/src/components/inputModals/deletePresetModal.tsx
@@ -25,6 +25,7 @@ const DeletePresetModal = ({
             Cancel
           </button>
           <button
+            autoFocus={true}
             className="m-input-modal__button-danger"
             onClick={() => {
               if (window.FS) {

--- a/assets/src/components/inputModals/deletePresetModal.tsx
+++ b/assets/src/components/inputModals/deletePresetModal.tsx
@@ -12,7 +12,14 @@ const DeletePresetModal = ({
   const [, dispatch] = useContext(StateDispatchContext)
   return (
     <>
-      <div className="m-input-modal">
+      <div
+        className="m-input-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            dispatch(closeInputModal())
+          }
+        }}
+      >
         <div className="m-input-modal__title">Delete preset?</div>
         <div className="m-input-modal__text">
           <span className="m-input-modal__name-text">{presetName}</span>

--- a/assets/src/components/inputModals/overwritePresetModal.tsx
+++ b/assets/src/components/inputModals/overwritePresetModal.tsx
@@ -12,7 +12,14 @@ const OverwritePresetModal = ({
   const [, dispatch] = useContext(StateDispatchContext)
   return (
     <>
-      <div className="m-input-modal">
+      <div
+        className="m-input-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            dispatch(closeInputModal())
+          }
+        }}
+      >
         <div className="m-input-modal__title">
           A preset named{" "}
           <span className="m-input-modal__name-text">{presetName}</span> already

--- a/assets/src/components/inputModals/overwritePresetModal.tsx
+++ b/assets/src/components/inputModals/overwritePresetModal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react"
+import InputModal from "../inputModal"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { Action, closeInputModal } from "../../state"
 
@@ -11,45 +12,35 @@ const OverwritePresetModal = ({
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
   return (
-    <>
-      <div
-        className="m-input-modal"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            dispatch(closeInputModal())
-          }
-        }}
-      >
-        <div className="m-input-modal__title">
-          A preset named{" "}
-          <span className="m-input-modal__name-text">{presetName}</span> already
-          exists.
-        </div>
-        <div className="m-input-modal__title">
-          Overwrite{" "}
-          <span className="m-input-modal__name-text">{presetName}</span>?
-        </div>
-        <div className="m-input-modal__buttons">
-          <button
-            className="m-input-modal__button"
-            onClick={() => dispatch(closeInputModal())}
-          >
-            Cancel
-          </button>
-          <button
-            autoFocus={true}
-            className="m-input-modal__button-confirm"
-            onClick={() => {
-              confirmCallback(dispatch)
-              dispatch(closeInputModal())
-            }}
-          >
-            Save
-          </button>
-        </div>
+    <InputModal>
+      <div className="m-input-modal__title">
+        A preset named{" "}
+        <span className="m-input-modal__name-text">{presetName}</span> already
+        exists.
       </div>
-      <div className="m-input-modal__overlay" />
-    </>
+      <div className="m-input-modal__title">
+        Overwrite <span className="m-input-modal__name-text">{presetName}</span>
+        ?
+      </div>
+      <div className="m-input-modal__buttons">
+        <button
+          className="m-input-modal__button"
+          onClick={() => dispatch(closeInputModal())}
+        >
+          Cancel
+        </button>
+        <button
+          autoFocus={true}
+          className="m-input-modal__button-confirm"
+          onClick={() => {
+            confirmCallback(dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </InputModal>
   )
 }
 

--- a/assets/src/components/inputModals/overwritePresetModal.tsx
+++ b/assets/src/components/inputModals/overwritePresetModal.tsx
@@ -30,6 +30,7 @@ const OverwritePresetModal = ({
             Cancel
           </button>
           <button
+            autoFocus={true}
             className="m-input-modal__button-confirm"
             onClick={() => {
               confirmCallback(dispatch)

--- a/assets/src/components/inputModals/savePresetModal.tsx
+++ b/assets/src/components/inputModals/savePresetModal.tsx
@@ -12,7 +12,14 @@ const SavePresetModal = ({
   const [, dispatch] = useContext(StateDispatchContext)
   return (
     <>
-      <div className="m-input-modal">
+      <div
+        className="m-input-modal"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            dispatch(closeInputModal())
+          }
+        }}
+      >
         <div className="m-input-modal__title">
           Overwrite{" "}
           <span className="m-input-modal__name-text">{presetName}</span>?

--- a/assets/src/components/inputModals/savePresetModal.tsx
+++ b/assets/src/components/inputModals/savePresetModal.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react"
+import InputModal from "../inputModal"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { Action, closeInputModal } from "../../state"
 
@@ -11,40 +12,30 @@ const SavePresetModal = ({
 }) => {
   const [, dispatch] = useContext(StateDispatchContext)
   return (
-    <>
-      <div
-        className="m-input-modal"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            dispatch(closeInputModal())
-          }
-        }}
-      >
-        <div className="m-input-modal__title">
-          Overwrite{" "}
-          <span className="m-input-modal__name-text">{presetName}</span>?
-        </div>
-        <div className="m-input-modal__buttons">
-          <button
-            className="m-input-modal__button"
-            onClick={() => dispatch(closeInputModal())}
-          >
-            Cancel
-          </button>
-          <button
-            autoFocus={true}
-            className="m-input-modal__button-confirm"
-            onClick={() => {
-              saveCallback(dispatch)
-              dispatch(closeInputModal())
-            }}
-          >
-            Save
-          </button>
-        </div>
+    <InputModal>
+      <div className="m-input-modal__title">
+        Overwrite <span className="m-input-modal__name-text">{presetName}</span>
+        ?
       </div>
-      <div className="m-input-modal__overlay" />
-    </>
+      <div className="m-input-modal__buttons">
+        <button
+          className="m-input-modal__button"
+          onClick={() => dispatch(closeInputModal())}
+        >
+          Cancel
+        </button>
+        <button
+          autoFocus={true}
+          className="m-input-modal__button-confirm"
+          onClick={() => {
+            saveCallback(dispatch)
+            dispatch(closeInputModal())
+          }}
+        >
+          Save
+        </button>
+      </div>
+    </InputModal>
   )
 }
 

--- a/assets/src/components/inputModals/savePresetModal.tsx
+++ b/assets/src/components/inputModals/savePresetModal.tsx
@@ -25,6 +25,7 @@ const SavePresetModal = ({
             Cancel
           </button>
           <button
+            autoFocus={true}
             className="m-input-modal__button-confirm"
             onClick={() => {
               saveCallback(dispatch)

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -78,6 +78,7 @@ Array [
         Cancel
       </button>
       <button
+        autoFocus={true}
         className="m-input-modal__button-danger"
         onClick={[Function]}
       >
@@ -198,6 +199,7 @@ Array [
         Cancel
       </button>
       <button
+        autoFocus={true}
         className="m-input-modal__button-confirm"
         onClick={[Function]}
       >
@@ -238,6 +240,7 @@ Array [
         Cancel
       </button>
       <button
+        autoFocus={true}
         className="m-input-modal__button-confirm"
         onClick={[Function]}
       >

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Modal renders create preset modal 1`] = `
 Array [
   <div
     className="m-input-modal"
+    onKeyDown={[Function]}
   >
     <form
       onSubmit={[Function]}
@@ -53,6 +54,7 @@ exports[`Modal renders delete preset modal 1`] = `
 Array [
   <div
     className="m-input-modal"
+    onKeyDown={[Function]}
   >
     <div
       className="m-input-modal__title"
@@ -164,6 +166,7 @@ exports[`Modal renders overwrite preset modal 1`] = `
 Array [
   <div
     className="m-input-modal"
+    onKeyDown={[Function]}
   >
     <div
       className="m-input-modal__title"
@@ -180,8 +183,7 @@ Array [
     <div
       className="m-input-modal__title"
     >
-      Overwrite
-       
+      Overwrite 
       <span
         className="m-input-modal__name-text"
       >
@@ -217,12 +219,12 @@ exports[`Modal renders save preset modal 1`] = `
 Array [
   <div
     className="m-input-modal"
+    onKeyDown={[Function]}
   >
     <div
       className="m-input-modal__title"
     >
-      Overwrite
-       
+      Overwrite 
       <span
         className="m-input-modal__name-text"
       >

--- a/assets/tests/components/__snapshots__/modal.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/modal.test.tsx.snap
@@ -5,37 +5,43 @@ Array [
   <div
     className="m-input-modal"
   >
-    <div
-      className="m-input-modal__title"
+    <form
+      onSubmit={[Function]}
     >
-      Save open routes as preset
-    </div>
-    <div
-      className="m-input-modal__input"
-    >
-      <input
-        autoFocus={true}
-        onChange={[Function]}
-        placeholder="Name your preset…"
-      />
-    </div>
-    <div
-      className="m-input-modal__buttons"
-    >
-      <button
-        className="m-input-modal__button"
-        onClick={[Function]}
+      <div
+        className="m-input-modal__title"
       >
-        Cancel
-      </button>
-      <button
-        className="m-input-modal__button-disabled"
-        disabled={true}
-        onClick={[Function]}
+        Save open routes as preset
+      </div>
+      <div
+        className="m-input-modal__input"
       >
-        Save
-      </button>
-    </div>
+        <input
+          autoFocus={true}
+          onChange={[Function]}
+          placeholder="Name your preset…"
+          required={true}
+        />
+      </div>
+      <div
+        className="m-input-modal__buttons"
+      >
+        <button
+          className="m-input-modal__button"
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className="m-input-modal__button-disabled"
+          disabled={true}
+          type="submit"
+        >
+          Save
+        </button>
+      </div>
+    </form>
   </div>,
   <div
     className="m-input-modal__overlay"

--- a/assets/tests/components/inputModal.test.tsx
+++ b/assets/tests/components/inputModal.test.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react"
+import InputModal from "../../src/components/inputModal"
+import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import { initialState, closeInputModal } from "../../src/state"
+
+describe("InputModal", () => {
+  test("can be dismissed with escape key", () => {
+    const mockDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <InputModal>
+          <>Hello, world!</>
+        </InputModal>
+      </StateDispatchProvider>
+    )
+
+    fireEvent.keyDown(result.getByText("Hello, world!"), { key: "Escape" })
+
+    expect(mockDispatch).toHaveBeenCalledWith(closeInputModal())
+  })
+})


### PR DESCRIPTION
Asana ticket: [⚙️ Key shortcuts: User can "save" by clicking the "return key"](https://app.asana.com/0/1200180014510248/1201862253651608/f)

In terms of being able to press the "return" key, I'm mainly relying on autofocusing the corresponding button to just rely as much as possible on default browser behavior instead of ad-hoc custom event handlers. Similarly, I made the create preset modal into a form so that the return key would trigger a submit, just moving the already-existing logic into a custom `onSubmit` handler. Since all of the modals share the same basic functionality with the "escape" key I went ahead and made a shared top-level modal component and defined the handler there.