### PR TITLE
First batch of useEffect cleanup

### DIFF
--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -140,10 +140,10 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
   } = state
 
   useEffect(() => {
-    if (routeTabs.filter((routeTab) => isOpenTab(routeTab)).length === 0) {
+    if (routeTabs.filter(isOpenTab).length === 0) {
       dispatch(createRouteTab())
     }
-  }, [JSON.stringify(routeTabs)])
+  }, [dispatch, routeTabs])
 
   const { selectedRouteIds, ladderDirections, ladderCrowdingToggles } =
     currentRouteTab(routeTabs) || {

--- a/assets/src/helpers/array.ts
+++ b/assets/src/helpers/array.ts
@@ -50,3 +50,11 @@ export const intersperseString = (s: string, delimiter: string): string => {
   }
   return result
 }
+
+export const equalByElements = <T>(array1: T[], array2: T[]): boolean => {
+  if (array1.length === array2.length) {
+    return array1.every((element, index) => array2[index] === element)
+  } else {
+    return false
+  }
+}

--- a/assets/src/hooks/useMinischedule.ts
+++ b/assets/src/hooks/useMinischedule.ts
@@ -3,6 +3,7 @@ import { fetchScheduleBlock, fetchScheduleRun } from "../api"
 import { Block, Run } from "../minischedule"
 import { TripId } from "../schedule"
 import { RunId } from "../realtime"
