### PR TITLE
feat: Save user email on login

### DIFF
--- a/lib/report/user_names_and_uuids.ex
+++ b/lib/report/user_names_and_uuids.ex
@@ -15,7 +15,8 @@ defmodule Report.UserNamesAndUuids do
      from(u in DbUser,
        select: %{
          "username" => u.username,
-         "uuid" => u.uuid
+         "uuid" => u.uuid,
+         "email" => u.email
        }
      )
      |> Skate.Repo.all()}

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -12,6 +12,7 @@ defmodule Skate.Settings.Db.User do
   schema "users" do
     field(:username, :string)
     field(:uuid, :binary_id)
+    field(:email, :string)
     has_one(:user_settings, DbUserSettings)
     timestamps()
 
@@ -24,7 +25,8 @@ defmodule Skate.Settings.Db.User do
     user
     |> cast(attrs, [
       :id,
-      :username
+      :username,
+      :email
     ])
     |> cast_assoc(:route_tabs, with: &DbRouteTab.changeset/2)
     |> validate_required([

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -51,7 +51,7 @@ defmodule Skate.Settings.RouteTab do
       Enum.filter(route_tabs, fn route_tab -> is_nil(route_tab.save_changes_to_tab_uuid) end)
 
     username
-    |> User.get_or_create()
+    |> User.get()
     |> Repo.preload(:route_tabs)
     |> DbUser.changeset(%{route_tabs: Enum.map(unmodified_route_tabs, &Map.from_struct/1)})
     |> Repo.update!()

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -3,7 +3,11 @@ defmodule Skate.Settings.User do
 
   import Ecto.Query
 
-  def get_or_create(username) do
+  def get(username) do
+    Skate.Repo.get_by!(DbUser, username: username)
+  end
+
+  def upsert(username) do
     user =
       Skate.Repo.insert!(
         DbUser.changeset(%DbUser{}, %{username: username}),

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -2,20 +2,57 @@ defmodule Skate.Settings.User do
   alias Skate.Settings.Db.User, as: DbUser
 
   import Ecto.Query
+  require Logger
 
+  @spec get(String.t()) :: DbUser.t()
+  @doc """
+  Get a user by their username
+  """
   def get(username) do
     Skate.Repo.get_by!(DbUser, username: username)
   end
 
-  def upsert(username) do
+  @spec get_by_email(String.t()) :: DbUser.t() | nil
+  @doc """
+  Get a user with the matching email, if one exists
+  """
+  def get_by_email(email) do
+    Skate.Repo.get_by(DbUser, email: email)
+  end
+
+  @spec upsert(username :: String.t(), email :: String.t()) :: DbUser.t()
+  def upsert(username, email) do
+    userMatchingEmail = get_by_email(email)
+
     user =
-      Skate.Repo.insert!(
-        DbUser.changeset(%DbUser{}, %{username: username}),
-        returning: true,
-        conflict_target: [:username],
-        # update a row with no effect so the returning works
-        on_conflict: {:replace, [:username]}
-      )
+      cond do
+        is_nil(userMatchingEmail) ->
+          Skate.Repo.insert!(
+            DbUser.changeset(%DbUser{}, %{
+              username: username,
+              email: email
+            }),
+            returning: true,
+            conflict_target: [:username],
+            on_conflict: {:replace, [:email]}
+          )
+
+        # existing user has same username - no update needed
+        userMatchingEmail.username == username ->
+          userMatchingEmail
+
+        # username format has changed. Create a new record for this user without an associated email
+        # This record will be used only temporarily until user settings are universally fetched by email.
+        userMatchingEmail.username != username ->
+          Skate.Repo.insert!(
+            DbUser.changeset(%DbUser{}, %{
+              username: username
+            }),
+            returning: true,
+            conflict_target: [:username],
+            on_conflict: {:replace, [:email]}
+          )
+      end
 
     if is_nil(user.uuid) do
       user |> Ecto.Changeset.change(%{uuid: Ecto.UUID.generate()}) |> Skate.Repo.update!()

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -54,7 +54,8 @@ defmodule Skate.Settings.User do
             }),
             returning: true,
             conflict_target: [:username],
-            on_conflict: {:replace, [:email]}
+            # update a row with no effect so the returning works
+            on_conflict: {:replace, [:username]}
           )
       end
 

