### PR TITLE
fix: use delete_if_exists for route_tabs association on user

### DIFF
--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -16,7 +16,7 @@ defmodule Skate.Settings.Db.User do
 
     has_many(:notification_users, DbNotificationUser)
     many_to_many(:notifications, DbNotification, join_through: DbNotificationUser)
-    has_many(:route_tabs, DbRouteTab, on_replace: :delete)
+    has_many(:route_tabs, DbRouteTab, on_replace: :delete_if_exists)
   end
 
   def changeset(user, attrs \\ %{}) do


### PR DESCRIPTION
Asana ticket: [⚙️ Fix Ecto.StaleEntryError on update to route_tabs](https://app.asana.com/0/1200180014510248/1201880022483811/f)

We've seen this error occasionally reported in Sentry, but I haven't quite been able to reproduce it locally or fully figure out why there's a stale entry happening in the first place. It's probably something related to the logic in `Skate.Settings.RouteTab.update_all_for_user!/2` combined with the schema definitions. Based on the [Ecto documentation](https://hexdocs.pm/ecto/Ecto.Changeset.html#module-the-on_replace-option) it seems like changing the `on_replace` option from `delete` to `delete_if_exists` is at least a good first step that's unlikely to hurt anything.