### PR TITLE
fix: reorder children in application supervisor

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -14,12 +14,7 @@ defmodule Skate.Application do
 
     # List all child processes to be supervised
     children =
-      [
-        {Phoenix.PubSub, name: Skate.PubSub},
-        SkateWeb.Endpoint,
-        RefreshTokenStore,
-        {Skate.Repo, []}
-      ] ++
+      [RefreshTokenStore, {Skate.Repo, []}] ++
         if Application.get_env(:skate, :start_data_processes) do
           [
             Schedule.Supervisor,
@@ -29,7 +24,11 @@ defmodule Skate.Application do
           ]
         else
           []
-        end
+        end ++
+        [
+          {Phoenix.PubSub, name: Skate.PubSub},
+          SkateWeb.Endpoint
+        ]
 
     link = Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
 


### PR DESCRIPTION
Asana ticket: [[extra] Misc Elixir dependabot upgrades](https://app.asana.com/0/1200180014510248/1202075746704834/f)

Prevent a race condition on shutdown where the web endpoint can still be running when important other processes like Realtime.Server are already shut down, causing errors.

I noticed this after merging #1382. My theory is that the [Postgrex change](https://github.com/elixir-ecto/postgrex/blob/master/CHANGELOG.md#v0160-2022-01-23) to cancel all pending requests before closing the socket slightly increased the amount of time required to shut down the `Skate.Repo` process, meaning that the pre-existing race condition where the various realtime data processes could shut down before the web endpoint much more likely to actually trigger. Example error:

```
d682a7c02944 14:00:35.132 [error] node=skate@ip-10-2-43-13 GenServer #PID<0.5759.0> terminating

d682a7c02944 ** (stop) exited in: GenServer.call(Realtime.DataStatusPubSub, :subscribe, 5000)

d682a7c02944 ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started

d682a7c02944 (elixir 1.13.3) lib/gen_server.ex:1019: GenServer.call/3

d682a7c02944 (skate 0.1.0) lib/realtime/data_status_pub_sub.ex:35: Realtime.DataStatusPubSub.subscribe/1

d682a7c02944 (skate 0.1.0) lib/skate_web/channels/data_status_channel.ex:8: SkateWeb.DataStatusChannel.join/3

d682a7c02944 (phoenix 1.6.6) lib/phoenix/channel/server.ex:376: Phoenix.Channel.Server.channel_join/4

d682a7c02944 (phoenix 1.6.6) lib/phoenix/channel/server.ex:298: Phoenix.Channel.Server.handle_info/2

d682a7c02944 (stdlib 3.17.1) gen_server.erl:695: :gen_server.try_dispatch/4

d682a7c02944 (stdlib 3.17.1) gen_server.erl:771: :gen_server.handle_msg/6

d682a7c02944 (stdlib 3.17.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3

d682a7c02944 Last message: {Phoenix.Channel, %{}, {#PID<0.5134.0>, #Reference<0.3685454375.1067712514.212307>}, %Phoenix.Socket{assigns: %{[guardian stuff trimmed for brevity], channel: SkateWeb.DataStatusChannel, channel_pid: nil, endpoint: SkateWeb.Endpoint, handler: SkateWeb.UserSocket, id: nil, join_ref: "71", joined: false, private: %{}, pubsub_server: Skate.PubSub, ref: nil, serializer: Phoenix.Socket.V2.JSONSerializer, topic: "data_status", transport: :websocket, transport_pid: #PID<0.5134.0>}}

d682a7c02944 14:00:35.133 [error] node=skate@ip-10-2-43-13 exited in: GenServer.call(Realtime.DataStatusPubSub, :subscribe, 5000)
```

Per [the docs](https://hexdocs.pm/elixir/Supervisor.html#module-start-and-shutdown), shutdown of supervised processes happens in the reverse order of startup.

I have tried a couple of deploys to dev with this branch and not seen any errors.