### PR TITLE
More useEffect fixes

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
     "prettier",
   ],

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5530,6 +5530,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -62,6 +62,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
     "fishery": "^2.2.2",
     "jest": "^26.6.3",

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -1,4 +1,4 @@
-import Leaflet, { LatLngExpression, Map as LeafletMap } from "leaflet"
+import Leaflet, { LatLng, LatLngExpression, Map as LeafletMap } from "leaflet"
 import "leaflet-defaulticon-compatibility" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
 import React, {
   MutableRefObject,
@@ -36,6 +36,7 @@ import { Shape } from "../schedule"
 import { selectVehicle } from "../state"
 import { UserSettings } from "../userSettings"
 import featureIsEnabled from "../laboratoryFeatures"
+import { equalByElements } from "../helpers/array"
 
 export interface Props {
   vehicles: Vehicle[]
@@ -426,24 +427,28 @@ const useAutoCenter = (
   reactLeafletMapRef: MutableRefObject<ReactLeafletMap | null>,
   shouldAutoCenter: boolean,
   isAutoCentering: MutableRefObject<boolean>,
-  latLngs: LatLngExpression[]
+  latLngs: LatLng[]
 ) => {
   const [appState] = useContext(StateDispatchContext)
+  const [currentLatLngs, setCurrentLatLngs] = useState<LatLng[]>(latLngs)
   const pickerContainerIsVisible: boolean = appState.pickerContainerIsVisible
+
+  if (
+    !equalByElements(latLngs, currentLatLngs, (latLng1, latLng2) =>
+      latLng1.equals(latLng2)
+    )
+  ) {
+    setCurrentLatLngs(latLngs)
+  }
+
   useEffect(() => {
     const reactLeafletMap: ReactLeafletMap | null = reactLeafletMapRef.current
     if (reactLeafletMap !== null && shouldAutoCenter) {
       const leafletMap: LeafletMap = reactLeafletMap.leafletElement
       isAutoCentering.current = true
-      autoCenter(leafletMap, latLngs, pickerContainerIsVisible)
+      autoCenter(leafletMap, currentLatLngs, pickerContainerIsVisible)
     }
-  }, [
-    shouldAutoCenter,
-    // useEffect uses ===, which doesn't work on arrays.
-    // convert the array to a string so useEffect can tell if it doesn't change.
-    JSON.stringify(latLngs),
-    pickerContainerIsVisible,
-  ])
+  }, [shouldAutoCenter, currentLatLngs, pickerContainerIsVisible])
 }
 
 const Map = (props: Props): ReactElement<HTMLDivElement> => {
@@ -461,8 +466,8 @@ const MapWithLeaflet = (props: Props): ReactElement<HTMLDivElement> => {
   const [shouldAutoCenter, setShouldAutoCenter] = useState<boolean>(true)
   const isAutoCentering: MutableRefObject<boolean> = useRef(false)
 
-  const latLngs: LatLngExpression[] = props.vehicles.map(
-    ({ latitude, longitude }) => Leaflet.latLng(latitude, longitude)
+  const latLngs: LatLng[] = props.vehicles.map(({ latitude, longitude }) =>
+    Leaflet.latLng(latitude, longitude)
   )
   useAutoCenter(mapRef, shouldAutoCenter, isAutoCentering, latLngs)
 

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -448,7 +448,13 @@ const useAutoCenter = (
       isAutoCentering.current = true
       autoCenter(leafletMap, currentLatLngs, pickerContainerIsVisible)
     }
-  }, [shouldAutoCenter, currentLatLngs, pickerContainerIsVisible])
+  }, [
+    shouldAutoCenter,
+    isAutoCentering,
+    reactLeafletMapRef,
+    currentLatLngs,
+    pickerContainerIsVisible,
+  ])
 }
 
 const Map = (props: Props): ReactElement<HTMLDivElement> => {
@@ -462,6 +468,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
 const MapWithLeaflet = (props: Props): ReactElement<HTMLDivElement> => {
   const mapRef: MutableRefObject<ReactLeafletMap | null> =
     // this prop is only for tests, and is consistent between renders, so the hook call is consistent
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     props.reactLeafletRef || useRef(null)
   const [shouldAutoCenter, setShouldAutoCenter] = useState<boolean>(true)
   const isAutoCentering: MutableRefObject<boolean> = useRef(false)

--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -30,9 +30,12 @@ const NotificationDrawer = () => {
 
   const [isInitialRender, setIsInitialRender] = useState<boolean>(true)
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useLayoutEffect(() => {
     const restoreScrollPosition = isInitialRender
     setIsInitialRender(false)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const currentElement = elementRef.current!
 
     if (restoreScrollPosition && elementRef) {
       const element = elementRef.current
@@ -42,10 +45,10 @@ const NotificationDrawer = () => {
     }
 
     return () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      rememberScrollPosition(elementRef.current!.scrollTop)
+      rememberScrollPosition(currentElement.scrollTop)
     }
   }, [])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <div className="m-notification-drawer" ref={elementRef}>
@@ -135,6 +138,7 @@ const EllipsisSubmenu = ({ notification }: { notification: Notification }) => {
   const submenuRef = useRef<HTMLDivElement | null>(null)
   const otherReadState = otherNotificationReadState(notification.state)
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     const closeOnClickOutside = (event: MouseEvent) => {
       if (
@@ -152,6 +156,7 @@ const EllipsisSubmenu = ({ notification }: { notification: Notification }) => {
       document.removeEventListener("mousedown", closeOnClickOutside)
     }
   }, [submenuRef])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <>

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -80,7 +80,7 @@ export const NotificationsProvider = ({
       dispatch(setNotifications(notificationsData, isInitialLoad))
     }
   )
-  useEffect(() => setIsInitialLoad(false))
+  useEffect(() => setIsInitialLoad(false), [])
 
   useInterval(() => dispatch(expireNotifications(now)), 10000)
 

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -93,11 +93,13 @@ export const NotificationsProvider = ({
     socket
   )
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (selectedNotification) {
       stateDispatch(selectVehicleFromNotification(vehicleForNotification))
     }
   }, [selectedNotification, vehicleForNotification])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <NotificationsContext.Provider

--- a/assets/src/helpers/array.ts
+++ b/assets/src/helpers/array.ts
@@ -51,9 +51,17 @@ export const intersperseString = (s: string, delimiter: string): string => {
   return result
 }
 
-export const equalByElements = <T>(array1: T[], array2: T[]): boolean => {
+export const equalByElements = <T>(
+  array1: T[],
+  array2: T[],
+  fun?: (v1: T, v2: T) => boolean
+): boolean => {
   if (array1.length === array2.length) {
-    return array1.every((element, index) => array2[index] === element)
+    if (fun) {
+      return array1.every((element, index) => fun(array2[index], element))
+    } else {
+      return array1.every((element, index) => array2[index] === element)
+    }
   } else {
     return false
   }

--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -58,6 +58,6 @@ export const useChannel = <T>({
         channel = undefined
       }
     }
-  }, [socket, topic, event, loadingState])
+  }, [socket, topic, event, loadingState, parser, closeAfterFirstRead])
   return state
 }

