### PR TITLE
fix: don't make late view take up full screen on old nav

### DIFF
--- a/assets/css/_late_view.scss
+++ b/assets/css/_late_view.scss
@@ -8,10 +8,6 @@ $late-view-background-color: $color-bg-light;
   right: 0;
   top: 0;
   z-index: 1001;
-
-  .m-tab-bar ~ & {
-    left: $tab-bar-width;
-  }
 }
 
 .m-late-view__content-wrapper {


### PR DESCRIPTION
Asana ticket: [🐞 [extra] Late view taking up entire screen](https://app.asana.com/0/1200180014510248/1202707315274268/f)

With the old nav combined with the changes to make late view open on the right, we were setting both `left` and `right` values for the late view that caused it to take up basically the whole screen.