### PR TITLE
fix(README): remove extra `s` from `POSTGRES_PASSWORD`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are the configuration details defined in `.envrc`:
 - **API_KEY**: Access key for the API
 - **GTFS_URL**: Location of the GTFS zip file
 - **BUSLOC_URL**: Source of GTFS-realtime enhanced VehiclePositions json data file
-- **POSTGRES_USERNAME**, **POSTGRESS_PASSWORD**, **POSTGRES_HOSTNAME**: Postgres username, password, and hostname
+- **POSTGRES_USERNAME**, **POSTGRES_PASSWORD**, **POSTGRES_HOSTNAME**: Postgres username, password, and hostname
 - **SWIFTLY_AUTHORIZATION_KEY**: for dev only, see below for prod
 - **SWIFTLY_REALTIME_VEHICLES_URL**: Source of Swiftly vehicle data
 - **TRIP_UPDATES_URL**: Source of GTFS-realtime enhanced TripUpdates json data file (optional)


### PR DESCRIPTION
When reading through I noticed that the `POSTGRES_PASSWORD` variable spelling in the `README.md` didn't match the variable in `.envrc.example`.

---

Also, first PR! 🎉 