### PR TITLE
feat(NotificationsChannel): support new format of initial notifications message

### DIFF
--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -36,6 +36,11 @@ defmodule SkateWeb.NotificationsChannel do
 
     initial_notifications = notification_fetch.(username)
 
-    {:ok, %{initial_notifications: initial_notifications}, socket}
+    {:ok,
+     %{
+       data: %{initial_notifications: initial_notifications},
+       # for backwards compatability with format expected by frontend
+       initial_notifications: initial_notifications
+     }, socket}
   end
 end

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -28,8 +28,11 @@ defmodule SkateWeb.NotificationsChannelTest do
       mock_fetch = fn _ -> ["fake notification 1", "fake notification 2"] end
       reassign_env(:skate, :unexpired_notifications_for_user, mock_fetch)
 
-      assert {:ok, %{initial_notifications: ["fake notification 1", "fake notification 2"]},
-              %Socket{}} = subscribe_and_join(socket, NotificationsChannel, "notifications")
+      assert {:ok,
+              %{
+                initial_notifications: ["fake notification 1", "fake notification 2"],
+                data: %{initial_notifications: ["fake notification 1", "fake notification 2"]}
+              }, %Socket{}} = subscribe_and_join(socket, NotificationsChannel, "notifications")
     end
   end
 


### PR DESCRIPTION
This updates the format of the initial notifications message to support the new format expected in https://github.com/mbta/skate/pull/1765 (`%{data: %{initial_notifications: initial_notifications}}`). This PR will need to be merged & deployed first to ensure that both the new and old frontends are simultaneously supported during the deploy of https://github.com/mbta/skate/pull/1765.