--- a/lib/skate/settings/user_settings.ex
+++ b/lib/skate/settings/user_settings.ex
@@ -30,7 +30,7 @@ defmodule Skate.Settings.UserSettings do
 
   @spec get_or_create(String.t()) :: t()
   def get_or_create(username) do
-    user = User.get_or_create(username)
+    user = User.get(username)
 
     user_settings =
       insert!(

--- a/lib/skate/ueberauth/strategy/fake.ex
+++ b/lib/skate/ueberauth/strategy/fake.ex
@@ -34,7 +34,7 @@ defmodule Skate.Ueberauth.Strategy.Fake do
 
   @impl Ueberauth.Strategy
   def info(_conn) do
-    %Ueberauth.Auth.Info{}
+    %Ueberauth.Auth.Info{email: "fake@email.com"}
   end
 
   @impl Ueberauth.Strategy

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -2,6 +2,7 @@ defmodule SkateWeb.AuthController do
   use SkateWeb, :controller
   plug(Ueberauth)
 
+  alias Skate.Settings.User
   alias SkateWeb.AuthManager
   alias SkateWeb.Router.Helpers
 
@@ -11,6 +12,8 @@ defmodule SkateWeb.AuthController do
     expiration = credentials.expires_at
 
     current_time = System.system_time(:second)
+
+    User.upsert(username)
 
     conn
     |> Guardian.Plug.sign_in(

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -8,12 +8,13 @@ defmodule SkateWeb.AuthController do
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     username = auth.uid
+    email = auth.info.email
     credentials = auth.credentials
     expiration = credentials.expires_at
 
     current_time = System.system_time(:second)
 
-    User.upsert(username)
+    User.upsert(username, email)
 
     conn
     |> Guardian.Plug.sign_in(

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -12,7 +12,7 @@ defmodule SkateWeb.PageController do
     username = AuthManager.Plug.current_resource(conn)
     _ = Logger.info("uid=#{username}")
 
-    user = User.get_or_create(username)
+    user = User.get(username)
     user_settings = UserSettings.get_or_create(username)
     route_tabs = RouteTab.get_all_for_user(username)
 

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -9,9 +9,8 @@ defmodule Notifications.NotificationServerTest do
   alias Realtime.BlockWaiver
   alias Realtime.Ghost
   alias Realtime.Vehicle
-  alias Skate.Repo
-  alias Skate.Settings.Db.User, as: DbUser
   alias Skate.Settings.RouteTab
+  alias Skate.Settings.User
 
   import Ecto.Query
   import ExUnit.CaptureLog, only: [capture_log: 2]
@@ -267,6 +266,7 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["39"]
         })
 
+      User.upsert("fake_uid")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
       :ok
     end
@@ -335,14 +335,13 @@ defmodule Notifications.NotificationServerTest do
     end
 
     test "doesn't send notifications to a user not looking at the route in question" do
-      Repo.delete_all(from(DbUser))
-
       route_tab1 =
         build(:route_tab, %{
           preset_name: "some routes",
           selected_route_ids: ["1", "83", "77"]
         })
 
+      User.upsert("fake_uid")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
 
       set_log_level(:info)
@@ -422,8 +421,6 @@ defmodule Notifications.NotificationServerTest do
     test "broadcasts, saves to the DB, and logs new notifications for users looking at routes affected by the Chelsea drawbridge when bridge is lowered" do
       {:ok, server} = setup_server()
 
-      Repo.delete_all(from(DbUser))
-
       set_log_level(:info)
 
       for i <- Range.new(0, length(@chelsea_bridge_route_ids) - 1) do
@@ -436,6 +433,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
+        User.upsert(uid)
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 
@@ -464,8 +462,6 @@ defmodule Notifications.NotificationServerTest do
     test "broadcasts, saves to the DB, and logs new notifications for users looking at routes affected by the Chelsea drawbridge when bridge is raised" do
       {:ok, server} = setup_server()
 
-      Repo.delete_all(from(DbUser))
-
       set_log_level(:info)
 
       for i <- Range.new(0, length(@chelsea_bridge_route_ids) - 1) do
@@ -478,6 +474,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
+        User.upsert(uid)
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 
@@ -517,14 +514,13 @@ defmodule Notifications.NotificationServerTest do
     test "doesn't send notifications to a user not looking at the Chelsea bridge routes" do
       {:ok, server} = setup_server()
 
-      Repo.delete_all(from(DbUser))
-
       route_tab1 =
         build(:route_tab, %{
           preset_name: "some routes",
           selected_route_ids: ["1", "83", "77"]
         })
 
+      User.upsert("fake_uid")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
 
       set_log_level(:info)
@@ -556,8 +552,6 @@ defmodule Notifications.NotificationServerTest do
     test "doesn't log or save a notification within a blackout period after one was created, but does broadcast" do
       {:ok, server} = setup_server()
 
-      Repo.delete_all(from(DbUser))
-
       set_log_level(:info)
 
       for i <- Range.new(0, length(@chelsea_bridge_route_ids) - 1) do
@@ -570,6 +564,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
+        User.upsert(uid)
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -266,7 +266,7 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["39"]
         })
 
