### PR TITLE
Remove flex gap

### DIFF
--- a/assets/css/_garage_filter.scss
+++ b/assets/css/_garage_filter.scss
@@ -55,13 +55,16 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  row-gap: 0.5rem;
   color: $color-gray-700;
 }
 
 .m-garage-filter__garage {
   display: flex;
   justify-content: space-between;
+
+  &:not(:last-child) {
+    margin-bottom: 0.5rem;
+  }
 }
 
 .m-garage-filter__button {

--- a/assets/css/_input_modal.scss
+++ b/assets/css/_input_modal.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
   position: fixed;
   left: 50%;
   top: 50%;
@@ -14,11 +13,18 @@
   border-radius: 0.25rem;
   line-height: 1.125rem;
 
+  & > :not(:last-child) {
+    margin-bottom: 1rem;
+  }
+
   form {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
+
+    & > :not(:last-child) {
+      margin-bottom: 1rem;
+    }
   }
 }
 
@@ -64,7 +70,10 @@
 
 .m-input-modal__buttons {
   display: flex;
-  gap: 1rem;
+
+  & > :not(:last-child) {
+    margin-right: 1rem;
+  }
 }
 
 @mixin input-modal-button {

--- a/assets/css/_picker_container.scss
+++ b/assets/css/_picker_container.scss
@@ -7,12 +7,15 @@
   // Required for pinning to the left side of the screen on the tablets
   left: 0;
   padding: 1rem;
-  row-gap: 1rem;
   position: absolute;
   top: inherit;
   transition: $transition-slide;
   width: $route-picker-width;
   z-index: 100;
+
+  & > :not(:last-child) {
+    margin-bottom: 1rem;
+  }
 
   &.visible {
     left: 0;

--- a/assets/css/_route_picker.scss
+++ b/assets/css/_route_picker.scss
@@ -2,8 +2,11 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  row-gap: 1rem;
   min-height: 0;
+
+  & > :not(:last-child) {
+    margin-bottom: 1rem;
+  }
 }
 
 .m-route-picker__label {
@@ -30,10 +33,13 @@
     overflow-y: scroll;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
 
     li {
       position: relative;
+
+      &:not(:last-child) {
+        margin-bottom: 0.5rem;
+      }
     }
   }
 


### PR DESCRIPTION
Asana ticket: [⚙️ Remove existing uses of "gap" property inside of flexboxes](https://app.asana.com/0/1148853526253437/1202219847571496/f)

Ideally everyone is using an up-to-date browser and this is a non-issue, but I didn't realize how recent an addition use of this property inside of flexbox was in most browsers. As such I'm moving existing uses of gap properties to instead use margins on the children where appropriate. Use of the gap properties inside of grid layouts apparently has a longer precedent of support so I'm leaving those in place.