--- a/assets/src/hooks/useDataStatus.ts
+++ b/assets/src/hooks/useDataStatus.ts
@@ -3,12 +3,14 @@ import { useChannel } from "./useChannel"
 
 export type DataStatus = "good" | "outage"
 
+const parser = (status: DataStatus): DataStatus => status
+
 const useDataStatus = (socket: Socket | undefined) => {
   return useChannel<DataStatus>({
     socket,
     topic: "data_status",
     event: "data_status",
-    parser: (status) => status,
+    parser,
     loadingState: "good",
   })
 }

--- a/assets/src/hooks/useMinischedule.ts
+++ b/assets/src/hooks/useMinischedule.ts
@@ -16,7 +16,7 @@ export const useMinischeduleRun = (
   const [run, setRun] = useState<Run | null | undefined>(undefined)
   useEffect(() => {
     fetchScheduleRun(tripId, runId).then(setRun)
-  }, [tripId])
+  }, [tripId, runId])
   return run
 }
 

--- a/assets/src/hooks/useNotifications.ts
+++ b/assets/src/hooks/useNotifications.ts
@@ -30,6 +30,7 @@ export const useNotifications = (
     setRouteIds(newRouteIds)
   }
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     let channel: Channel | undefined
 
@@ -61,4 +62,5 @@ export const useNotifications = (
       }
     }
   }, [socket, routeIds])