-      User.upsert("fake_uid")
+      User.upsert("fake_uid", "fakeemail@test.com")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
       :ok
     end
@@ -341,7 +341,7 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["1", "83", "77"]
         })
 
-      User.upsert("fake_uid")
+      User.upsert("fake_uid", "fakeemail@test.com")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
 
       set_log_level(:info)
@@ -433,7 +433,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid)
+        User.upsert(uid, "#{uid}@test.com")
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 
@@ -474,7 +474,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid)
+        User.upsert(uid, "#{uid}@test.com")
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 
@@ -520,7 +520,7 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["1", "83", "77"]
         })
 
-      User.upsert("fake_uid")
+      User.upsert("fake_uid", "fake_uid@test.com")
       RouteTab.update_all_for_user!("fake_uid", [route_tab1])
 
       set_log_level(:info)
@@ -564,7 +564,7 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid)
+        User.upsert(uid, "#{uid}@test.com")
         RouteTab.update_all_for_user!(uid, [route_tab1])
       end
 

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -14,9 +14,9 @@ defmodule Notifications.NotificationTest do
 
   describe "get_or_create_from_block_waiver/1" do
     test "associates a new notification with users subscribed to an affected route" do
-      user1 = User.upsert("user1")
-      user2 = User.upsert("user2")
-      User.upsert("user3")
+      user1 = User.upsert("user1", "user1@test.com")
+      user2 = User.upsert("user2", "user2@test.com")
+      User.upsert("user3", "user3@test.com")
 
       route_tab1 =
         build(:route_tab, %{
@@ -70,8 +70,8 @@ defmodule Notifications.NotificationTest do
 
   describe "unexpired_notifications_for_user/2" do
     test "returns all unexpired notifications for the given user, in chronological order by creation timestamp" do
-      User.upsert("user1")
-      User.upsert("user2")
+      User.upsert("user1", "user1@test.com")
+      User.upsert("user2", "user2@test.com")
       baseline_time = 1_000_000_000
       now_fn = fn -> baseline_time end
       naive_now_fn = fn -> baseline_time |> DateTime.from_unix!() |> DateTime.to_naive() end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -14,9 +14,9 @@ defmodule Notifications.NotificationTest do
 
   describe "get_or_create_from_block_waiver/1" do
     test "associates a new notification with users subscribed to an affected route" do
-      user1 = User.get_or_create("user1")
-      user2 = User.get_or_create("user2")
-      User.get_or_create("user3")
+      user1 = User.upsert("user1")
+      user2 = User.upsert("user2")
+      User.upsert("user3")
 
       route_tab1 =
         build(:route_tab, %{
@@ -70,6 +70,8 @@ defmodule Notifications.NotificationTest do
 
   describe "unexpired_notifications_for_user/2" do
     test "returns all unexpired notifications for the given user, in chronological order by creation timestamp" do
+      User.upsert("user1")
+      User.upsert("user2")
       baseline_time = 1_000_000_000
       now_fn = fn -> baseline_time end
       naive_now_fn = fn -> baseline_time |> DateTime.from_unix!() |> DateTime.to_naive() end

--- a/test/report/user_names_and_uuids_test.exs
+++ b/test/report/user_names_and_uuids_test.exs
@@ -14,7 +14,8 @@ defmodule Report.UserNamesAndUuidsTest do
       assert result == [
                %{
                  "username" => username,
-                 "uuid" => user.uuid
+                 "uuid" => user.uuid,
+                 "email" => user.email
                }
              ]
     end

--- a/test/report/user_names_and_uuids_test.exs
+++ b/test/report/user_names_and_uuids_test.exs
@@ -7,7 +7,7 @@ defmodule Report.UserNamesAndUuidsTest do
     test "returns database contents" do
       username = "username"
 
-      user = User.upsert(username)
+      user = User.upsert(username, "user@test.com")
 
       {:ok, result} = Report.UserNamesAndUuids.run()
 

--- a/test/report/user_names_and_uuids_test.exs
+++ b/test/report/user_names_and_uuids_test.exs
@@ -7,7 +7,7 @@ defmodule Report.UserNamesAndUuidsTest do
     test "returns database contents" do
       username = "username"
 
-      user = User.get_or_create(username)
+      user = User.upsert(username)
 
       {:ok, result} = Report.UserNamesAndUuids.run()
 

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -18,8 +18,8 @@ defmodule Skate.Settings.RouteTabTest do
       route_tab1 = build_test_tab()
       route_tab2 = build_test_tab()
 
-      User.upsert("user1")
-      User.upsert("user2")
+      User.upsert("user1", "user1@test.com")
+      User.upsert("user2", "user2@test.com")
 
       RouteTab.update_all_for_user!("user1", [route_tab1])
       RouteTab.update_all_for_user!("user2", [route_tab2])
@@ -37,7 +37,7 @@ defmodule Skate.Settings.RouteTabTest do
 
   describe "update_all_for_user!/2" do
     setup do
-      User.upsert("charlie")
+      User.upsert("charlie", "charlie@test.com")
       :ok
     end
 

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -2,6 +2,7 @@ defmodule Skate.Settings.RouteTabTest do
   use Skate.DataCase
   import Skate.Factory
   alias Skate.Settings.RouteTab
+  alias Skate.Settings.User
 
   def build_test_tab() do
     build(:route_tab, %{
@@ -16,6 +17,9 @@ defmodule Skate.Settings.RouteTabTest do
     test "retrieves route tabs by username" do
       route_tab1 = build_test_tab()
       route_tab2 = build_test_tab()
+
+      User.upsert("user1")
+      User.upsert("user2")
 
       RouteTab.update_all_for_user!("user1", [route_tab1])
       RouteTab.update_all_for_user!("user2", [route_tab2])
@@ -32,6 +36,11 @@ defmodule Skate.Settings.RouteTabTest do
   end
 
   describe "update_all_for_user!/2" do
+    setup do
+      User.upsert("charlie")
+      :ok
+    end
+
     test "adds a new tab entry" do
       route_tab = build_test_tab()
 

--- a/test/skate/settings/user_settings_test.exs
+++ b/test/skate/settings/user_settings_test.exs
@@ -3,20 +3,18 @@ defmodule Skate.Settings.UserSettingsTest do
 
   import Skate.Repo
 
+  alias Skate.Settings.User
   alias Skate.Settings.UserSettings
-  alias Skate.Settings.Db.User, as: DbUser
   alias Skate.Settings.Db.UserSettings, as: DbUserSettings
 
+  @username "username"
+
+  setup do
+    {:ok, %{user: User.upsert(@username)}}
+  end
+
   describe "get_or_create" do
-    test "gets settings for an existing user" do
-      username = "username"
-
-      user =
-        insert!(
-          DbUser.changeset(%DbUser{}, %{username: username}),
-          returning: true
-        )
-
+    test "gets settings for an existing user", %{user: user} do
       insert!(
         DbUserSettings.changeset(%DbUserSettings{}, %{
           user_id: user.id,
@@ -27,7 +25,7 @@ defmodule Skate.Settings.UserSettingsTest do
         returning: true
       )
 
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(@username)
 
       assert result == %UserSettings{
                ladder_page_vehicle_label: :vehicle_id,
@@ -37,8 +35,7 @@ defmodule Skate.Settings.UserSettingsTest do
     end
 
     test "for a new user, initializes and stores the default settings" do
-      username = "username"
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(@username)
 
       assert result == %UserSettings{
                ladder_page_vehicle_label: :run_id,
@@ -48,7 +45,9 @@ defmodule Skate.Settings.UserSettingsTest do
 
       # created data for the new user
       assert [user_id] =
-               Repo.all(from(user in "users", where: user.username == ^username, select: user.id))
+               Repo.all(
+                 from(user in "users", where: user.username == ^@username, select: user.id)
+               )
 
       assert [^user_id] =
                Repo.all(
@@ -59,10 +58,9 @@ defmodule Skate.Settings.UserSettingsTest do
 
   describe "set" do
     test "can set a setting" do
-      username = "username"
-      UserSettings.get_or_create(username)
-      UserSettings.set(username, :ladder_page_vehicle_label, :vehicle_id)
-      result = UserSettings.get_or_create(username)
+      UserSettings.get_or_create(@username)
+      UserSettings.set(@username, :ladder_page_vehicle_label, :vehicle_id)
+      result = UserSettings.get_or_create(@username)
       assert result.ladder_page_vehicle_label == :vehicle_id
     end
   end

--- a/test/skate/settings/user_settings_test.exs
+++ b/test/skate/settings/user_settings_test.exs
@@ -8,9 +8,10 @@ defmodule Skate.Settings.UserSettingsTest do
   alias Skate.Settings.Db.UserSettings, as: DbUserSettings
 
   @username "username"
+  @email "user@test.com"
 
   setup do
-    {:ok, %{user: User.upsert(@username)}}
+    {:ok, %{user: User.upsert(@username, @email)}}
   end
 
   describe "get_or_create" do

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -4,13 +4,28 @@ defmodule Skate.Settings.UserTest do
   alias Skate.Settings.User
   alias Skate.Settings.Db.User, as: DbUser
 
-  describe "get_or_create/1" do
+  describe "get/1" do
+    test "gets user by email" do
+      username = "username"
+
+      Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: username}))
+      Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: "otheruser"}))
+
+      assert %DbUser{username: ^username} = User.get(username)
+    end
+
+    test "raises if user not found" do
+      assert_raise Ecto.NoResultsError, fn -> User.get("missinguser") end
+    end
+  end
+
+  describe "upsert/1" do
     test "assigns a UUID if none is present" do
       username = "username"
 
       Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: username}))
 
-      user = User.get_or_create(username)
+      user = User.upsert(username)
 
       refute is_nil(user.uuid)
     end
@@ -18,9 +33,9 @@ defmodule Skate.Settings.UserTest do
     test "keeps old UUID if present" do
       username = "username"
 
-      user = User.get_or_create(username)
+      user = User.upsert(username)
 
-      new_user = User.get_or_create(username)
+      new_user = User.upsert(username)
 
       assert user.uuid == new_user.uuid
     end

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -19,6 +19,26 @@ defmodule Skate.Settings.UserTest do
     end
   end
 
+  describe "get_by/1" do
+    test "returns nil if no match" do
+      assert nil == User.get_by_email("missingemail@test.com")
+    end
+
+    test "returns exact matching email" do
+      username = "user1"
+      email = "user1@test.com"
+      User.upsert(username, email)
+      assert %{username: ^username, email: ^email} = User.get_by_email(email)
+    end
+
+    test "matches ignoring case" do
+      username = "user1"
+      email = "user1@test.com"
+      User.upsert(username, email)
+      assert %{username: ^username, email: ^email} = User.get_by_email(String.capitalize(email))
+    end
+  end
+
   describe "upsert/1" do
     test "assigns a UUID if none is present" do
       Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: @username}))
