### PR TITLE
chore(Sentry): configure allowed domains

### DIFF
--- a/assets/src/helpers/sentryInit.ts
+++ b/assets/src/helpers/sentryInit.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react"
 interface sentryOptions {
   dsn?: string
   environment?: string
+  allowUrls?: Array<string | RegExp>
 }
 
 const sentryInit = (

--- a/assets/tests/helpers/sentryInit.test.ts
+++ b/assets/tests/helpers/sentryInit.test.ts
@@ -9,6 +9,7 @@ jest.mock("@sentry/react", () => ({
 
 const opts = {
   environment: "test_env",
+  allowedUrls: ["url1", "url2"],
 }
 
 const username = "test_username"

--- a/lib/skate_web/templates/layout/_sentry.html.eex
+++ b/lib/skate_web/templates/layout/_sentry.html.eex
@@ -2,5 +2,6 @@
   window.sentry = {
     dsn: "<%= Application.get_env(:skate, :sentry_frontend_dsn) %>",
     environment: "<%= Application.get_env(:skate, :sentry_environment) %>"
+    allowUrls: ["skate.mbtace.com", "skate-*.mbtace.com"]
   }
 </script>

--- a/lib/skate_web/templates/layout/_sentry.html.eex
+++ b/lib/skate_web/templates/layout/_sentry.html.eex
@@ -1,7 +1,7 @@
 <script>
   window.sentry = {
     dsn: "<%= Application.get_env(:skate, :sentry_frontend_dsn) %>",
-    environment: "<%= Application.get_env(:skate, :sentry_environment) %>"
+    environment: "<%= Application.get_env(:skate, :sentry_environment) %>",
     allowUrls: ["skate.mbtace.com", "skate-*.mbtace.com"]
   }
 </script>

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -77,6 +77,15 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
+    test "sentry allowed urls set", %{conn: conn} do
+      reassign_env(:skate, :record_sentry, true)
+      conn = get(conn, "/")
+
+      assert html_response(conn, 200) =~
+               "allowUrls: [\"skate.mbtace.com\", \"skate-*.mbtace.com\"]"
+    end
+
+    @tag :authenticated
     test "correct clarity tag set", %{conn: conn} do
       reassign_env(:skate, :clarity_tag, "test_tag")
 


### PR DESCRIPTION
ticket: https://app.asana.com/0/1152340551558956/1202640449465629/f

To test, I deployed to dev-blue with a simple button that would raise an exception on click. Confirmed that [the error was recorded in sentry](https://sentry.io/organizations/mbtace/issues/3583902693/?environment=dev-blue&project=5303927) as expected. 

It seems that with this approach of configuring `allowedUrls` it could be possible to configure a different list of `allowUrls` per environment. I'm not whether it is worth adding that extra configuration - an error from `skate.mbtace.com` showing up while a user is on `skate-dev.mbtace.com` seems unlikely to me, but I may be misunderstanding something there and can add the configuration per-environment if desired.