### PR TITLE
fix: handle cases of %Schedule.AsDirected{} turning up in pieces

### DIFF
--- a/lib/schedule/swing.ex
+++ b/lib/schedule/swing.ex
@@ -100,14 +100,20 @@ defmodule Schedule.Swing do
       }
     end)
     |> Enum.filter(fn %{swing_off_trip: trip1, swing_on_trip: trip2} ->
-      trip1.route_id || trip2.route_id
+      !is_nil(trip1) && !is_nil(trip2) && (trip1.route_id || trip2.route_id)
     end)
   end
 
-  @spec trip_or_trip_id_to_trip(Trip.id() | Schedule.Trip.t(), Trip.by_id()) ::
-          Schedule.Trip.t() | Trip.t()
+  @spec trip_or_trip_id_to_trip(
+          Trip.id() | Schedule.Trip.t() | Schedule.AsDirected.t(),
+          Trip.by_id()
+        ) ::
+          Schedule.Trip.t() | Trip.t() | nil
   defp trip_or_trip_id_to_trip(%Schedule.Trip{} = trip, trips_by_id),
     do: Map.get(trips_by_id, trip.id, trip)
+
+  defp trip_or_trip_id_to_trip(%Schedule.AsDirected{}, _trips_by_id),
+    do: nil
 
   defp trip_or_trip_id_to_trip(trip_id, trips_by_id), do: Map.fetch!(trips_by_id, trip_id)
 end

--- a/test/schedule/swing_test.exs
+++ b/test/schedule/swing_test.exs
@@ -370,4 +370,77 @@ defmodule Schedule.SwingTest do
              }
     end
   end
+
+  test "ignores as directed work" do
+    trip1 =
+      build(
+        :trip,
+        id: "0123",
+        service_id: "b",
+        block_id: "A12-34",
+        route_id: "11",
+        headsign: "Somewhere Else",
+        direction_id: 0,
+        run_id: "123-456",
+        start_time: 1,
+        end_time: 100,
+        start_place: "place3",
+        end_place: "place1"
+      )
+
+    trip2 =
+      build(
+        :as_directed,
+        start_time: 101,
+        end_time: 200,
+        start_place: "place1",
+        end_place: "place2"
+      )
+
+    blocks = %{
+      "A12-34" =>
+        build(
+          :block,
+          schedule_id: "a",
+          service_id: "b",
+          start_time: 1,
+          end_time: 500,
+          id: "A12-34",
+          pieces: [
+            build(
+              :piece,
+              schedule_id: "a",
+              run_id: "123-456",
+              block_id: "A12-34",
+              start_time: 1,
+              start_place: "place3",
+              trips: [
+                trip1
+              ],
+              end_time: 100,
+              end_place: "place1",
+              start_mid_route?: nil,
+              end_mid_route?: false
+            ),
+            build(
+              :piece,
+              schedule_id: "a",
+              run_id: "123-789",
+              block_id: "A12-34",
+              start_time: 101,
+              start_place: "place1",
+              trips: [
+                trip2
+              ],
+              end_time: 200,
+              end_place: "place2",
+              start_mid_route?: nil,
+              end_mid_route?: false
+            )
+          ]
+        )
+    }
+
+    assert Swing.from_blocks(blocks, %{}) == %{}
+  end
 end


### PR DESCRIPTION
Asana ticket: [[extra] Fix issue with parsing + loading fall schedule](https://app.asana.com/0/1200180014510248/1202737931015267/f)

The contents of `piece.trips` can actually include not just `Trip` structs but also `AsDirected` structs, which was causing an error. This adds come handling for that case, opting to simply ignore anything in the schedule that looks like a swing where the swing on / off trip is actually a work as directed piece.