### PR TITLE
Add filter to remove private carrier routes

### DIFF
--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -306,7 +306,7 @@ defmodule Schedule.Data do
     bus_routes =
       Csv.parse(
         gtfs_files["routes.txt"],
-        filter: &Route.bus_route_validrow?/1,
+        filter: &Route.bus_route_valid_row?/1,
         parse: &Route.from_csv_row(&1, directions_by_route_id)
       )
 

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -306,7 +306,7 @@ defmodule Schedule.Data do
     bus_routes =
       Csv.parse(
         gtfs_files["routes.txt"],
-        filter: &Route.bus_route_row?/1,
+        filter: &Route.bus_route_validrow?/1,
         parse: &Route.from_csv_row(&1, directions_by_route_id)
       )
 

--- a/lib/schedule/gtfs/route.ex
+++ b/lib/schedule/gtfs/route.ex
@@ -71,6 +71,18 @@ defmodule Schedule.Gtfs.Route do
     row["route_type"] == "3"
   end
 
+  @spec bus_route_mbta?(Csv.row()) :: boolean
+  def bus_route_mbta?(row) do
+    # Verify that route number is not one of the private carriers: 710, 712, 713, 714, 716
+    row["route_id"] not in ["710", "712", "713", "714", "716"]
+  end
+
+  @spec bus_route_validrow?(Csv.row()) :: boolean
+  def bus_route_validrow?(row) do
+    # Run all filters on the bus route row
+    bus_route_row?(row) and bus_route_mbta?(row)
+  end
+
   @spec shuttle_route?(t) :: boolean
   def shuttle_route?(%__MODULE__{description: "Rail Replacement Bus"}), do: true
   def shuttle_route?(%__MODULE__{}), do: false

--- a/lib/schedule/gtfs/route.ex
+++ b/lib/schedule/gtfs/route.ex
@@ -62,7 +62,7 @@ defmodule Schedule.Gtfs.Route do
   end
 
   @spec bus_route_row?(Csv.row()) :: boolean
-  def bus_route_row?(row) do
+  defp bus_route_row?(row) do
     # Verify that "route_type" exists on the row, especially to prevent issues while testing
     if row["route_type"] == nil do
       raise ArgumentError, message: "route_type is required on route rows"
@@ -72,13 +72,13 @@ defmodule Schedule.Gtfs.Route do
   end
 
   @spec bus_route_mbta?(Csv.row()) :: boolean
-  def bus_route_mbta?(row) do
+  defp bus_route_mbta?(row) do
     # Verify that route number is not one of the private carriers: 710, 712, 713, 714, 716
     row["route_id"] not in ["710", "712", "713", "714", "716"]
   end
 
-  @spec bus_route_validrow?(Csv.row()) :: boolean
-  def bus_route_validrow?(row) do
+  @spec bus_route_valid_row?(Csv.row()) :: boolean
+  def bus_route_valid_row?(row) do
     # Run all filters on the bus route row
     bus_route_row?(row) and bus_route_mbta?(row)
   end

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -102,7 +102,7 @@ defmodule Schedule.Gtfs.RouteTest do
 
       assert Route.bus_route_valid_row?(bus_csv_row)
       refute Route.bus_route_valid_row?(subway_csv_row)
-      refute(Route.bus_route_valid_row?(private_carrier_csv_row))
+      refute Route.bus_route_valid_row?(private_carrier_csv_row)
     end
 
     test "ensures a `route_type` property" do

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -102,7 +102,7 @@ defmodule Schedule.Gtfs.RouteTest do
 
       assert Route.bus_route_valid_row?(bus_csv_row)
       refute Route.bus_route_valid_row?(subway_csv_row)
-      refuse(Route.bus_route_valid_row?(private_carrier_csv_row))
+      refute(Route.bus_route_valid_row?(private_carrier_csv_row))
     end
 
     test "ensures a `route_type` property" do

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -50,7 +50,7 @@ defmodule Schedule.Gtfs.RouteTest do
     end
   end
 
-  describe "bus_route_row?/1" do
+  describe "bus_route_valid_row?/1" do
     test "returns whether or not this row represents a bus route" do
       bus_csv_row = %{
         "route_id" => "39",
@@ -84,8 +84,25 @@ defmodule Schedule.Gtfs.RouteTest do
         "listed_route" => ""
       }
 
-      assert Route.bus_route_row?(bus_csv_row)
-      refute Route.bus_route_row?(subway_csv_row)
+      private_carrier_csv_row = %{
+        "route_id" => "710",
+        "agency_id" => "1",
+        "route_short_name" => "710",
+        "route_long_name" => "North Medford - Wellington Station",
+        "route_desc" => "Local Bus",
+        "route_type" => "3",
+        "route_url" => "https://www.mbta.com/schedules/710",
+        "route_color" => "FFC72C",
+        "route_text_color" => "000000",
+        "route_sort_order" => "57100",
+        "route_fare_class" => "Local Bus",
+        "line_id" => "line-710",
+        "listed_route" => ""
+      }
+
+      assert Route.bus_route_valid_row?(bus_csv_row)
+      refute Route.bus_route_valid_row?(subway_csv_row)
+      refuse(Route.bus_route_valid_row?(private_carrier_csv_row))
     end
 
     test "ensures a `route_type` property" do
@@ -106,7 +123,7 @@ defmodule Schedule.Gtfs.RouteTest do
       }
 
       assert_raise ArgumentError, fn ->
-        Route.bus_route_row?(bad_csv_row)
+        Route.bus_route_valid_row?(bad_csv_row)
       end
     end
   end


### PR DESCRIPTION
Asana: https://app.asana.com/0/1148853526253437/1201220680602259/f

Manually identifies the private carrier routes by route ID and filters them out of GTFS pull of routes. 