@@ -40,6 +60,14 @@ defmodule Skate.Settings.UserTest do
       Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: @username}))
 
       user = User.upsert(@username, @email)
+      assert length(Skate.Repo.all(DbUser)) == 1
+      assert user.email == @email
+    end
+
+    test "downcases email" do
+      Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: @username}))
+
+      user = User.upsert(@username, String.capitalize(@email))
       assert length(Skate.Repo.all(DbUser)) == 1
       assert user.email == @email
     end

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -19,7 +19,7 @@ defmodule Skate.Settings.UserTest do
     end
   end
 
-  describe "get_by/1" do
+  describe "get_by_email/1" do
     test "returns nil if no match" do
       assert nil == User.get_by_email("missingemail@test.com")
     end
@@ -81,13 +81,13 @@ defmodule Skate.Settings.UserTest do
     end
 
     test "if email address is associated with existing user that has different username, creates new user without email" do
-      originalUser = User.upsert(@username, @email)
+      original_user = User.upsert(@username, @email)
 
-      newUser = User.upsert("newusername", @email)
+      new_user = User.upsert("newusername", @email)
 
-      assert %{username: @username, email: @email} = originalUser
-      assert %{username: "newusername", email: nil} = newUser
-      refute is_nil(newUser.uuid)
+      assert %{username: @username, email: @email} = original_user
+      assert %{username: "newusername", email: nil} = new_user
+      refute is_nil(new_user.uuid)
     end
   end
 end

