### PR TITLE
chore: clean up ordering of timepoints on the 22

### DIFF
--- a/data/timepoint_order.json
+++ b/data/timepoint_order.json
@@ -20,6 +20,10 @@
   "19": {
     "0": ["brlng", "louis", "hrugg", "rugg", "malcx", "nubn"]
   },
+  "22": {
+    "comment": "insert timepoints for outbound school trips at sensible locations",
+    "0": ["rugg", "malcx", "roxbs", "jasst", "egles", "svrhm", "latac", "ghall", "frnpk"]
+  },
   "23": {
     "comment": "malcx is a timepoint only for school trip short turns",
     "0": ["roxbs", "malcx", "nubn"]


### PR DESCRIPTION
Asana ticket: [🐞 Investigate route ladder timepoint order for routes 22, 28](https://app.asana.com/0/1148853526253437/1203010279695366/f)

The better understand how the `timepoint_order.json` file is used, see the `Schedule.TimepointOrder` module. Basically, it allows us to force a particular subset of the timepoints in one direction or another of a route to appear in a particular order. In this case the relevant trips are all outbound (direction 0), so that's the only direction we need to change.