### PR TITLE
chore: drop route_settings table

### DIFF
--- a/priv/repo/migrations/20220308201555_remove_route_settings.exs
+++ b/priv/repo/migrations/20220308201555_remove_route_settings.exs
@@ -1,0 +1,28 @@
+defmodule Skate.Repo.Migrations.RemoveRouteSettings do
+  use Ecto.Migration
+
+  def up do
+    drop table(:route_settings)
+
+    create(index(:route_tabs, [:selected_route_ids], using: :gin))
+  end
+
+  def down do
+    create table(:route_settings, primary_key: false) do
+      add(
+        :user_id,
+        references(:users, on_delete: :delete_all, on_update: :update_all, primary_key: true),
+        primary_key: true
+      )
+
+      add(:selected_route_ids, {:array, :string}, null: false)
+      add(:ladder_directions, :map, null: false)
+      add(:ladder_crowding_toggles, :map, null: false)
+      timestamps()
+    end
+
+    create(index(:route_settings, [:selected_route_ids], using: :gin))
+
+    drop(index(:route_tabs, [:selected_route_ids], using: :gin))
+  end
+end


### PR DESCRIPTION
Asana ticket: [⚙️ Remove old non-tabs ladder page code](https://app.asana.com/0/1152340551558956/1201442401995240/f)

Removing the one last bit of old-style route settings code / infrastructure. Also adds an index to `route_tabs` to make delivering notifications more efficient - I'll watch the deploy on dev and make sure that doing this part of the migration is relatively snappy.