### PR TITLE
fix(formattedScheduledTime): Interpret given offset in seconds

### DIFF
--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -55,8 +55,8 @@ export const formattedScheduledTime = (
   time: number,
   offset?: number | undefined
 ): string => {
-  const offsetInMinutes = offset ? Math.floor(offset / 60) : 0
-  let minutes = Math.floor(time / 60) + offsetInMinutes
+  const offsetSeconds = offset || 0
+  let minutes = Math.floor((time + offsetSeconds) / 60)
   if (minutes < 0) {
     /* if the offset shifts the time before midnight */
     minutes += 1440

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -49,13 +49,14 @@ export const formattedTimeDiffUnderThreshold = (
     : formattedTime(b)
 }
 
-/** Takes a time of day in seconds since midnight, offset in minutes (reasonably -720 to 720)
+/** Takes a time of day in seconds since midnight, offset in seconds (reasonably -8640 to 8640 seconds, or -12 to 12 hours)
  */
 export const formattedScheduledTime = (
   time: number,
   offset?: number | undefined
 ): string => {
-  let minutes = Math.floor(time / 60) + (offset ? offset : 0)
+  const offsetInMinutes = offset ? Math.floor(offset / 60) : 0
+  let minutes = Math.floor(time / 60) + offsetInMinutes
   if (minutes < 0) {
     /* if the offset shifts the time before midnight */
     minutes += 1440

--- a/assets/tests/components/propertiesPanel/minischedule.test.tsx
+++ b/assets/tests/components/propertiesPanel/minischedule.test.tsx
@@ -301,7 +301,7 @@ const vehicle: Vehicle = vehicleFactory.build({
 
 const vehicleWithOffset: Vehicle = {
   ...vehicle,
-  overloadOffset: 8,
+  overloadOffset: 480,
   isOverload: true,
 }
 

--- a/assets/tests/util/dateTime.test.ts
+++ b/assets/tests/util/dateTime.test.ts
@@ -123,7 +123,7 @@ describe("formattedScheduledTime", () => {
     expect(formattedScheduledTime(86400)).toEqual("12:00 AM")
     expect(formattedScheduledTime(90900)).toEqual("1:15 AM")
   })
-  test("applies offset minutes", () => {
+  test("applies offset seconds", () => {
     expect(formattedScheduledTime(34100, 120)).toEqual("9:30 AM")
     expect(formattedScheduledTime(34100, -180)).toEqual("9:25 AM")
     expect(formattedScheduledTime(34100, 0)).toEqual("9:28 AM")

--- a/assets/tests/util/dateTime.test.ts
+++ b/assets/tests/util/dateTime.test.ts
@@ -124,12 +124,12 @@ describe("formattedScheduledTime", () => {
     expect(formattedScheduledTime(90900)).toEqual("1:15 AM")
   })
   test("applies offset minutes", () => {
-    expect(formattedScheduledTime(34100, 2)).toEqual("9:30 AM")
-    expect(formattedScheduledTime(34100, -3)).toEqual("9:25 AM")
+    expect(formattedScheduledTime(34100, 120)).toEqual("9:30 AM")
+    expect(formattedScheduledTime(34100, -180)).toEqual("9:25 AM")
     expect(formattedScheduledTime(34100, 0)).toEqual("9:28 AM")
-    expect(formattedScheduledTime(46800, 61)).toEqual("2:01 PM")
-    expect(formattedScheduledTime(86399, 2)).toEqual("12:01 AM")
-    expect(formattedScheduledTime(1, -3)).toEqual("11:57 PM")
+    expect(formattedScheduledTime(46800, 3660)).toEqual("2:01 PM")
+    expect(formattedScheduledTime(86399, 120)).toEqual("12:01 AM")
+    expect(formattedScheduledTime(1, -180)).toEqual("11:57 PM")
   })
 })
 


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1202737931015251/f

Interprets the offset given to `formattedScheduledTime` in seconds to match the unit as defined in the TM XML API. 