+  /* eslint-enable react-hooks/exhaustive-deps */
 }

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -51,6 +51,7 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
   const [routeTabsPushRetriesLeft, setRouteTabsPushRetriesLeft] =
     useState(routeTabsPushRetries)
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (routeTabsToPush && !routeTabsPushInProgress) {
       dispatch(startingRouteTabsPush())
@@ -78,6 +79,7 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
         })
     }
   }, [routeTabsToPush, routeTabsPushInProgress])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return [state, dispatch]
 }

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -77,7 +77,7 @@ const usePersistedStateReducer = (): [State, Dispatch] => {
           }
         })
     }
-  }, [JSON.stringify(routeTabsToPush), routeTabsPushInProgress])
+  }, [routeTabsToPush, routeTabsPushInProgress])
 
   return [state, dispatch]
 }

--- a/assets/src/hooks/useSocket.ts
+++ b/assets/src/hooks/useSocket.ts
@@ -42,7 +42,7 @@ const useSocket = (): SocketStatus => {
       setConnectionStatus(ConnectionStatus.Disconnected)
     )
     setSocket(initialSocket)
-  }, [])
+  }, [userToken])
 
   return { socket, connectionStatus }
 }

--- a/assets/src/hooks/useTrainVehicles.ts
+++ b/assets/src/hooks/useTrainVehicles.ts
@@ -160,6 +160,7 @@ const useTrainVehicles = (
   const [state, dispatch] = useReducer(reducer, initialState)
   const { channelsByRouteId, trainVehiclesByRouteId } = state
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (socket) {
       // Unsubscribe from any routes we don't care about anymore
@@ -179,6 +180,7 @@ const useTrainVehicles = (
       })
     }
   }, [socket, selectedTrainRouteIds])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return trainVehiclesByRouteId
 }

--- a/assets/src/hooks/useVehicleForId.ts
+++ b/assets/src/hooks/useVehicleForId.ts
@@ -11,6 +11,7 @@ import { useChannel } from "./useChannel"
 const parser = (data: VehicleOrGhostData): VehicleOrGhost[] => [
   vehicleOrGhostFromData(data),
 ]
+const parserWithNull = nullableParser(parser)
 
 const useVehicleForId = (
   socket: Socket | undefined,
@@ -22,7 +23,7 @@ const useVehicleForId = (
     socket,
     topic,
     event: "vehicle",
-    parser: nullableParser(parser),
+    parser: parserWithNull,
     loadingState: undefined,
   })
 

--- a/assets/src/hooks/useVehicleForNotification.ts
+++ b/assets/src/hooks/useVehicleForNotification.ts
@@ -1,7 +1,5 @@
 import { Socket } from "phoenix"
-import { useEffect, useState } from "react"
 import useVehiclesForRunIds from "./useVehiclesForRunIds"
