### PR TITLE
feat(Reports): New report for all user configuration

### DIFF
--- a/lib/report.ex
+++ b/lib/report.ex
@@ -4,7 +4,7 @@ defmodule Report do
   """
   @type t :: module()
 
-  @report_modules [Report.UserSettings, Report.UserNamesAndUuids]
+  @report_modules [Report.UserSettings, Report.UserNamesAndUuids, Report.UserConfigurations]
 
   @callback run() :: {:ok, [map()]} | :error
   @callback short_name() :: String.t()

--- a/lib/report/user_configurations.ex
+++ b/lib/report/user_configurations.ex
@@ -1,0 +1,42 @@
+defmodule Report.UserConfigurations do
+  @moduledoc """
+  Report the configuration each Skate user has done, including route tabs
+  & settings.
+  """
+  import Ecto.Query
+
+  @behaviour Report
+
+  @impl Report
+  def run() do
+    all_user_configuration =
+      from(user in Skate.Settings.Db.User)
+      |> Skate.Repo.all()
+      |> Skate.Repo.preload([:user_settings, :route_tabs])
+      |> Enum.map(&format_configuration(&1))
+
+    {:ok, all_user_configuration}
+  end
+
+  @spec format_configuration(map()) :: map()
+  defp format_configuration(user) do
+    %{
+      email: user.email,
+      username: user.username,
+      user_uuid: user.uuid,
+      ladder_page_vehicle_label: user.user_settings.ladder_page_vehicle_label,
+      shuttle_page_vehicle_label: user.user_settings.shuttle_page_vehicle_label,
+      vehicle_adherence_colors: user.user_settings.vehicle_adherence_colors,
+      routes_per_tab:
+        inspect(Enum.map(user.route_tabs, fn rt -> length(rt.selected_route_ids) end))
+    }
+  end
+
+  @impl Report
+  @spec short_name :: <<_::152>>
+  def short_name(), do: "user_configurations"
+
+  @impl Report
+  @spec description :: <<_::208>>
+  def description(), do: "User settings & route tabs"
+end

--- a/test/report/user_configurations_test.exs
+++ b/test/report/user_configurations_test.exs
@@ -1,0 +1,81 @@
+defmodule Report.UserConfigurationsTest do
+  use Skate.DataCase
+
+  import Skate.Repo
+
+  alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+  alias Skate.Settings.Db.User, as: DbUser
+  alias Skate.Settings.Db.UserSettings, as: DbUserSettings
+
+  describe "run/0" do
+    test "returns users with their settings & route tabs" do
+      %{email: email, username: username, uuid: uuid} =
+        user =
+        insert!(
+          DbUser.changeset(%DbUser{}, %{
+            username: "username",
+            email: "test@email.com",
+            uuid: "12345"
+          }),
+          returning: true
+        )
+
+      tab_1 = %DbRouteTab{
+        user_id: user.id,
+        uuid: Ecto.UUID.generate(),
+        selected_route_ids: ["1", "2"],
+        ladder_directions: %{},
+        ladder_crowding_toggles: %{},
+        ordering: 1,
+        is_current_tab: false,
+        save_changes_to_tab_uuid: nil
+      }
+
+      tab_2 = %{
+        tab_1
+        | selected_route_ids: ["3", "4", "5"],
+          ordering: 2,
+          uuid: Ecto.UUID.generate()
+      }
+
+      insert!(tab_1)
+      insert!(tab_2)
+
+      insert!(
+        DbUserSettings.changeset(%DbUserSettings{}, %{
+          user_id: user.id,
+          ladder_page_vehicle_label: :vehicle_id,
+          shuttle_page_vehicle_label: :run_id,
+          vehicle_adherence_colors: :early_blue
+        }),
+        returning: true
+      )
+
+      {:ok, result} = Report.UserConfigurations.run()
+
+      assert [
+               %{
+                 email: ^email,
+                 ladder_page_vehicle_label: :vehicle_id,
+                 routes_per_tab: "[2, 3]",
+                 shuttle_page_vehicle_label: :run_id,
+                 user_uuid: ^uuid,
+                 username: ^username,
+                 vehicle_adherence_colors: :early_blue
+               }
+             ] = result
+    end
+  end
+
+  describe "short_name/0" do
+    test "returns short name" do
+      assert Report.UserConfigurations.short_name() == "user_configurations"
+    end
+  end
+
+  describe "description/0" do
+    test "returns description" do
+      assert Report.UserConfigurations.description() == "User settings & route tabs"
+    end
+  end
+end

--- a/test/report_test.exs
+++ b/test/report_test.exs
@@ -52,6 +52,7 @@ defmodule ReportTest do
   describe "all_reports/0" do
     test "returns full list of reports" do
       assert Report.all_reports() == %{
+               "user_configurations" => Report.UserConfigurations,
                "user_settings" => Report.UserSettings,
                "user_names_and_uuids" => Report.UserNamesAndUuids
              }


### PR DESCRIPTION
ticket: https://app.asana.com/0/1152340551558956/1201646081199380/f

A new report to understand how users will be affected by the above ticket. 

There is an existing `UserSettings` report that includes only settings with no username attached. I opted to create a new report for this specific use case, but can combine into the existing `UserSettings` report if that seems more appropriate.