### PR TITLE
feat: Bus stops added to the VPP

### DIFF
--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -73,6 +73,10 @@
   stroke-width: 1;
 }
 
+.m-vehicle-map__stop:focus {
+  outline: 0;
+}
+
 .m-vehicle-map__recenter-button {
   path {
     fill: none;

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -22,6 +22,7 @@ import {
   Marker,
   Polyline,
   TileLayer,
+  Tooltip,
   useMap,
   useMapEvents,
   ZoomControl,
@@ -228,7 +229,9 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
           className="m-vehicle-map__stop"
           center={[stop.lat, stop.lon]}
           radius={3}
-        />
+        >
+          <Tooltip className="m-vehicle-map__stop-tooltip">{stop.name}</Tooltip>
+        </CircleMarker>
       ))}
     </>
   )

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -21,8 +21,8 @@ import {
   MapContainer,
   Marker,
   Polyline,
+  Popup,
   TileLayer,
-  Tooltip,
   useMap,
   useMapEvents,
   ZoomControl,
@@ -230,7 +230,7 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
           center={[stop.lat, stop.lon]}
           radius={3}
         >
-          <Tooltip className="m-vehicle-map__stop-tooltip">{stop.name}</Tooltip>
+          <Popup className="m-vehicle-map__stop-tooltip">{stop.name}</Popup>
         </CircleMarker>
       ))}
     </>

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -142,6 +142,12 @@ defmodule Schedule do
     call_with_data(persistent_term_key, [trip_id], :shape_for_trip, nil)
   end
 