--- a/test/skate/ueberauth/strategy/fake_test.exs
+++ b/test/skate/ueberauth/strategy/fake_test.exs
@@ -16,7 +16,7 @@ defmodule Skate.Ueberauth.Strategy.FakeTest do
   end
 
   test "info returns an empty Info struct" do
-    assert Fake.info(%{}) == %Info{}
+    assert Fake.info(%{}) == %Info{email: "fake@email.com"}
   end
 
   test "extra returns an Extra struct with empty raw_info" do

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule SkateWeb.AuthControllerTest do
   use SkateWeb.ConnCase
+  alias Skate.Settings.User
 
   describe "GET /auth/:provider" do
     test "redirects to the callback", %{conn: conn} do
@@ -12,12 +13,13 @@ defmodule SkateWeb.AuthControllerTest do
   describe "GET /auth/:provider/callback" do
     test "redirects to the index page for an ueberauth auth", %{conn: conn} do
       mock_auth = %Ueberauth.Auth{
-        uid: "test@mbta.com",
+        uid: "test_username",
         credentials: %Ueberauth.Auth.Credentials{
           expires_at: System.system_time(:second) + 1_000,
           refresh_token: "test_refresh_token",
           other: %{groups: ["test1"]}
-        }
+        },
+        info: %{email: "test@mbta.com"}
       }
 
       conn =
