### PR TITLE
Nav beta group

### DIFF
--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -13,7 +13,9 @@ export const Nav: React.FC<Props> = ({
   pickerContainerIsVisible,
   openView,
 }) => {
-  return (
+  return readNavBetaFlag() ? (
+    <div>New and improved navigation coming soon!</div>
+  ) : (
     <>
       <TabBar
         pickerContainerIsVisible={pickerContainerIsVisible}
@@ -32,4 +34,13 @@ const readDispatcherFlag = (): boolean => {
   }
 
   return data.dispatcherFlag === "true"
+}
+
+const readNavBetaFlag = (): boolean => {
+  const data = appData()
+  if (!data) {
+    return false
+  }
+
+  return data.navBetaFlag === "true"
 }

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -48,4 +48,24 @@ describe("Nav", () => {
 
     expect(result.queryByTestId("late-view-icon")).not.toBeNull()
   })
+
+  test("renders placeholder for new nav content", () => {
+    ;(appData as jest.Mock).mockImplementation(() => {
+      return {
+        navBetaFlag: "true",
+      }
+    })
+
+    const result = render(
+      <BrowserRouter>
+        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+          Hello, world!
+        </Nav>
+      </BrowserRouter>
+    )
+
+    expect(
+      result.queryByText("New and improved navigation coming soon!")
+    ).not.toBeNull()
+  })
 })

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,7 +34,7 @@ config :skate, SkateWeb.AuthManager, secret_key: "dev key"
 
 config :ueberauth, Ueberauth,
   providers: [
-    cognito: {Skate.Ueberauth.Strategy.Fake, []}
+    cognito: {Skate.Ueberauth.Strategy.Fake, [groups: ["skate-dispathcer"]]}
   ]
 
 config :logger, level: :notice

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,7 +34,7 @@ config :skate, SkateWeb.AuthManager, secret_key: "dev key"
 
 config :ueberauth, Ueberauth,
   providers: [
-    cognito: {Skate.Ueberauth.Strategy.Fake, [groups: ["skate-dispathcer"]]}
+    cognito: {Skate.Ueberauth.Strategy.Fake, [groups: ["skate-dispatcher"]]}
   ]
 
 config :logger, level: :notice

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,7 +22,7 @@ config :skate, Skate.Repo,
 
 config :ueberauth, Ueberauth,
   providers: [
-    cognito: {Skate.Ueberauth.Strategy.Fake, []}
+    cognito: {Skate.Ueberauth.Strategy.Fake, [groups: ["skate-dispatcher", "skate-nav-beta"]]}
   ]
 
 config :logger, level: :warn

--- a/lib/skate/ueberauth/strategy/fake.ex
+++ b/lib/skate/ueberauth/strategy/fake.ex
@@ -19,7 +19,7 @@ defmodule Skate.Ueberauth.Strategy.Fake do
   end
 
   @impl Ueberauth.Strategy
-  def credentials(_conn) do
+  def credentials(conn) do
     nine_hours_in_seconds = 9 * 60 * 60
     expiration_time = System.system_time(:second) + nine_hours_in_seconds
 
@@ -28,7 +28,7 @@ defmodule Skate.Ueberauth.Strategy.Fake do
       refresh_token: "fake_refresh_token",
       expires: true,
       expires_at: expiration_time,
-      other: %{groups: ["skate-admin"]}
+      other: %{groups: Ueberauth.Strategy.Helpers.options(conn)[:groups]}
     }
   end
 

--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -5,6 +5,7 @@ defmodule SkateWeb.AuthManager do
 
   @skate_admin_group "skate-admin"
   @skate_dispatcher_group "skate-dispatcher"
+  @skate_nav_beta_group "skate-nav-beta"
 
   def subject_for_token(resource, _claims) do
     {:ok, resource}
@@ -50,6 +51,15 @@ defmodule SkateWeb.AuthManager do
   end
 
   def claims_grant_dispatcher_access?(_claims) do
+    false
+  end
+
+  @spec claims_grant_nav_beta_access?(Guardian.Token.claims()) :: boolean()
+  def claims_grant_nav_beta_access?(%{"groups" => groups}) do
+    not is_nil(groups) and @skate_nav_beta_group in groups
+  end
+
+  def claims_grant_nav_beta_access?(_claims) do
     false
   end
 end

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -17,12 +17,16 @@ defmodule SkateWeb.PageController do
     dispatcher_flag =
       conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_dispatcher_access?()
 
