### PR TITLE
fix(components/map): ensure autocentering stays on when backgrounded

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -323,7 +323,7 @@ const EventAdder = ({
     dragstart() {
       setShouldAutoCenter(false)
     },
-    moveend: () => {
+    moveend() {
       // Wait until the auto centering is finished to start listening for manual moves again.
       if (isAutoCentering.current) {
         isAutoCentering.current = false

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -311,20 +311,25 @@ const EventAdder = ({
   setShouldAutoCenter: (arg0: boolean) => void
 }): ReactElement => {
   useMapEvents({
+    // If the user drags or zooms, they want manual control of the map.
+
+    // `zoomstart` is fired when the map changes zoom levels
+    // this can be because of animating the zoom change or user input
     zoomstart() {
-      // If the user drags or zooms, they want manual control of the map.
-      // But don't disable shouldAutoCenter if the move was triggered by an auto center.
+      // But don't disable `shouldAutoCenter` if the zoom was triggered by AutoCenterer.
       if (!isAutoCentering.current) {
         setShouldAutoCenter(false)
       }
     },
     // `dragstart` is fired when a user drags the map
+    // it is expected that this event is not fired for anything but user input
     // by [handler/Map.Drag.js](https://github.com/Leaflet/Leaflet/blob/6b90c169d6cd11437bfbcc8ba261255e009afee3/src/map/handler/Map.Drag.js#L113-L115)
     dragstart() {
       setShouldAutoCenter(false)
     },
+    // `moveend` is called when the leaflet map has finished animating a pan
     moveend() {
-      // Wait until the auto centering is finished to start listening for manual moves again.
+      // Wait until the auto centering animation is finished to resume listening for user interaction.
       if (isAutoCentering.current) {
         isAutoCentering.current = false
       }

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -318,6 +318,11 @@ const EventAdder = ({
         setShouldAutoCenter(false)
       }
     },
+    // `dragstart` is fired when a user drags the map
+    // by [handler/Map.Drag.js](https://github.com/Leaflet/Leaflet/blob/6b90c169d6cd11437bfbcc8ba261255e009afee3/src/map/handler/Map.Drag.js#L113-L115)
+    dragstart() {
+      setShouldAutoCenter(false)
+    },
     moveend: () => {
       // Wait until the auto centering is finished to start listening for manual moves again.
       if (isAutoCentering.current) {

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -311,7 +311,7 @@ const EventAdder = ({
   setShouldAutoCenter: (arg0: boolean) => void
 }): ReactElement => {
   useMapEvents({
-    movestart: () => {
+    zoomstart() {
       // If the user drags or zooms, they want manual control of the map.
       // But don't disable shouldAutoCenter if the move was triggered by an auto center.
       if (!isAutoCentering.current) {

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -201,6 +201,7 @@ describe("auto centering", () => {
     const manualLatLng = { lat: 41.9, lng: -70.9 }
 
     act(() => {
+      mapRef.current!.fire("dragstart")
       mapRef.current!.panTo(manualLatLng)
     })
 
@@ -261,6 +262,7 @@ describe("auto centering", () => {
     // Manual move to turn off auto centering
     const manualLatLng = { lat: 41.9, lng: -70.9 }
     act(() => {
+      mapRef.current!.fire("dragstart")
       mapRef.current!.panTo(manualLatLng)
     })
     await animationFramePromise()


### PR DESCRIPTION
When the `Autocenterer` calls `autoCenter` in rapid succession before the animation of the map pan/zoom is finished, the autocentering control gets disabled by out of order events recieved by `useMapEvents`.

This PR uses `dragstart` to detect _user_ input, which disables the autocentering mode. In addition, the movestart handler has been changed to `zoomstart` because there are no other _user specific_ events fired when the zoom level also changes, and `zoomstart` is fired by `[leaflet::]setView` when the zoom level needs to change.

---

Asana Ticket: https://app.asana.com/0/1148853526253437/1199678649889552/f