### PR TITLE
fix: Shape on map in VPP not updating when trip changes

### DIFF
--- a/assets/src/hooks/useShapes.ts
+++ b/assets/src/hooks/useShapes.ts
@@ -56,7 +56,7 @@ export const useTripShape = (tripId: TripId | null): Shape[] => {
         setShape(shapeResult)
       )
     }
-  }, [])
+  }, [tripId])
 
   return shape === null ? [] : [shape]
 }

--- a/assets/tests/hooks/useShapes.test.ts
+++ b/assets/tests/hooks/useShapes.test.ts
@@ -3,7 +3,6 @@ import * as Api from "../../src/api"
 import shapesRed from "../../src/data/shapesRed"
 import { useRouteShapes, useTripShape } from "../../src/hooks/useShapes"
 import { Shape } from "../../src/schedule.d"
-import { TripId } from "../../src/schedule"
 import { instantPromise, mockUseStateOnce } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
@@ -144,11 +143,8 @@ describe("useTripShape", () => {
 
   test("doesn't refetch shape when trip Ids don't change", () => {
     const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
-    const { rerender } = renderHook((tripId: TripId | null) => {
-      useTripShape(tripId),
-      {
-        initialProps: "1"
-      }
+    const { rerender } = renderHook((tripId) => useTripShape(tripId), {
+      initialProps: "1",
     })
     rerender("1")
     expect(mockFetchShape).toHaveBeenCalledTimes(1)
@@ -156,11 +152,8 @@ describe("useTripShape", () => {
 
   test("does refetch shape when the trip Id changes", () => {
     const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
-    const { rerender } = renderHook((tripId: TripId | null) => {
-      useTripShape(tripId),
-      {
-        initialProps: "1"
-      }
+    const { rerender } = renderHook((tripId) => useTripShape(tripId), {
+      initialProps: "1",
     })
     rerender("2")
     expect(mockFetchShape).toHaveBeenCalledTimes(2)

--- a/assets/tests/hooks/useShapes.test.ts
+++ b/assets/tests/hooks/useShapes.test.ts
@@ -140,4 +140,22 @@ describe("useTripShape", () => {
 
     expect(result.current).toEqual([shape])
   })
+
+  test("doesn't refetch shape when trip Ids don't change", () => {
+    const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
+    const { rerender } = renderHook(() => {
+      useTripShape("1")
+    })
+    rerender("1")
+    expect(mockFetchShape).toHaveBeenCalledTimes(1)
+  })
+
+  test("does refetch shape when the trip Id changes", () => {
+    const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
+    const { rerender } = renderHook(() => {
+      useTripShape("1")
+    })
+    rerender("2")
+    expect(mockFetchShape).toHaveBeenCalledTimes(2)
+  })
 })

--- a/assets/tests/hooks/useShapes.test.ts
+++ b/assets/tests/hooks/useShapes.test.ts
@@ -3,6 +3,7 @@ import * as Api from "../../src/api"
 import shapesRed from "../../src/data/shapesRed"
 import { useRouteShapes, useTripShape } from "../../src/hooks/useShapes"
 import { Shape } from "../../src/schedule.d"
+import { TripId } from "../../src/schedule"
 import { instantPromise, mockUseStateOnce } from "../testHelpers/mockHelpers"
 
 jest.mock("../../src/api", () => ({
@@ -143,8 +144,11 @@ describe("useTripShape", () => {
 
   test("doesn't refetch shape when trip Ids don't change", () => {
     const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
-    const { rerender } = renderHook(() => {
-      useTripShape("1")
+    const { rerender } = renderHook((tripId: TripId | null) => {
+      useTripShape(tripId),
+      {
+        initialProps: "1"
+      }
     })
     rerender("1")
     expect(mockFetchShape).toHaveBeenCalledTimes(1)
@@ -152,8 +156,11 @@ describe("useTripShape", () => {
 
   test("does refetch shape when the trip Id changes", () => {
     const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
-    const { rerender } = renderHook(() => {
-      useTripShape("1")
+    const { rerender } = renderHook((tripId: TripId | null) => {
+      useTripShape(tripId),
+      {
+        initialProps: "1"
+      }
     })
     rerender("2")
     expect(mockFetchShape).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
https://app.asana.com/0/1148853526253437/1202207261666275/f

Simple fix - adding tripID to dependency array in useMapShape hook