### PR TITLE
fix(MobilePortraitNav): use single grid layout to prevent scroll position resetting when a view is opened

### DIFF
--- a/assets/css/_nav.scss
+++ b/assets/css/_nav.scss
@@ -3,9 +3,7 @@
   gap: 0;
   grid-template-columns: max-content minmax(0, 1fr);
   grid-template-rows: max-content minmax(0, 1fr);
-  grid-template-areas:
-    "top top"
-    "left content";
+  grid-template-areas: "top top" "left content";
   width: 100%;
   height: 100%;
 }
@@ -25,17 +23,9 @@
   gap: 0;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: max-content minmax(0, 1fr) max-content;
-  grid-template-areas:
-    "top"
-    "content"
-    "bottom";
+  grid-template-areas: "top" "content" "bottom";
   width: 100%;
   height: 100%;
-}
-
-.m-nav--narrow.m-nav--covered {
-  grid-template-rows: minmax(0, 1fr);
-  grid-template-areas: "content";
 }
 
 .m-nav__nav-bar {

--- a/assets/css/_nav.scss
+++ b/assets/css/_nav.scss
@@ -3,7 +3,9 @@
   gap: 0;
   grid-template-columns: max-content minmax(0, 1fr);
   grid-template-rows: max-content minmax(0, 1fr);
-  grid-template-areas: "top top" "left content";
+  grid-template-areas:
+    "top top"
+    "left content";
   width: 100%;
   height: 100%;
 }
@@ -23,7 +25,10 @@
   gap: 0;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: max-content minmax(0, 1fr) max-content;
-  grid-template-areas: "top" "content" "bottom";
+  grid-template-areas:
+    "top"
+    "content"
+    "bottom";
   width: 100%;
   height: 100%;
 }

--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -9,6 +9,7 @@
   top: 0;
   width: 23.5rem;
   z-index: 1001;
+
   @media screen and (max-width: $mobile-max-width) {
     width: 100%;
   }
@@ -38,6 +39,7 @@
   cursor: pointer;
   position: absolute;
   right: 0;
+
   &:hover {
     font-weight: 700;
   }

--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -13,11 +13,10 @@
   @media screen and (max-width: $mobile-max-width) {
     width: 100%;
   }
-  @media screen and (max-width: $mobile-max-width) {
+  @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
     top: 0;
     bottom: 0;
-    width: 100%;
     overflow-y: scroll;
   }
 }

--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -15,9 +15,7 @@
   }
   @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
-    top: 0;
     bottom: 0;
-    overflow-y: scroll;
   }
 }
 

--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -9,9 +9,15 @@
   top: 0;
   width: 23.5rem;
   z-index: 1001;
-
   @media screen and (max-width: $mobile-max-width) {
     width: 100%;
+  }
+  @media screen and (max-width: $mobile-max-width) {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    overflow-y: scroll;
   }
 }
 
@@ -32,7 +38,6 @@
   cursor: pointer;
   position: absolute;
   right: 0;
-
   &:hover {
     font-weight: 700;
   }

--- a/assets/css/_properties_panel.scss
+++ b/assets/css/_properties_panel.scss
@@ -18,11 +18,10 @@
       width: 100%;
     }
   }
-  @media screen and (max-width: $mobile-max-width) {
+  @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
     top: 0;
     bottom: 0;
-    width: 100%;
     overflow-y: scroll;
   }
 }

--- a/assets/css/_properties_panel.scss
+++ b/assets/css/_properties_panel.scss
@@ -10,13 +10,18 @@
   top: 0;
   width: 23.5rem;
   z-index: 1002;
-
   @media screen and (max-width: $mobile-max-width) {
     width: 100vw;
-
     .m-nav__app-content & {
       width: 100%;
     }
+  }
+  @media screen and (max-width: $mobile-max-width) {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    overflow-y: scroll;
   }
 }
 

--- a/assets/css/_properties_panel.scss
+++ b/assets/css/_properties_panel.scss
@@ -20,9 +20,7 @@
   }
   @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
-    top: 0;
     bottom: 0;
-    overflow-y: scroll;
   }
 }
 

--- a/assets/css/_properties_panel.scss
+++ b/assets/css/_properties_panel.scss
@@ -10,8 +10,10 @@
   top: 0;
   width: 23.5rem;
   z-index: 1002;
+
   @media screen and (max-width: $mobile-max-width) {
     width: 100vw;
+
     .m-nav__app-content & {
       width: 100%;
     }

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -29,9 +29,8 @@
   }
   @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
-    top: 0;
     bottom: 0;
-    overflow-y: scroll;
+    width: 100vw;
   }
 }
 

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -9,23 +9,27 @@
   right: 0;
   top: 0;
   z-index: 1001;