+    nav_beta_flag =
+      conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_nav_beta_access?()
+
     conn
     |> assign(:username, username)
     |> assign(:csrf_token, Plug.CSRFProtection.get_csrf_token())
     |> assign(:user_settings, user_settings)
     |> assign(:route_tabs, route_tabs)
     |> assign(:dispatcher_flag, dispatcher_flag)
+    |> assign(:nav_beta_flag, nav_beta_flag)
     |> render("index.html")
   end
 

--- a/lib/skate_web/templates/page/index.html.eex
+++ b/lib/skate_web/templates/page/index.html.eex
@@ -5,4 +5,5 @@
   data-route-tabs="<%= Jason.encode!(@route_tabs) %>"
   data-laboratory-features="<%= Jason.encode!(@laboratory_features) %>"
   data-dispatcher-flag="<%= Jason.encode!(@dispatcher_flag) %>"
+  data-nav-beta-flag="<%= Jason.encode!(@nav_beta_flag) %>"
 ></div>

--- a/test/skate/ueberauth/strategy/fake_test.exs
+++ b/test/skate/ueberauth/strategy/fake_test.exs
@@ -1,16 +1,17 @@
 defmodule Skate.Ueberauth.Strategy.FakeTest do
-  use ExUnit.Case, async: true
+  use SkateWeb.ConnCase
 
   alias Skate.Ueberauth.Strategy.Fake
   alias Ueberauth.Auth.{Credentials, Extra, Info}
 
-  test "credentials returns a credentials struct" do
-    assert Fake.credentials(%{}) == %Credentials{
+  @tag :authenticated
+  test "credentials returns a credentials struct with groups specified in config", %{conn: conn} do
+    assert conn |> get("/auth/cognito") |> Fake.credentials() == %Credentials{
              token: "fake_access_token",
              refresh_token: "fake_refresh_token",
              expires: true,
              expires_at: System.system_time(:second) + 9 * 60 * 60,
-             other: %{groups: ["skate-admin"]}
+             other: %{groups: ["skate-dispatcher", "skate-nav-beta"]}
            }
   end
 

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -48,4 +48,22 @@ defmodule SkateWeb.AuthManagerTest do
       refute AuthManager.claims_grant_dispatcher_access?(%{})
     end
   end
+
+  describe "claims_grant_nav_beta_access?/1" do
+    test "grants nav_beta access when in nav beta group" do
+      assert AuthManager.claims_grant_nav_beta_access?(%{"groups" => ["skate-nav-beta"]})
+    end
+
+    test "doesn't grant access with nil groups" do
+      refute AuthManager.claims_grant_nav_beta_access?(%{"groups" => nil})
+    end
+
+    test "doesn't grant access with non-nav beta groups" do
+      refute AuthManager.claims_grant_nav_beta_access?(%{"groups" => ["other-group"]})
+    end
+
+    test "doesn't grant access with no group information present" do
+      refute AuthManager.claims_grant_nav_beta_access?(%{})
+    end
+  end
 end

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -39,6 +39,20 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
+    test "doesn't set nav beta flag when not in nav beta group", %{conn: conn} do
+      conn = get(conn, "/")
+
+      refute conn.assigns.nav_beta_flag
+    end
+
+    @tag :authenticated_nav_beta
+    test "does set nav beta flag when in nav beta group", %{conn: conn} do
+      conn = get(conn, "/")
+
+      assert conn.assigns.nav_beta_flag
+    end
+
+    @tag :authenticated
     test "includes route tabs in HTML", %{conn: conn, user: user} do
       Skate.Settings.RouteTab.update_all_for_user!(user, [
         build(:route_tab, %{selected_route_ids: ["1"]})

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -70,6 +70,18 @@ defmodule SkateWeb.ConnCase do
 
           {conn, user}
 
+        tags[:authenticated_nav_beta] ->
+          user = "test_user"
+
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> init_test_session(%{})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user, %{
+              "groups" => ["skate-nav-beta"]
+            })
+
+          {conn, user}
+
         true ->
           {Phoenix.ConnTest.build_conn(), nil}
       end


### PR DESCRIPTION
Asana ticket: [⚙️ Add support for beta group in Nav component](https://app.asana.com/0/1200180014510248/1202131476892155/f)

In addition to running this locally I've put it on dev-blue and tested it there by adding myself to the group.

This will allow us to develop the new navigation incrementally behind the beta group flag, but we won't actually be adding any users to it in prod until it's actually up to the level of quality that we want to be providing.