### PR TITLE
Revert "fix: change anchor in ellipsis submenu to button"

### DIFF
--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -108,7 +108,7 @@
   text-align: left;
   z-index: 1000;
 
-  button {
+  a {
     color: $color-secondary-dark;
 
     &:hover {

--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -164,7 +164,8 @@ const EllipsisSubmenu = ({ notification }: { notification: Notification }) => {
         tabIndex={0}
       >
         {/* eslint-enable jsx-a11y/click-events-have-key-events */}
-        <button
+        {/* eslint-disable jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events */}
+        <a
           onClick={(event) => {
             event.stopPropagation()
             dispatch(toggleReadState(notification))
@@ -175,7 +176,8 @@ const EllipsisSubmenu = ({ notification }: { notification: Notification }) => {
           tabIndex={-1}
         >
           mark as {otherReadState}
-        </button>
+        </a>
+        {/* eslint-enable jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events */}
       </div>
     </>
   )


### PR DESCRIPTION
Asana ticket: followup on [⚙️ [extra] Clean up ignored jsx-a11y errors](https://app.asana.com/0/1152340551558956/1202375393472375/f)

This reverts commit cf2f0ac13e4b17004427c29a8533044b277d0a46.

I somehow forgot about the fact that the whole submenu is itself nested inside of a button, so I can't turn the anchor tag into a button without creating a nested buttons scenario. This just reverts the relevant commit from the other PR.