### PR TITLE
Make opening notifications work from all modes

### DIFF
--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -7,14 +7,8 @@ import {
   hideLatestNotification,
   toggleReadState,
 } from "../hooks/useNotificationsReducer"
-import useSocket from "../hooks/useSocket"
-import useVehicleForNotification from "../hooks/useVehicleForNotification"
 import { Notification, NotificationReason } from "../realtime.d"
-import {
-  Dispatch as StateDispatch,
-  selectVehicleFromNotification,
-  setNotification,
-} from "../state"
+import { Dispatch as StateDispatch, setNotification } from "../state"
 import { NotificationContent } from "./notificationContent"
 
 export const Notifications = () => {
@@ -22,8 +16,7 @@ export const Notifications = () => {
     useContext(NotificationsContext)
   const currentTime = useCurrentTime()
 
-  const [state, stateDispatch] = useContext(StateDispatchContext)
-  const { selectedNotification } = state
+  const [, stateDispatch] = useContext(StateDispatchContext)
 
   const notificationToShow =
     showLatestNotification && notifications.length > 0 ? notifications[0] : null
@@ -36,21 +29,9 @@ export const Notifications = () => {
     }
   }, [notificationToShow])
 
-  const { socket } = useSocket()
-  const vehicleForNotification = useVehicleForNotification(
-    selectedNotification,
-    socket
-  )
-
   const openVPPForCurrentVehicle = (notification: Notification) => {
     openVPPForNotification(notification, stateDispatch, dispatch)
   }
-
-  useEffect(() => {
-    if (selectedNotification) {
-      stateDispatch(selectVehicleFromNotification(vehicleForNotification))
-    }
-  }, [selectedNotification, vehicleForNotification])
 
   return (
     <div className="m-notifications">

--- a/assets/src/components/settingsPage.tsx
+++ b/assets/src/components/settingsPage.tsx
@@ -18,16 +18,18 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "../userSettings"
+import { Notifications } from "./notifications"
 import RightPanel from "./rightPanel"
 
 const SettingsPage = (): ReactElement<HTMLDivElement> => {
-  const [{ userSettings, mobileMenuIsOpen }, dispatch] =
+  const [{ userSettings, mobileMenuIsOpen, selectedVehicleOrGhost }, dispatch] =
     useContext(StateDispatchContext)
 
   const mobileMenuClass = mobileMenuIsOpen ? "blurred-mobile" : ""
 
   return (
     <div className={`c-page c-page--settings ${mobileMenuClass}`}>
+      <Notifications />
       <div className="c-page__container">
         <h1 className="c-page__title">Settings</h1>
 
@@ -137,7 +139,7 @@ const SettingsPage = (): ReactElement<HTMLDivElement> => {
           />
         </div>
       </div>
-      <RightPanel />
+      <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
     </div>
   )
 }

--- a/assets/tests/components/__snapshots__/settingsPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/settingsPage.test.tsx.snap
@@ -5,6 +5,9 @@ exports[`SettingsPage renders 1`] = `
   className="c-page c-page--settings "
 >
   <div
+    className="m-notifications"
+  />
+  <div
     className="c-page__container"
   >
     <h1

--- a/assets/tests/components/settingsPage.test.tsx
+++ b/assets/tests/components/settingsPage.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
+import { render } from "@testing-library/react"
 import renderer from "react-test-renderer"
 import SettingsPage from "../../src/components/settingsPage"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
@@ -15,10 +16,21 @@ import {
   VehicleLabelSetting,
   VehicleAdherenceColorsSetting,
 } from "../../src/userSettings"
+import vehicleFactory from "../factories/vehicle"
 
 jest.mock("../../src/laboratoryFeatures", () => ({
   __esModule: true,
   default: jest.fn(),
+}))
+
+jest.mock("../../src/hooks/useNearestIntersection", () => ({
+  __esModule: true,
+  useNearestIntersection: jest.fn(() => null),
+}))
+
+jest.mock("../../src/hooks/useShapes", () => ({
+  __esModule: true,
+  useTripShape: jest.fn(() => null),
 }))
 
 const mockDispatch = jest.fn()
@@ -161,5 +173,20 @@ describe("SettingsPage", () => {
     expect((window.fetch as jest.Mock).mock.calls[0][0]).toEqual(
       "/api/user_settings?field=vehicle_adherence_colors&value=early_blue"
     )
+  })
+
+  test("renders vehicle properties panel if a vehicle is selected", () => {
+    const vehicle = vehicleFactory.build({ operatorLastName: "Smith" })
+
+    const result = render(
+      <StateDispatchProvider
+        state={{ ...initialState, selectedVehicleOrGhost: vehicle }}
+        dispatch={mockDispatch}
+      >
+        <SettingsPage />
+      </StateDispatchProvider>
+    )
+
+    expect(result.getByText(/Smith/)).not.toBeNull()
   })
 })


### PR DESCRIPTION
Asana ticket: [🐛 Clicking on a notification from any screen other than the route ladder never opens VPP](https://app.asana.com/0/1148853526253437/1199702340260447/f)

The underlying issue was that the logic to actually trigger the VPP opening based on which notification is selected was in the `Notifications` component itself, which also takes care of rendering the pop-up notification card when a new notification comes in. This component is only present on pages where this pop-up should display. I moved the logic in question over to the notifications context provider, which already has some other logic in it. This more appropriately separates out the visual presentation of the pop-up from the application logic to open the VPP. This also gave me a chance to add a better test for the logic in question.