### PR TITLE
Notification events

### DIFF
--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -157,6 +157,8 @@ const LeftNav = ({
               toggleView={() => {
                 dispatch(openNotificationDrawer())
 
+                tagManagerEvent("notifications_opened")
+
                 if (closePickerOnViewOpen && pickerContainerIsVisible) {
                   dispatch(togglePickerContainer())
                 }

--- a/assets/src/components/nav/topNavMobile.tsx
+++ b/assets/src/components/nav/topNavMobile.tsx
@@ -4,6 +4,7 @@ import { hamburgerIcon } from "../../helpers/icon"
 import NotificationBellIcon from "../notificationBellIcon"
 import { currentTabName, RouteTab } from "../../models/routeTab"
 import NavMenu from "./navMenu"
+import { tagManagerEvent } from "../../helpers/googleTagManager"
 
 export const toTitleCase = (str: string): string => {
   return str.replace(
@@ -69,7 +70,11 @@ const TopNavMobile: React.FC<Props> = ({
         <div className="m-top-nav-mobile__right-items">
           <button
             className="m-top-nav-mobile__right-item"
-            onClick={openNotificationDrawer}
+            onClick={() => {
+              openNotificationDrawer()
+
+              tagManagerEvent("notifications_opened")
+            }}
             title="Notifications"
           >
             <NotificationBellIcon

--- a/assets/src/contexts/notificationsContext.tsx
+++ b/assets/src/contexts/notificationsContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
+import { tagManagerEvent } from "../helpers/googleTagManager"
 import useCurrentTime from "../hooks/useCurrentTime"
 import useInterval from "../hooks/useInterval"
 import { useNotifications } from "../hooks/useNotifications"
@@ -74,6 +75,7 @@ export const NotificationsProvider = ({
   /* istanbul ignore next */
   useNotifications(
     (notification) => {
+      tagManagerEvent("notification_delivered")
       dispatch(addNotification(notification))
     },
     (notificationsData) => {

--- a/assets/src/hooks/useVehicleForNotification.ts
+++ b/assets/src/hooks/useVehicleForNotification.ts
@@ -1,6 +1,8 @@
 import { Socket } from "phoenix"
 import useVehiclesForRunIds from "./useVehiclesForRunIds"
 import { Notification, VehicleOrGhost } from "../realtime.d"
+import { useEffect, useState } from "react"
+import { tagManagerEvent } from "../helpers/googleTagManager"
 
 const useVehicleForNotification = (
   notification?: Notification,
@@ -14,6 +16,20 @@ const useVehicleForNotification = (
   const newVehicleOrGhost = Array.isArray(newVehiclesOrGhosts)
     ? newVehiclesOrGhosts[0] || null
     : newVehiclesOrGhosts
+
+  const [clickthroughLogged, setClickthroughLogged] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!clickthroughLogged) {
+      if (newVehicleOrGhost) {
+        setClickthroughLogged(true)
+        tagManagerEvent("notification_linked_to_vpp")
+      } else if (notification && newVehicleOrGhost === null) {
+        setClickthroughLogged(true)
+        tagManagerEvent("notification_linked_to_inactive_modal")
+      }
+    }
+  }, [clickthroughLogged, notification, newVehicleOrGhost])
 
   return newVehicleOrGhost
 }

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -246,7 +246,7 @@ describe("LeftNav", () => {
     expect(displayHelp).toHaveBeenCalled()
   })
 
-  test("clicking notifications icon toggles notifications drawer", async () => {
+  test("clicking notifications icon toggles notifications drawer and logs a tag manager event", async () => {
     const dispatch = jest.fn()
     const user = userEvent.setup()
     const result = render(
@@ -260,6 +260,7 @@ describe("LeftNav", () => {
     await user.click(result.getByTitle("Notifications"))
 
     expect(dispatch).toHaveBeenCalledWith(openNotificationDrawer())
+    expect(tagManagerEvent).toHaveBeenCalledWith("notifications_opened")
   })
 
   test("clicking notifications closes picker container when flag is set", async () => {

--- a/assets/tests/components/nav/topNavMobile.test.tsx
+++ b/assets/tests/components/nav/topNavMobile.test.tsx
@@ -8,6 +8,12 @@ import {
 import userEvent from "@testing-library/user-event"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
+import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
+
+jest.mock("../../../src/helpers/googleTagManager", () => ({
+  __esModule: true,
+  tagManagerEvent: jest.fn(),
+}))
 
 describe("TopNavMobile", () => {
   test("clicking the menu hamburger button toggles the mobile menu expanded/collapsed state", async () => {
@@ -31,7 +37,7 @@ describe("TopNavMobile", () => {
     expect(toggleMobileMenu).toHaveBeenCalled()
   })
 
-  test("clicking notifications icon toggles notifications drawer", async () => {
+  test("clicking notifications icon toggles notifications drawer and logs a tag manager event", async () => {
     const toggleMobileMenu = jest.fn()
     const openNotificationDrawer = jest.fn()
 
@@ -50,6 +56,7 @@ describe("TopNavMobile", () => {
     await user.click(result.getByTitle("Notifications"))
 
     expect(openNotificationDrawer).toHaveBeenCalled()
+    expect(tagManagerEvent).toHaveBeenCalledWith("notifications_opened")
   })
 })
 

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -15,6 +15,7 @@ import {
   State,
 } from "../../src/state"
 import vehicleFactory from "../factories/vehicle"
+import { tagManagerEvent } from "../../src/helpers/googleTagManager"
 
 jest.mock("../../src/hooks/useCurrentTime", () => ({
   __esModule: true,
@@ -29,6 +30,11 @@ jest.mock("../../src/hooks/useNotifications", () => ({
 jest.mock("../../src/laboratoryFeatures", () => ({
   __esModule: true,
   default: () => true,
+}))
+
+jest.mock("../../src/helpers/googleTagManager", () => ({
+  __esModule: true,
+  tagManagerEvent: jest.fn(),
 }))
 
 const vehicle = vehicleFactory.build()
@@ -61,7 +67,7 @@ describe("NotificationsProvider", () => {
     expect(result.current.notifications).toEqual([])
   })
 
-  test("receives incoming notifications", () => {
+  test("receives incoming notifications and logs a tag manager event", () => {
     let handler: (notification: Notification) => void
     ;(useNotifications as jest.Mock).mockImplementationOnce((h) => {
       handler = h
@@ -74,6 +80,7 @@ describe("NotificationsProvider", () => {
       handler!(notification)
     })
     expect(result.current.notifications).toHaveLength(1)
+    expect(tagManagerEvent).toHaveBeenCalledWith("notification_delivered")
   })
 
   test("expires notifications after 8 hours", () => {


### PR DESCRIPTION
Asana ticket: [⚙️ Google Analytics | Custom events for Notifications](https://app.asana.com/0/1200180014510248/1202675730248192/f)

This just adds tagging for some events in Google Analytics for some research we're trying to do on usage of the notifications feature. The `tagManagerEvent` function is a helper that encapsulates the modification of the global `window.dataLayer` state that's used to pass things into Google Tag Manager.