### PR TITLE
Use Superstruct for (some) back-end data

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10100,6 +10100,11 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
+    "superstruct": {
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.16.5.tgz",
+      "integrity": "sha512-GBa1VPdCUDAIrsoMVy2lzE/hKQnieUlc1JVoVzJ2YLx47SoPY4AqF85Ht1bPg5r+8I0v54GbaRdNTnYQ0p+T+Q=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.1.0",
     "react-router-dom": "^6.3.0",
+    "superstruct": "^0.16.5",
     "uuid": "^8.3.2",
     "whatwg-fetch": "^3.6.2"
   },

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -82,10 +82,7 @@ export const checkedApiCall = <T, U>({
 }): Promise<U> =>
   fetch(url, fetchArgs)
     .then(checkResponseStatus)
-    .then(
-      (response) =>
-        parseJson(response) as Record<string, unknown> & { data: unknown }
-    )
+    .then((response) => parseJson(response) as { data: unknown })
     .then(({ data: data }) => {
       assert(data, dataStruct)
       return parser(data)

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -88,10 +88,10 @@ export const checkedApiCall = <T, U>({
       return parser(data)
     })
     .catch((error) => {
-      if (defaultResult === undefined) {
-        throw error
-      } else {
+      if (defaultResult !== undefined) {
         return defaultResult
+      } else {
+        throw error
       }
     })
 

--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -1,5 +1,6 @@
 import { Channel, Socket } from "phoenix"
 import { useEffect, useState } from "react"
+import { assert, Struct } from "superstruct"
 import { reload } from "../models/browser"
 
 /** Opens a channel for the given topic
@@ -59,5 +60,72 @@ export const useChannel = <T>({
       }
     }
   }, [socket, topic, event, loadingState, parser, closeAfterFirstRead])
+  return state
+}
+
+export const useCheckedChannel = <T, U>({
+  socket,
+  topic,
+  event,
+  dataStruct,
+  parser,
+  loadingState,
+  closeAfterFirstRead,
+}: {
+  socket: Socket | undefined
+  topic: string | null
+  event: string
+  dataStruct: Struct<T, any>
+  parser: (data: T) => U
+  loadingState: U
+  closeAfterFirstRead?: boolean
+}): U => {
+  const [state, setState] = useState<U>(loadingState)
+
+  useEffect(() => {
+    setState(loadingState)
+    let channel: Channel | undefined
+    if (socket !== undefined && topic !== null) {
+      channel = socket.channel(topic)
+      channel.on(event, ({ data: data }: { data: unknown }) => {
+        assert(data, dataStruct)
+
+        setState(parser(data))
+      })
+
+      channel
+        .join()
+        .receive("ok", ({ data: data }: { data: unknown }) => {
+          assert(data, dataStruct)
+
+          setState(parser(data))
+          if (closeAfterFirstRead) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            channel!.leave()
+            channel = undefined
+          }
+        })
+        .receive("error", ({ reason }) =>
+          // eslint-disable-next-line no-console
+          console.error(`joining topic ${topic} failed`, reason)
+        )
+        .receive("timeout", reload)
+    }
+
+    return () => {
+      if (channel !== undefined) {
+        channel.leave()
+        channel = undefined
+      }
+    }
+  }, [
+    socket,
+    topic,
+    event,
+    loadingState,
+    dataStruct,
+    parser,
+    closeAfterFirstRead,
+  ])
   return state
 }

--- a/assets/src/hooks/useNotifications.ts
+++ b/assets/src/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { Socket } from "phoenix"
-import { array, Infer, object, union } from "superstruct"
+import { array, Infer, type, union } from "superstruct"
 import {
   NotificationData,
   notificationFromData,
@@ -7,7 +7,7 @@ import {
 import { Notification } from "../realtime.d"
 import { useCheckedChannel } from "./useChannel"
 
-const InitialNotificationData = object({
+const InitialNotificationData = type({
   initial_notifications: array(NotificationData),
 })
 type InitialNotificationData = Infer<typeof InitialNotificationData>

--- a/assets/src/hooks/usePersistedStateReducer.ts
+++ b/assets/src/hooks/usePersistedStateReducer.ts
@@ -19,7 +19,8 @@ import {
   UserSettings,
   userSettingsFromData,
 } from "../userSettings"
-import { RouteTab, parseRouteTabData } from "../models/routeTab"
+import { RouteTab, parseRouteTabData, RouteTabData } from "../models/routeTab"
+import { array, assert } from "superstruct"
 
 const APP_STATE_KEY = "mbta-skate-state"
 
@@ -130,7 +131,11 @@ const getRouteTabs = (): RouteTab[] => {
 
   const backendSettingsString: string | undefined = appData()?.routeTabs
   if (backendSettingsString !== undefined) {
-    routeTabs = parseRouteTabData(JSON.parse(backendSettingsString))
+    const backendSettings = JSON.parse(backendSettingsString) as unknown
+
+    assert(backendSettings, array(RouteTabData))
+
+    routeTabs = parseRouteTabData(backendSettings)
   }
 
   return routeTabs

--- a/assets/src/models/ladderDirection.ts
+++ b/assets/src/models/ladderDirection.ts
@@ -1,3 +1,4 @@
+import { enums, Infer, record, string } from "superstruct"
 import { ByRouteId, DirectionId, RouteId, Timepoint } from "../schedule"
 
 export enum LadderDirection {
@@ -8,6 +9,9 @@ export enum LadderDirection {
 const defaultLadderDirection: LadderDirection = LadderDirection.ZeroToOne
 
 export type LadderDirections = ByRouteId<LadderDirection>
+
+export const LadderDirectionsData = record(string(), enums([0, 1]))
+export type LadderDirectionsData = Infer<typeof LadderDirectionsData>
 
 export const emptyLadderDirectionsByRouteId: LadderDirections = {}
 

--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -4,13 +4,13 @@ import {
   Infer,
   nullable,
   number,
-  object,
+  type,
   string,
 } from "superstruct"
 import { Notification } from "../realtime.d"
 import { dateFromEpochSeconds } from "../util/dateTime"
 
-export const NotificationData = object({
+export const NotificationData = type({
   id: number(),
   created_at: number(),
   reason: enums([

--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -1,32 +1,46 @@
 import {
-  Notification,
-  NotificationId,
-  NotificationReason,
-  NotificationState,
-  RunId,
-} from "../realtime.d"
-import { RouteId, TripId } from "../schedule.d"
+  array,
+  enums,
+  Infer,
+  nullable,
+  number,
+  object,
+  string,
+} from "superstruct"
+import { Notification } from "../realtime.d"
 import { dateFromEpochSeconds } from "../util/dateTime"
 
-export interface NotificationData {
-  id: NotificationId
-  created_at: number
-  reason: NotificationReason
-  route_ids: RouteId[]
-  run_ids: RunId[]
-  trip_ids: TripId[]
-  operator_name: string | null
-  operator_id: string | null
-  route_id_at_creation: string | null
-  start_time: number
-  end_time: number | null
-  state: NotificationState
-}
+export const NotificationData = object({
+  id: number(),
+  created_at: number(),
+  reason: enums([
+    "manpower",
+    "disabled",
+    "diverted",
+    "accident",
+    "other",
+    "adjusted",
+    "operator_error",
+    "traffic",
+    "chelsea_st_bridge_raised",
+    "chelsea_st_bridge_lowered",
+  ]),
+  route_ids: array(string()),
+  run_ids: array(string()),
+  trip_ids: array(string()),
+  operator_name: nullable(string()),
+  operator_id: nullable(string()),
+  route_id_at_creation: nullable(string()),
+  start_time: number(),
+  end_time: nullable(number()),
+  state: enums(["unread", "read", "deleted"]),
+})
+export type NotificationData = Infer<typeof NotificationData>
 
 export const notificationFromData = (
   notificationData: NotificationData
 ): Notification => ({
-  id: notificationData.id,
+  id: notificationData.id.toString(),
   createdAt: dateFromEpochSeconds(notificationData.created_at),
   reason: notificationData.reason,
   routeIds: notificationData.route_ids,

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -16,7 +16,7 @@ import {
   Infer,
   nullable,
   number,
-  object,
+  type,
   record,
   string,
 } from "superstruct"
@@ -32,7 +32,7 @@ export interface RouteTab {
   saveChangesToTabUuid?: string
 }
 
-export const RouteTabData = object({
+export const RouteTabData = type({
   uuid: string(),
   preset_name: nullable(string()),
   selected_route_ids: array(string()),

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -2,6 +2,7 @@ import { RouteId } from "../schedule.d"
 import {
   LadderDirections,
   emptyLadderDirectionsByRouteId,
+  LadderDirectionsData,
 } from "./ladderDirection"
 import {
   LadderCrowdingToggles,
@@ -9,6 +10,16 @@ import {
 } from "./ladderCrowdingToggle"
 import { v4 as uuidv4 } from "uuid"
 import { uniq, flatten } from "../helpers/array"
+import {
+  array,
+  boolean,
+  Infer,
+  nullable,
+  number,
+  object,
+  record,
+  string,
+} from "superstruct"
 
 export interface RouteTab {
   uuid: string
@@ -21,16 +32,17 @@ export interface RouteTab {
   saveChangesToTabUuid?: string
 }
 
-export interface RouteTabData {
-  uuid: string
-  preset_name?: string
-  selected_route_ids: RouteId[]
-  ordering: number
-  ladder_directions: LadderDirections
-  ladder_crowding_toggles: LadderCrowdingToggles
-  is_current_tab?: boolean
-  save_changes_to_tab_uuid?: string
-}
+export const RouteTabData = object({
+  uuid: string(),
+  preset_name: nullable(string()),
+  selected_route_ids: array(string()),
+  ordering: nullable(number()),
+  ladder_directions: LadderDirectionsData,
+  ladder_crowding_toggles: record(string(), boolean()),
+  is_current_tab: nullable(boolean()),
+  save_changes_to_tab_uuid: nullable(string()),
+})
+export type RouteTabData = Infer<typeof RouteTabData>
 
 export const newRouteTab = (ordering: number): RouteTab => ({
   uuid: uuidv4(),

--- a/assets/src/models/swingsData.ts
+++ b/assets/src/models/swingsData.ts
@@ -1,16 +1,17 @@
-import { RunId } from "../realtime"
-import { BlockId, RouteId, Swing, TripId } from "../schedule"
+import { Infer, number, object, string } from "superstruct"
+import { Swing } from "../schedule"
 
-export interface SwingData {
-  block_id: BlockId
-  from_route_id: RouteId
-  from_run_id: RunId
-  from_trip_id: TripId
-  to_route_id: RouteId
-  to_run_id: RunId
-  to_trip_id: TripId
-  time: number
-}
+export const SwingData = object({
+  block_id: string(),
+  from_route_id: string(),
+  from_run_id: string(),
+  from_trip_id: string(),
+  to_route_id: string(),
+  to_run_id: string(),
+  to_trip_id: string(),
+  time: number(),
+})
+export type SwingData = Infer<typeof SwingData>
 
 export const swingsFromData = (swingsData: SwingData[]): Swing[] =>
   swingsData.map((swingData) => ({

--- a/assets/src/models/swingsData.ts
+++ b/assets/src/models/swingsData.ts
@@ -1,7 +1,7 @@
-import { Infer, number, object, string } from "superstruct"
+import { Infer, number, type, string } from "superstruct"
 import { Swing } from "../schedule"
 
-export const SwingData = object({
+export const SwingData = type({
   block_id: string(),
   from_route_id: string(),
   from_run_id: string(),

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -476,6 +476,7 @@ describe("fetchNearestIntersection", () => {
 describe("fetchSwings", () => {
   test("parses swings", (done) => {
     const swing = {
+      block_id: "B1",
       from_route_id: "1",
       from_run_id: "123-456",
       from_trip_id: "1234",
@@ -492,6 +493,7 @@ describe("fetchSwings", () => {
     fetchSwings(["1"]).then((swings) => {
       expect(swings).toEqual([
         {
+          blockId: "B1",
           fromRouteId: "1",
           fromRunId: "123-456",
           fromTripId: "1234",

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react"
-import { useChannel } from "../../src/hooks/useChannel"
+import { string, unknown } from "superstruct"
+import { useChannel, useCheckedChannel } from "../../src/hooks/useChannel"
 import * as browser from "../../src/models/browser"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 
@@ -300,6 +301,394 @@ describe("useChannel", () => {
         socket: mockSocket,
         topic: "topic",
         event: "event",
+        parser,
+        loadingState: "loading",
+        closeAfterFirstRead: true,
+      })
+    )
+
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+    expect(mockChannel.leave).toHaveBeenCalled()
+  })
+})
+
+describe("useCheckedChannel", () => {
+  test("returns loadingState initially", () => {
+    const dataStruct = unknown()
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: undefined,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+    expect(result.current).toEqual("loading")
+  })
+
+  test("if given no topic, doesn't open a channel and returns loadingState", () => {
+    const mockSocket = makeMockSocket()
+    const dataStruct = unknown()
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: null,
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+    expect(result.current).toEqual("loading")
+    expect(mockSocket.channel).not.toHaveBeenCalled()
+  })
+
+  test("subscribes to the given topic", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    const dataStruct = unknown()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(mockSocket.channel).toHaveBeenCalledTimes(1)
+    expect(mockSocket.channel).toHaveBeenCalledWith("topic")
+    expect(mockChannel.join).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns loadingState while loading", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = unknown()
+
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+    expect(result.current).toEqual("loading")
+  })
+
+  test("returns data from the initial join", () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = string()
+
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser,
+        loadingState: "loading",
+      })
+    )
+
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+  })
+
+  test("handles malformed data from the initial join", () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: 12 })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = string()
+    const onError = jest.fn()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser,
+        loadingState: "loading",
+        onError,
+      })
+    )
+    expect(onError).toHaveBeenCalledWith(12)
+  })
+
+  test("returns data pushed to the channel", async () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "event") {
+        handler({
+          data: "raw",
+        })
+      }
+    })
+    const dataStruct = string()
+
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser,
+        loadingState: "loading",
+      })
+    )
+
+    expect(parser).toHaveBeenCalledWith("raw")
+    expect(result.current).toEqual("parsed")
+  })
+
+  test("handles malformed data pushed to the channel", async () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "event") {
+        handler({
+          data: 12,
+        })
+      }
+    })
+    const dataStruct = string()
+    const onError = jest.fn()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser,
+        loadingState: "loading",
+        onError,
+      })
+    )
+    expect(onError).toHaveBeenCalledWith(12)
+  })
+
+  test("leaves the channel on unmount", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = unknown()
+
+    const { unmount } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(mockChannel.join).toHaveBeenCalled()
+
+    unmount()
+
+    expect(mockChannel.leave).toHaveBeenCalled()
+  })
+
+  test("leaves the channel, removes old data, and joins new channel when the topic changes", () => {
+    const mockSocket = makeMockSocket()
+    const channel1 = makeMockChannel("ok", { data: "raw" })
+    const channel2 = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => channel1)
+    mockSocket.channel.mockImplementationOnce(() => channel2)
+    const dataStruct = string()
+
+    const parser = jest.fn(() => "parsed")
+    const { rerender, result } = renderHook(
+      (topic) =>
+        useCheckedChannel({
+          socket: mockSocket,
+          topic,
+          event: "event",
+          dataStruct,
+          parser,
+          loadingState: "loading",
+        }),
+      { initialProps: "topic1" }
+    )
+
+    expect(result.current).toEqual("parsed")
+    rerender("topic2")
+
+    expect(channel1.leave).toHaveBeenCalled()
+    expect(result.current).toEqual("loading")
+    expect(channel2.join).toHaveBeenCalled()
+  })
+
+  test("leaves the channel, removes old data, and joins new channel when the parser changes", () => {
+    const mockSocket = makeMockSocket()
+    const channel1 = makeMockChannel("ok", { data: "raw" })
+    const channel2 = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => channel1)
+    mockSocket.channel.mockImplementationOnce(() => channel2)
+    const dataStruct = string()
+
+    const { rerender, result } = renderHook(
+      (parser: (data: any) => string) =>
+        useCheckedChannel({
+          socket: mockSocket,
+          topic: "topic",
+          event: "event",
+          dataStruct,
+          parser,
+          loadingState: "loading",
+        }),
+      { initialProps: jest.fn(() => "parsed") }
+    )
+
+    expect(result.current).toEqual("parsed")
+    rerender(jest.fn(() => "parsed2"))
+
+    expect(channel1.leave).toHaveBeenCalled()
+    expect(result.current).toEqual("loading")
+    expect(channel2.join).toHaveBeenCalled()
+  })
+
+  test("leaves the channel, removes old data, and joins new channel when closeAfterFirstRead changes", () => {
+    const mockSocket = makeMockSocket()
+    const channel1 = makeMockChannel("ok", { data: "raw" })
+    const channel2 = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => channel1)
+    mockSocket.channel.mockImplementationOnce(() => channel2)
+    const dataStruct = string()
+
+    const parser = jest.fn(() => "parsed")
+    const { rerender, result } = renderHook(
+      (closeAfterFirstRead: boolean) =>
+        useCheckedChannel({
+          socket: mockSocket,
+          topic: "topic",
+          event: "event",
+          dataStruct,
+          parser,
+          loadingState: "loading",
+          closeAfterFirstRead,
+        }),
+      { initialProps: false }
+    )
+
+    expect(result.current).toEqual("parsed")
+    rerender(true)
+
+    expect(channel1.leave).toHaveBeenCalled()
+    expect(result.current).toEqual("loading")
+    expect(channel2.join).toHaveBeenCalled()
+  })
+
+  test("leaves the channel and removes old data when topic is changed to null", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = string()
+
+    const parser = jest.fn(() => "parsed")
+    const { rerender, result } = renderHook<string | null, any>(
+      (topic) =>
+        useCheckedChannel({
+          socket: mockSocket,
+          topic,
+          event: "event",
+          dataStruct,
+          parser,
+          loadingState: "loading",
+        }),
+      { initialProps: "topic" }
+    )
+
+    expect(result.current).toEqual("parsed")
+    rerender(null)
+
+    expect(mockChannel.leave).toHaveBeenCalledTimes(1)
+    expect(result.current).toEqual("loading")
+  })
+
+  test("console.error on join error", async () => {
+    const spyConsoleError = jest.spyOn(console, "error")
+    spyConsoleError.mockImplementationOnce((msg) => msg)
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("error")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = unknown()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(spyConsoleError).toHaveBeenCalled()
+    spyConsoleError.mockRestore()
+  })
+
+  test("reloads the window on channel timeout", async () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("timeout")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = unknown()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
+  })
+
+  test("returns data from the initial join with closeAfterFirstRead, leaves", () => {
+    const parser = jest.fn(() => "parsed")
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: "raw" })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = string()
+
+    const { result } = renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
         parser,
         loadingState: "loading",
         closeAfterFirstRead: true,

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -20,7 +20,7 @@ const notification1: Notification = {
 }
 
 const notification1Data: NotificationData = {
-  id: "0",
+  id: 0,
   created_at: 0,
   reason: "manpower",
   route_ids: ["route1", "route2"],
@@ -50,7 +50,7 @@ const notification2: Notification = {
 }
 
 const notification2Data: NotificationData = {
-  id: "1",
+  id: 1,
   created_at: 0,
   reason: "accident",
   route_ids: ["route1", "route2"],

--- a/assets/tests/hooks/useNotificationsReducer.test.tsx
+++ b/assets/tests/hooks/useNotificationsReducer.test.tsx
@@ -41,7 +41,7 @@ const notification1: Notification = {
 }
 
 const notification1Data: NotificationData = {
-  id: "0",
+  id: 0,
   created_at: 0,
   reason: "manpower",
   route_ids: ["route1", "route2"],

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -100,6 +100,7 @@ describe("usePersistedStateReducer", () => {
           selected_route_ids: ["1"],
           ladder_directions: {},
           ladder_crowding_toggles: {},
+          save_changes_to_tab_uuid: null,
         },
       ]),
     }

--- a/assets/tests/models/notificationData.test.tsx
+++ b/assets/tests/models/notificationData.test.tsx
@@ -7,7 +7,7 @@ import {
 describe("notificationFromData", () => {
   test("handles a null endTime", () => {
     const data: NotificationData = {
-      id: "1",
+      id: 1,
       created_at: 0,
       reason: "manpower",
       route_ids: [],


### PR DESCRIPTION
Asana ticket: [⚙️ Adopt Superstruct](https://app.asana.com/0/1152340551558956/1201917242620476/f)

It will help to refer to the [section of the Superstruct docs on Typescript](https://docs.superstructjs.org/guides/06-using-typescript) to understand these changes.

There are many places in the code that we will eventually want to change to use Superstruct, but for new this gets us started with a few examples. In particular, it establishes the `checkedApiCall` and `useCheckedChannel` corollaries of the existing `apiCall` and `useChannel` functions, which will be important for most future places where we want to use the library.

We already had the convention of having a separate `FooData` type in addition to `Foo` and having a parser to transform from the former to the latter. I have built on that somewhat for this approach. Generally the `FooData` Superstruct objects just use the basic types like `string()` and `number()` as opposed to creating aliases for things like a particular kind of ID that's actually just a string under the hood. The only exceptions are when the string or number or whatever has to have some particular property for the parsing to work out. Then, the function to transform from `FooData` to `Foo` needs to make all of the types work out. For instance if we have a `route_id` key on `FooData` and that's declared using the Superstruct `object` function as being a `string()`, and `Foo` has a `roueId` of type `RouteId` which is actually an alias for string, everything will work out if they're mapped in the obvious way.

The one par of this that I'm still not really sure about is error handling. Traditionally there has been no error handling around any of this, because of `any` types we were just operating in a situation where a bad response from the backend could just put us in a position inconsistent with the supposed Typescript types. So far, I've optimized mainly for encapsulation and easy testing, which has resulted in `checkedApiCall` throwing on errors and `useCheckedChannel` using an error handler callback. I'm not entirely happy with this somewhat-inconsistent approach so I'm open to suggestions.