-
   .m-old-close-button {
     padding: 1.5rem;
     position: absolute;
     right: 0rem;
     top: 0rem;
   }
-
   // Full width on mobile portrait, to be updated with more responsive designs
   @media screen and (max-width: 480px) {
     .m-nav__app-content & {
       width: 100%;
-
       .m-swings-view__table {
         width: 100%;
       }
     }
+  }
+  @media screen and (max-width: $mobile-max-width) {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    overflow-y: scroll;
   }
 }
 
@@ -58,17 +62,14 @@
   position: -webkit-sticky;
   top: -1px;
   z-index: 1002;
-
   .m-swings-view__table-header-cell-subheaders {
     display: flex;
     justify-content: flex-end;
-
     .m-swings-view__table-header-cell-subheader {
       padding-top: 0.125rem;
       font-size: 0.6875rem;
       font-weight: 400;
     }
-
     .m-swings-view__table-header-cell-route-subheader {
       display: inline-block;
       padding-top: 0.125rem;
@@ -77,15 +78,12 @@
       font-weight: 400;
     }
   }
-
   &.m-swings-view__table-header-cell-swing-on {
     vertical-align: bottom;
   }
-
   &.m-swings-view__table-header-cell-swing-off {
     padding-left: 3.0625rem;
   }
-
   &:last-child {
     padding-right: 1.1875rem;
   }
@@ -118,17 +116,14 @@
   font-size: 0.6875rem;
   font-variant-numeric: tabular-nums;
   text-align: right;
-
   &:last-child {
     padding-left: 1.0625rem;
     padding-right: 1.1875rem;
   }