@@ -29,10 +31,28 @@ defmodule SkateWeb.AuthControllerTest do
       assert Guardian.Plug.current_claims(conn)["groups"] == ["test1"]
     end
 
+    test "creates user record if it doesn't already exist", %{conn: conn} do
+      mock_auth = %Ueberauth.Auth{
+        uid: "test_username",
+        credentials: %Ueberauth.Auth.Credentials{
+          expires_at: System.system_time(:second) + 1_000,
+          refresh_token: "test_refresh_token",
+          other: %{groups: ["test1"]}
+        },
+        info: %{email: "test@mbta.com"}
+      }
+
+      conn
+      |> assign(:ueberauth_auth, mock_auth)
+      |> get("/auth/cognito/callback")
+
+      assert %{username: "test_username", email: "test@mbta.com"} = User.get("test_username")
+    end
+
     test "redirects home for an ueberauth failure", %{conn: conn} do
       conn =
         conn
-        |> init_test_session(%{username: "test@mbta.com"})
+        |> init_test_session(%{username: "test_username"})
         |> assign(:ueberauth_failure, "failed")
         |> get("/auth/cognito/callback")
 

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -25,7 +25,7 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
       route_tab1 = build_test_tab()
       RouteTab.update_all_for_user!(username, [route_tab1])
 
-      User.upsert("otheruser")
+      User.upsert("otheruser", "other@email.com")
       route_tab2 = build_test_tab()
       RouteTab.update_all_for_user!("otheruser", [route_tab2])
 

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.NotificationReadStatesControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
   import Skate.Factory
   alias Notifications.Notification
   alias Notifications.Db.NotificationUser, as: DbNotificationUser
@@ -22,11 +21,11 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
       conn: conn,
       user: username
     } do
-      user = User.get_or_create(username)
+      user = User.get(username)
       route_tab1 = build_test_tab()
       RouteTab.update_all_for_user!(username, [route_tab1])
 
-      User.get_or_create("otheruser")
+      User.upsert("otheruser")
       route_tab2 = build_test_tab()
       RouteTab.update_all_for_user!("otheruser", [route_tab2])
 

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.PageControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
   import Skate.Factory
   import Test.Support.Helpers
 
