### PR TITLE
Eliminate references to window.username

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -24,7 +24,11 @@ import clarityInit from "./helpers/clarityInit"
 import clarityIdentify from "./helpers/clarityIdentify"
 import { tagManagerIdentify } from "./helpers/googleTagManager"
 
-sentryInit(window.sentry, window.username)
+const username = document
+  .querySelector("meta[name=username]")
+  ?.getAttribute("content")
+
+sentryInit(window.sentry, username)
 
 const clarityTag = document
   .querySelector("meta[name=clarity-tag]")

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -28,7 +28,7 @@ const username = document
   .querySelector("meta[name=username]")
   ?.getAttribute("content")
 
-sentryInit(window.sentry, username)
+sentryInit(window.sentry, username || undefined)
 
 const clarityTag = document
   .querySelector("meta[name=clarity-tag]")

--- a/assets/src/hooks/useAppcues.ts
+++ b/assets/src/hooks/useAppcues.ts
@@ -7,9 +7,15 @@ export const cleanUsername = (usernameWithPrefix: string): string =>
 const useAppcues = () => {
   const location = useLocation()
   useEffect(() => {
+    let username = document
+      .querySelector("meta[name=username]")
+      ?.getAttribute("content")
+
+    if (username == undefined || username == null) username = ""
+
     if (window.Appcues) {
       window.Appcues.page()
-      window.Appcues.identify(cleanUsername(window.username))
+      window.Appcues.identify(cleanUsername(username))
     }
   }, [location])
 }

--- a/assets/tests/hooks/useAppcues.test.tsx
+++ b/assets/tests/hooks/useAppcues.test.tsx
@@ -25,7 +25,6 @@ jest.mock("react-router-dom", () => ({
   useLocation: jest.fn().mockImplementation(() => mockLocation),
 }))
 
-window.username = "mbta-active-directory_jdoe"
 window.Appcues = {
   identify: jest.fn(),
   page: jest.fn(),
@@ -33,6 +32,12 @@ window.Appcues = {
 }
 
 describe("useAppcues", () => {
+  const originalQuerySelector = document.querySelector
+
+  afterEach(() => {
+    document.querySelector = originalQuerySelector
+  })
+
   test("calls Appcues page on load", () => {
     renderHook(() => useAppcues())
 
@@ -40,6 +45,8 @@ describe("useAppcues", () => {
   })
 
   test("calls Appcues indentify with the clean username on load", () => {
+    document.querySelector = () => ({ getAttribute: () => "jdoe" })
+
     renderHook(() => useAppcues())
 
     expect(window.Appcues!.identify).toHaveBeenCalledWith("jdoe")


### PR DESCRIPTION
window.username was previously set in fullStory.

Instead, pull username from meta tag.