+import { equalByElements } from "../helpers/array"
 
 /**
  * undefined means loading
@@ -27,11 +28,18 @@ export const useMinischeduleRuns = (
   tripIds: TripId[]
 ): (Run | null)[] | undefined => {
   const [runs, setRuns] = useState<(Run | null)[] | undefined>(undefined)
+  const [currentTripIds, setCurrentTripIds] = useState<TripId[]>(tripIds)
+
+  if (!equalByElements(tripIds, currentTripIds)) {
+    setCurrentTripIds(tripIds)
+  }
+
   useEffect(() => {
-    Promise.all(tripIds.map((tripId) => fetchScheduleRun(tripId, null))).then(
-      setRuns
-    )
-  }, [JSON.stringify(tripIds)])
+    Promise.all(
+      currentTripIds.map((tripId) => fetchScheduleRun(tripId, null))
+    ).then(setRuns)
+  }, [currentTripIds])
+
   return runs
 }
 

--- a/assets/src/hooks/useNotifications.ts
+++ b/assets/src/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { Channel, Socket } from "phoenix"
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useState } from "react"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { reload } from "../models/browser"
@@ -9,6 +9,8 @@ import {
 } from "../models/notificationData"
 import { Notification } from "../realtime.d"
 import { allOpenRouteIds } from "../models/routeTab"
+import { RouteId } from "../schedule"
+import { equalByElements } from "../helpers/array"
 
 export const useNotifications = (
   handleNewNotification: (notification: Notification) => void,
@@ -18,6 +20,15 @@ export const useNotifications = (
   const topic = "notifications"
   const event = "notification"
   const [{ routeTabs }] = useContext(StateDispatchContext)
+  const [routeIds, setRouteIds] = useState<RouteId[]>(
+    allOpenRouteIds(routeTabs)
+  )
+
+  const newRouteIds = allOpenRouteIds(routeTabs)
+
+  if (!equalByElements(routeIds, newRouteIds)) {
+    setRouteIds(newRouteIds)
+  }
 
   useEffect(() => {
     let channel: Channel | undefined
@@ -49,5 +60,5 @@ export const useNotifications = (
         channel = undefined
       }
     }
-  }, [socket, JSON.stringify(allOpenRouteIds(routeTabs))])
+  }, [socket, routeIds])
 }

--- a/assets/src/hooks/useSwings.ts
+++ b/assets/src/hooks/useSwings.ts
@@ -1,20 +1,27 @@
 import { useEffect, useState, useContext } from "react"
 import { fetchSwings } from "../api"
-import { Swing } from "../schedule.d"
+import { RouteId, Swing } from "../schedule.d"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { allOpenRouteIds } from "../models/routeTab"
+import { equalByElements } from "../helpers/array"
 
 const useSwings = (): Swing[] | null => {
   const [{ routeTabs }] = useContext(StateDispatchContext)
   const [swings, setSwings] = useState<Swing[] | null>(null)
+  const [routeIds, setRouteIds] = useState<RouteId[]>(
+    allOpenRouteIds(routeTabs)
+  )
 
-  const routeIds = allOpenRouteIds(routeTabs)
+  const newRouteIds = allOpenRouteIds(routeTabs)
+
+  if (!equalByElements(routeIds, newRouteIds)) {
+    setRouteIds(newRouteIds)
+  }
 
   useEffect(() => {
-    fetchSwings(routeIds).then((newSwings: Swing[] | null) => {
-      setSwings(newSwings)
-    })
-  }, [JSON.stringify(routeIds)])
+    fetchSwings(routeIds).then(setSwings)
+  }, [routeIds])
+
   return swings
 }
 

--- a/assets/tests/helpers/array.test.ts
+++ b/assets/tests/helpers/array.test.ts
@@ -1,4 +1,5 @@
 import {
+  equalByElements,
   flatten,
   intersperseString,
   partition,
@@ -73,5 +74,23 @@ describe("intersperseString", () => {
 
   test("intersperses the delimiter", () => {
     expect(intersperseString("abc", "--")).toEqual("a--b--c")
+  })
+})
+
+describe("equalByElements", () => {
+  test("returns true with equal elements", () => {
+    expect(equalByElements(["a", "b"], ["a", "b"])).toBeTruthy()
+  })
+
+  test("returns false with the same elements in different order", () => {
+    expect(equalByElements(["a", "b"], ["b", "a"])).toBeFalsy()
+  })
+
+  test("returns false with same length but different elements", () => {
+    expect(equalByElements(["a", "b"], ["c", "d"])).toBeFalsy()
+  })
+
+  test("returns false with different length", () => {
+    expect(equalByElements(["a", "b"], ["c"])).toBeFalsy()
   })
 })

--- a/assets/tests/hooks/useMinischedule.test.ts
+++ b/assets/tests/hooks/useMinischedule.test.ts
@@ -79,6 +79,15 @@ describe("useMinischeduleRuns", () => {
     expect(mockFetchScheduleRun).toHaveBeenCalledTimes(1)
   })
 
+  test("doesn't refetch with same trip IDs", () => {
+    const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
+    const { rerender } = renderHook(() => {
+      return useMinischeduleRuns(["trip"])
+    })
+    rerender(["trip"])
+    expect(mockFetchScheduleRun).toHaveBeenCalledTimes(1)
+  })
+
   test("does refetch when trip IDs changed", () => {
     const mockFetchScheduleRun: jest.Mock = Api.fetchScheduleRun as jest.Mock
     const { rerender } = renderHook(

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -160,6 +160,29 @@ describe("useNotifications", () => {
         initialProps: { socket: mockSocket, selectedRouteIds: ["route"] },
       }
     )
+    rerender()
+
+    expect(mockChannel.join).toHaveBeenCalledTimes(1)
+  })
+
+  test("doesn't rejoin channel when route IDs don't change", () => {
+    const mockAddNotification = jest.fn()
+    const mockSetNotifications = jest.fn()
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", {
+      initial_notifications: [],
+    })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    const { rerender } = renderHook(
+      () => {
+        useNotifications(mockAddNotification, mockSetNotifications)
+      },
+      {
+        wrapper,
+        initialProps: { socket: mockSocket, selectedRouteIds: ["route"] },
+      }
+    )
     rerender({ socket: mockSocket, selectedRouteIds: ["route"] })
 
     expect(mockChannel.join).toHaveBeenCalledTimes(1)

--- a/assets/tests/hooks/useSwings.test.tsx
+++ b/assets/tests/hooks/useSwings.test.tsx
@@ -96,6 +96,38 @@ describe("useSwings", () => {
     expect(mockFetchSwings).toHaveBeenCalledTimes(1)
   })
 
+  test("doesn't refetch swings when route Ids don't change", () => {
+    const mockFetchSwings: jest.Mock = Api.fetchSwings as jest.Mock
+    const { rerender } = renderHook(
+      () => {
+        useSwings()
+      },
+
+      {
+        wrapper,
+        initialProps: {
+          routeTabs: [
+            routeTabFactory.build({
+              selectedRouteIds: ["1"],
+              isCurrentTab: true,
+            }),
+            routeTabFactory.build({
+              selectedRouteIds: ["2"],
+              isCurrentTab: false,
+            }),
+          ],
+        },
+      }
+    )
+    rerender({
+      routeTabs: [
+        routeTabFactory.build({ selectedRouteIds: ["1"], isCurrentTab: false }),
+        routeTabFactory.build({ selectedRouteIds: ["2"], isCurrentTab: true }),
+      ],
+    })
+    expect(mockFetchSwings).toHaveBeenCalledTimes(1)
+  })
+
   test("does refetch swings when selected routes change", () => {
     const mockFetchSwings: jest.Mock = Api.fetchSwings as jest.Mock
     const { rerender } = renderHook(


### PR DESCRIPTION
Asana ticket: [⚙️ [extra] First batch of useEffect hooks cleanup](https://app.asana.com/0/1152340551558956/1202292117886162/f)

A few quick notes on the approach:
1. For the changes in the `LadderPage` component, I felt comfortable just using `routeTabs` as a dependency directly because it's fairly easy to understand how and why it changes in the state reducer, plus the effect doesn't do any sort of API calls or other expensive opertations.
2. For the other hooks with some sort of array dependency, I have opted to check arrays element-by-element for equality. This guards against things like references to two arrays containing the same elements in the same order, but doesn't handle cases where the arrays contain the same elements in different orders. I think this is fine for the particular cases in question, since we are mainly trying to prevent cases where something unrelated to the list at hand (like which route tab is current vs. the routes open in all of the selected tabs).
3. I have done some testing, including placing `console.log` statements inside of the relevant hooks, to make sure we aren't introducing new infinite loop bugs.
4. The `useNotifications` reducer takes a couple of functions as arguments that are used in the effect, and should therefore be dependencies of the effect. However, these are closures that the `NotificationContext` puts together based on some reducer dispatch calls, and adding them to the dependency array triggers a lot of excess re-runs of the notification subscription effect. I'm still thinking over exactly how to address this.