+  @spec shape_with_stops_for_trip(Trip.id(), persistent_term_key()) ::
+          Schedule.ShapeWithStops.t() | nil
+  def shape_with_stops_for_trip(trip_id, persistent_term_key \\ __MODULE__) do
+    call_with_data(persistent_term_key, [trip_id], :shape_with_stops_for_trip, nil)
+  end
+
   @spec first_route_pattern_for_route_and_direction(Route.id(), Direction.id()) ::
           RoutePattern.t() | nil
   @spec first_route_pattern_for_route_and_direction(

--- a/lib/schedule/shape_with_stops.ex
+++ b/lib/schedule/shape_with_stops.ex
@@ -1,0 +1,45 @@
+defmodule Schedule.ShapeWithStops do
+  @moduledoc """
+  The shape of a route pattern with all associated stops
+  """
+  alias Schedule.Gtfs.{Shape, Stop}
+
+  @type id :: String.t()
+
+  @type t :: %__MODULE__{
+          id: id(),
+          points: [Shape.Point.t()],
+          stops: [Stop.t()]
+        }
+
+  @enforce_keys [
+    :id,
+    :points,
+    :stops
+  ]
+
+  defimpl Jason.Encoder do
+    def encode(shape_with_stops, opts) do
+      stops_to_encode =
+        shape_with_stops
+        |> Map.get(:stops, [])
+        |> Enum.map(&%{id: &1.id, name: &1.name, lat: &1.latitude, lon: &1.longitude})
+
+      Jason.Encode.map(
+        %{id: shape_with_stops.id, points: shape_with_stops.points, stops: stops_to_encode},
+        opts
+      )
+    end
+  end
+
+  defstruct [
+    :id,
+    points: [],
+    stops: []
+  ]
+
+  @spec create(Shape.t(), [Stop.t()]) :: t()
+  def create(shape, stops) do
+    %__MODULE__{id: shape.id, points: shape.points, stops: stops}
+  end
+end

--- a/lib/skate_web/controllers/shape_controller.ex
+++ b/lib/skate_web/controllers/shape_controller.ex
@@ -12,7 +12,11 @@ defmodule SkateWeb.ShapeController do
   @spec trip(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def trip(conn, %{"trip_id" => trip_id}) do
     shape_for_trip_fn =
-      Application.get_env(:skate_web, :shape_for_trip_fn, &Schedule.shape_for_trip/1)
+      Application.get_env(
+        :skate_web,
+        :shape_with_stops_fn,
+        &Schedule.shape_with_stops_for_trip/1
+      )
 
     shape = shape_for_trip_fn.(trip_id)
 

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -532,13 +532,13 @@ defmodule Schedule.DataTest do
     test "returns nil when no trip found", %{trip: trip, shape: shape} do
       data = %Data{trips: %{}, shapes: %{trip.route_id => [shape]}}
 
-      assert nil == Data.shape_with_stops_for_trip(data, trip.id)
+      assert is_nil(Data.shape_with_stops_for_trip(data, trip.id))
     end
 
     test "returns nil when no shape found", %{trip: trip} do
       data = %Data{trips: %{trip.id => trip}, shapes: %{}}
 
-      assert nil == Data.shape_with_stops_for_trip(data, trip.id)
+      assert is_nil(Data.shape_with_stops_for_trip(data, trip.id))
     end
 
     test "returns the shape without stops when no stops found", %{trip: trip, shape: shape} do

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -14,6 +14,7 @@ defmodule Schedule.DataTest do
   alias Schedule.Hastus.Activity
   alias Schedule.Piece
   alias Schedule.Run
+  alias Schedule.ShapeWithStops
 
   test "all_routes/1 returns all the routes" do
     routes = [
@@ -492,6 +493,89 @@ defmodule Schedule.DataTest do
       }
 
       assert Data.shapes(data, "shapelessRoute") == []
+    end
+  end
+
+  describe "shape_with_stops_for_trip" do
+    setup do
+      trip = %Schedule.Trip{
+        id: "trip",
+        block_id: "block",
+        route_id: "route",
+        shape_id: "shape",
+        stop_times: [
+          %StopTime{stop_id: "stop1", time: 150, timepoint_id: "t1"},
+          %StopTime{stop_id: "stop2", time: 160, timepoint_id: "t2"}
+        ]
+      }
+
+      stops = [
+        %Stop{id: "stop1", name: "Stop 1", latitude: 42.01, longitude: -71.01},
+        %Stop{id: "stop2", name: "Stop 2", latitude: 42.02, longitude: -71.02}
+      ]
+
+      shape = %Shape{
+        id: "shape",
+        points: [
+          %Point{
+            shape_id: "shape",
+            lat: 42.413560,
+            lon: -70.992110,
+            sequence: 0
+          }
+        ]
+      }
+
+      {:ok, %{trip: trip, stops: stops, shape: shape}}
+    end
+
+    test "returns nil when no trip found", %{trip: trip, shape: shape} do
+      data = %Data{trips: %{}, shapes: %{trip.route_id => [shape]}}
+
+      assert nil == Data.shape_with_stops_for_trip(data, trip.id)
+    end
+
+    test "returns nil when no shape found", %{trip: trip} do
+      data = %Data{trips: %{trip.id => trip}, shapes: %{}}
+
+      assert nil == Data.shape_with_stops_for_trip(data, trip.id)
+    end
+
+    test "returns the shape without stops when no stops found", %{trip: trip, shape: shape} do
+      data = %Data{trips: %{trip.id => trip}, stops: %{}, shapes: %{trip.route_id => [shape]}}
+
+      assert %ShapeWithStops{id: shape.id, points: shape.points, stops: []} ==
+               Data.shape_with_stops_for_trip(data, trip.id)
+    end
+
+    test "returns  all stops when all stops are found", %{
+      trip: trip,
+      stops: [stop1, stop2],
+      shape: shape
+    } do
+      data = %Data{
+        trips: %{trip.id => trip},
+        stops: %{stop1.id => stop1, stop2.id => stop2},
+        shapes: %{trip.route_id => [shape]}
+      }
+
+      assert %ShapeWithStops{id: shape.id, points: shape.points, stops: [stop1, stop2]} ==
+               Data.shape_with_stops_for_trip(data, trip.id)
+    end
+
+    test "returns the shape with a subset of stops when not all found", %{
+      trip: trip,
+      stops: [stop1, _stop2],
+      shape: shape
+    } do
+      data = %Data{
+        trips: %{trip.id => trip},
+        stops: %{stop1.id => stop1},
+        shapes: %{trip.route_id => [shape]}
+      }
+
+      assert %ShapeWithStops{id: shape.id, points: shape.points, stops: [stop1]} ==
+               Data.shape_with_stops_for_trip(data, trip.id)
     end
   end
 

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -548,7 +548,7 @@ defmodule Schedule.DataTest do
                Data.shape_with_stops_for_trip(data, trip.id)
     end
 
-    test "returns  all stops when all stops are found", %{
+    test "returns all stops when all stops are found", %{
       trip: trip,
       stops: [stop1, stop2],
       shape: shape

--- a/test/schedule/shape_with_stops_test.exs
+++ b/test/schedule/shape_with_stops_test.exs
@@ -1,0 +1,32 @@
+defmodule Schedule.ShapeWithStopsTest do
+  use ExUnit.Case, async: true
+  alias Schedule.Gtfs.{Shape, Stop}
+  alias Schedule.ShapeWithStops
+
+  describe "create/2" do
+    test "creates struct with all fields populated" do
+      points = [
+        %Shape.Point{
+          shape_id: "shape1",
+          lat: "42.413560",
+          lon: "-70.992110",
+          sequence: "0"
+        }
+      ]
+
+      %{id: shape_id} =
+        shape = %Shape{
+          id: "shape1",
+          points: points
+        }
+
+      stops = [
+        %Stop{id: "stop1", name: "Stop One", latitude: 42.12, longitude: -71.12},
+        %Stop{id: "stop2", name: "Stop Two", latitude: 42.34, longitude: -71.34}
+      ]
+
+      assert %ShapeWithStops{id: ^shape_id, points: ^points, stops: ^stops} =
+               ShapeWithStops.create(shape, stops)
+    end
+  end
+end

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -685,6 +685,56 @@ defmodule ScheduleTest do
     end
   end
 
+  describe "shape_with_stops_for_trip" do
+    test "returns the shape with stops for the trip" do
+      pid =
+        Schedule.start_mocked(%{
+          gtfs: %{
+            "routes.txt" => [
+              "route_id,route_type,route_short_name,route_desc",
+              "route,3,route,\"Key Bus\""
+            ],
+            "route_patterns.txt" => [
+              "route_pattern_id,route_id,direction_id,representative_trip_id",
+              "p1,route,1,trip"
+            ],
+            "trips.txt" => [
+              "route_id,service_id,trip_id,trip_headsign,direction_id,block_id,route_pattern_id,shape_id",
+              "route,service,trip,headsign,1,block,route-_-0,shape"
+            ],
+            "stop_times.txt" => [
+              "trip_id,arrival_time,departure_time,stop_id,stop_sequence,checkpoint_id",
+              "trip,,00:00:01,stop1_id,1,"
+            ],
+            "stops.txt" => [
+              "stop_id,stop_name,stop_lat,stop_lon,parent_station",
+              "stop1_id,One,1.0,1.5,"
+            ],
+            "shapes.txt" => [
+              "shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled",
+              "shape,42.373178,-71.118170,0,"
+            ]
+          }
+        })
+
+      assert Schedule.shape_with_stops_for_trip("trip", pid) ==
+               %Schedule.ShapeWithStops{
+                 id: "shape",
+                 points: [
+                   %Point{
+                     shape_id: "shape",
+                     lat: 42.373178,
+                     lon: -71.118170,
+                     sequence: 0
+                   }
+                 ],
+                 stops: [
+                   %Stop{id: "stop1_id", name: "One", latitude: 1.0, longitude: 1.5}
+                 ]
+               }
+    end
+  end
+
   describe "first_route_pattern_for_route_and_direction" do
     test "returns the first route pattern matching the route and direction" do
       pid =

--- a/test/skate_web/controllers/shape_controller_test.exs
+++ b/test/skate_web/controllers/shape_controller_test.exs
@@ -2,16 +2,17 @@ defmodule SkateWeb.ShapeControllerTest do
   use SkateWeb.ConnCase
   import Test.Support.Helpers
 
-  alias Schedule.Gtfs.Shape
+  alias Schedule.Gtfs.{Shape, Stop}
   alias Schedule.Gtfs.Shape.Point
+  alias Schedule.ShapeWithStops
 
   @shape %Shape{
     id: "shape1",
     points: [
       %Point{
         shape_id: "shape1",
-        lat: "42.413560",
-        lon: "-70.992110",
+        lat: 42.413560,
+        lon: -70.992110,
         sequence: "0"
       }
     ]
@@ -22,9 +23,51 @@ defmodule SkateWeb.ShapeControllerTest do
     "points" => [
       %{
         "shape_id" => "shape1",
-        "lat" => "42.413560",
-        "lon" => "-70.992110",
+        "lat" => 42.413560,
+        "lon" => -70.992110,
         "sequence" => "0"
+      }
+    ]
+  }
+
+  @shape_with_stops %ShapeWithStops{
+    id: "shape1",
+    points: [
+      %Point{
+        shape_id: "shape1",
+        lat: 42.413560,
+        lon: -70.992110,
+        sequence: "0"
+      }
+    ],
+    stops: [
+      %Stop{id: "stop_1", name: "One", latitude: 42.01, longitude: -71.01},
+      %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02}
+    ]
+  }
+
+  @shape_with_stops_json %{
+    "id" => "shape1",
+    "points" => [
+      %{
+        "shape_id" => "shape1",
+        "lat" => 42.413560,
+        "lon" => -70.992110,
+        "sequence" => "0"
+      }
+    ],
+    "stops" => [
+      %{
+        "id" => "stop_1",
+        "name" => "One",
+        "lat" => 42.01,
+        "lon" => -71.01
+      },
+      %{
+        "id" => "stop_2",
+        "name" => "Two",
+        "lat" => 42.02,
+        "lon" => -71.02
       }
     ]
   }
@@ -56,7 +99,7 @@ defmodule SkateWeb.ShapeControllerTest do
 
   describe "GET /api/shapes/trip/:trip_id" do
     setup do
-      reassign_env(:skate_web, :shape_for_trip_fn, fn _trip_id -> @shape end)
+      reassign_env(:skate_web, :shape_with_stops_fn, fn _trip_id -> @shape_with_stops end)
     end
 
     @tag :authenticated
@@ -66,12 +109,12 @@ defmodule SkateWeb.ShapeControllerTest do
         |> api_headers()
         |> get("/api/shapes/trip/1")
 
-      assert json_response(conn, 200) == %{"data" => @shape_json}
+      assert json_response(conn, 200) == %{"data" => @shape_with_stops_json}
     end
 
     @tag :authenticated
     test "returns null if we don't have a shape for this trip", %{conn: conn} do
-      reassign_env(:skate_web, :shape_for_trip_fn, fn _trip_id -> nil end)
+      reassign_env(:skate_web, :shape_with_stops_fn, fn _trip_id -> nil end)
 
       conn =
         conn


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203119002718952/f

This PR mostly pulls from https://github.com/mbta/skate/pull/1752 with additional testing.

I couldn't find a suitable way to test for the tooltip's appearance on stop hover in the map component. It seems that the tooltip is only added to the DOM on hover, and after trying a few ways to pass accessible selectors (`title`, `alt`), I didn't find a way to hover over the stop in testing to trigger the tooltip. This is one of the rare cases where I wish RTL had a workaround to find an element by class name! Open to suggestions for other ways to unit test this behavior.