-import { isVehicle } from "../models/vehicle"
 import { Notification, VehicleOrGhost } from "../realtime.d"
 
 const useVehicleForNotification = (
@@ -16,32 +14,6 @@ const useVehicleForNotification = (
   const newVehicleOrGhost = Array.isArray(newVehiclesOrGhosts)
     ? newVehiclesOrGhosts[0] || null
     : newVehiclesOrGhosts
-
-  const [clickthroughLogged, setClickthroughLogged] = useState<boolean>(false)
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    if (window.FS) {
-      if (!clickthroughLogged) {
-        if (newVehicleOrGhost) {
-          setClickthroughLogged(true)
-          if (isVehicle(newVehicleOrGhost)) {
-            window.FS.event("Notification linked to VPP")
-          } else {
-            window.FS.event("Notification linked to ghost")
-          }
-        } else if (notification && newVehicleOrGhost === null) {
-          setClickthroughLogged(true)
-          window.FS.event(
-            new Date() < notification.startTime
-              ? "Notification link failed upcoming"
-              : "Notification link failed"
-          )
-        }
-      }
-    }
-  }, [newVehicleOrGhost, notification])
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   return newVehicleOrGhost
 }

--- a/assets/src/hooks/useVehicleForNotification.ts
+++ b/assets/src/hooks/useVehicleForNotification.ts
@@ -19,6 +19,7 @@ const useVehicleForNotification = (
 
   const [clickthroughLogged, setClickthroughLogged] = useState<boolean>(false)
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (window.FS) {
       if (!clickthroughLogged) {
@@ -40,6 +41,7 @@ const useVehicleForNotification = (
       }
     }
   }, [newVehicleOrGhost, notification])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return newVehicleOrGhost
 }

--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -154,6 +154,7 @@ const useVehicles = (
   const [invalidVehicleIds, setInvalidVehicleIds] = useState<VehicleId[]>([])
   const { channelsByRouteId, vehiclesByRouteId } = state
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (socket) {
       // Unsubscribe from any routes we don't care about anymore
@@ -173,7 +174,9 @@ const useVehicles = (
       })
     }
   }, [socket, selectedRouteIds])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     const newInvalidVehicles = flatten(Object.values(vehiclesByRouteId)).filter(
       (vehicleOrGhost) =>
@@ -198,6 +201,7 @@ const useVehicles = (
 
     setInvalidVehicleIds(newInvalidVehicles.map((vehicle) => vehicle.id))
   }, [vehiclesByRouteId])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return vehiclesByRouteId
 }

--- a/assets/src/hooks/useVehicles.ts
+++ b/assets/src/hooks/useVehicles.ts
@@ -1,19 +1,12 @@
 import { Channel, Socket } from "phoenix"
-import {
-  Dispatch as ReactDispatch,
-  useEffect,
-  useReducer,
-  useState,
-} from "react"
+import { Dispatch as ReactDispatch, useEffect, useReducer } from "react"
 import { reload } from "../models/browser"
 import {
   VehicleOrGhostData,
   vehicleOrGhostFromData,
 } from "../models/vehicleData"
-import { isVehicle } from "../models/vehicle"
-import { VehicleId, VehicleOrGhost } from "../realtime.d"
+import { VehicleOrGhost } from "../realtime.d"
 import { ByRouteId, RouteId } from "../schedule.d"
-import { flatten } from "../helpers/array"
 
 interface State {
   channelsByRouteId: ByRouteId<Channel>
@@ -151,7 +144,6 @@ const useVehicles = (
   selectedRouteIds: RouteId[]
 ): ByRouteId<VehicleOrGhost[]> => {
   const [state, dispatch] = useReducer(reducer, initialState)
-  const [invalidVehicleIds, setInvalidVehicleIds] = useState<VehicleId[]>([])
   const { channelsByRouteId, vehiclesByRouteId } = state
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -174,33 +166,6 @@ const useVehicles = (
       })
     }
   }, [socket, selectedRouteIds])
