### PR TITLE
fix: specify size of logo icon SVG so it doesn't get too large

### DIFF
--- a/assets/css/nav/_top_nav.scss
+++ b/assets/css/nav/_top_nav.scss
@@ -15,6 +15,11 @@
 .m-top-nav__logo {
   width: 2.5rem;
   height: 1.5rem;
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .m-top-nav__logo-icon {


### PR DESCRIPTION
Asana ticket: related to [⚙️ Implement top nav (desktop / tablet version)](https://app.asana.com/0/1200180014510248/1201682620805412/f)

Here is an example of what the logo SVG looked like before:
![Screen Shot 2022-05-16 at 3 25 11 PM](https://user-images.githubusercontent.com/2010157/168668330-312baa5c-f47a-499e-9fac-2452b8dd730a.png)
This covered up other elements of the page making them un-clickable.