-
   .m-swings-view__table-cell-contents {
     display: flex;
     justify-content: flex-end;
     align-items: center;
-
     button {
       text-decoration-line: underline;
     }
@@ -141,11 +136,9 @@
   color: $color-primary;
   padding-top: 0.6875rem;
   padding-bottom: 0.6875rem;
-
   &.m-swings-view__show-past-enabled {
     border-bottom: 1px solid #dcdcdc;
   }
-
   &.m-swings-view__show-past-disabled {
     border-bottom: 1px solid #515459;
   }
@@ -156,7 +149,6 @@
   display: inline-block;
   padding-left: 0.5rem;
   padding-right: 0.375rem;
-
   svg {
     fill: $color-primary;
     stroke: $color-primary;
@@ -185,24 +177,20 @@
   display: flex;
   justify-content: center;
   align-items: center;
-
   &.m-swings-view__run-icon-arrow {
     padding-right: 0.375rem;
     stroke: $color-primary-dark;
     width: 0.5rem;
     height: 0.5rem;
-
     svg {
       width: 0.5rem;
       height: 0.5rem;
     }
   }
-
   &.m-swings-view__run-icon-ghost {
     padding-right: 0.375rem;
     width: 1.1875rem;
     height: 1.1875rem;
-
     svg {
       width: 1.1875rem;
       height: 1.1875rem;
@@ -214,21 +202,17 @@
   .m-swings-view__header {
     padding-left: 1.75rem;
   }
-
   .m-swings-view__description {
     padding-left: 1.75rem;
   }
-
   .m-swings-view__table-container {
     padding-left: 0rem;
     padding-right: 0rem;
   }
-
   .m-swings-view__table-header-cell {
     &.m-swings-view__table-header-cell-swing-off {
       padding-left: 3rem;
     }
-
     &.m-swings-view__table-header-cell-swing-on {
       padding-left: 1.5625rem;
     }

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -27,11 +27,10 @@
       }
     }
   }
-  @media screen and (max-width: $mobile-max-width) {
+  @media screen and (max-width: $mobile-portrait-max-width) {
     position: fixed;
     top: 0;
     bottom: 0;
-    width: 100%;
     overflow-y: scroll;
   }
 }

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -9,16 +9,19 @@
   right: 0;
   top: 0;
   z-index: 1001;
+
   .m-old-close-button {
     padding: 1.5rem;
     position: absolute;
     right: 0rem;
     top: 0rem;
   }
+
   // Full width on mobile portrait, to be updated with more responsive designs
   @media screen and (max-width: 480px) {
     .m-nav__app-content & {
       width: 100%;
+
       .m-swings-view__table {
         width: 100%;
       }
@@ -62,14 +65,17 @@
   position: -webkit-sticky;
   top: -1px;
   z-index: 1002;
+
   .m-swings-view__table-header-cell-subheaders {
     display: flex;
     justify-content: flex-end;
+
     .m-swings-view__table-header-cell-subheader {
       padding-top: 0.125rem;
       font-size: 0.6875rem;
       font-weight: 400;
     }
+
     .m-swings-view__table-header-cell-route-subheader {
       display: inline-block;
       padding-top: 0.125rem;
@@ -78,12 +84,15 @@
       font-weight: 400;
     }
   }
+
   &.m-swings-view__table-header-cell-swing-on {
     vertical-align: bottom;
   }
+
   &.m-swings-view__table-header-cell-swing-off {
     padding-left: 3.0625rem;
   }
+
   &:last-child {
     padding-right: 1.1875rem;
   }
@@ -116,14 +125,17 @@
   font-size: 0.6875rem;
   font-variant-numeric: tabular-nums;
   text-align: right;
+
   &:last-child {
     padding-left: 1.0625rem;
     padding-right: 1.1875rem;
   }
+
   .m-swings-view__table-cell-contents {
     display: flex;
     justify-content: flex-end;
     align-items: center;
+
     button {
       text-decoration-line: underline;
     }
@@ -136,9 +148,11 @@
   color: $color-primary;
   padding-top: 0.6875rem;
   padding-bottom: 0.6875rem;
+
   &.m-swings-view__show-past-enabled {
     border-bottom: 1px solid #dcdcdc;
   }
+
   &.m-swings-view__show-past-disabled {
     border-bottom: 1px solid #515459;
   }
@@ -149,6 +163,7 @@
   display: inline-block;
   padding-left: 0.5rem;
   padding-right: 0.375rem;
+
   svg {
     fill: $color-primary;
     stroke: $color-primary;
@@ -177,20 +192,24 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   &.m-swings-view__run-icon-arrow {
     padding-right: 0.375rem;
     stroke: $color-primary-dark;
     width: 0.5rem;
     height: 0.5rem;
+
     svg {
       width: 0.5rem;
       height: 0.5rem;
     }
   }
+
   &.m-swings-view__run-icon-ghost {
     padding-right: 0.375rem;
     width: 1.1875rem;
     height: 1.1875rem;
+
     svg {
       width: 1.1875rem;
       height: 1.1875rem;
@@ -202,17 +221,21 @@
   .m-swings-view__header {
     padding-left: 1.75rem;
   }
+
   .m-swings-view__description {
     padding-left: 1.75rem;
   }
+
   .m-swings-view__table-container {
     padding-left: 0rem;
     padding-right: 0rem;
   }
+
   .m-swings-view__table-header-cell {
     &.m-swings-view__table-header-cell-swing-off {
       padding-left: 3rem;
     }
+
     &.m-swings-view__table-header-cell-swing-on {
       padding-left: 1.5625rem;
     }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,5 +1,6 @@
 $non-mobile-min-width: 768px;
 $mobile-max-width: $non-mobile-min-width - 1;
+$mobile-portrait-max-width: 480px;
 $tab-bar-width: 3rem;
 $drawer-tab-width: 2rem;
 $route-picker-width: 21.875rem;

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -59,6 +59,7 @@
   margin-top: 1rem;
   min-height: 320px;
   z-index: 9;
+
   .m-vehicle-map {
     flex: 1 0 auto;
   }
@@ -70,6 +71,7 @@
 
 .m-vehicle-properties-panel__data-discrepancy-source-id {
   font-style: italic;
+
   &::after {
     content: ": ";
   }

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -59,7 +59,6 @@
   margin-top: 1rem;
   min-height: 320px;
   z-index: 9;
-
   .m-vehicle-map {
     flex: 1 0 auto;
   }
@@ -71,7 +70,6 @@
 
 .m-vehicle-properties-panel__data-discrepancy-source-id {
   font-style: italic;
-
   &::after {
     content: ": ";
   }

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -21,28 +21,32 @@ const MobilePortraitNav = ({
 
   const isViewOpen = openView !== OpenView.None || selectedVehicleOrGhost
 
+  const navVisibilityStyle = isViewOpen ? "hidden" : "visible"
+
   return (
     <div className="m-nav--narrow">
-      <div className="m-nav__nav-bar m-nav__nav-bar--top">
-        {!isViewOpen && (
-          <TopNavMobile
-            toggleMobileMenu={() => dispatch(toggleMobileMenu())}
-            openNotificationDrawer={() => dispatch(openNotificationDrawer())}
-            routeTabs={routeTabs}
-            mobileMenuIsOpen={mobileMenuIsOpen}
-          />
-        )}
+      <div
+        className="m-nav__nav-bar m-nav__nav-bar--top"
+        style={{ visibility: navVisibilityStyle }}
+      >
+        <TopNavMobile
+          toggleMobileMenu={() => dispatch(toggleMobileMenu())}
+          openNotificationDrawer={() => dispatch(openNotificationDrawer())}
+          routeTabs={routeTabs}
+          mobileMenuIsOpen={mobileMenuIsOpen}
+        />
       </div>
 
       <div className="m-nav__app-content">{children}</div>
 
-      <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
-        {!isViewOpen && (
-          <BottomNavMobile
-            mobileMenuIsOpen={mobileMenuIsOpen}
-            openSwingsView={() => dispatch(openSwingsView())}
-          />
-        )}
+      <div
+        className="m-nav__nav-bar m-nav__nav-bar--bottom"
+        style={{ visibility: navVisibilityStyle }}
+      >
+        <BottomNavMobile
+          mobileMenuIsOpen={mobileMenuIsOpen}
+          openSwingsView={() => dispatch(openSwingsView())}
+        />
       </div>
     </div>
   )

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -19,33 +19,33 @@ const MobilePortraitNav = ({
   const { mobileMenuIsOpen, routeTabs, openView, selectedVehicleOrGhost } =
     state
 
-  if (openView !== OpenView.None || selectedVehicleOrGhost) {
-    return (
-      <div className="m-nav--narrow m-nav--covered">
-        <div className="m-nav__app-content">{children}</div>
-      </div>
-    )
-  } else {
-    return (
-      <div className="m-nav--narrow">
-        <div className="m-nav__nav-bar m-nav__nav-bar--top">
+  const isViewOpen = openView !== OpenView.None || selectedVehicleOrGhost
+
+  return (
+    <div className="m-nav--narrow">
+      <div className="m-nav__nav-bar m-nav__nav-bar--top">
+        {!isViewOpen && (
           <TopNavMobile
             toggleMobileMenu={() => dispatch(toggleMobileMenu())}
             openNotificationDrawer={() => dispatch(openNotificationDrawer())}
             routeTabs={routeTabs}
             mobileMenuIsOpen={mobileMenuIsOpen}
           />
-        </div>
-        <div className="m-nav__app-content">{children}</div>
-        <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
+        )}
+      </div>
+
+      <div className="m-nav__app-content">{children}</div>
+
+      <div className="m-nav__nav-bar m-nav__nav-bar--bottom">
+        {!isViewOpen && (
           <BottomNavMobile
             mobileMenuIsOpen={mobileMenuIsOpen}
             openSwingsView={() => dispatch(openSwingsView())}
           />
-        </div>
+        )}
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 export default MobilePortraitNav

--- a/assets/tests/components/nav/mobilePortraitNav.test.tsx
+++ b/assets/tests/components/nav/mobilePortraitNav.test.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { render } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
 import MobilePortraitNav from "../../../src/components/nav/mobilePortraitNav"
 import { StateDispatchProvider } from "../../../src/contexts/stateDispatchContext"
 import { initialState, OpenView } from "../../../src/state"
@@ -17,8 +19,8 @@ describe("MobilePortraitNav", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.queryByTitle("Swings View")).not.toBeNull()
-    expect(result.queryByTitle("Notifications")).not.toBeNull()
+    expect(result.queryByTitle("Swings View")).toBeVisible()
+    expect(result.queryByTitle("Notifications")).toBeVisible()
   })
 
   test("doesn't render top / bottom nav when a view is open", () => {
@@ -34,8 +36,8 @@ describe("MobilePortraitNav", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.queryByTitle("Swings View")).toBeNull()
-    expect(result.queryByTitle("Notifications")).toBeNull()
+    expect(result.queryByTitle("Swings View")).not.toBeVisible()
+    expect(result.queryByTitle("Notifications")).not.toBeVisible()
   })
 
   test("doesn't render top / bottom nav when a vehicle is selected", () => {
@@ -54,8 +56,8 @@ describe("MobilePortraitNav", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.queryByTitle("Swings View")).toBeNull()
-    expect(result.queryByTitle("Notifications")).toBeNull()
+    expect(result.queryByTitle("Swings View")).not.toBeVisible()
+    expect(result.queryByTitle("Notifications")).not.toBeVisible()
   })
 
   test("doesn't render top / bottom nav when notification drawer is open", () => {
@@ -74,7 +76,7 @@ describe("MobilePortraitNav", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.queryByTitle("Swings View")).toBeNull()
-    expect(result.queryByTitle("Notifications")).toBeNull()
+    expect(result.queryByTitle("Swings View")).not.toBeVisible()
+    expect(result.queryByTitle("Notifications")).not.toBeVisible()
   })
 })


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1202946731207901/f

The issue seemed to be that when opening the VPP, the page was rendered with a new grid, which seemed to reset the scroll position of the ladder page. 

I'm not sure that the approach I've taken here is the cleanest one. My intention was to fix the issue without having to introduce storing the scroll position in state. By using one grid class and conditionally hiding the top / bottom navs, the scroll reset issue is no longer a problem. If there is a cleaner or more conventional approach here I am certainly open to changing!

I also wasn't sure of the best way to introduce a regression test for this - there is already test coverage to make sure the navs are conditionally shown / hidden, but maintaining scroll position seems like it might require using something like Cypress.