-  /* eslint-enable react-hooks/exhaustive-deps */
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    const newInvalidVehicles = flatten(Object.values(vehiclesByRouteId)).filter(
-      (vehicleOrGhost) =>
-        isVehicle(vehicleOrGhost) &&
-        vehicleOrGhost.isOffCourse &&
-        vehicleOrGhost.isRevenue
-    )
-
-    const oldInvalidVehicleIds = new Set(invalidVehicleIds)
-
-    newInvalidVehicles.forEach((vehicle) => {
-      if (
-        !oldInvalidVehicleIds.has(vehicle.id) &&
-        window.FS &&
-        window.username
-      ) {
-        window.FS.event("Vehicle went invalid", {
-          route_id: vehicle.routeId,
-        })
-      }
-    })
-
-    setInvalidVehicleIds(newInvalidVehicles.map((vehicle) => vehicle.id))
-  }, [vehiclesByRouteId])
   /* eslint-enable react-hooks/exhaustive-deps */
 
   return vehiclesByRouteId

--- a/assets/src/hooks/useVehiclesForBlockIds.ts
+++ b/assets/src/hooks/useVehiclesForBlockIds.ts
@@ -10,6 +10,7 @@ import { useChannel } from "./useChannel"
 
 const parser = (data: VehicleOrGhostData[]): VehicleOrGhost[] =>
   data.map(vehicleOrGhostFromData)
+const parserWithNull = nullableParser(parser)
 
 const useVehiclesForBlockIds = (
   socket: Socket | undefined,
@@ -22,7 +23,7 @@ const useVehiclesForBlockIds = (
     socket,
     topic,
     event: "vehicles",
-    parser: nullableParser(parser),
+    parser: parserWithNull,
     loadingState: undefined,
   })
 }

--- a/assets/src/hooks/useVehiclesForRunIds.ts
+++ b/assets/src/hooks/useVehiclesForRunIds.ts
@@ -10,6 +10,7 @@ import { useChannel } from "./useChannel"
 
 const parser = (data: VehicleOrGhostData[]): VehicleOrGhost[] =>
   data.map(vehicleOrGhostFromData)
+const parserWithNull = nullableParser(parser)
 
 const useVehiclesForRunIds = (
   socket: Socket | undefined,
@@ -23,7 +24,7 @@ const useVehiclesForRunIds = (
     socket,
     topic,
     event: "vehicles",
-    parser: nullableParser(parser),
+    parser: parserWithNull,
     loadingState: undefined,
     closeAfterFirstRead,
   })

--- a/assets/tests/helpers/array.test.ts
+++ b/assets/tests/helpers/array.test.ts
@@ -82,12 +82,24 @@ describe("equalByElements", () => {
     expect(equalByElements(["a", "b"], ["a", "b"])).toBeTruthy()
   })
 
