### PR TITLE
feat: disabled state for save as preset button

### DIFF
--- a/assets/css/_presets.scss
+++ b/assets/css/_presets.scss
@@ -50,5 +50,18 @@
         }
       }
     }
+
+    &:disabled {
+      cursor: default;
+      font-weight: 500;
+      color: #e5e7eb;
+      background: #9fa2ac;
+
+      svg {
+        path {
+          stroke: #e5e7eb;
+        }
+      }
+    }
   }
 }

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -6,7 +6,7 @@ import {
 } from "../state"
 import CloseButton from "./closeButton"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { currentRouteTab, isPreset } from "../models/routeTab"
+import { currentRouteTab, isPreset, isEditedPreset } from "../models/routeTab"
 import { plusThinIcon } from "../helpers/icon"
 
 const Presets = () => {
@@ -14,6 +14,8 @@ const Presets = () => {
   const presets = routeTabs
     .filter(isPreset)
     .sort((a, b) => (a.presetName || "").localeCompare(b.presetName || ""))
+
+  const currentTab = currentRouteTab(routeTabs)
 
   return (
     <div className="m-presets-panel">
@@ -36,7 +38,6 @@ const Presets = () => {
       <button
         className="m-presets-panel__save-as-preset-button"
         onClick={() => {
-          const currentTab = currentRouteTab(routeTabs)
           if (currentTab) {
             if (window.FS) {
               window.FS.event("Preset saved from presets panel")
@@ -44,6 +45,9 @@ const Presets = () => {
             dispatch(promptToSaveOrCreatePreset(currentTab))
           }
         }}
+        disabled={
+          !currentTab || (isPreset(currentTab) && !isEditedPreset(currentTab))
+        }
       >
         {plusThinIcon("m-presets-panel__save-as-preset-button-icon")}
         Save as preset

--- a/assets/tests/components/__snapshots__/presets.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/presets.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Presets renders current presets 1`] = `
   </ul>
   <button
     className="m-presets-panel__save-as-preset-button"
+    disabled={true}
     onClick={[Function]}
   >
     <span


### PR DESCRIPTION
Asana ticket: [⚙️ Grey out "Save as Preset" button when inactive](https://app.asana.com/0/1200180014510248/1201862941782394/f)

Active state (already implemented previously):
![Screen Shot 2022-03-08 at 4 24 01 PM](https://user-images.githubusercontent.com/2010157/157327505-43260067-c9f4-4240-b4e9-4eb79e6e285d.png)

New disabled state:
![Screen Shot 2022-03-08 at 4 24 05 PM](https://user-images.githubusercontent.com/2010157/157327634-b49103da-c391-42fe-88c1-7cac6f98d41a.png)

