### PR TITLE
feat: persistent state on reload for views and filter visibility

### DIFF
--- a/assets/css/_garage_filter.scss
+++ b/assets/css/_garage_filter.scss
@@ -68,6 +68,10 @@
 }
 
 .m-garage-filter__button {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
   span {
     display: inline-block;
     width: 1.6875rem;

--- a/assets/css/_garage_filter.scss
+++ b/assets/css/_garage_filter.scss
@@ -16,7 +16,7 @@
   }
 }
 
-.m-garage-filter__header {
+.m-garage-filter__show-hide-button {
   height: 2.25rem;
   padding: 0 0.5rem 0 1rem;
   width: 100%;
@@ -30,13 +30,13 @@
     border-bottom: 1px solid $color-gray-300;
   }
 
-  &:focus .m-garage-filter__show-hide-button {
+  &:focus .m-garage-filter__show-hide-icon {
     background-color: $color-gray-200;
     border-radius: 4px;
   }
 }
 
-.m-garage-filter__show-hide-button {
+.m-garage-filter__show-hide-icon {
   @include button-icon(0.5625rem);
   transform: rotate(90deg);
   width: 1.5rem;

--- a/assets/src/hooks/useGarageFilter.tsx
+++ b/assets/src/hooks/useGarageFilter.tsx
@@ -83,9 +83,10 @@ export const GarageFilter = ({
       {showGaragesFilter ? (
         <ul className="m-garage-filter__garages">
           {sortedGarages.map((garage) => (
-            <li key={garage} data-testid={garage} className="m-garage-filter__garage">
+            <li key={garage} className="m-garage-filter__garage">
               {garage}
               <button
+                title={"Toggle Garage: " + garage}
                 onClick={() => {
                   if (!filteredGarages.includes(garage) && window.FS) {
                     window.FS.event("User filtered routes by garage")

--- a/assets/src/hooks/useGarageFilter.tsx
+++ b/assets/src/hooks/useGarageFilter.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useState } from "react"
+import { useContext, useState } from "react"
 import { Route, GarageName } from "../schedule.d"
 import { flatten, uniq } from "../helpers/array"
 import {
@@ -9,6 +9,8 @@ import {
   toggleOffIcon,
 } from "../helpers/icon"
 import { tagManagerEvent } from "../helpers/googleTagManager"
+import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import { toggleShowGaragesFilter } from "../state"
 
 export interface GarageFilterData {
   filteredGarages: GarageName[]
@@ -60,24 +62,28 @@ export const GarageFilter = ({
   allGarages,
   toggleGarage,
 }: GarageFilterData) => {
-  const [showGaragesFilter, setShowGaragesFilter] = useState<boolean>(false)
+  const [{ showGaragesFilter }, dispatch] = useContext(StateDispatchContext)
+
   const sortedGarages = allGarages.sort((a, b) => a.localeCompare(b))
+
+  const toggleVisibility = () => dispatch(toggleShowGaragesFilter())
 
   return (
     <div className="m-garage-filter">
       <button
-        className="m-garage-filter__header"
-        onClick={() => setShowGaragesFilter(!showGaragesFilter)}
+        className="m-garage-filter__show-hide-button"
+        title="Toggle Garage Filter"
+        onClick={toggleVisibility}
       >
-        Filter garages
-        <div className="m-garage-filter__show-hide-button">
+        <div className="m-garage-filter__header">Filter garages</div>
+        <div className="m-garage-filter__show-hide-icon">
           {showGaragesFilter ? collapseIcon() : expandIcon()}
         </div>
       </button>
       {showGaragesFilter ? (
         <ul className="m-garage-filter__garages">
           {sortedGarages.map((garage) => (
-            <li key={garage} className="m-garage-filter__garage">
+            <li key={garage} data-testid={garage} className="m-garage-filter__garage">
               {garage}
               <button
                 onClick={() => {

--- a/assets/src/hooks/useGarageFilter.tsx
+++ b/assets/src/hooks/useGarageFilter.tsx
@@ -84,7 +84,6 @@ export const GarageFilter = ({
         <ul className="m-garage-filter__garages">
           {sortedGarages.map((garage) => (
             <li key={garage} className="m-garage-filter__garage">
-              {garage}
               <button
                 title={"Toggle Garage: " + garage}
                 onClick={() => {
@@ -98,6 +97,7 @@ export const GarageFilter = ({
                 }}
                 className="m-garage-filter__button"
               >
+                {garage}
                 {filteredGarages.includes(garage)
                   ? toggleOnIcon()
                   : toggleOffIcon()}

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -31,7 +31,6 @@ const LOCALLY_PERSISTED_KEYS: Key[] = [
   ["pickerContainerIsVisible"],
   ["selectedShuttleRouteIds"],
   ["selectedShuttleRunIds"],
-  ["selectedVehicleOrGhost"],
   ["searchPageState", "savedQueries"],
   ["showGaragesFilter"],
 ]

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -26,8 +26,12 @@ const APP_STATE_KEY = "mbta-skate-state"
 type Key = string[]
 
 const LOCALLY_PERSISTED_KEYS: Key[] = [
+  ["notificationDrawerIsOpen"],
+  ["openView"],
+  ["pickerContainerIsVisible"],
   ["selectedShuttleRouteIds"],
   ["selectedShuttleRunIds"],
+  ["selectedVehicleOrGhost"],
   ["searchPageState", "savedQueries"],
 ]
 

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -33,6 +33,7 @@ const LOCALLY_PERSISTED_KEYS: Key[] = [
   ["selectedShuttleRunIds"],
   ["selectedVehicleOrGhost"],
   ["searchPageState", "savedQueries"],
+  ["showGaragesFilter"],
 ]
 
 const routeTabsPushRetries = 2

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -87,6 +87,7 @@ export interface State {
   openView: OpenView
   openInputModal: OpenInputModal | null
   mobileMenuIsOpen: boolean
+  showGaragesFilter: boolean
 }
 
 export const initialState: State = {
@@ -105,6 +106,7 @@ export const initialState: State = {
   openView: OpenView.None,
   openInputModal: null,
   mobileMenuIsOpen: false,
+  showGaragesFilter: false,
 }
 
 interface CreateRouteTabAction {
@@ -542,6 +544,14 @@ export const toggleMobileMenu = (): ToggleMobileMenuAction => ({
   type: "TOGGLE_MOBILE_MENU",
 })
 
+interface ToggleShowGaragesFilterAction {
+  type: "TOGGLE_SHOW_GARAGES_FILTER"
+}
+
+export const toggleShowGaragesFilter = (): ToggleShowGaragesFilterAction => ({
+  type: "TOGGLE_SHOW_GARAGES_FILTER",
+})
+
 export type Action =
   // Route tabs and ladder management in tabs
   | CreateRouteTabAction
@@ -596,6 +606,8 @@ export type Action =
   | CloseInputModalAction
   // Mobile Menu
   | ToggleMobileMenuAction
+  // Routepicker Garage Filter
+  | ToggleShowGaragesFilterAction
 
 export type Dispatch = ReactDispatch<Action>
 
@@ -938,6 +950,15 @@ const mobileMenuReducer = (state: boolean, action: Action): boolean => {
   }
 }
 
+const garageFilterReducer = (state: boolean, action: Action): boolean => {
+  switch (action.type) {
+    case "TOGGLE_SHOW_GARAGES_FILTER":
+      return !state
+    default:
+      return state
+  }
+}
+
 const userSettingsReducer = (
   state: UserSettings,
   action: Action
@@ -1096,5 +1117,6 @@ export const reducer = (state: State, action: Action): State => {
     openView,
     openInputModal: openInputModalReducer(state.openInputModal, action),
     mobileMenuIsOpen: mobileMenuReducer(state.mobileMenuIsOpen, action),
+    showGaragesFilter: garageFilterReducer(state.showGaragesFilter, action),
   }
 }

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -254,12 +254,17 @@ exports[`App renders 1`] = `
             className="m-garage-filter"
           >
             <button
-              className="m-garage-filter__header"
+              className="m-garage-filter__show-hide-button"
               onClick={[Function]}
+              title="Toggle Garage Filter"
             >
-              Filter garages
               <div
-                className="m-garage-filter__show-hide-button"
+                className="m-garage-filter__header"
+              >
+                Filter garages
+              </div>
+              <div
+                className="m-garage-filter__show-hide-icon"
               >
                 <span
                   className=""
@@ -589,12 +594,17 @@ exports[`App shows data outage banner if there's a data outage 1`] = `
             className="m-garage-filter"
           >
             <button
-              className="m-garage-filter__header"
+              className="m-garage-filter__show-hide-button"
               onClick={[Function]}
+              title="Toggle Garage Filter"
             >
-              Filter garages
               <div
-                className="m-garage-filter__show-hide-button"
+                className="m-garage-filter__header"
+              >
+                Filter garages
+              </div>
+              <div
+                className="m-garage-filter__show-hide-icon"
               >
                 <span
                   className=""

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -254,12 +254,17 @@ exports[`renders 1`] = `
             className="m-garage-filter"
           >
             <button
-              className="m-garage-filter__header"
+              className="m-garage-filter__show-hide-button"
               onClick={[Function]}
+              title="Toggle Garage Filter"
             >
-              Filter garages
               <div
-                className="m-garage-filter__show-hide-button"
+                className="m-garage-filter__header"
+              >
+                Filter garages
+              </div>
+              <div
+                className="m-garage-filter__show-hide-icon"
               >
                 <span
                   className=""

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -70,12 +70,17 @@ exports[`LadderPage renders the empty state 1`] = `
         className="m-garage-filter"
       >
         <button
-          className="m-garage-filter__header"
+          className="m-garage-filter__show-hide-button"
           onClick={[Function]}
+          title="Toggle Garage Filter"
         >
-          Filter garages
           <div
-            className="m-garage-filter__show-hide-button"
+            className="m-garage-filter__header"
+          >
+            Filter garages
+          </div>
+          <div
+            className="m-garage-filter__show-hide-icon"
           >
             <span
               className=""
@@ -204,12 +209,17 @@ exports[`LadderPage renders with route tabs 1`] = `
         className="m-garage-filter"
       >
         <button
-          className="m-garage-filter__header"
+          className="m-garage-filter__show-hide-button"
           onClick={[Function]}
+          title="Toggle Garage Filter"
         >
-          Filter garages
           <div
-            className="m-garage-filter__show-hide-button"
+            className="m-garage-filter__header"
+          >
+            Filter garages
+          </div>
+          <div
+            className="m-garage-filter__show-hide-icon"
           >
             <span
               className=""
@@ -484,12 +494,17 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         className="m-garage-filter"
       >
         <button
-          className="m-garage-filter__header"
+          className="m-garage-filter__show-hide-button"
           onClick={[Function]}
+          title="Toggle Garage Filter"
         >
-          Filter garages
           <div
-            className="m-garage-filter__show-hide-button"
+            className="m-garage-filter__header"
+          >
+            Filter garages
+          </div>
+          <div
+            className="m-garage-filter__show-hide-icon"
           >
             <span
               className=""
@@ -782,12 +797,17 @@ exports[`LadderPage renders with timepoints 1`] = `
         className="m-garage-filter"
       >
         <button
-          className="m-garage-filter__header"
+          className="m-garage-filter__show-hide-button"
           onClick={[Function]}
+          title="Toggle Garage Filter"
         >
-          Filter garages
           <div
-            className="m-garage-filter__show-hide-button"
+            className="m-garage-filter__header"
+          >
+            Filter garages
+          </div>
+          <div
+            className="m-garage-filter__show-hide-icon"
           >
             <span
               className=""
@@ -1324,12 +1344,17 @@ exports[`LadderPage renders with vehicles and selected vehicles 1`] = `
         className="m-garage-filter"
       >
         <button
-          className="m-garage-filter__header"
+          className="m-garage-filter__show-hide-button"
           onClick={[Function]}
+          title="Toggle Garage Filter"
         >
-          Filter garages
           <div
-            className="m-garage-filter__show-hide-button"
+            className="m-garage-filter__header"
+          >
+            Filter garages
+          </div>
+          <div
+            className="m-garage-filter__show-hide-icon"
           >
             <span
               className=""

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -24,12 +24,17 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
     className="m-garage-filter"
   >
     <button
-      className="m-garage-filter__header"
+      className="m-garage-filter__show-hide-button"
       onClick={[Function]}
+      title="Toggle Garage Filter"
     >
-      Filter garages
       <div
-        className="m-garage-filter__show-hide-button"
+        className="m-garage-filter__header"
+      >
+        Filter garages
+      </div>
+      <div
+        className="m-garage-filter__show-hide-icon"
       >
         <span
           className=""
@@ -145,12 +150,17 @@ exports[`RoutePicker renders a loading/empty state 1`] = `
     className="m-garage-filter"
   >
     <button
-      className="m-garage-filter__header"
+      className="m-garage-filter__show-hide-button"
       onClick={[Function]}
+      title="Toggle Garage Filter"
     >
-      Filter garages
       <div
-        className="m-garage-filter__show-hide-button"
+        className="m-garage-filter__header"
+      >
+        Filter garages
+      </div>
+      <div
+        className="m-garage-filter__show-hide-icon"
       >
         <span
           className=""

--- a/assets/tests/hooks/useGarageFilter.test.tsx
+++ b/assets/tests/hooks/useGarageFilter.test.tsx
@@ -12,10 +12,7 @@ import {
 import { tagManagerEvent } from "../../src/helpers/googleTagManager"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { BrowserRouter } from "react-router-dom"
-import { 
-  initialState,
-  toggleShowGaragesFilter 
-} from "../../src/state"
+import { initialState, toggleShowGaragesFilter } from "../../src/state"
 
 jest.mock("../../src/helpers/googleTagManager", () => ({
   __esModule: true,
@@ -90,7 +87,6 @@ describe("filterRoutesByGarage", () => {
 })
 
 describe("GarageFilter", () => {
-
   const dispatch = jest.fn()
 
   const mockGarageFilter: GarageFilterData = {
@@ -100,7 +96,6 @@ describe("GarageFilter", () => {
   }
 
   test("click the button to toggle the global to hide / show the filters", async () => {
-
     const user = userEvent.setup()
 
     const result = render(
@@ -109,33 +104,29 @@ describe("GarageFilter", () => {
           <GarageFilter {...mockGarageFilter} />
         </BrowserRouter>
       </StateDispatchProvider>
-    )  
+    )
 
     await user.click(result.getByTitle("Toggle Garage Filter"))
     expect(dispatch).toHaveBeenCalledWith(toggleShowGaragesFilter())
-
   })
 
   test("Garage filter does not render by default", () => {
-
     const result = render(
-        <StateDispatchProvider state={initialState} dispatch={dispatch}>
-          <BrowserRouter>
-            <GarageFilter {...mockGarageFilter} />
-          </BrowserRouter>
-        </StateDispatchProvider>
-      ) 
+      <StateDispatchProvider state={initialState} dispatch={dispatch}>
+        <BrowserRouter>
+          <GarageFilter {...mockGarageFilter} />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
 
-      expect(result.queryByText("Garage A")).toBeFalsy() 
-
+    expect(result.queryByText("Garage A")).toBeFalsy()
   })
 
   test("Garage filter renders when showGaragesFilter is true, and individual garages are clickable", async () => {
-
     const user = userEvent.setup()
 
     const result = render(
-      <StateDispatchProvider 
+      <StateDispatchProvider
         state={{ ...initialState, showGaragesFilter: true }}
         dispatch={dispatch}
       >
@@ -143,7 +134,7 @@ describe("GarageFilter", () => {
           <GarageFilter {...mockGarageFilter} />
         </BrowserRouter>
       </StateDispatchProvider>
-    )  
+    )
 
     expect(result.getByText("Garage A")).toBeTruthy()
 
@@ -159,7 +150,5 @@ describe("GarageFilter", () => {
       "User filtered routes by garage"
     )
     expect(tagManagerEvent).toHaveBeenCalledWith("filtered_routes_by_garage")
-
   })
-
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -174,6 +174,17 @@ describe("reducer", () => {
     expect(newState).toEqual(expectedState)
   })
 
+  test("toggleShowGaragesFilter", () => {
+    const expectedState: State.State = {
+      ...initialState,
+      showGaragesFilter: true,
+    }
+
+    const newState = reducer(initialState, State.toggleShowGaragesFilter())
+
+    expect(newState).toEqual(expectedState)
+  })
+
   describe("notification drawer", () => {
     test("openNotificationDrawer opens the drawer", () => {
       const state = {


### PR DESCRIPTION
Created a `showGaragesFilter` global variable.

Added the following to local storage:

1. `notificationDrawerIsOpen`
2. `openView`
3. `selectedVehicleOrGhost`
4. `pickerContainerIsVisible`
5. `showGaragesFilter`