### PR TITLE
feat(skate/test-groups): send test group information to frontend

### DIFF
--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -1,8 +1,17 @@
+import { array, create, Infer, string } from "superstruct"
 import appData from "./appData"
 
+const TestGroups = array(string())
+type TestGroups = Infer<typeof TestGroups>
+
 const getTestGroups = (): string[] => {
-  const groups = appData()?.userTestGroups
-  const testGroups: string[] = groups === undefined ? [] : JSON.parse(groups)
+  const testGroupsJson = appData()?.userTestGroups
+
+  if (testGroupsJson === undefined) {
+    return []
+  }
+
+  const testGroups = create(JSON.parse(testGroupsJson) as unknown, TestGroups)
 
   return testGroups
 }

--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -16,7 +16,7 @@ const getTestGroups = (): string[] => {
   return testGroups
 }
 
-const inTestGroup = (key: string) => {
+const inTestGroup = (key: string): boolean => {
   return getTestGroups().includes(key)
 }
 

--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -1,12 +1,14 @@
 import appData from "./appData"
 
-function getTestGroups(): string[] {
+const getTestGroups = (): string[] => {
   const groups = appData()?.userTestGroups
   const testGroups: string[] = groups === undefined ? [] : JSON.parse(groups)
 
   return testGroups
 }
 
-export default function inTestGroup(key: string) {
+const inTestGroup = (key: string) => {
   return getTestGroups().includes(key)
 }
+
+export default inTestGroup

--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -1,0 +1,12 @@
+import appData from "./appData"
+
+function getTestGroups(): string[] {
+  const groups = appData()?.userTestGroups
+  const testGroups: string[] = groups === undefined ? [] : JSON.parse(groups)
+
+  return testGroups
+}
+
+export default function inTestGroup(key: string) {
+  return getTestGroups().includes(key)
+}

--- a/assets/tests/laboratoryFeatures.test.ts
+++ b/assets/tests/laboratoryFeatures.test.ts
@@ -8,7 +8,7 @@ jest.mock("../src/appData", () => ({
   __esModule: true,
   default: jest
     .fn()
-    // Ipmlementation sequence matches
+    // Implementation sequence matches
     .mockImplementationOnce(() => ({
       laboratoryFeatures: JSON.stringify(testFeatures),
     }))

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -1,24 +1,64 @@
+import { StructError } from "superstruct"
 import appData from "../src/appData"
 import inTestGroup from "../src/userTestGroups"
 
 jest.mock("appData")
 
-describe("User test groups helper", () => {
-  // test("Assert")
-  test("Assert detect user in group", () => {
-    const group_1 = "user-test-group-1"
-    const group_2 = "user-test-group-2"
-    const mockSettings = {
-      userTestGroups: JSON.stringify([group_1, group_2]),
-    }
+describe("User Test Groups API", () => {
+  test("raise error when given wrong json data type", () => {
     ;(appData as jest.Mock)
-      .mockImplementationOnce(() => {})
-      .mockImplementation(() => mockSettings)
+      .mockImplementationOnce(() => ({
+        // Wrong data type
+        userTestGroups: null,
+      }))
+      .mockImplementationOnce(() => ({
+        // Wrong data type
+        userTestGroups: "1.0",
+      }))
+      .mockImplementation(() => ({
+        // Wrong data type
+        userTestGroups: "{}",
+      }))
 
     // Start with no groups or keys
-    expect(inTestGroup(group_1)).toBe(false)
-    // Once groups are "loaded", check if in groups
+    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
+    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
+    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
+  })
+
+  test("raise error when given invalid json", () => {
+    ;(appData as jest.Mock)
+      .mockImplementationOnce(() => ({
+        userTestGroups: "asdf1234!@#$",
+      }))
+      .mockImplementationOnce(() => ({
+        userTestGroups: [1, 2, 3],
+      }))
+      .mockImplementation(() => ({
+        userTestGroups: "",
+      }))
+
+    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
+    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
+    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
+  })
+
+  test("confirm user is not in test group when missing user test group information", () => {
+    // Missing data key
+    ;(appData as jest.Mock).mockImplementation(() => {})
+
+    expect(inTestGroup("non-existent-group")).toBe(false)
+  })
+
+  test("confirm user in multiple test groups", () => {
+    const group_1 = "user-test-group-1"
+    const group_2 = "user-test-group-2"
+    ;(appData as jest.Mock).mockImplementation(() => ({
+      userTestGroups: JSON.stringify([group_1, group_2]),
+    }))
+
     expect(inTestGroup(group_1)).toBe(true)
     expect(inTestGroup(group_2)).toBe(true)
+    expect(inTestGroup(group_1 + group_2)).toBe(false)
   })
 })

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -1,26 +1,24 @@
-import appData from "../src/appData";
-import inTestGroup from "../src/userTestGroups";
+import appData from "../src/appData"
+import inTestGroup from "../src/userTestGroups"
 
 jest.mock("appData")
 
 describe("User test groups helper", () => {
-   // test("Assert")
-   test("Assert detect user in group", () => {
-      const group_1 = "user-test-group-1"
-      const group_2 = "user-test-group-2"
-      const mockSettings = {
-         userTestGroups: JSON.stringify([
-            group_1, group_2
-         ])
-      }
-      ;(appData as jest.Mock)
-         .mockImplementationOnce(() => {})
-         .mockImplementation(() => mockSettings)
+  // test("Assert")
+  test("Assert detect user in group", () => {
+    const group_1 = "user-test-group-1"
+    const group_2 = "user-test-group-2"
+    const mockSettings = {
+      userTestGroups: JSON.stringify([group_1, group_2]),
+    }
+    ;(appData as jest.Mock)
+      .mockImplementationOnce(() => {})
+      .mockImplementation(() => mockSettings)
 
-      // Start with no groups or keys
-      expect(inTestGroup(group_1)).toBe(false)
-      // Once groups are "loaded", check if in groups
-      expect(inTestGroup(group_1)).toBe(true)
-      expect(inTestGroup(group_2)).toBe(true)
-   })
+    // Start with no groups or keys
+    expect(inTestGroup(group_1)).toBe(false)
+    // Once groups are "loaded", check if in groups
+    expect(inTestGroup(group_1)).toBe(true)
+    expect(inTestGroup(group_2)).toBe(true)
+  })
 })

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -5,52 +5,7 @@ import inTestGroup from "../src/userTestGroups"
 jest.mock("appData")
 
 describe("User Test Groups API", () => {
-  test("raise error when given wrong json data type", () => {
-    ;(appData as jest.Mock)
-      .mockImplementationOnce(() => ({
-        // Wrong data type
-        userTestGroups: null,
-      }))
-      .mockImplementationOnce(() => ({
-        // Wrong data type
-        userTestGroups: "1.0",
-      }))
-      .mockImplementation(() => ({
-        // Wrong data type
-        userTestGroups: "{}",
-      }))
-
-    // Start with no groups or keys
-    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
-    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
-    expect(() => inTestGroup("non-existent-group")).toThrow(StructError)
-  })
-
-  test("raise error when given invalid json", () => {
-    ;(appData as jest.Mock)
-      .mockImplementationOnce(() => ({
-        userTestGroups: "asdf1234!@#$",
-      }))
-      .mockImplementationOnce(() => ({
-        userTestGroups: [1, 2, 3],
-      }))
-      .mockImplementation(() => ({
-        userTestGroups: "",
-      }))
-
-    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
-    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
-    expect(() => inTestGroup("non-existent-group")).toThrow(SyntaxError)
-  })
-
-  test("confirm user is not in test group when missing user test group information", () => {
-    // Missing data key
-    ;(appData as jest.Mock).mockImplementation(() => {})
-
-    expect(inTestGroup("non-existent-group")).toBe(false)
-  })
-
-  test("confirm user in multiple test groups", () => {
+  test("returns true if user is in test group", () => {
     const group_1 = "user-test-group-1"
     const group_2 = "user-test-group-2"
     ;(appData as jest.Mock).mockImplementation(() => ({
@@ -61,4 +16,45 @@ describe("User Test Groups API", () => {
     expect(inTestGroup(group_2)).toBe(true)
     expect(inTestGroup(group_1 + group_2)).toBe(false)
   })
+
+  test.each([{}, { userTestGroup: undefined }])(
+    "returns false if the test group information is not found: case %#",
+    (mock) => {
+      // Missing data key
+      ;(appData as jest.Mock).mockImplementation(() => mock)
+
+      expect(inTestGroup("non-existent-group")).toBe(false)
+    }
+  )
+
+  test.each([
+    // JSON.parse should throw when given invalid json
+    { expectedError: SyntaxError, mockTestGroupData: "" },
+    { expectedError: SyntaxError, mockTestGroupData: "test 1234 !@#$ []{}" },
+    { expectedError: SyntaxError, mockTestGroupData: [1, 2, 3] },
+
+    // Superstruct catches valid json but invalid types
+    { expectedError: StructError, mockTestGroupData: null },
+    { expectedError: StructError, mockTestGroupData: JSON.stringify(null) },
+    { expectedError: StructError, mockTestGroupData: true },
+    { expectedError: StructError, mockTestGroupData: JSON.stringify(true) },
+    {
+      expectedError: StructError,
+      mockTestGroupData: JSON.stringify([1, 2, 3]),
+    },
+    {
+      expectedError: StructError,
+      mockTestGroupData: JSON.stringify({ irrelevant: "keys" }),
+    },
+  ])(
+    "raise error when test group data is not the correct type: case %#",
+    ({ mockTestGroupData, expectedError: expectedError }) => {
+      ;(appData as jest.Mock).mockImplementationOnce(() => ({
+        userTestGroups: mockTestGroupData,
+      }))
+      expect(() => inTestGroup("non-existent-test-group")).toThrowError(
+        expectedError
+      )
+    }
+  )
 })

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -1,0 +1,26 @@
+import appData from "../src/appData";
+import inTestGroup from "../src/userTestGroups";
+
+jest.mock("appData")
+
+describe("User test groups helper", () => {
+   // test("Assert")
+   test("Assert detect user in group", () => {
+      const group_1 = "user-test-group-1"
+      const group_2 = "user-test-group-2"
+      const mockSettings = {
+         userTestGroups: JSON.stringify([
+            group_1, group_2
+         ])
+      }
+      ;(appData as jest.Mock)
+         .mockImplementationOnce(() => {})
+         .mockImplementation(() => mockSettings)
+
+      // Start with no groups or keys
+      expect(inTestGroup(group_1)).toBe(false)
+      // Once groups are "loaded", check if in groups
+      expect(inTestGroup(group_1)).toBe(true)
+      expect(inTestGroup(group_2)).toBe(true)
+   })
+})

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -17,7 +17,7 @@ describe("User Test Groups API", () => {
     expect(inTestGroup(group_1 + group_2)).toBe(false)
   })
 
-  test.each([{}, { userTestGroup: undefined }])(
+  test.each([undefined, {}, { userTestGroup: undefined }])(
     "returns false if the test group information is not found: case %#",
     (mock) => {
       // Missing data key

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -5,6 +5,7 @@ defmodule Skate.Settings.Db.User do
   alias Notifications.Db.Notification, as: DbNotification
   alias Notifications.Db.NotificationUser, as: DbNotificationUser
   alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+  alias Skate.Settings.Db.TestGroupUser, as: DbTestGroupUser
   alias Skate.Settings.Db.UserSettings, as: DbUserSettings
 
   @type t :: %__MODULE__{}
@@ -19,6 +20,10 @@ defmodule Skate.Settings.Db.User do
     has_many(:notification_users, DbNotificationUser)
     many_to_many(:notifications, DbNotification, join_through: DbNotificationUser)
     has_many(:route_tabs, DbRouteTab, on_replace: :delete_if_exists)
+
+    # :test_groups goes through :test_group_users to find the :test_group's the user belongs to
+    has_many(:test_group_users, DbTestGroupUser, on_replace: :delete_if_exists)
+    has_many(:test_groups, through: [:test_group_users, :test_group])
   end
 
   def changeset(user, attrs \\ %{}) do

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -21,7 +21,6 @@ defmodule Skate.Settings.Db.User do
     many_to_many(:notifications, DbNotification, join_through: DbNotificationUser)
     has_many(:route_tabs, DbRouteTab, on_replace: :delete_if_exists)
 
-    # :test_groups goes through :test_group_users to find the :test_group's the user belongs to
     has_many(:test_group_users, DbTestGroupUser, on_replace: :delete_if_exists)
     has_many(:test_groups, through: [:test_group_users, :test_group])
   end

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -4,8 +4,8 @@ defmodule Skate.Settings.Db.User do
 
   alias Notifications.Db.Notification, as: DbNotification
   alias Notifications.Db.NotificationUser, as: DbNotificationUser
-  alias Skate.Settings.Db.UserSettings, as: DbUserSettings
   alias Skate.Settings.Db.RouteTab, as: DbRouteTab
+  alias Skate.Settings.Db.UserSettings, as: DbUserSettings
 
   @type t :: %__MODULE__{}
 

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -12,7 +12,7 @@ defmodule SkateWeb.PageController do
     username = AuthManager.Plug.current_resource(conn)
     _ = Logger.info("uid=#{username}")
 
-    user = User.get(username)
+    user = username |> User.get() |> Skate.Repo.preload(:test_groups)
     user_settings = UserSettings.get_or_create(username)
     route_tabs = RouteTab.get_all_for_user(username)
 
@@ -29,6 +29,7 @@ defmodule SkateWeb.PageController do
     |> assign(:clarity_tag, Application.get_env(:skate, :clarity_tag))
     |> assign(:google_tag_manager_id, Application.get_env(:skate, :google_tag_manager_id))
     |> assign(:tileset_url, Application.get_env(:skate, :tileset_url))
+    |> assign(:user_test_groups, (user.test_groups))
     |> render("index.html")
   end
 

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -29,7 +29,7 @@ defmodule SkateWeb.PageController do
     |> assign(:clarity_tag, Application.get_env(:skate, :clarity_tag))
     |> assign(:google_tag_manager_id, Application.get_env(:skate, :google_tag_manager_id))
     |> assign(:tileset_url, Application.get_env(:skate, :tileset_url))
-    |> assign(:user_test_groups, (user.test_groups))
+    |> assign(:user_test_groups, user.test_groups |> Enum.map(& &1.name))
     |> render("index.html")
   end
 

--- a/lib/skate_web/templates/page/index.html.eex
+++ b/lib/skate_web/templates/page/index.html.eex
@@ -6,4 +6,5 @@
   data-laboratory-features="<%= Jason.encode!(@laboratory_features) %>"
   data-tileset-url="<%= @tileset_url %>"
   data-dispatcher-flag="<%= Jason.encode!(@dispatcher_flag) %>"
+  data-user-test-groups="<%= Jason.encode!(@user_test_groups) %>"
 ></div>

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -68,7 +68,9 @@ defmodule SkateWeb.PageControllerTest do
       html = html_response(conn, 200)
 
       json =
-        Jason.encode!(user_struct.test_groups |> Enum.map(& &1.name))
+        user_struct.test_groups
+        |> Enum.map(& &1.name)
+        |> Jason.encode!()
         |> Phoenix.HTML.html_escape()
         |> Phoenix.HTML.safe_to_string()
 

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -53,6 +53,23 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
+    test "includes user test groups in HTML", %{conn: conn, user: user} do
+      user_struct = user |> Skate.Settings.User.get() |> Skate.Repo.preload(:test_groups)
+
+      Skate.Settings.TestGroup.update(%{
+        Skate.Settings.TestGroup.create("html-test-group")
+        | users: [user_struct]
+      })
+
+      conn = get(conn, "/")
+
+      html = html_response(conn, 200)
+
+      assert html =~ "data-user-test-groups"
+      assert html =~ Jason.encode!(user_struct.test_groups |> Enum.map(& &1.name))
+    end
+
+    @tag :authenticated
     test "/settings returns 200", %{conn: conn} do
       conn = get(conn, "/settings")
 


### PR DESCRIPTION
This implements access to a user's test groups via storing the information in the database schema, rendering it to the frontend, and providing a utility function to access the data.

---

Closes: https://app.asana.com/0/1200180014510248/1202519045249749/f