@@ -100,7 +99,7 @@ defmodule SkateWeb.PageControllerTest do
 
     @tag :authenticated
     test "includes UUID in HTML", %{conn: conn, user: user} do
-      user_struct = Skate.Settings.User.get_or_create(user)
+      user_struct = Skate.Settings.User.get(user)
 
       conn = get(conn, "/")
 

--- a/test/skate_web/controllers/report_controller_test.exs
+++ b/test/skate_web/controllers/report_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.ReportControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
 
   alias Skate.Settings.Db.User, as: DbUser
   alias Skate.Settings.Db.UserSettings, as: DbUserSettings

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.RouteTabsControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
 
   alias Skate.Settings.RouteTab
 

--- a/test/skate_web/controllers/swing_controller_test.exs
+++ b/test/skate_web/controllers/swing_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.SwingsControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
   import Test.Support.Helpers
 
   alias Schedule.Swing

--- a/test/skate_web/controllers/user_settings_controller_test.exs
+++ b/test/skate_web/controllers/user_settings_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.UserSettingsControllerTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
 
   alias Skate.Settings.UserSettings
 

--- a/test/skate_web/router_test.exs
+++ b/test/skate_web/router_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.RouterTest do
   use SkateWeb.ConnCase
-  use Skate.DataCase
 
   describe "GET /" do
     @tag :authenticated

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,6 +32,8 @@ defmodule SkateWeb.ConnCase do
   setup tags do
     alias Ecto.Adapters.SQL.Sandbox
     :ok = Sandbox.checkout(Skate.Repo)
+    username = "test_user"
+    email = "test_user@test.com"
 
     unless tags[:async] do
       Sandbox.mode(Skate.Repo, {:shared, self()})
@@ -40,39 +42,38 @@ defmodule SkateWeb.ConnCase do
     {conn, user} =
       cond do
         tags[:authenticated] ->
-          user = "test_user"
-          User.upsert(user)
+          User.upsert(username, email)
 
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user, %{})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{})
 
-          {conn, user}
+          {conn, username}
 
         tags[:authenticated_admin] ->
-          user = "test_user"
-          User.upsert(user)
+          User.upsert(username, email)
 
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user, %{"groups" => ["skate-admin"]})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
+              "groups" => ["skate-admin"]
+            })
 
-          {conn, user}
+          {conn, username}
 
         tags[:authenticated_dispatcher] ->
-          user = "test_user"
-          User.upsert(user)
+          User.upsert(username, email)
 
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user, %{
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
               "groups" => ["skate-dispatcher"]
             })
 
-          {conn, user}
+          {conn, username}
 
         true ->
           {Phoenix.ConnTest.build_conn(), nil}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,7 @@ defmodule SkateWeb.ConnCase do
 
   use ExUnit.CaseTemplate
   import Plug.Test
+  alias Skate.Settings.User
 
   using do
     quote do
@@ -29,10 +30,18 @@ defmodule SkateWeb.ConnCase do
   end
 
   setup tags do
+    alias Ecto.Adapters.SQL.Sandbox
+    :ok = Sandbox.checkout(Skate.Repo)
+
+    unless tags[:async] do
+      Sandbox.mode(Skate.Repo, {:shared, self()})
+    end
+
     {conn, user} =
       cond do
         tags[:authenticated] ->
           user = "test_user"
+          User.upsert(user)
 
           conn =
             Phoenix.ConnTest.build_conn()
@@ -43,6 +52,7 @@ defmodule SkateWeb.ConnCase do
 
         tags[:authenticated_admin] ->
           user = "test_user"
+          User.upsert(user)
 
           conn =
             Phoenix.ConnTest.build_conn()
@@ -53,6 +63,7 @@ defmodule SkateWeb.ConnCase do
 
         tags[:authenticated_dispatcher] ->
           user = "test_user"
+          User.upsert(user)
 
           conn =
             Phoenix.ConnTest.build_conn()


### PR DESCRIPTION
ticket: https://app.asana.com/0/1152340551558956/1201189412881312/f

This moves the logic for creating/updating user records into the login flow and adds functionality for saving the user's email.