### PR TITLE
fix: better handle partially- or fully-missing operator information

### DIFF
--- a/assets/src/components/propertiesList.tsx
+++ b/assets/src/components/propertiesList.tsx
@@ -33,6 +33,11 @@ export const vehicleProperties = (vehicle: Vehicle): Property[] => {
     operatorLogonTime,
   } = vehicle
 
+  const operatorValue =
+    [operatorFirstName, operatorLastName, operatorId ? `#${operatorId}` : null]
+      .filter((e) => e !== null)
+      .join(" ") || "Not Available"
+
   return [
     {
       label: "Run",
@@ -48,7 +53,7 @@ export const vehicleProperties = (vehicle: Vehicle): Property[] => {
     },
     {
       label: "Operator",
-      value: `${operatorFirstName} ${operatorLastName} #${operatorId}`,
+      value: operatorValue,
       classNameModifier: "operator",
     },
     {

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -185,6 +185,39 @@ describe("vehicleProperties", () => {
       properties.find((prop) => prop.label === "Last Login")!.value
     ).toEqual("Not Available")
   })
+
+  test("operator information is 'Not Available' if all fields are missing", () => {
+    /* The type for Vehicle doesn't actually allow nulls, but the way we coerce values we
+     *  receive from the backend doesn't account for this fact. One more reason to adopt
+     *  Superstruct to handle the translation of data from the backend to JS values. */
+    const vehicleSansOperator = {
+      ...vehicle,
+      operatorId: null,
+      operatorFirstName: null,
+      operatorLastName: null,
+    } as unknown
+
+    const properties = vehicleProperties(vehicleSansOperator as Vehicle)
+
+    expect(properties.find((prop) => prop.label === "Operator")!.value).toEqual(
+      "Not Available"
+    )
+  })
+
+  test("operator information gives last name if that's all that's available", () => {
+    const vehicleSansOperator = {
+      ...vehicle,
+      operatorId: "1234",
+      operatorFirstName: null,
+      operatorLastName: "SMITH",
+    } as unknown
+
+    const properties = vehicleProperties(vehicleSansOperator as Vehicle)
+
+    expect(properties.find((prop) => prop.label === "Operator")!.value).toEqual(
+      "SMITH #1234"
+    )
+  })
 })
 
 describe("Highlighted", () => {


### PR DESCRIPTION
Asana ticket: [⚙️ Update data null message](https://app.asana.com/0/1200180014510248/1202883819004130/f)

Previously, when we were missing operator information, the application would display "null null #null" in that field. This provides a more user-friendly "Not Available" message as well as handling intermediate cases where some pieces of the operator information are available but others aren't.