### PR TITLE
fix(Map): controls not blocked by iphone 'notch' in mobile landscape

### DIFF
--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -3,6 +3,10 @@
   height: 100%;
 }
 
+.leaflet-right {
+  padding-right: env(safe-area-inset-right);
+}
+
 .leaflet-bar.leaflet-control-zoom .leaflet-disabled {
   background-color: $color-button-disabled;
   color: $color-font-grey;

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.m-vehicle-properties-panel__location .m-vehicle-map .leaflet-right {
+  padding-right: calc(env(safe-area-inset-right) - #{$vpp-location-padding});
+}
+
 .m-vehicle-map__train-icon {
   fill: $white;
   stroke: $color-component-dark;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -7,6 +7,7 @@ $route-picker-width: 21.875rem;
 $mobile-route-picker-width: 18.125rem;
 $shuttle-picker-width: 12.6rem;
 $view-header-height: 2.5rem;
+$vpp-location-padding: 1rem;
 
 @import "base";
 @import "inter";

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -21,7 +21,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  padding: 1rem;
+  padding: $vpp-location-padding;
 }
 
 .m-vehicle-properties-panel__latlng {


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203057881715593/f

Note this adjusts the controls on mobile landscape whether the notch is on the left or righthand side. 

Tested using Xcode simulator on iphone 14 pro max