### PR TITLE
fix: reduce required number of stop times on SL2 for health check

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -78,7 +78,7 @@ config :skate,
       },
       %{
         route_id: "742",
-        min_length: 10
+        min_length: 5
       }
     ]
   }


### PR DESCRIPTION
Something unusual happened with pattern typicality on the SL2 (742) recently, meaning that the typical trip had less than 10 stop times on it. The underlying schedule data still looks fine for Skate's purposes, so I'm reducing (but not removing) the required number of stop times. In addition, I have created [a ticket](https://app.asana.com/0/1152340551558956/1201994849078241/f) for better logging - in this case I had to do some local debugging that could have been obviated by just being able to look at logs in prod. This has been successfully deployed to dev.