### PR TITLE
Bump Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=assets-builder /root/priv/static ./priv/static
 
 RUN mix do compile --force, phx.digest, release
 
-FROM alpine:3.15.0
+FROM alpine:3.15.4
 
 RUN apk add --no-cache --update libssl1.1 libstdc++ \
     libgcc ncurses-libs bash curl dumb-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN mix do compile --force, phx.digest, release
 
 FROM alpine:3.15.4
 
+RUN apk upgrade --no-cache --update
+
 RUN apk add --no-cache --update libssl1.1 libstdc++ \
     libgcc ncurses-libs bash curl dumb-init
 


### PR DESCRIPTION
Additionally adding a run of `apk upgrade` to catch any upgrades to the packages in the base image.