### PR TITLE
fix: use flex display for button-icon mixin

### DIFF
--- a/assets/css/_drawer_tab.scss
+++ b/assets/css/_drawer_tab.scss
@@ -17,15 +17,4 @@
   line-height: 1.5rem;
   margin: 0;
   padding: 2rem 0;
-
-  span {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    svg {
-      height: 0.9rem;
-      width: 0.9rem;
-    }
-  }
 }

--- a/assets/css/_garage_filter.scss
+++ b/assets/css/_garage_filter.scss
@@ -45,16 +45,8 @@
   justify-content: center;
   align-items: center;
 
-  span {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    svg {
-      height: 0.5625rem;
-      width: 0.5625rem;
-      fill: #525560;
-    }
+  span svg {
+    fill: #525560;
   }
 }
 

--- a/assets/css/_ladder_page.scss
+++ b/assets/css/_ladder_page.scss
@@ -91,6 +91,7 @@ $color-route-tabs-separator: #9fa2ac;
   display: flex;
   align-items: center;
   padding-left: 0.75rem;
+  padding-right: 0.40625rem;
   min-width: 0;
   cursor: default;
 
@@ -108,15 +109,25 @@ $color-route-tabs-separator: #9fa2ac;
 
   .m-close-button {
     @include button-icon(0.5rem);
-    font-size: unset;
-    padding-right: 0.625rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 0.9375rem;
+    height: 0.9375rem;
   }
 
-  .m-ladder-page__tab-save-icon {
-    padding-right: 0.625rem;
-    svg {
-      width: 0.625rem;
-      height: 0.625rem;
+  .m-ladder-page__tab-save-button {
+    @include button-icon(0.625rem);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 0.9375rem;
+    height: 0.9375rem;
+    margin-right: 0.25rem;
+
+    span svg {
+      stroke: initial;
+      fill: initial;
     }
   }
 }

--- a/assets/css/_presets.scss
+++ b/assets/css/_presets.scss
@@ -6,7 +6,7 @@
     li {
       display: flex;
       justify-content: space-between;
-      align-items: flex-start;
+      align-items: flex-end;
       padding-bottom: 1rem;
       line-height: 0.75rem;
 
@@ -24,7 +24,6 @@
 
       .m-close-button {
         @include button-icon(0.625rem);
-        font-size: unset;
       }
     }
   }

--- a/assets/css/_route_filter.scss
+++ b/assets/css/_route_filter.scss
@@ -51,10 +51,4 @@
   &:focus-within {
     color: #3c3f4c;
   }
-
-  span {
-    // inline-block causes weird vertical alignment issues involving line-height
-    // created a tech debt ticket to come back and refactor the button-icon mixin
-    display: flex;
-  }
 }

--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -35,6 +35,10 @@
   @include button-icon(0.625rem);
   flex: 0 1 auto;
   margin-top: 0.5rem;
