### PR TITLE
Render different versions of Nav based on screen size

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
       ],
       "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/no-empty-function": "off",
       },
     },
     {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1298,6 +1298,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
+    "@react-hook/media-query": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/media-query/-/media-query-1.1.1.tgz",
+      "integrity": "sha512-VM14wDOX5CW5Dn6b2lTiMd79BFMTut9AZj2+vIRT3LCKgMCYmdqruTtzDPSnIVDQdtxdPgtOzvU9oK20LopuOw=="
+    },
     "@rehooks/component-size": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rehooks/component-size/-/component-size-1.0.3.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -16,6 +16,7 @@
     "format:check": "prettier --check \"{.,**}/*.{js,json,ts,tsx,css,scss}\""
   },
   "dependencies": {
+    "@react-hook/media-query": "^1.1.1",
     "@rehooks/component-size": "^1.0.3",
     "@sentry/react": "^6.18.2",
     "@tippyjs/react": "^4.2.6",

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { OpenView } from "../state"
 import TabBar from "./tabBar"
 import appData from "../appData"
+import useDeviceType from "../hooks/useDeviceType"
 
 interface Props {
   pickerContainerIsVisible: boolean
@@ -13,18 +14,29 @@ export const Nav: React.FC<Props> = ({
   pickerContainerIsVisible,
   openView,
 }) => {
-  return readNavBetaFlag() ? (
-    <div>New and improved navigation coming soon!</div>
-  ) : (
-    <>
-      <TabBar
-        pickerContainerIsVisible={pickerContainerIsVisible}
-        openView={openView}
-        dispatcherFlag={readDispatcherFlag()}
-      />
-      {children}
-    </>
-  )
+  const deviceType = useDeviceType()
+
+  if (readNavBetaFlag()) {
+    switch (deviceType) {
+      case "mobile":
+        return <div>Mobile nav placeholder.</div>
+      case "tablet":
+        return <div>Tablet nav placeholder.</div>
+      default:
+        return <div>Desktop nav placeholder.</div>
+    }
+  } else {
+    return (
+      <>
+        <TabBar
+          pickerContainerIsVisible={pickerContainerIsVisible}
+          openView={openView}
+          dispatcherFlag={readDispatcherFlag()}
+        />
+        {children}
+      </>
+    )
+  }
 }
 
 const readDispatcherFlag = (): boolean => {

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -3,6 +3,7 @@ import { OpenView } from "../state"
 import TabBar from "./tabBar"
 import appData from "../appData"
 import useDeviceType from "../hooks/useDeviceType"
+import featureIsEnabled from "../laboratoryFeatures"
 
 interface Props {
   pickerContainerIsVisible: boolean
@@ -16,7 +17,7 @@ export const Nav: React.FC<Props> = ({
 }) => {
   const deviceType = useDeviceType()
 
-  if (readNavBetaFlag()) {
+  if (readNavBetaFlag() || featureIsEnabled("nav_beta")) {
     switch (deviceType) {
       case "mobile":
         return <div>Mobile nav placeholder.</div>

--- a/assets/src/hooks/useDeviceType.ts
+++ b/assets/src/hooks/useDeviceType.ts
@@ -3,7 +3,7 @@ import { DeviceType } from "../skate"
 
 const maxMobileWidth = 480
 const minTabletWidth = maxMobileWidth + 1
-const maxTabletWidth = 768
+const maxTabletWidth = 800
 
 const useDeviceType = (): DeviceType => {
   const { matches } = useMediaQueries({

--- a/assets/src/hooks/useDeviceType.ts
+++ b/assets/src/hooks/useDeviceType.ts
@@ -1,0 +1,23 @@
+import { useMediaQueries } from "@react-hook/media-query"
+import { DeviceType } from "../skate"
+
+const maxMobileWidth = 480
+const minTabletWidth = maxMobileWidth + 1
+const maxTabletWidth = 768
+
+const useDeviceType = (): DeviceType => {
+  const { matches } = useMediaQueries({
+    mobile: `(max-width: ${maxMobileWidth}px)`,
+    tablet: `(min-width: ${minTabletWidth}px) and (max-width: ${maxTabletWidth}px)`,
+  })
+
+  if (matches.mobile) {
+    return "mobile"
+  } else if (matches.tablet) {
+    return "tablet"
+  } else {
+    return "desktop"
+  }
+}
+
+export default useDeviceType

--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -32,3 +32,5 @@ declare global {
 }
 
 export type UserToken = string
+
+export type DeviceType = "mobile" | "tablet" | "desktop"

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -37,7 +37,6 @@ describe("apiCall", () => {
   beforeEach(() => {
     browserReloadSpy = jest
       .spyOn(browser, "reload")
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       .mockImplementation(() => {})
   })
 

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -5,6 +5,7 @@ import appData from "../../src/appData"
 import { Nav } from "../../src/components/nav"
 import featureIsEnabled from "../../src/laboratoryFeatures"
 import { OpenView } from "../../src/state"
+import useDeviceType from "../../src/hooks/useDeviceType"
 
 jest.mock("../../src/laboratoryFeatures", () => ({
   __esModule: true,
@@ -14,6 +15,11 @@ jest.mock("../../src/laboratoryFeatures", () => ({
 jest.mock("../../src/appData", () => ({
   __esModule: true,
   default: jest.fn(() => false),
+}))
+
+jest.mock("../../src/hooks/useDeviceType", () => ({
+  __esModule: true,
+  default: jest.fn(() => "desktop"),
 }))
 
 describe("Nav", () => {
@@ -49,7 +55,49 @@ describe("Nav", () => {
     expect(result.queryByTestId("late-view-icon")).not.toBeNull()
   })
 
-  test("renders placeholder for new nav content", () => {
+  test("renders mobile placeholder for new nav content", () => {
+    ;(appData as jest.Mock).mockImplementation(() => {
+      return {
+        navBetaFlag: "true",
+      }
+    })
+    ;(useDeviceType as jest.Mock).mockImplementationOnce(() => "mobile")
+
+    const result = render(
+      <BrowserRouter>
+        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+          Hello, world!
+        </Nav>
+      </BrowserRouter>
+    )
+
+    expect(result.queryByText("Mobile nav placeholder.")).not.toBeNull()
+    expect(result.queryByText("Tablet nav placeholder.")).toBeNull()
+    expect(result.queryByText("Desktop nav placeholder.")).toBeNull()
+  })
+
+  test("renders tablet placeholder for new nav content", () => {
+    ;(appData as jest.Mock).mockImplementation(() => {
+      return {
+        navBetaFlag: "true",
+      }
+    })
+    ;(useDeviceType as jest.Mock).mockImplementationOnce(() => "tablet")
+
+    const result = render(
+      <BrowserRouter>
+        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+          Hello, world!
+        </Nav>
+      </BrowserRouter>
+    )
+
+    expect(result.queryByText("Mobile nav placeholder.")).toBeNull()
+    expect(result.queryByText("Tablet nav placeholder.")).not.toBeNull()
+    expect(result.queryByText("Desktop nav placeholder.")).toBeNull()
+  })
+
+  test("renders desktop placeholder for new nav content", () => {
     ;(appData as jest.Mock).mockImplementation(() => {
       return {
         navBetaFlag: "true",
@@ -64,8 +112,8 @@ describe("Nav", () => {
       </BrowserRouter>
     )
 
-    expect(
-      result.queryByText("New and improved navigation coming soon!")
-    ).not.toBeNull()
+    expect(result.queryByText("Mobile nav placeholder.")).toBeNull()
+    expect(result.queryByText("Tablet nav placeholder.")).toBeNull()
+    expect(result.queryByText("Desktop nav placeholder.")).not.toBeNull()
   })
 })

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -116,4 +116,23 @@ describe("Nav", () => {
     expect(result.queryByText("Tablet nav placeholder.")).toBeNull()
     expect(result.queryByText("Desktop nav placeholder.")).not.toBeNull()
   })
+
+  test("renders beta version with feature flag", () => {
+    ;(featureIsEnabled as jest.Mock).mockImplementationOnce(() => true)
+    ;(appData as jest.Mock).mockImplementation(() => {
+      return {
+        navBetaFlag: "false",
+      }
+    })
+
+    const result = render(
+      <BrowserRouter>
+        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+          Hello, world!
+        </Nav>
+      </BrowserRouter>
+    )
+
+    expect(result.queryByText("Desktop nav placeholder.")).not.toBeNull()
+  })
 })

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -151,11 +151,8 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={undefined}
           selectedVehicleId={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -203,11 +200,8 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={(vehicles as VehicleOrGhost[]).concat([ghost])}
           selectedVehicleId={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -238,11 +232,8 @@ describe("routeLadder", () => {
             routeStatus: "pulling_out" as RouteStatus,
           }))}
           selectedVehicleId={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -276,11 +267,8 @@ describe("routeLadder", () => {
             { ...v1, routeStatus: "laying_over" },
             { ...v2, routeStatus: "laying_over" },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -326,11 +314,8 @@ describe("routeLadder", () => {
               crowding: null,
             },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={ladderCrowdingToggles}
@@ -370,11 +355,8 @@ describe("routeLadder", () => {
               isRevenue: false,
             },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -421,11 +403,8 @@ describe("routeLadder", () => {
               crowding: null,
             },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={ladderCrowdingToggles}
@@ -472,11 +451,8 @@ describe("routeLadder", () => {
               },
             },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={ladderCrowdingToggles}
@@ -501,11 +477,8 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={undefined}
           selectedVehicleId={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}
@@ -535,9 +508,7 @@ describe("routeLadder", () => {
         vehiclesAndGhosts={undefined}
         selectedVehicleId={undefined}
         deselectRoute={mockDeselect}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         reverseLadder={() => {}}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleCrowding={() => {}}
         ladderDirections={{}}
         ladderCrowdingToggles={{}}
@@ -566,10 +537,8 @@ describe("routeLadder", () => {
         timepoints={timepoints}
         vehiclesAndGhosts={undefined}
         selectedVehicleId={undefined}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         deselectRoute={() => {}}
         reverseLadder={mockReverse}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         toggleCrowding={() => {}}
         ladderDirections={{}}
         ladderCrowdingToggles={{}}
@@ -612,9 +581,7 @@ describe("routeLadder", () => {
           },
         ]}
         selectedVehicleId={undefined}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         deselectRoute={() => {}}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         reverseLadder={() => {}}
         toggleCrowding={mockToggle}
         ladderDirections={{}}
@@ -688,11 +655,8 @@ describe("routeLadder", () => {
           timepoints={timepoints}
           vehiclesAndGhosts={[vehicle]}
           selectedVehicleId={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           deselectRoute={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           reverseLadder={() => {}}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           toggleCrowding={() => {}}
           ladderDirections={{}}
           ladderCrowdingToggles={{}}

--- a/assets/tests/hooks/useDeviceType.test.ts
+++ b/assets/tests/hooks/useDeviceType.test.ts
@@ -1,5 +1,7 @@
 import { useMediaQueries } from "@react-hook/media-query"
-import useDeviceType from "../../src/hooks/useDeviceType"
+const useDeviceType = jest.requireActual(
+  "../../src/hooks/useDeviceType"
+).default
 
 jest.mock("@react-hook/media-query", () => ({
   __esModule: true,

--- a/assets/tests/hooks/useDeviceType.test.ts
+++ b/assets/tests/hooks/useDeviceType.test.ts
@@ -1,0 +1,54 @@
+import { useMediaQueries } from "@react-hook/media-query"
+import useDeviceType from "../../src/hooks/useDeviceType"
+
+jest.mock("@react-hook/media-query", () => ({
+  __esModule: true,
+  useMediaQueries: jest.fn(() => {}),
+}))
+
+describe("useDeviceType", () => {
+  test("returns mobile when media query matches mobile", () => {
+    ;(useMediaQueries as jest.Mock).mockImplementationOnce(() => {
+      return {
+        matches: {
+          mobile: true,
+          tablet: false,
+        },
+        matchesAny: true,
+        matchesAll: false,
+      }
+    })
+
+    expect(useDeviceType()).toBe("mobile")
+  })
+
+  test("returns tablet when media query matches tablet", () => {
+    ;(useMediaQueries as jest.Mock).mockImplementationOnce(() => {
+      return {
+        matches: {
+          mobile: false,
+          tablet: true,
+        },
+        matchesAny: true,
+        matchesAll: false,
+      }
+    })
+
+    expect(useDeviceType()).toBe("tablet")
+  })
+
+  test("returns desktop in other cases", () => {
+    ;(useMediaQueries as jest.Mock).mockImplementationOnce(() => {
+      return {
+        matches: {
+          mobile: false,
+          tablet: false,
+        },
+        matchesAny: false,
+        matchesAll: false,
+      }
+    })
+
+    expect(useDeviceType()).toBe("desktop")
+  })
+})

--- a/assets/tests/hooks/useRoutes.test.ts
+++ b/assets/tests/hooks/useRoutes.test.ts
@@ -5,7 +5,7 @@ import { instantPromise } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchRoutes: jest.fn(() => new Promise(() => {})),
 }))
 

--- a/assets/tests/hooks/useShapes.test.ts
+++ b/assets/tests/hooks/useShapes.test.ts
@@ -7,9 +7,9 @@ import { instantPromise, mockUseStateOnce } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchShapeForRoute: jest.fn(() => new Promise<Shape[]>(() => {})),
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchShapeForTrip: jest.fn(() => new Promise<Shape[]>(() => {})),
 }))
 

--- a/assets/tests/hooks/useShuttleRoutes.test.ts
+++ b/assets/tests/hooks/useShuttleRoutes.test.ts
@@ -6,7 +6,7 @@ import { instantPromise } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchShuttleRoutes: jest.fn(() => new Promise(() => {})),
 }))
 

--- a/assets/tests/hooks/useSwings.test.tsx
+++ b/assets/tests/hooks/useSwings.test.tsx
@@ -10,7 +10,7 @@ import routeTabFactory from "../factories/routeTab"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchSwings: jest.fn(() => new Promise(() => {})),
 }))
 

--- a/assets/tests/hooks/useTimepoints.test.ts
+++ b/assets/tests/hooks/useTimepoints.test.ts
@@ -6,7 +6,7 @@ import { instantPromise, mockUseStateOnce } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
   __esModule: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   fetchTimepointsForRoute: jest.fn(() => new Promise<Timepoint[]>(() => {})),
 }))
 

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -30,7 +30,6 @@ document.createElementNS = function (namespaceURI, qualifiedName) {
     namespaceURI === "http://www.w3.org/2000/svg" &&
     qualifiedName === "svg"
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     element.createSVGRect = () => {}
   }
   return element

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -21,6 +21,11 @@ jest.mock("@tippyjs/react", () => ({
   )),
 }))
 
+jest.mock("../src/hooks/useDeviceType", () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => "desktop"),
+}))
+
 // JSDOM doesn't support part of SVG that's needed for Leaflet to run in tests.
 // https://stackoverflow.com/questions/54382414/fixing-react-leaflet-testing-error-cannot-read-property-layeradd-of-null
 const createElementNSOrig = document.createElementNS

--- a/config/config.exs
+++ b/config/config.exs
@@ -106,7 +106,8 @@ config :skate, Skate.Repo,
 config :laboratory,
   features: [
     {:late_view, "Late View", "Grants access to experimental Late View"},
-    {:pigeon_maps, "Pigeon maps", "Replaces Leaflet-based maps with Pigeon"}
+    {:pigeon_maps, "Pigeon maps", "Replaces Leaflet-based maps with Pigeon"},
+    {:nav_beta, "Improved navigation beta", "New and improved navigation components"}
   ],
   cookie: [
     # one month,


### PR DESCRIPTION
Asana ticket: [⚙️ Nav component: code to determine mobile vs. tablet vs. desktop](https://app.asana.com/0/1200180014510248/1202131476892160/f)

This change has two main pieces:
1. Creating a new, reusable `useDeviceType` hook to determine whether our screen size counts as mobile vs. tablet vs. desktop.
1. Updating the `<Nav>` component to render unique placeholder text depending on which of these screen size classes is present.
1. Added a feature flag for the nav beta in addition to the user group, so that we don't have to constantly add and remove people from the group on dev for testing.

I also went ahead and disabled an ESLint rule that was an issue for a lot of our tests, but disabled it on tests only.