### PR TITLE
fix(Report.UserConfigurations): routes per tab as comma separated list

### DIFF
--- a/lib/report/user_configurations.ex
+++ b/lib/report/user_configurations.ex
@@ -28,7 +28,9 @@ defmodule Report.UserConfigurations do
       shuttle_page_vehicle_label: user.user_settings.shuttle_page_vehicle_label,
       vehicle_adherence_colors: user.user_settings.vehicle_adherence_colors,
       routes_per_tab:
-        inspect(Enum.map(user.route_tabs, fn rt -> length(rt.selected_route_ids) end))
+        user.route_tabs
+        |> Enum.map(&Integer.to_string(length(&1.selected_route_ids)))
+        |> Enum.join(",")
     }
   end
 

--- a/lib/report/user_configurations.ex
+++ b/lib/report/user_configurations.ex
@@ -27,10 +27,7 @@ defmodule Report.UserConfigurations do
       ladder_page_vehicle_label: user.user_settings.ladder_page_vehicle_label,
       shuttle_page_vehicle_label: user.user_settings.shuttle_page_vehicle_label,
       vehicle_adherence_colors: user.user_settings.vehicle_adherence_colors,
-      routes_per_tab:
-        user.route_tabs
-        |> Enum.map(&Integer.to_string(length(&1.selected_route_ids)))
-        |> Enum.join(",")
+      routes_per_tab: Enum.map_join(user.route_tabs, ",", &length(&1.selected_route_ids))
     }
   end
 

--- a/test/report/user_configurations_test.exs
+++ b/test/report/user_configurations_test.exs
@@ -23,7 +23,7 @@ defmodule Report.UserConfigurationsTest do
       tab_1 = %DbRouteTab{
         user_id: user.id,
         uuid: Ecto.UUID.generate(),
-        selected_route_ids: ["1", "2"],
+        selected_route_ids: ["1", "2", "3", "4", "5", "6", "7"],
         ladder_directions: %{},
         ladder_crowding_toggles: %{},
         ordering: 1,
@@ -33,7 +33,7 @@ defmodule Report.UserConfigurationsTest do
 
       tab_2 = %{
         tab_1
-        | selected_route_ids: ["3", "4", "5"],
+        | selected_route_ids: ["1", "2", "3", "4", "5", "6", "7", "8"],
           ordering: 2,
           uuid: Ecto.UUID.generate()
       }
@@ -57,7 +57,7 @@ defmodule Report.UserConfigurationsTest do
                %{
                  email: ^email,
                  ladder_page_vehicle_label: :vehicle_id,
-                 routes_per_tab: "[2, 3]",
+                 routes_per_tab: "7,8",
                  shuttle_page_vehicle_label: :run_id,
                  user_uuid: ^uuid,
                  username: ^username,


### PR DESCRIPTION
A fix for https://github.com/mbta/skate/pull/1784 - 
using `inspect` resulted in strings being turned for lists where the numbers in that list were all codepoints. For example, someone with a tab that has 7 routes and another with 8 would return '\a\b', instead of the expected "[7, 8]". 

Now, the number of routes is converted to a string & concatenated. 