+
+  span {
+    display: inline-flex;
+  }
 }
 
 .m-route-ladder__reverse-icon,

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -4,7 +4,7 @@
 
 .m-search-form__text {
   position: relative;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 .m-search-form__input {
@@ -17,19 +17,22 @@
   right: 0;
   padding: 0 0.375rem;
   position: absolute;
-  top: 0.6rem;
+  top: 0.875rem;
 }
 
 .m-search-form__submit {
   @include button-primary;
   @include button-icon(1.3125rem);
+  flex: 1 0 auto;
   margin-left: 0.5rem;
-  padding: 0.375rem 0.5625rem;
-  vertical-align: -0.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   &:disabled {
     @include button-disabled;
-    padding: 0.375rem 0.5625rem;
   }
 }
 

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -202,13 +202,19 @@ $color-stop-stroke: $black;
   // Typical HTML: <button><span><svg/></span>optional text</button>
   // @include alongside other button mixins styles
   span {
-    display: inline-block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
     height: $size;
     width: $size;
 
     svg {
       stroke: currentColor;
       fill: currentColor;
+
+      height: $size;
+      width: $size;
     }
   }
 }

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -81,7 +81,8 @@ const LadderTab = ({
           {title}
         </div>
         {tab.isCurrentTab && showSaveIcon ? (
-          <div
+          <button
+            className="m-ladder-page__tab-save-button"
             onClick={(e) => {
               e.stopPropagation()
 
@@ -92,8 +93,8 @@ const LadderTab = ({
               saveTab()
             }}
           >
-            {saveIcon("m-ladder-page__tab-save-icon")}
-          </div>
+            {saveIcon()}
+          </button>
         ) : null}
         <CloseButton onClick={() => closeTab()} />
       </div>

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -281,18 +281,19 @@ exports[`LadderPage renders with route tabs 1`] = `
           >
             Untitled
           </div>
-          <div
+          <button
+            className="m-ladder-page__tab-save-button"
             onClick={[Function]}
           >
             <span
-              className="m-ladder-page__tab-save-icon"
+              className=""
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "SVG",
                 }
               }
             />
-          </div>
+          </button>
           <button
             className="m-close-button"
             data-testid="close-button"
@@ -559,18 +560,19 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
           >
             Untitled
           </div>
-          <div
+          <button
+            className="m-ladder-page__tab-save-button"
             onClick={[Function]}
           >
             <span
-              className="m-ladder-page__tab-save-icon"
+              className=""
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "SVG",
                 }
               }
             />
-          </div>
+          </button>
           <button
             className="m-close-button"
             data-testid="close-button"
@@ -851,18 +853,19 @@ exports[`LadderPage renders with timepoints 1`] = `
           >
             Untitled
           </div>
-          <div
+          <button
+            className="m-ladder-page__tab-save-button"
             onClick={[Function]}
           >
             <span
-              className="m-ladder-page__tab-save-icon"
+              className=""
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "SVG",
                 }
               }
             />
-          </div>
+          </button>
           <button
             className="m-close-button"
             data-testid="close-button"
@@ -1380,18 +1383,19 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
           >
             Untitled
           </div>
-          <div
+          <button
+            className="m-ladder-page__tab-save-button"
             onClick={[Function]}
           >
             <span
-              className="m-ladder-page__tab-save-icon"
+              className=""
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "SVG",
                 }
               }
             />
-          </div>
+          </button>
           <button
             className="m-close-button"
             data-testid="close-button"

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -134,7 +134,9 @@ describe("LadderPage", () => {
       </StateDispatchProvider>
     )
 
-    wrapper.find(".m-ladder-page__tab-contents button").simulate("click")
+    wrapper
+      .find(".m-ladder-page__tab-contents .m-close-button")
+      .simulate("click")
 
     expect(mockDispatch).toHaveBeenCalledWith(
       closeRouteTab(mockState.routeTabs[0].uuid)
@@ -166,7 +168,7 @@ describe("LadderPage", () => {
       </StateDispatchProvider>
     )
 
-    wrapper.find(".m-ladder-page__tab-save-icon").simulate("click")
+    wrapper.find(".m-ladder-page__tab-save-button").simulate("click")
 
     expect(mockDispatch).toHaveBeenCalledWith(
       promptToSaveOrCreatePreset(mockState.routeTabs[0])
@@ -202,7 +204,7 @@ describe("LadderPage", () => {
       </StateDispatchProvider>
     )
 
-    wrapper.find(".m-ladder-page__tab-save-icon").simulate("click")
+    wrapper.find(".m-ladder-page__tab-save-button").simulate("click")
 
     expect(mockDispatch).toHaveBeenCalledWith(
       promptToSaveOrCreatePreset(mockState.routeTabs[1])
@@ -230,7 +232,7 @@ describe("LadderPage", () => {
       </StateDispatchProvider>
     )
 
-    expect(wrapper.find(".m-ladder-page__tab-save-icon").length).toBe(0)
+    expect(wrapper.find(".m-ladder-page__tab-save-button").length).toBe(0)
   })
 
   test("can add a new route tab", () => {


### PR DESCRIPTION
Asana ticket: [⚙️ Fix up button-icon CSS mixin](https://app.asana.com/0/1152340551558956/1201979636832835/f)

Previously, the `button-icon` mixin used `inline-block` display, which is fine but didn't really line up well with most of the places in the application that use the mixin, resulting in a lot of weird hacks to override the styles it set, as well as some places with minor styling bugs. In particular, the bounds of the containing `<span>` element often ended up not lining up well with the `<svg>` element inside. This uses flex display for the mixin, cleans up the existing hacks / overrides, and fixes a couple of minor pre-existing layout bugs. The comments of the tickets include screenshots of all of the locations in the application where this mixin is used (albeit mainly to highlight them for QA, not necessarily in their final form after the changes in this PR).