### PR TITLE
feat: close Drift widget on chat close

### DIFF
--- a/assets/src/components/nav/topNavMobile.tsx
+++ b/assets/src/components/nav/topNavMobile.tsx
@@ -10,12 +10,12 @@ import {
   questionMarkIcon,
   refreshIcon,
   settingsIcon,
-  //speechBubbleIcon,
+  speechBubbleIcon,
 } from "../../helpers/icon"
 import { toggleMobileMenu, toggleNotificationDrawer } from "../../state"
 import NotificationBellIcon from "../notificationBellIcon"
 import { currentTabName, RouteTab } from "../../models/routeTab"
-//import { openDrift } from "../../helpers/drift"
+import { openDrift } from "../../helpers/drift"
 import { reload } from "../../models/browser"
 
 export const toTitleCase = (str: string): string => {
@@ -91,8 +91,6 @@ const TopNavMobile = (): JSX.Element => {
               Refresh
             </button>
           </li>
-
-          {/* commenting out support until drift is upgraded 
           <li>
             <button
               className="m-top-nav-mobile__menu-button"
@@ -106,8 +104,6 @@ const TopNavMobile = (): JSX.Element => {
               Support
             </button>
           </li>
-          */}
-
           <li>
             <button
               className="m-top-nav-mobile__menu-button"

--- a/assets/tests/components/nav/topNavMobile.test.tsx
+++ b/assets/tests/components/nav/topNavMobile.test.tsx
@@ -15,7 +15,7 @@ import {
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import * as browser from "../../../src/models/browser"
-//import { openDrift } from "../../../src/helpers/drift"
+import { openDrift } from "../../../src/helpers/drift"
 import { displayHelp } from "../../../src/helpers/appCue"
 import { locationForPath } from "../../testHelpers/locationHelpers"
 
@@ -170,39 +170,34 @@ describe("TopNavMobile", () => {
     expect(reloadSpy).toHaveBeenCalled()
   })
 
-  {
-    /* commenting out until drift is upgraded 
-    test("clicking Support button opens Drift", async () => {
-      const user = userEvent.setup()
-      const result = render(
+  test("clicking Support button opens Drift", async () => {
+    const user = userEvent.setup()
+    const result = render(
+      <BrowserRouter>
+        <TopNavMobile />
+      </BrowserRouter>
+    )
+
+    await user.click(result.getByTitle("Support"))
+
+    expect(openDrift).toHaveBeenCalled()
+  })
+
+  test("clicking the Support button closes the mobile menu", async () => {
+    const dispatch = jest.fn()
+    const user = userEvent.setup()
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={dispatch}>
         <BrowserRouter>
           <TopNavMobile />
         </BrowserRouter>
-      )
+      </StateDispatchProvider>
+    )
 
-      await user.click(result.getByTitle("Support"))
+    await user.click(result.getByTitle("Support"))
 
-      expect(openDrift).toHaveBeenCalled()
-    })
-
-    test("clicking the Support button closes the mobile menu", async () => {
-      const dispatch = jest.fn()
-      const user = userEvent.setup()
-      const result = render(
-        <StateDispatchProvider state={initialState} dispatch={dispatch}>
-          <BrowserRouter>
-            <TopNavMobile />
-          </BrowserRouter>
-        </StateDispatchProvider>
-      )
-
-      await user.click(result.getByTitle("Support"))
-
-      expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
-    })
-
-  */
-  }
+    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+  })
 
   test("clicking the settings button closes the mobile menu", async () => {
     const dispatch = jest.fn()

--- a/lib/skate_web/templates/layout/_drift.html.eex
+++ b/lib/skate_web/templates/layout/_drift.html.eex
@@ -26,5 +26,10 @@ drift.load('xhxx5rayxher');
 
 drift.on('ready', function(api) {
   api.widget.hide();
+
+  // don't leave the widget open and taking up screen space
+  drift.on('chatClose', function(e) {
+    api.widget.hide()
+  })
 })
 </script>


### PR DESCRIPTION
Asana ticket: [⚙️ Update Drift to most recent version](https://app.asana.com/0/1200180014510248/1202424493437018/f)

This adds a handler to close the widget whenever the chat closes, so we don't have the widget just hanging out there taking up screen space. I confirmed that this works as intended whether you're closing the chat from the widget itself, or using the nav entry which calls the Drift API.