### PR TITLE
Make late view open on the right

### DIFF
--- a/assets/css/_late_view.scss
+++ b/assets/css/_late_view.scss
@@ -1,14 +1,12 @@
 $late-view-background-color: $color-bg-light;
-$late-view-width: 34.5rem;
 
 .m-late-view {
   @include modal-content;
   background-color: $late-view-background-color;
   height: 100%;
   position: absolute;
-  left: 0;
+  right: 0;
   top: 0;
-  width: $late-view-width;
   z-index: 1001;
 
   .m-tab-bar ~ & {
@@ -26,7 +24,8 @@ $late-view-width: 34.5rem;
   box-shadow: $modal-box-shadow;
   clip-path: inset(-2rem -2rem -2rem 0);
   -webkit-clip-path: inset(-2rem -2rem -2rem 0);
-  left: $late-view-width;
+  left: -$drawer-tab-width;
+  transform: scaleX(-1);
 }
 
 .m-late-view__title {
@@ -41,6 +40,7 @@ $late-view-width: 34.5rem;
   display: flex;
   flex-direction: column;
   padding-left: 1.5rem;
+  padding-right: 1.6rem;
 }
 
 .m-late-view__panel {

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,11 @@
 {
-  "repository": {},
-  "license": "MIT",
+  "name": "skate",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mbta/skate.git",
+    "directory": "assets"
+  },
+  "license": "AGPL-3.0-only",
   "scripts": {
     "deploy": "webpack --mode production",
     "build": "webpack --mode development",

--- a/assets/src/components/lateView.tsx
+++ b/assets/src/components/lateView.tsx
@@ -283,6 +283,10 @@ const LateView = (): ReactElement<HTMLElement> => {
   return (
     <div className={`m-late-view ${mobileMenuClass}`}>
       <div className="m-late-view__content-wrapper">
+        <DrawerTab
+          isVisible={true}
+          toggleVisibility={() => dispatch(closeLateView())}
+        />
         <div className="m-late-view__title">Late View</div>
         <div className="m-late-view__panels">
           <div className="m-late-view__panel m-late-view__missing-logons">
@@ -382,10 +386,6 @@ const LateView = (): ReactElement<HTMLElement> => {
             </table>
           </div>
         </div>
-        <DrawerTab
-          isVisible={true}
-          toggleVisibility={() => dispatch(closeLateView())}
-        />
       </div>
       {anyRowsSelected && (
         <HidePopup

--- a/assets/tests/components/__snapshots__/lateView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/lateView.test.tsx.snap
@@ -8,6 +8,24 @@ exports[`LateView renders missing logons and late buses 1`] = `
     className="m-late-view__content-wrapper"
   >
     <div
+      className="c-drawer-tab"
+    >
+      <button
+        className="c-drawer-tab__tab-button"
+        data-testid="drawer-tab-button"
+        onClick={[Function]}
+      >
+        <span
+          className=""
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "SVG",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
       className="m-late-view__title"
     >
       Late View
@@ -370,24 +388,6 @@ exports[`LateView renders missing logons and late buses 1`] = `
           </tbody>
         </table>
       </div>
-    </div>
-    <div
-      className="c-drawer-tab"
-    >
-      <button
-        className="c-drawer-tab__tab-button"
-        data-testid="drawer-tab-button"
-        onClick={[Function]}
-      >
-        <span
-          className=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "SVG",
-            }
-          }
-        />
-      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Asana ticket: [⚙️ Nav | Late View should open on the right, like other views](https://app.asana.com/0/1200180014510248/1202630445285831/f)

For the drawer tab, I was initially thinking I'd add an optional prop to flip it, but seeing that the late view CSS already defines some custom styling for its drawer tab and realizing I could get away with `transform: scaleX(-1)` to flip it, I decided to go with that, especially given that we're going to be getting rid of the drawer tab on late view as part of some of the other nav changes anyway.

I also fixed up some minor things that had been bugging me in `package.json`.