### PR TITLE
chore: migration to add test_groups and test_groups_users tables

### DIFF
--- a/priv/repo/migrations/20221031170029_add_test_group.exs
+++ b/priv/repo/migrations/20221031170029_add_test_group.exs
@@ -1,0 +1,38 @@
+defmodule Skate.Repo.Migrations.AddTestGroup do
+  use Ecto.Migration
+
+  def change do
+    create table(:test_groups) do
+      add(:name, :string, null: false)
+      timestamps()
+    end
+
+    create table(:test_groups_users) do
+      add(
+        :test_group_id,
+        references(:test_groups,
+          on_delete: :delete_all,
+          on_update: :update_all
+        ),
+        primary_key: true
+      )
+
+      add(
+        :user_id,
+        references(:users, on_delete: :delete_all, on_update: :update_all),
+        primary_key: true
+      )
+
+      timestamps()
+    end
+
+    create(
+      index(
+        :test_groups,
+        [:name],
+        unique: true,
+        name: "test_groups_unique_index"
+      )
+    )
+  end
+end


### PR DESCRIPTION
Asana ticket: [⚙️ Database work for user test groups](https://app.asana.com/0/1200180014510248/1202519045249746/f)

The one thing worth noting about this change is that normally for a join table like this I wouldn't include a primary key, but the way that Ecto implements `through` associations (see upcoming PR) seems to require a primary key on the intermediate table. In any event I don't think it hurts anything even if it later turns out we figure out a way to avoid using it.