+  test("returns true with equal elements according to provided function", () => {
+    expect(
+      equalByElements([3, 7], [13, 17], (x, y) => x % 10 === y % 10)
+    ).toBeTruthy()
+  })
+
   test("returns false with the same elements in different order", () => {
     expect(equalByElements(["a", "b"], ["b", "a"])).toBeFalsy()
   })
 
   test("returns false with same length but different elements", () => {
     expect(equalByElements(["a", "b"], ["c", "d"])).toBeFalsy()
+  })
+
+  test("returns false with same length but different elements according to provided function", () => {
+    expect(
+      equalByElements([3, 7], [14, 18], (x, y) => x % 10 === y % 10)
+    ).toBeFalsy()
   })
 
   test("returns false with different length", () => {

--- a/assets/tests/hooks/useMinischedule.test.ts
+++ b/assets/tests/hooks/useMinischedule.test.ts
@@ -43,6 +43,30 @@ describe("useMinischeduleRun", () => {
     rerender()
     expect(mockFetchShuttles).toHaveBeenCalledTimes(1)
   })
+
+  test("refetches when trip changes", () => {
+    const mockFetchShuttles: jest.Mock = Api.fetchScheduleRun as jest.Mock
+    const { rerender } = renderHook(
+      ({ trip, run }) => useMinischeduleRun(trip, run),
+      {
+        initialProps: { trip: "trip1", run: "run1" },
+      }
+    )
+    rerender({ trip: "trip2", run: "run1" })
+    expect(mockFetchShuttles).toHaveBeenCalledTimes(2)
+  })
+
+  test("refetches when run changes", () => {
+    const mockFetchShuttles: jest.Mock = Api.fetchScheduleRun as jest.Mock
+    const { rerender } = renderHook(
+      ({ trip, run }) => useMinischeduleRun(trip, run),
+      {
+        initialProps: { trip: "trip1", run: "run1" },
+      }
+    )
+    rerender({ trip: "trip1", run: "run2" })
+    expect(mockFetchShuttles).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe("useMinischeduleRuns", () => {

--- a/assets/tests/hooks/useVehicleForId.test.ts
+++ b/assets/tests/hooks/useVehicleForId.test.ts
@@ -1,0 +1,22 @@
+import {
+  makeMockOneShotChannel,
+  makeMockSocket,
+} from "../testHelpers/socketHelpers"
+import vehicleDataFactory from "../factories/vehicle_data"
+import { renderHook } from "@testing-library/react-hooks"
+import useVehicleForId from "../../src/hooks/useVehicleForId"
+
+describe("useVehicleForId", () => {
+  test("parses vehicle data from channel", () => {
+    const vehicleData = vehicleDataFactory.build()
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockOneShotChannel(vehicleData)
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(({ id }) => useVehicleForId(mockSocket, id), {
+      initialProps: { id: vehicleData.id },
+    })
+
+    expect(result.current).toMatchObject({ id: vehicleData.id })
+  })
+})

--- a/assets/tests/hooks/useVehicleForNotification.test.tsx
+++ b/assets/tests/hooks/useVehicleForNotification.test.tsx
@@ -116,11 +116,6 @@ describe("useVehicleForNotification", () => {
   }
 
   test("parses vehicle data from channel", () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockOneShotChannel([vehicleData])
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -190,17 +185,9 @@ describe("useVehicleForNotification", () => {
       tripId: "12345678",
       viaVariant: "3",
     })
-    expect(window.FS!.event).toHaveBeenCalledWith("Notification linked to VPP")
-    window.FS = originalFS
-    window.username = originalUsername
   })
 
   test("parses ghost data from channel", () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockOneShotChannel([ghostData])
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -233,19 +220,9 @@ describe("useVehicleForNotification", () => {
       currentPieceStartPlace: null,
       incomingTripDirectionId: null,
     })
-    expect(window.FS!.event).toHaveBeenCalledWith(
-      "Notification linked to ghost"
-    )
-    window.FS = originalFS
-    window.username = originalUsername
   })
 
   test("handles missing data from channel for a current or past notification", () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockOneShotChannel(null)
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -263,17 +240,9 @@ describe("useVehicleForNotification", () => {
       { wrapper }
     )
     expect(result.current).toBeNull()
-    expect(window.FS!.event).toHaveBeenCalledWith("Notification link failed")
-    window.FS = originalFS
-    window.username = originalUsername
   })
 
   test("handles missing data from channel for an upcoming notification", () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockOneShotChannel(null)
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -291,19 +260,9 @@ describe("useVehicleForNotification", () => {
       { wrapper }
     )
     expect(result.current).toBeNull()
-    expect(window.FS!.event).toHaveBeenCalledWith(
-      "Notification link failed upcoming"
-    )
-    window.FS = originalFS
-    window.username = originalUsername
   })
 
   test("handles empty result from channel", () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockOneShotChannel([])
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
@@ -321,8 +280,5 @@ describe("useVehicleForNotification", () => {
       { wrapper }
     )
     expect(result.current).toBeNull()
-    expect(window.FS!.event).toHaveBeenCalledWith("Notification link failed")
-    window.FS = originalFS
-    window.username = originalUsername
   })
 })

--- a/assets/tests/hooks/useVehicles.test.ts
+++ b/assets/tests/hooks/useVehicles.test.ts
@@ -191,96 +191,6 @@ describe("useVehicles", () => {
       crowding: null,
     },
   ]
-  const vehiclesDataWithInvalid: VehicleData[] = [
-    vehicleDataFactory.build({
-      bearing: 33,
-      block_id: "block-1",
-      data_discrepancies: [
-        {
-          attribute: "trip_id",
-          sources: [
-            {
-              id: "swiftly",
-              value: "swiftly-trip-id",
-            },
-            {
-              id: "busloc",
-              value: "busloc-trip-id",
-            },
-          ],
-        },
-        {
-          attribute: "route_id",
-          sources: [
-            {
-              id: "swiftly",
-              value: null,
-            },
-            {
-              id: "busloc",
-              value: "busloc-route-id",
-            },
-          ],
-        },
-      ],
-      direction_id: 0,
-      headsign: "Forest Hills",
-      id: "v1",
-      is_shuttle: false,
-      is_overload: false,
-      is_off_course: true,
-      is_revenue: true,
-      layover_departure_time: null,
-      label: "v1-label",
-      latitude: 0,
-      longitude: 0,
-      operator_id: "op1",
-      operator_first_name: "PATTI",
-      operator_last_name: "SMITH",
-      operator_logon_time: 1_534_340_301,
-      previous_vehicle_id: "v2",
-      route_id: "39",
-      run_id: "run-1",
-      schedule_adherence_secs: 0,
-      scheduled_location: {
-        route_id: "39",
-        direction_id: 0,
-        trip_id: "scheduled trip",
-        run_id: "scheduled run",
-        time_since_trip_start_time: 0,
-        headsign: "scheduled headsign",
-        via_variant: "scheduled via variant",
-        timepoint_status: {
-          fraction_until_timepoint: 0.5,
-          timepoint_id: "tp1",
-        },
-      },
-      sources: ["swiftly", "busloc"],
-      stop_status: {
-        stop_id: "s1",
-        stop_name: "Stop Name",
-      },
-      timepoint_status: {
-        fraction_until_timepoint: 0.5,
-        timepoint_id: "tp1",
-      },
-      timestamp: 123,
-      trip_id: "t1",
-      via_variant: "X",
-      route_status: "on_route",
-      end_of_trip_type: "another_trip",
-      block_waivers: [
-        {
-          start_time: 1_534_340_301,
-          end_time: 1_534_340_321,
-          cause_id: 0,
-          cause_description: "Block Waiver",
-          remark: null,
-        },
-      ],
-      crowding: null,
-    }),
-  ]
 
   test("vehicles is empty to start with", () => {
     const { result } = renderHook(() => useVehicles(undefined, []))
@@ -423,27 +333,5 @@ describe("useVehicles", () => {
 
     expect(reloadSpy).toHaveBeenCalled()
     reloadSpy.mockRestore()
-  })
-
-  test("makes a FullStory event when a bus goes invalid", async () => {
-    const originalFS = window.FS
-    const originalUsername = window.username
-    window.FS = { event: jest.fn(), identify: jest.fn() }
-    window.username = "username"
-
-    const mockSocket = makeMockSocket()
-    const mockChannel = makeMockChannel("ok", {
-      data: vehiclesDataWithInvalid,
-    })
-    mockSocket.channel.mockImplementation(() => mockChannel)
-
-    renderHook(() => useVehicles(mockSocket, ["39"]))
-
-    expect(window.FS!.event).toHaveBeenCalledWith("Vehicle went invalid", {
-      route_id: "39",
-    })
-
-    window.FS = originalFS
-    window.username = originalUsername
   })
 })


### PR DESCRIPTION
Asana ticket: [⚙️ Finish cleanup of dependencies in useEffect hooks, adopt linter rule](https://app.asana.com/0/1152340551558956/1201957254872278/f)

This finally gets rid of all of the uses of `JSON.stringify`. There are still quite a few cases of `useEffect` hooks with non-exhaustive dependencies. Some I was able to fix up quite easily, others look like they're going to be harder. In any event I have enabled the linter rule so we won't accumulate more problems going forward.