### PR TITLE
fix: don't mess with autoflow on mobile search page

### DIFF
--- a/assets/css/_nav.scss
+++ b/assets/css/_nav.scss
@@ -37,7 +37,7 @@
 
 .m-nav__nav-bar--bottom {
   grid-area: bottom;
-  z-index: 1000;
+  z-index: 1099;
 }
 
 .m-nav__app-content {

--- a/assets/css/_search_page.scss
+++ b/assets/css/_search_page.scss
@@ -44,7 +44,6 @@
 @media screen and (max-width: $mobile-max-width) {
   .m-search-page {
     flex-direction: column;
-    overflow: auto; /* Unset overflow: visible to prevent showing map below */
   }
 
   .m-search-page--show-list {


### PR DESCRIPTION
Asana ticket: [🐛 Tab bar covers part of VPP on search page on mobile](https://app.asana.com/0/1148853526253437/1202412997478435/f)

I tracked this down to the fact that the search page CSS was changed to set `overflow: auto` specifically on mobile. Also tweaks the z-index of the bottom nav to make sure that it remains underneath all of the top nav content (i.e. hamburger menu) while also preventing box-shadows from various modals from bleeding out over the bottom nav. I suspect this issue may have been the original impetus for the `overflow: auto`, so this solves the problem not just on the search page but more generally.