### PR TITLE
Speed up notification open

### DIFF
--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -33,25 +33,23 @@ export const useChannel = <T>({
       channel = socket.channel(topic)
       channel.on(event, ({ data: data }) => {
         setState(parser(data))
-        if (closeAfterFirstRead) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          channel!.leave()
-          channel = undefined
-        }
       })
 
-      const push = channel.join()
-      if (!closeAfterFirstRead) {
-        push
-          .receive("ok", ({ data: data }) => {
-            setState(parser(data))
-          })
-          .receive("error", ({ reason }) =>
-            // eslint-disable-next-line no-console
-            console.error(`joining topic ${topic} failed`, reason)
-          )
-          .receive("timeout", reload)
-      }
+      channel
+        .join()
+        .receive("ok", ({ data: data }) => {
+          setState(parser(data))
+          if (closeAfterFirstRead) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            channel!.leave()
+            channel = undefined
+          }
+        })
+        .receive("error", ({ reason }) =>
+          // eslint-disable-next-line no-console
+          console.error(`joining topic ${topic} failed`, reason)
+        )
+        .receive("timeout", reload)
     }
 
     return () => {

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -230,4 +230,26 @@ describe("useChannel", () => {
     expect(reloadSpy).toHaveBeenCalled()
     reloadSpy.mockRestore()
   })
+
+  test("returns data from the initial join with closeAfterFirstRead, leaves", () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser,
+        loadingState: "loading",
+        closeAfterFirstRead: true,
+      })
+    )
+
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+    expect(mockChannel.leave).toHaveBeenCalled()
+  })
 })

--- a/assets/tests/hooks/useVehiclesForRunIds.test.ts
+++ b/assets/tests/hooks/useVehiclesForRunIds.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks"
-import useVehicleForRunIds from "../../src/hooks/useVehiclesForRunIds"
+import useVehiclesForRunIds from "../../src/hooks/useVehiclesForRunIds"
 import { VehicleData } from "../../src/models/vehicleData"
 import { dateFromEpochSeconds } from "../../src/util/dateTime"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
@@ -71,7 +71,7 @@ describe("useVehiclesForRunIds", () => {
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
 
     const { result } = renderHook(() => {
-      return useVehicleForRunIds(mockSocket, ["123-456"])
+      return useVehiclesForRunIds(mockSocket, ["123-456"])
     })
     expect(result.current).toEqual([
       {

--- a/assets/tests/testHelpers/socketHelpers.ts
+++ b/assets/tests/testHelpers/socketHelpers.ts
@@ -40,10 +40,14 @@ export const makeMockChannel = (
 }
 
 export const makeMockOneShotChannel = (dataOnJoin?: any) => {
-  const result: { join: any; on: any; leave: any } = {
-    join: jest.fn(),
-    on: (_: any, handler: ({ data }: { data: any }) => void) => {
-      result.join = () => handler({ data: dataOnJoin })
+  const result: { join: any; on: any; receive: any; leave: any } = {
+    join: () => result,
+    on: jest.fn(),
+    receive: (event: any, handler: ({ data }: { data: any }) => void) => {
+      if (event === "ok") {
+        handler({ data: dataOnJoin })
+      }
+      return result
     },
     leave: jest.fn(),
   }


### PR DESCRIPTION
Asana ticket: [⚙️ Improve performance of opening VPP or showing error when clicking notification](https://app.asana.com/0/1152340551558956/1201890023661619/f)

This ended up being an interesting one. The `useChannel` hook has a `closeAfterFirstRead` option to close the channel after the initial message rather than continuing to return updates. This is used in on specific place, namely the `useVehiclesByRunId` hook when it's called by `useVehicleForNotification`. The problem is that this argument wasn't actually implemented quite correctly. When the argument was set to true, the function was not adding `receive` handlers on the push object from `channel.join()` and was just closing out the channel when the `channel.on` handler runs. However, this is actually backwards from the way it should be: the `.receive` handlers on the push object handle the results of the initial join, including the initial message, and the `.on` handler on the channel handles subsequent events. See the [documentation on the Phoenix JavaScript library](https://hexdocs.pm/phoenix/js/) for more details.

The end result was that, when that argument was sent, we were actually waiting until the server pushed a new message _after_ the channel had already joined. Since we get new vehicle data about every second or so, this meant that depending on timing we might add about a second of wait time. With the changes made it's much more snappy.