### PR TITLE
Mobile portrait nav changes

### DIFF
--- a/assets/css/_nav.scss
+++ b/assets/css/_nav.scss
@@ -23,6 +23,11 @@
   height: 100%;
 }
 
+.m-nav--narrow.m-nav--covered {
+  grid-template-rows: minmax(0, 1fr);
+  grid-template-areas: "content";
+}
+
 .m-nav__nav-bar {
   z-index: 1100;
 }

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -21,6 +21,10 @@
   @media screen and (max-width: 480px) {
     .m-nav__app-content & {
       width: 100%;
+
+      .m-swings-view__table {
+        width: 100%;
+      }
     }
   }
 }
@@ -194,9 +198,15 @@
 }
 
 .m-swings-view__run-icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   &.m-swings-view__run-icon-arrow {
     padding-right: 0.375rem;
     stroke: $color-primary-dark;
+    width: 0.5rem;
+    height: 0.5rem;
 
     svg {
       width: 0.5rem;
@@ -205,9 +215,9 @@
   }
 
   &.m-swings-view__run-icon-ghost {
-    position: absolute;
-    left: 1.5625rem;
-    top: 0.875rem;
+    padding-right: 0.375rem;
+    width: 1.1875rem;
+    height: 1.1875rem;
 
     svg {
       width: 1.1875rem;

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -16,6 +16,13 @@
     right: 0rem;
     top: 0rem;
   }
+
+  // Full width on mobile portrait, to be updated with more responsive designs
+  @media screen and (max-width: 480px) {
+    .m-nav__app-content & {
+      width: 100%;
+    }
+  }
 }
 
 .m-swings-view__header {

--- a/assets/src/components/lateView.tsx
+++ b/assets/src/components/lateView.tsx
@@ -26,7 +26,7 @@ import { saveState, loadState } from "../localStorage"
 import { isVehicle, isGhost } from "../models/vehicle"
 import { Vehicle, Ghost, RunId, VehicleOrGhost } from "../realtime"
 import { ByRouteId } from "../schedule"
-import { Action, selectVehicle, toggleLateView } from "../state"
+import { Action, closeLateView, selectVehicle } from "../state"
 import {
   secondsToMinutes,
   formattedTime,
@@ -384,7 +384,7 @@ const LateView = (): ReactElement<HTMLElement> => {
         </div>
         <DrawerTab
           isVisible={true}
-          toggleVisibility={() => dispatch(toggleLateView())}
+          toggleVisibility={() => dispatch(closeLateView())}
         />
       </div>
       {anyRowsSelected && (

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -6,8 +6,7 @@ import useDeviceType from "../hooks/useDeviceType"
 import featureIsEnabled from "../laboratoryFeatures"
 import LeftNav from "./nav/leftNav"
 import TopNav from "./nav/topNav"
-import TopNavMobile from "./nav/topNavMobile"
-import BottomNavMobile from "./nav/bottomNavMobile"
+import MobilePortraitNav from "./nav/mobilePortraitNav"
 
 interface Props {
   pickerContainerIsVisible: boolean
@@ -24,17 +23,7 @@ const Nav: React.FC<Props> = ({
   if (readNavBetaFlag() || featureIsEnabled("nav_beta")) {
     switch (deviceType) {
       case "mobile":
-        return (
-          <div className="m-nav--narrow">
-            <div className="m-nav__nav-bar m-nav__nav-bar--top">
-              <TopNavMobile />
-            </div>
-            <div className="m-nav__app-content">{children}</div>
-            <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
-              <BottomNavMobile />
-            </div>
-          </div>
-        )
+        return <MobilePortraitNav>{children}</MobilePortraitNav>
       case "tablet":
         return (
           <div className="m-nav--wide">

--- a/assets/src/components/nav/bottomNavMobile.tsx
+++ b/assets/src/components/nav/bottomNavMobile.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { ladderIcon, mapIcon, searchIcon, swingIcon } from "../../helpers/icon"
 import { NavLink } from "react-router-dom"
-import { toggleSwingsView } from "../../state"
+import { openSwingsView } from "../../state"
 import { tagManagerEvent } from "../../helpers/googleTagManager"
 
 const BottomNavMobile = (): JSX.Element => {
@@ -62,7 +62,7 @@ const BottomNavMobile = (): JSX.Element => {
             className="m-bottom-nav-mobile__button"
             onClick={() => {
               tagManagerEvent("swings_view_toggled")
-              dispatch(toggleSwingsView())
+              dispatch(openSwingsView())
             }}
             title="Swings View"
           >

--- a/assets/src/components/nav/bottomNavMobile.tsx
+++ b/assets/src/components/nav/bottomNavMobile.tsx
@@ -1,79 +1,79 @@
-import React, { useContext } from "react"
-import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import React from "react"
 import { ladderIcon, mapIcon, searchIcon, swingIcon } from "../../helpers/icon"
 import { NavLink } from "react-router-dom"
-import { openSwingsView } from "../../state"
 import { tagManagerEvent } from "../../helpers/googleTagManager"
 
-const BottomNavMobile = (): JSX.Element => {
-  const [state, dispatch] = useContext(StateDispatchContext)
-
-  const { mobileMenuIsOpen } = state
-
-  return (
-    <div
-      data-testid="bottom-nav-mobile"
-      className={
-        "m-bottom-nav-mobile" + (mobileMenuIsOpen ? " blurred-mobile" : "")
-      }
-    >
-      <ul className="m-bottom-nav-mobile__links">
-        <li>
-          <NavLink
-            className={({ isActive }) =>
-              "m-bottom-nav-mobile__link" +
-              (isActive ? " m-bottom-nav-mobile__link--active" : "")
-            }
-            title="Route Ladders"
-            to="/"
-          >
-            {ladderIcon("m-bottom-nav-mobile__icon")}
-          </NavLink>
-        </li>
-
-        <li>
-          <NavLink
-            className={({ isActive }) =>
-              "m-bottom-nav-mobile__link" +
-              (isActive ? " m-bottom-nav-mobile__link--active" : "")
-            }
-            title="Shuttle Map"
-            to="/shuttle-map"
-          >
-            {mapIcon("m-bottom-nav-mobile__icon")}
-          </NavLink>
-        </li>
-
-        <li>
-          <NavLink
-            className={({ isActive }) =>
-              "m-bottom-nav-mobile__link" +
-              (isActive ? " m-bottom-nav-mobile__link--active" : "")
-            }
-            title="Search"
-            to="/search"
-          >
-            {searchIcon("m-bottom-nav-mobile__icon")}
-          </NavLink>
-        </li>
-
-        <li>
-          <button
-            className="m-bottom-nav-mobile__button"
-            onClick={() => {
-              tagManagerEvent("swings_view_toggled")
-              dispatch(openSwingsView())
-            }}
-            title="Swings View"
-          >
-            {swingIcon(
-              "m-bottom-nav-mobile__icon m-bottom-nav-mobile__icon--swings-view"
-            )}
-          </button>
-        </li>
-      </ul>
-    </div>
-  )
+interface Props {
+  mobileMenuIsOpen: boolean
+  openSwingsView: () => void
 }
+
+const BottomNavMobile: React.FC<Props> = ({
+  mobileMenuIsOpen,
+  openSwingsView,
+}) => (
+  <div
+    data-testid="bottom-nav-mobile"
+    className={
+      "m-bottom-nav-mobile" + (mobileMenuIsOpen ? " blurred-mobile" : "")
+    }
+  >
+    <ul className="m-bottom-nav-mobile__links">
+      <li>
+        <NavLink
+          className={({ isActive }) =>
+            "m-bottom-nav-mobile__link" +
+            (isActive ? " m-bottom-nav-mobile__link--active" : "")
+          }
+          title="Route Ladders"
+          to="/"
+        >
+          {ladderIcon("m-bottom-nav-mobile__icon")}
+        </NavLink>
+      </li>
+
+      <li>
+        <NavLink
+          className={({ isActive }) =>
+            "m-bottom-nav-mobile__link" +
+            (isActive ? " m-bottom-nav-mobile__link--active" : "")
+          }
+          title="Shuttle Map"
+          to="/shuttle-map"
+        >
+          {mapIcon("m-bottom-nav-mobile__icon")}
+        </NavLink>
+      </li>
+
+      <li>
+        <NavLink
+          className={({ isActive }) =>
+            "m-bottom-nav-mobile__link" +
+            (isActive ? " m-bottom-nav-mobile__link--active" : "")
+          }
+          title="Search"
+          to="/search"
+        >
+          {searchIcon("m-bottom-nav-mobile__icon")}
+        </NavLink>
+      </li>
+
+      <li>
+        <button
+          className="m-bottom-nav-mobile__button"
+          onClick={() => {
+            tagManagerEvent("swings_view_toggled")
+            openSwingsView()
+          }}
+          title="Swings View"
+        >
+          {swingIcon(
+            "m-bottom-nav-mobile__icon m-bottom-nav-mobile__icon--swings-view"
+          )}
+        </button>
+      </li>
+    </ul>
+  </div>
+)
 
 export default BottomNavMobile

--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -17,7 +17,7 @@ import {
   settingsIcon,
 } from "../../helpers/icon"
 import featureIsEnabled from "../../laboratoryFeatures"
-import { OpenView, toggleLateView, toggleSwingsView } from "../../state"
+import { openSwingsView, OpenView, toggleLateView } from "../../state"
 
 interface Props {
   defaultToCollapsed: boolean
@@ -68,7 +68,7 @@ const LeftNav = ({
             viewIsOpen={openView === OpenView.Swings}
             toggleView={() => {
               tagManagerEvent("swings_view_toggled")
-              dispatch(toggleSwingsView())
+              dispatch(openSwingsView())
             }}
             collapsed={collapsed}
           />

--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -17,7 +17,7 @@ import {
   settingsIcon,
 } from "../../helpers/icon"
 import featureIsEnabled from "../../laboratoryFeatures"
-import { openSwingsView, OpenView, toggleLateView } from "../../state"
+import { openLateView, openSwingsView, OpenView } from "../../state"
 
 interface Props {
   defaultToCollapsed: boolean
@@ -55,7 +55,7 @@ const LeftNav = ({
               viewIsOpen={openView === OpenView.Late}
               toggleView={() => {
                 tagManagerEvent("late_view_toggled")
-                dispatch(toggleLateView())
+                dispatch(openLateView())
               }}
               collapsed={collapsed}
             />

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -1,0 +1,42 @@
+import React, { useContext } from "react"
+import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import {
+  openNotificationDrawer,
+  openSwingsView,
+  toggleMobileMenu,
+} from "../../state"
+import BottomNavMobile from "./bottomNavMobile"
+import TopNavMobile from "./topNavMobile"
+
+const MobilePortraitNav = ({
+  children,
+}: {
+  children?: React.ReactNode | undefined
+}): JSX.Element => {
+  const [state, dispatch] = useContext(StateDispatchContext)
+
+  const { mobileMenuIsOpen, routeTabs, notificationDrawerIsOpen } = state
+
+  return (
+    <div className="m-nav--narrow">
+      <div className="m-nav__nav-bar m-nav__nav-bar--top">
+        <TopNavMobile
+          toggleMobileMenu={() => dispatch(toggleMobileMenu())}
+          openNotificationDrawer={() => dispatch(openNotificationDrawer())}
+          routeTabs={routeTabs}
+          notificationDrawerIsOpen={notificationDrawerIsOpen}
+          mobileMenuIsOpen={mobileMenuIsOpen}
+        />
+      </div>
+      <div className="m-nav__app-content">{children}</div>
+      <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
+        <BottomNavMobile
+          mobileMenuIsOpen={mobileMenuIsOpen}
+          openSwingsView={() => dispatch(openSwingsView())}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default MobilePortraitNav

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -3,6 +3,7 @@ import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import {
   openNotificationDrawer,
   openSwingsView,
+  OpenView,
   toggleMobileMenu,
 } from "../../state"
 import BottomNavMobile from "./bottomNavMobile"
@@ -15,28 +16,46 @@ const MobilePortraitNav = ({
 }): JSX.Element => {
   const [state, dispatch] = useContext(StateDispatchContext)
 
-  const { mobileMenuIsOpen, routeTabs, notificationDrawerIsOpen } = state
+  const {
+    mobileMenuIsOpen,
+    routeTabs,
+    notificationDrawerIsOpen,
+    openView,
+    selectedVehicleOrGhost,
+  } = state
 
-  return (
-    <div className="m-nav--narrow">
-      <div className="m-nav__nav-bar m-nav__nav-bar--top">
-        <TopNavMobile
-          toggleMobileMenu={() => dispatch(toggleMobileMenu())}
-          openNotificationDrawer={() => dispatch(openNotificationDrawer())}
-          routeTabs={routeTabs}
-          notificationDrawerIsOpen={notificationDrawerIsOpen}
-          mobileMenuIsOpen={mobileMenuIsOpen}
-        />
+  if (
+    openView !== OpenView.None ||
+    selectedVehicleOrGhost ||
+    notificationDrawerIsOpen
+  ) {
+    return (
+      <div className="m-nav--narrow m-nav--covered">
+        <div className="m-nav__app-content">{children}</div>
       </div>
-      <div className="m-nav__app-content">{children}</div>
-      <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
-        <BottomNavMobile
-          mobileMenuIsOpen={mobileMenuIsOpen}
-          openSwingsView={() => dispatch(openSwingsView())}
-        />
+    )
+  } else {
+    return (
+      <div className="m-nav--narrow">
+        <div className="m-nav__nav-bar m-nav__nav-bar--top">
+          <TopNavMobile
+            toggleMobileMenu={() => dispatch(toggleMobileMenu())}
+            openNotificationDrawer={() => dispatch(openNotificationDrawer())}
+            routeTabs={routeTabs}
+            notificationDrawerIsOpen={notificationDrawerIsOpen}
+            mobileMenuIsOpen={mobileMenuIsOpen}
+          />
+        </div>
+        <div className="m-nav__app-content">{children}</div>
+        <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
+          <BottomNavMobile
+            mobileMenuIsOpen={mobileMenuIsOpen}
+            openSwingsView={() => dispatch(openSwingsView())}
+          />
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 export default MobilePortraitNav

--- a/assets/src/components/nav/topNav.tsx
+++ b/assets/src/components/nav/topNav.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { logoIcon, refreshIcon } from "../../helpers/icon"
 import { reload } from "../../models/browser"
-import { toggleNotificationDrawer } from "../../state"
+import { openNotificationDrawer } from "../../state"
 import NotificationBellIcon from "../notificationBellIcon"
 
 const TopNav = (): JSX.Element => {
@@ -23,7 +23,7 @@ const TopNav = (): JSX.Element => {
         <li>
           <button
             className="m-top-nav__right-item"
-            onClick={() => dispatch(toggleNotificationDrawer())}
+            onClick={() => dispatch(openNotificationDrawer())}
             title="Notifications"
           >
             <NotificationBellIcon extraClasses={bellIconClasses} />

--- a/assets/src/components/nav/topNavMobile.tsx
+++ b/assets/src/components/nav/topNavMobile.tsx
@@ -1,6 +1,5 @@
-import React, { useContext } from "react"
+import React from "react"
 import { useLocation, Link, NavLink } from "react-router-dom"
-import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { displayHelp } from "../../helpers/appCue"
 import {
   closeIcon,
@@ -11,7 +10,6 @@ import {
   settingsIcon,
   speechBubbleIcon,
 } from "../../helpers/icon"
-import { openNotificationDrawer, toggleMobileMenu } from "../../state"
 import NotificationBellIcon from "../notificationBellIcon"
 import { currentTabName, RouteTab } from "../../models/routeTab"
 import { openDrift } from "../../helpers/drift"
@@ -37,14 +35,22 @@ export const pageOrTabName = (
   return tabName
 }
 
-const TopNavMobile = (): JSX.Element => {
+interface Props {
+  toggleMobileMenu: () => void
+  openNotificationDrawer: () => void
+  routeTabs: RouteTab[]
+  notificationDrawerIsOpen: boolean
+  mobileMenuIsOpen: boolean
+}
+
+const TopNavMobile: React.FC<Props> = ({
+  toggleMobileMenu,
+  openNotificationDrawer,
+  routeTabs,
+  notificationDrawerIsOpen,
+  mobileMenuIsOpen,
+}) => {
   const location = useLocation()
-
-  const [state, dispatch] = useContext(StateDispatchContext)
-
-  const toggleVisibility = () => dispatch(toggleMobileMenu())
-
-  const { routeTabs, notificationDrawerIsOpen, mobileMenuIsOpen } = state
 
   const bellIconClasses = notificationDrawerIsOpen
     ? ["m-top-nav__notifications-icon", "m-top-nav__notifications-icon--active"]
@@ -63,7 +69,7 @@ const TopNavMobile = (): JSX.Element => {
         <div className="m-top-nav-mobile__menu-header">
           <Link
             className="m-top-nav__logo"
-            onClick={toggleVisibility}
+            onClick={toggleMobileMenu}
             to="/"
             title="Skate"
           >
@@ -72,7 +78,7 @@ const TopNavMobile = (): JSX.Element => {
 
           <button
             className="m-top-nav-mobile__close"
-            onClick={toggleVisibility}
+            onClick={toggleMobileMenu}
             title="Close"
           >
             {closeIcon("m-top-nav-mobile__close-icon")}
@@ -94,7 +100,7 @@ const TopNavMobile = (): JSX.Element => {
               className="m-top-nav-mobile__menu-button"
               onClick={() => {
                 openDrift()
-                toggleVisibility()
+                toggleMobileMenu()
               }}
               title="Support"
             >
@@ -107,7 +113,7 @@ const TopNavMobile = (): JSX.Element => {
               className="m-top-nav-mobile__menu-button"
               onClick={() => {
                 displayHelp(location)
-                toggleVisibility()
+                toggleMobileMenu()
               }}
               title="About Skate"
             >
@@ -124,7 +130,7 @@ const TopNavMobile = (): JSX.Element => {
               }
               title="Settings"
               to="/settings"
-              onClick={toggleVisibility}
+              onClick={toggleMobileMenu}
             >
               {settingsIcon("m-top-nav-mobile__menu-icon")}
               Settings
@@ -139,8 +145,8 @@ const TopNavMobile = (): JSX.Element => {
           "m-top-nav-mobile__overlay" +
           (mobileMenuIsOpen ? " m-top-nav-mobile__overlay--open" : "")
         }
-        onClick={toggleVisibility}
-        onKeyDown={toggleVisibility}
+        onClick={toggleMobileMenu}
+        onKeyDown={toggleMobileMenu}
         aria-hidden={true}
       />
 
@@ -153,7 +159,7 @@ const TopNavMobile = (): JSX.Element => {
         <div className="m-top-nav-mobile__left-items">
           <button
             className="m-top-nav=mobile__left-item"
-            onClick={toggleVisibility}
+            onClick={toggleMobileMenu}
             title="Menu"
           >
             {hamburgerIcon("m-top-nav-mobile__icon")}
@@ -167,7 +173,7 @@ const TopNavMobile = (): JSX.Element => {
         <div className="m-top-nav-mobile__right-items">
           <button
             className="m-top-nav-mobile__right-item"
-            onClick={() => dispatch(openNotificationDrawer())}
+            onClick={openNotificationDrawer}
             title="Notifications"
           >
             <NotificationBellIcon extraClasses={bellIconClasses} />

--- a/assets/src/components/nav/topNavMobile.tsx
+++ b/assets/src/components/nav/topNavMobile.tsx
@@ -11,7 +11,7 @@ import {
   settingsIcon,
   speechBubbleIcon,
 } from "../../helpers/icon"
-import { toggleMobileMenu, toggleNotificationDrawer } from "../../state"
+import { openNotificationDrawer, toggleMobileMenu } from "../../state"
 import NotificationBellIcon from "../notificationBellIcon"
 import { currentTabName, RouteTab } from "../../models/routeTab"
 import { openDrift } from "../../helpers/drift"
@@ -167,7 +167,7 @@ const TopNavMobile = (): JSX.Element => {
         <div className="m-top-nav-mobile__right-items">
           <button
             className="m-top-nav-mobile__right-item"
-            onClick={() => dispatch(toggleNotificationDrawer())}
+            onClick={() => dispatch(openNotificationDrawer())}
             title="Notifications"
           >
             <NotificationBellIcon extraClasses={bellIconClasses} />

--- a/assets/src/components/swingsView.tsx
+++ b/assets/src/components/swingsView.tsx
@@ -14,7 +14,7 @@ import useVehiclesForRunIds from "../hooks/useVehiclesForRunIds"
 import useVehiclesForBlockIds from "../hooks/useVehiclesForBlockIds"
 import { ByRunId, VehicleOrGhost } from "../realtime"
 import { ByBlockId, ByRouteId, Route, Swing } from "../schedule"
-import { selectVehicle, toggleSwingsView } from "../state"
+import { closeSwingsView, selectVehicle } from "../state"
 import { formattedScheduledTime, serviceDaySeconds } from "../util/dateTime"
 import { tagManagerEvent } from "../helpers/googleTagManager"
 
@@ -69,7 +69,7 @@ const SwingsView = (): ReactElement<HTMLElement> => {
     return { ...map, [route.id]: route }
   }, {})
 
-  const hideMe = () => dispatch(toggleSwingsView())
+  const hideMe = () => dispatch(closeSwingsView())
 
   const mobileMenuClass = mobileMenuIsOpen ? "blurred-mobile" : ""
 

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -13,9 +13,9 @@ import {
 import { reload } from "../models/browser"
 import {
   toggleNotificationDrawer,
-  toggleLateView,
   OpenView,
   openSwingsView,
+  openLateView,
 } from "../state"
 import NotificationBellIcon from "./notificationBellIcon"
 import featureIsEnabled from "../laboratoryFeatures"
@@ -115,7 +115,7 @@ const TabBar = ({
               }
               onClick={() => {
                 tagManagerEvent("late_view_toggled")
-                dispatch(toggleLateView())
+                dispatch(openLateView())
               }}
               data-testid="late-view-icon"
             >

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -12,10 +12,10 @@ import {
 } from "../helpers/icon"
 import { reload } from "../models/browser"
 import {
-  toggleNotificationDrawer,
   OpenView,
   openSwingsView,
   openLateView,
+  openNotificationDrawer,
 } from "../state"
 import NotificationBellIcon from "./notificationBellIcon"
 import featureIsEnabled from "../laboratoryFeatures"
@@ -130,7 +130,7 @@ const TabBar = ({
         <button
           className="m-tab-bar__notifications"
           onClick={() => {
-            dispatch(toggleNotificationDrawer())
+            dispatch(openNotificationDrawer())
           }}
         >
           <NotificationBellIcon extraClasses={["m-tab-bar__icon"]} />

--- a/assets/src/components/tabBar.tsx
+++ b/assets/src/components/tabBar.tsx
@@ -13,9 +13,9 @@ import {
 import { reload } from "../models/browser"
 import {
   toggleNotificationDrawer,
-  toggleSwingsView,
   toggleLateView,
   OpenView,
+  openSwingsView,
 } from "../state"
 import NotificationBellIcon from "./notificationBellIcon"
 import featureIsEnabled from "../laboratoryFeatures"
@@ -98,7 +98,7 @@ const TabBar = ({
             }
             onClick={() => {
               tagManagerEvent("swings_view_toggled")
-              dispatch(toggleSwingsView())
+              dispatch(openSwingsView())
             }}
           >
             {swingIcon("m-tab-bar__icon")}

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -431,12 +431,20 @@ export const closeSwingsView = (): CloseSwingsViewAction => ({
   type: "CLOSE_SWINGS_VIEW",
 })
 
-interface ToggleLateViewAction {
-  type: "TOGGLE_LATE_VIEW"
+interface OpenLateViewAction {
+  type: "OPEN_LATE_VIEW"
 }
 
-export const toggleLateView = (): ToggleLateViewAction => ({
-  type: "TOGGLE_LATE_VIEW",
+export const openLateView = (): OpenLateViewAction => ({
+  type: "OPEN_LATE_VIEW",
+})
+
+interface CloseLateViewAction {
+  type: "CLOSE_LATE_VIEW"
+}
+
+export const closeLateView = (): CloseLateViewAction => ({
+  type: "CLOSE_LATE_VIEW",
 })
 
 interface SelectVehicleFromNotificationAction {
@@ -601,7 +609,8 @@ export type Action =
   // Views
   | OpenSwingsViewAction
   | CloseSwingsViewAction
-  | ToggleLateViewAction
+  | OpenLateViewAction
+  | CloseLateViewAction
   // Presets
   | CreatePresetAction
   | InstantiatePresetAction
@@ -937,12 +946,10 @@ const openViewAndNotificationDrawerReducer = (
       return [OpenView.Swings, false]
     case "CLOSE_SWINGS_VIEW":
       return [OpenView.None, notificationDrawerIsOpen]
-    case "TOGGLE_LATE_VIEW":
-      if (openView === OpenView.Late) {
-        return [OpenView.None, notificationDrawerIsOpen]
-      } else {
-        return [OpenView.Late, notificationDrawerIsOpen]
-      }
+    case "OPEN_LATE_VIEW":
+      return [OpenView.Late, notificationDrawerIsOpen]
+    case "CLOSE_LATE_VIEW":
+      return [OpenView.None, notificationDrawerIsOpen]
     default:
       return [openView, notificationDrawerIsOpen]
   }

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -343,14 +343,6 @@ export const closeNotificationDrawer = (): CloseNotificationDrawerAction => ({
   type: "CLOSE_NOTIFICATION_DRAWER",
 })
 
-interface ToggleNotificationDrawerAction {
-  type: "TOGGLE_NOTIFICATION_DRAWER"
-}
-
-export const toggleNotificationDrawer = (): ToggleNotificationDrawerAction => ({
-  type: "TOGGLE_NOTIFICATION_DRAWER",
-})
-
 interface SetLadderVehicleLabelSettingAction {
   type: "SET_LADDER_VEHICLE_LABEL_SETTING"
   payload: {
@@ -596,7 +588,6 @@ export type Action =
   // Notifications
   | OpenNotificationDrawerAction
   | CloseNotificationDrawerAction
-  | ToggleNotificationDrawerAction
   // Settings
   | SetLadderVehicleLabelSettingAction
   | SetShuttleVehicleLabelSettingAction
@@ -937,11 +928,6 @@ const openViewAndNotificationDrawerReducer = (
       return [openView === OpenView.Late ? OpenView.Late : OpenView.None, true]
     case "CLOSE_NOTIFICATION_DRAWER":
       return [openView, false]
-    case "TOGGLE_NOTIFICATION_DRAWER":
-      return [
-        openView === OpenView.Late ? OpenView.Late : OpenView.None,
-        !notificationDrawerIsOpen,
-      ]
     case "OPEN_SWINGS_VIEW":
       return [OpenView.Swings, false]
     case "CLOSE_SWINGS_VIEW":

--- a/assets/src/state.ts
+++ b/assets/src/state.ts
@@ -415,12 +415,20 @@ export const setNotification = (
   },
 })
 
-interface ToggleSwingsViewAction {
-  type: "TOGGLE_SWINGS_VIEW"
+interface OpenSwingsViewAction {
+  type: "OPEN_SWINGS_VIEW"
 }
 
-export const toggleSwingsView = (): ToggleSwingsViewAction => ({
-  type: "TOGGLE_SWINGS_VIEW",
+export const openSwingsView = (): OpenSwingsViewAction => ({
+  type: "OPEN_SWINGS_VIEW",
+})
+
+interface CloseSwingsViewAction {
+  type: "CLOSE_SWINGS_VIEW"
+}
+
+export const closeSwingsView = (): CloseSwingsViewAction => ({
+  type: "CLOSE_SWINGS_VIEW",
 })
 
 interface ToggleLateViewAction {
@@ -591,7 +599,8 @@ export type Action =
   | SetNotificationAction
   | SelectVehicleFromNotificationAction
   // Views
-  | ToggleSwingsViewAction
+  | OpenSwingsViewAction
+  | CloseSwingsViewAction
   | ToggleLateViewAction
   // Presets
   | CreatePresetAction
@@ -924,12 +933,10 @@ const openViewAndNotificationDrawerReducer = (
         openView === OpenView.Late ? OpenView.Late : OpenView.None,
         !notificationDrawerIsOpen,
       ]
-    case "TOGGLE_SWINGS_VIEW":
-      if (openView === OpenView.Swings) {
-        return [OpenView.None, notificationDrawerIsOpen]
-      } else {
-        return [OpenView.Swings, false]
-      }
+    case "OPEN_SWINGS_VIEW":
+      return [OpenView.Swings, false]
+    case "CLOSE_SWINGS_VIEW":
+      return [OpenView.None, notificationDrawerIsOpen]
     case "TOGGLE_LATE_VIEW":
       if (openView === OpenView.Late) {
         return [OpenView.None, notificationDrawerIsOpen]

--- a/assets/tests/components/lateView.test.tsx
+++ b/assets/tests/components/lateView.test.tsx
@@ -11,7 +11,7 @@ import {
   OpenView,
   State,
   selectVehicle,
-  toggleLateView,
+  closeLateView,
 } from "../../src/state"
 import blockWaiverFactory from "../factories/blockWaiver"
 import vehicleFactory from "../factories/vehicle"
@@ -132,7 +132,7 @@ describe("LateView", () => {
       .first()
       .simulate("click")
 
-    expect(mockDispatch).toHaveBeenCalledWith(toggleLateView())
+    expect(mockDispatch).toHaveBeenCalledWith(closeLateView())
   })
 
   test("clicking ghost run number opens ghost and sends Fullstory event", () => {

--- a/assets/tests/components/nav/bottomNavMobile.test.tsx
+++ b/assets/tests/components/nav/bottomNavMobile.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react"
 import BottomNavMobile from "../../../src/components/nav/bottomNavMobile"
 import userEvent from "@testing-library/user-event"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
-import { initialState, toggleSwingsView } from "../../../src/state"
+import { initialState, openSwingsView } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
 
@@ -26,7 +26,7 @@ describe("BottomNavMobile", () => {
 
     await user.click(result.getByTitle("Swings View"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleSwingsView())
+    expect(dispatch).toHaveBeenCalledWith(openSwingsView())
     expect(tagManagerEvent).toHaveBeenCalledWith("swings_view_toggled")
   })
 })

--- a/assets/tests/components/nav/bottomNavMobile.test.tsx
+++ b/assets/tests/components/nav/bottomNavMobile.test.tsx
@@ -2,8 +2,7 @@ import React from "react"
 import { render } from "@testing-library/react"
 import BottomNavMobile from "../../../src/components/nav/bottomNavMobile"
 import userEvent from "@testing-library/user-event"
-import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
-import { initialState, openSwingsView } from "../../../src/state"
+import { initialState } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
 
@@ -14,19 +13,20 @@ jest.mock("../../../src/helpers/googleTagManager", () => ({
 
 describe("BottomNavMobile", () => {
   test("clicking swings view button toggles swing view", async () => {
-    const dispatch = jest.fn()
+    const openSwingsView = jest.fn()
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <BottomNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <BottomNavMobile
+          mobileMenuIsOpen={initialState.mobileMenuIsOpen}
+          openSwingsView={openSwingsView}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Swings View"))
 
-    expect(dispatch).toHaveBeenCalledWith(openSwingsView())
+    expect(openSwingsView).toHaveBeenCalled()
     expect(tagManagerEvent).toHaveBeenCalledWith("swings_view_toggled")
   })
 })

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -7,9 +7,9 @@ import { BrowserRouter } from "react-router-dom"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
 import {
   initialState,
+  openLateView,
   openSwingsView,
   OpenView,
-  toggleLateView,
 } from "../../../src/state"
 import { openDrift } from "../../../src/helpers/drift"
 import { displayHelp } from "../../../src/helpers/appCue"
@@ -115,7 +115,7 @@ describe("LeftNav", () => {
 
     await user.click(result.getByTitle("Late View"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleLateView())
+    expect(dispatch).toHaveBeenCalledWith(openLateView())
     expect(tagManagerEvent).toHaveBeenCalledWith("late_view_toggled")
   })
 

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -7,9 +7,9 @@ import { BrowserRouter } from "react-router-dom"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
 import {
   initialState,
+  openSwingsView,
   OpenView,
   toggleLateView,
-  toggleSwingsView,
 } from "../../../src/state"
 import { openDrift } from "../../../src/helpers/drift"
 import { displayHelp } from "../../../src/helpers/appCue"
@@ -132,7 +132,7 @@ describe("LeftNav", () => {
 
     await user.click(result.getByTitle("Swings View"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleSwingsView())
+    expect(dispatch).toHaveBeenCalledWith(openSwingsView())
     expect(tagManagerEvent).toHaveBeenCalledWith("swings_view_toggled")
   })
 

--- a/assets/tests/components/nav/mobilePortraitNav.test.tsx
+++ b/assets/tests/components/nav/mobilePortraitNav.test.tsx
@@ -1,0 +1,80 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import MobilePortraitNav from "../../../src/components/nav/mobilePortraitNav"
+import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
+import { initialState, OpenView } from "../../../src/state"
+import { BrowserRouter } from "react-router-dom"
+import vehicleFactory from "../../factories/vehicle"
+
+describe("MobilePortraitNav", () => {
+  test("renders top / bottom nav", () => {
+    const dispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={dispatch}>
+        <BrowserRouter>
+          <MobilePortraitNav />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.queryByTitle("Swings View")).not.toBeNull()
+    expect(result.queryByTitle("Notifications")).not.toBeNull()
+  })
+
+  test("doesn't render top / bottom nav when a view is open", () => {
+    const dispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{ ...initialState, openView: OpenView.Swings }}
+        dispatch={dispatch}
+      >
+        <BrowserRouter>
+          <MobilePortraitNav />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.queryByTitle("Swings View")).toBeNull()
+    expect(result.queryByTitle("Notifications")).toBeNull()
+  })
+
+  test("doesn't render top / bottom nav when a vehicle is selected", () => {
+    const dispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{
+          ...initialState,
+          selectedVehicleOrGhost: vehicleFactory.build(),
+        }}
+        dispatch={dispatch}
+      >
+        <BrowserRouter>
+          <MobilePortraitNav />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.queryByTitle("Swings View")).toBeNull()
+    expect(result.queryByTitle("Notifications")).toBeNull()
+  })
+
+  test("doesn't render top / bottom nav when notification drawer is open", () => {
+    const dispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{
+          ...initialState,
+          notificationDrawerIsOpen: true,
+        }}
+        dispatch={dispatch}
+      >
+        <BrowserRouter>
+          <MobilePortraitNav />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.queryByTitle("Swings View")).toBeNull()
+    expect(result.queryByTitle("Notifications")).toBeNull()
+  })
+})

--- a/assets/tests/components/nav/topNav.test.tsx
+++ b/assets/tests/components/nav/topNav.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react"
 import TopNav from "../../../src/components/nav/topNav"
 import userEvent from "@testing-library/user-event"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
-import { initialState, toggleNotificationDrawer } from "../../../src/state"
+import { initialState, openNotificationDrawer } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import * as browser from "../../../src/models/browser"
@@ -22,7 +22,7 @@ describe("TopNav", () => {
 
     await user.click(result.getByTitle("Notifications"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleNotificationDrawer())
+    expect(dispatch).toHaveBeenCalledWith(openNotificationDrawer())
   })
 
   test("notifications icon gets active class when notifications drawer is open", () => {

--- a/assets/tests/components/nav/topNavMobile.test.tsx
+++ b/assets/tests/components/nav/topNavMobile.test.tsx
@@ -6,12 +6,6 @@ import {
   pageOrTabName,
 } from "../../../src/components/nav/topNavMobile"
 import userEvent from "@testing-library/user-event"
-import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
-import {
-  initialState,
-  toggleMobileMenu,
-  openNotificationDrawer,
-} from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import * as browser from "../../../src/models/browser"
@@ -30,48 +24,63 @@ jest.mock("../../../src/helpers/appCue", () => ({
 
 describe("TopNavMobile", () => {
   test("clicking the menu hamburger button toggles the mobile menu expanded/collapsed state", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Menu"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("clicking the overlay expanded/collapsed state", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTestId("mobile-overlay"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("mobile menu is visible", () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, mobileMenuIsOpen: true }}
-        dispatch={dispatch}
-      >
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={true}
+        />
+      </BrowserRouter>
     )
 
     expect(result.getByTestId("top-nav-mobile").children[0]).toHaveClass(
@@ -80,16 +89,19 @@ describe("TopNavMobile", () => {
   })
 
   test("mobile menu is not visible", () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, mobileMenuIsOpen: false }}
-        dispatch={dispatch}
-      >
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     expect(result.getByTestId("top-nav-mobile").children[0]).not.toHaveClass(
@@ -98,32 +110,41 @@ describe("TopNavMobile", () => {
   })
 
   test("clicking notifications icon toggles notifications drawer", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Notifications"))
 
-    expect(dispatch).toHaveBeenCalledWith(openNotificationDrawer())
+    expect(openNotificationDrawer).toHaveBeenCalled()
   })
 
   test("notifications icon gets active class when notifications drawer is open", () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, notificationDrawerIsOpen: true }}
-        dispatch={dispatch}
-      >
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={true}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     expect(result.getByTitle("Notifications").children[0]).toHaveClass(
@@ -132,16 +153,19 @@ describe("TopNavMobile", () => {
   })
 
   test("notifications icon doesn't get active class when notifications drawer is close", () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, notificationDrawerIsOpen: false }}
-        dispatch={dispatch}
-      >
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     expect(result.getByTitle("Notifications").children[0]).not.toHaveClass(
@@ -154,14 +178,20 @@ describe("TopNavMobile", () => {
       .spyOn(browser, "reload")
       .mockImplementationOnce(() => ({}))
 
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Refresh"))
@@ -170,10 +200,19 @@ describe("TopNavMobile", () => {
   })
 
   test("clicking Support button opens Drift", async () => {
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
       <BrowserRouter>
-        <TopNavMobile />
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
       </BrowserRouter>
     )
 
@@ -183,42 +222,63 @@ describe("TopNavMobile", () => {
   })
 
   test("clicking the Support button closes the mobile menu", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Support"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("clicking the settings button closes the mobile menu", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={true}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Settings"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("clicking About Skate button displays help", async () => {
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
       <BrowserRouter>
-        <TopNavMobile />
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={false}
+        />
       </BrowserRouter>
     )
 
@@ -228,51 +288,69 @@ describe("TopNavMobile", () => {
   })
 
   test("clicking the About button closes the mobile menu", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={true}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("About Skate"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("clicking the logo closes the mobile menu", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={true}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Skate"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
   test("clicking the close button closes the mobile menu", async () => {
-    const dispatch = jest.fn()
+    const toggleMobileMenu = jest.fn()
+    const openNotificationDrawer = jest.fn()
+
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={dispatch}>
-        <BrowserRouter>
-          <TopNavMobile />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <BrowserRouter>
+        <TopNavMobile
+          toggleMobileMenu={toggleMobileMenu}
+          openNotificationDrawer={openNotificationDrawer}
+          routeTabs={[]}
+          notificationDrawerIsOpen={false}
+          mobileMenuIsOpen={true}
+        />
+      </BrowserRouter>
     )
 
     await user.click(result.getByTitle("Close"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleMobileMenu())
+    expect(toggleMobileMenu).toHaveBeenCalled()
   })
 })
 

--- a/assets/tests/components/nav/topNavMobile.test.tsx
+++ b/assets/tests/components/nav/topNavMobile.test.tsx
@@ -9,8 +9,8 @@ import userEvent from "@testing-library/user-event"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
 import {
   initialState,
-  toggleNotificationDrawer,
   toggleMobileMenu,
+  openNotificationDrawer,
 } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
@@ -110,7 +110,7 @@ describe("TopNavMobile", () => {
 
     await user.click(result.getByTitle("Notifications"))
 
-    expect(dispatch).toHaveBeenCalledWith(toggleNotificationDrawer())
+    expect(dispatch).toHaveBeenCalledWith(openNotificationDrawer())
   })
 
   test("notifications icon gets active class when notifications drawer is open", () => {

--- a/assets/tests/components/swingsView.test.tsx
+++ b/assets/tests/components/swingsView.test.tsx
@@ -13,7 +13,7 @@ import useSwings from "../../src/hooks/useSwings"
 import useVehiclesForRunIds from "../../src/hooks/useVehiclesForRunIds"
 import useVehiclesForBlockIds from "../../src/hooks/useVehiclesForBlockIds"
 import { Route, Swing } from "../../src/schedule"
-import { initialState, selectVehicle, toggleSwingsView } from "../../src/state"
+import { closeSwingsView, initialState, selectVehicle } from "../../src/state"
 import { Vehicle, Ghost, VehicleOrGhost } from "../../src/realtime"
 import * as dateTime from "../../src/util/dateTime"
 import { runIdToLabel } from "../../src/helpers/vehicleLabel"
@@ -316,6 +316,6 @@ describe("SwingsView", () => {
     )
 
     wrapper.find(".m-close-button").first().simulate("click")
-    expect(dispatch).toHaveBeenCalledWith(toggleSwingsView())
+    expect(dispatch).toHaveBeenCalledWith(closeSwingsView())
   })
 })

--- a/assets/tests/components/tabBar.test.tsx
+++ b/assets/tests/components/tabBar.test.tsx
@@ -8,9 +8,9 @@ import * as browser from "../../src/models/browser"
 import {
   initialState,
   toggleNotificationDrawer,
-  toggleLateView,
   OpenView,
   openSwingsView,
+  openLateView,
 } from "../../src/state"
 import featureIsEnabled from "../../src/laboratoryFeatures"
 import { tagManagerEvent } from "../../src/helpers/googleTagManager"
@@ -197,7 +197,7 @@ describe("tabBar", () => {
     )
 
     wrapper.find(".m-tab-bar__late_view").first().simulate("click")
-    expect(dispatch).toHaveBeenCalledWith(toggleLateView())
+    expect(dispatch).toHaveBeenCalledWith(openLateView())
     expect(tagManagerEvent).toHaveBeenCalledWith("late_view_toggled")
   })
 

--- a/assets/tests/components/tabBar.test.tsx
+++ b/assets/tests/components/tabBar.test.tsx
@@ -7,10 +7,10 @@ import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import * as browser from "../../src/models/browser"
 import {
   initialState,
-  toggleNotificationDrawer,
   OpenView,
   openSwingsView,
   openLateView,
+  openNotificationDrawer,
 } from "../../src/state"
 import featureIsEnabled from "../../src/laboratoryFeatures"
 import { tagManagerEvent } from "../../src/helpers/googleTagManager"
@@ -154,7 +154,7 @@ describe("tabBar", () => {
     )
 
     wrapper.find(".m-tab-bar__notifications").first().simulate("click")
-    expect(dispatch).toHaveBeenCalledWith(toggleNotificationDrawer())
+    expect(dispatch).toHaveBeenCalledWith(openNotificationDrawer())
   })
 
   test("clicking the swings icon toggles the swings view and sends Fullstory event", () => {

--- a/assets/tests/components/tabBar.test.tsx
+++ b/assets/tests/components/tabBar.test.tsx
@@ -8,9 +8,9 @@ import * as browser from "../../src/models/browser"
 import {
   initialState,
   toggleNotificationDrawer,
-  toggleSwingsView,
   toggleLateView,
   OpenView,
+  openSwingsView,
 } from "../../src/state"
 import featureIsEnabled from "../../src/laboratoryFeatures"
 import { tagManagerEvent } from "../../src/helpers/googleTagManager"
@@ -173,7 +173,7 @@ describe("tabBar", () => {
     )
 
     wrapper.find(".m-tab-bar__swings").first().simulate("click")
-    expect(dispatch).toHaveBeenCalledWith(toggleSwingsView())
+    expect(dispatch).toHaveBeenCalledWith(openSwingsView())
     expect(tagManagerEvent).toHaveBeenCalledWith("swings_view_toggled")
   })
 

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -432,18 +432,18 @@ describe("reducer", () => {
     expect(newState).toEqual(initialState)
   })
 
-  test("toggleLateView enables late view when other views are closed", () => {
+  test("openLateView enables late view when other views are closed", () => {
     const expectedState: State.State = {
       ...initialState,
       openView: State.OpenView.Late,
     }
 
-    const newState = reducer(initialState, State.toggleLateView())
+    const newState = reducer(initialState, State.openLateView())
 
     expect(newState).toEqual(expectedState)
   })
 
-  test("toggleLateView enables late view when swings views is open", () => {
+  test("openLateView enables late view when swings views is open", () => {
     const expectedState: State.State = {
       ...initialState,
       openView: State.OpenView.Late,
@@ -451,16 +451,16 @@ describe("reducer", () => {
 
     const newState = reducer(
       { ...initialState, openView: State.OpenView.Swings },
-      State.toggleLateView()
+      State.openLateView()
     )
 
     expect(newState).toEqual(expectedState)
   })
 
-  test("toggleLateView disables late view when late view is open", () => {
+  test("closeLateView disables late view when late view is open", () => {
     const newState = reducer(
       { ...initialState, openView: State.OpenView.Late },
-      State.toggleLateView()
+      State.closeLateView()
     )
 
     expect(newState).toEqual(initialState)

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -253,66 +253,6 @@ describe("reducer", () => {
         expectedState
       )
     })
-
-    test("toggleNotificationDrawer opens the drawer if it's closed", () => {
-      const state = {
-        ...initialState,
-        notificationDrawerIsOpen: false,
-      }
-      const expectedState = {
-        ...initialState,
-        notificationDrawerIsOpen: true,
-      }
-      expect(reducer(state, State.toggleNotificationDrawer())).toEqual(
-        expectedState
-      )
-    })
-
-    test("toggleNotificationDrawer closes the drawer if it's open", () => {
-      const state = {
-        ...initialState,
-        notificationDrawerIsOpen: true,
-      }
-      const expectedState = {
-        ...initialState,
-        notificationDrawerIsOpen: false,
-      }
-      expect(reducer(state, State.toggleNotificationDrawer())).toEqual(
-        expectedState
-      )
-    })
-
-    test("toggleNotificationDrawer closes swings view when opening notifications drawer", () => {
-      const state = {
-        ...initialState,
-        notificationDrawerIsOpen: false,
-        openView: State.OpenView.Swings,
-      }
-      const expectedState = {
-        ...initialState,
-        notificationDrawerIsOpen: true,
-        openView: State.OpenView.None,
-      }
-      expect(reducer(state, State.toggleNotificationDrawer())).toEqual(
-        expectedState
-      )
-    })
-
-    test("toggleNotificationDrawer leaves late view open when opening notifications drawer", () => {
-      const state = {
-        ...initialState,
-        notificationDrawerIsOpen: false,
-        openView: State.OpenView.Late,
-      }
-      const expectedState = {
-        ...initialState,
-        notificationDrawerIsOpen: true,
-        openView: State.OpenView.Late,
-      }
-      expect(reducer(state, State.toggleNotificationDrawer())).toEqual(
-        expectedState
-      )
-    })
   })
 
   test("setLadderVehicleLabelSetting", () => {

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -398,18 +398,18 @@ describe("reducer", () => {
     expect(newState).toEqual(expectedState)
   })
 
-  test("toggleSwingsView enables swings view when other views are closed", () => {
+  test("openSwingsView enables swings view when other views are closed", () => {
     const expectedState: State.State = {
       ...initialState,
       openView: State.OpenView.Swings,
     }
 
-    const newState = reducer(initialState, State.toggleSwingsView())
+    const newState = reducer(initialState, State.openSwingsView())
 
     expect(newState).toEqual(expectedState)
   })
 
-  test("toggleSwingsView enables swings view when late view is open", () => {
+  test("openSwingsView enables swings view when late view is open", () => {
     const expectedState: State.State = {
       ...initialState,
       openView: State.OpenView.Swings,
@@ -417,16 +417,16 @@ describe("reducer", () => {
 
     const newState = reducer(
       { ...initialState, openView: State.OpenView.Late },
-      State.toggleSwingsView()
+      State.openSwingsView()
     )
 
     expect(newState).toEqual(expectedState)
   })
 
-  test("toggleSwingsView disables swings view when swings view is open", () => {
+  test("closeSwingsView disables swings view when swings view is open", () => {
     const newState = reducer(
       { ...initialState, openView: State.OpenView.Swings },
-      State.toggleSwingsView()
+      State.closeSwingsView()
     )
 
     expect(newState).toEqual(initialState)


### PR DESCRIPTION
Asana ticket: [⚙️ Nav | Implement mobile portrait changes](https://app.asana.com/0/1200180014510248/1202630445285825/f)

As part of this I split the components up a bit to create a separate `MobilePortraitNav` component that takes care of the logic to show / hide the top + bottom nav depending on whether or not a view is open. The "is a view open" logic is actually kind of complicated. As far as I can tell, for now it will be specific to mobile nav but in the future it might be good to make it a utility function... somewhere, I'm not sure what the most logical spot would be.