### PR TITLE
feat: Reduce usage of username field for retrieving user data

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -7,6 +7,7 @@ defmodule Notifications.Notification do
   alias Schedule.Trip
   alias Schedule.Hastus.Run
   alias Skate.Settings.User
+  alias Skate.Settings.Db.User, as: DbUser
   alias Notifications.NotificationReason
   alias Notifications.NotificationState
   alias Notifications.Db.Notification, as: DbNotification
@@ -197,12 +198,14 @@ defmodule Notifications.Notification do
     |> Enum.map(&convert_from_db_notification/1)
   end
 
-  def update_read_states(username, notification_ids, read_state)
+  @spec update_read_states(DbUser.id(), [id()], NotificationState.t()) ::
+          {non_neg_integer(), nil | [t()]}
+  def update_read_states(user_id, notification_ids, read_state)
       when read_state in [:read, :unread, :deleted] do
     query =
       from(nu in DbNotificationUser,
         join: u in assoc(nu, :user),
-        where: u.username == ^username,
+        where: u.id == ^user_id,
         where: nu.notification_id in ^notification_ids
       )
 

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -8,6 +8,7 @@ defmodule Skate.Settings.Db.User do
   alias Skate.Settings.Db.RouteTab, as: DbRouteTab
 
   @type t :: %__MODULE__{}
+  @type id :: integer()
 
   schema "users" do
     field(:username, :string)

--- a/lib/skate/settings/route_tab.ex
+++ b/lib/skate/settings/route_tab.ex
@@ -33,15 +33,15 @@ defmodule Skate.Settings.RouteTab do
     :save_changes_to_tab_uuid
   ]
 
-  @spec get_all_for_user(String.t()) :: [t()]
-  def get_all_for_user(username) do
-    from(rt in DbRouteTab, join: u in assoc(rt, :user), where: u.username == ^username)
+  @spec get_all_for_user(DbUser.id()) :: [t()]
+  def get_all_for_user(user_id) do
+    from(rt in DbRouteTab, join: u in assoc(rt, :user), where: u.id == ^user_id)
     |> Repo.all()
     |> Enum.map(&db_route_tab_to_route_tab(&1))
   end
 
-  @spec update_all_for_user!(String.t(), [t()]) :: [t()]
-  def update_all_for_user!(username, route_tabs) do
+  @spec update_all_for_user!(DbUser.id(), [t()]) :: [t()]
+  def update_all_for_user!(user_id, route_tabs) do
     # Do update in two stages to prevent foreign key constaint problem. A route_tabs entry
     # with unsaved modifications will have a save_changes_to_tab_uuid value pointing to the
     # original, unmodified entry (which itself will always be a preset as of currently). An
@@ -50,7 +50,7 @@ defmodule Skate.Settings.RouteTab do
     unmodified_route_tabs =
       Enum.filter(route_tabs, fn route_tab -> is_nil(route_tab.save_changes_to_tab_uuid) end)
 
-    username
+    user_id
     |> User.get()
     |> Repo.preload(:route_tabs)
     |> DbUser.changeset(%{route_tabs: Enum.map(unmodified_route_tabs, &Map.from_struct/1)})

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -4,12 +4,12 @@ defmodule Skate.Settings.User do
   import Ecto.Query
   require Logger
 
-  @spec get(String.t()) :: DbUser.t()
+  @spec get(DbUser.id()) :: DbUser.t()
   @doc """
   Get a user by their username
   """
-  def get(username) do
-    Skate.Repo.get_by!(DbUser, username: username)
+  def get(user_id) do
+    Skate.Repo.get!(DbUser, user_id)
   end
 
   @spec get_by_email(String.t()) :: DbUser.t() | nil

--- a/lib/skate/settings/user_settings.ex
+++ b/lib/skate/settings/user_settings.ex
@@ -28,9 +28,9 @@ defmodule Skate.Settings.UserSettings do
     :vehicle_adherence_colors
   ]
 
-  @spec get_or_create(String.t()) :: t()
-  def get_or_create(username) do
-    user = User.get(username)
+  @spec get_or_create(DbUser.id()) :: t()
+  def get_or_create(user_id) do
+    user = User.get(user_id)
 
     user_settings =
       insert!(
@@ -53,15 +53,15 @@ defmodule Skate.Settings.UserSettings do
     }
   end
 
-  @spec set(String.t(), atom(), any()) :: :ok
-  def set(username, field, value) do
+  @spec set(DbUser.id(), atom(), any()) :: :ok
+  def set(user_id, field, value) do
     {:ok, db_value} = db_value(field, value)
 
     update_all(
       from(user_settings in "user_settings",
         join: user in DbUser,
         on: user.id == user_settings.user_id,
-        where: user.username == ^username
+        where: user.id == ^user_id
       ),
       set: [{field, db_value}]
     )

--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -10,14 +10,14 @@ defmodule SkateWeb.AuthManager do
     {:ok, resource}
   end
 
-  def resource_from_claims(%{"sub" => %{"username" => username, "user_id" => user_id}}) do
-    {:ok, %{username: username, user_id: user_id}}
+  def resource_from_claims(%{"sub" => username}) do
+    {:ok, username}
   end
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
   def username_from_socket!(socket) do
-    {:ok, %{username: username}} =
+    {:ok, username} =
       socket
       |> Guardian.Phoenix.Socket.current_token()
       |> decode_and_verify!()

--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -10,14 +10,14 @@ defmodule SkateWeb.AuthManager do
     {:ok, resource}
   end
 
-  def resource_from_claims(%{"sub" => username}) do
-    {:ok, username}
+  def resource_from_claims(%{"sub" => %{"username" => username, "user_id" => user_id}}) do
+    {:ok, %{username: username, user_id: user_id}}
   end
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
   def username_from_socket!(socket) do
-    {:ok, username} =
+    {:ok, %{username: username}} =
       socket
       |> Guardian.Phoenix.Socket.current_token()
       |> decode_and_verify!()

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -14,12 +14,12 @@ defmodule SkateWeb.AuthController do
 
     current_time = System.system_time(:second)
 
-    User.upsert(username, email)
+    %{id: user_id} = User.upsert(username, email)
 
     conn
     |> Guardian.Plug.sign_in(
       AuthManager,
-      username,
+      %{username: username, user_id: user_id},
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -19,11 +19,12 @@ defmodule SkateWeb.AuthController do
     conn
     |> Guardian.Plug.sign_in(
       AuthManager,
-      %{username: username, user_id: user_id},
+      username,
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )
     |> Plug.Conn.put_session(:username, username)
+    |> Plug.Conn.put_session(:user_id, user_id)
     |> redirect(to: Helpers.page_path(conn, :index))
   end
 

--- a/lib/skate_web/controllers/notification_read_states_controller.ex
+++ b/lib/skate_web/controllers/notification_read_states_controller.ex
@@ -2,10 +2,9 @@ defmodule SkateWeb.NotificationReadStatesController do
   use SkateWeb, :controller
 
   alias Notifications.Notification
-  alias SkateWeb.AuthManager
 
   def update(conn, %{"new_state" => new_read_state, "notification_ids" => notification_ids}) do
-    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
+    user_id = get_session(conn, :user_id)
 
     new_read_state = String.to_existing_atom(new_read_state)
     notification_ids = String.split(notification_ids, ",")

--- a/lib/skate_web/controllers/notification_read_states_controller.ex
+++ b/lib/skate_web/controllers/notification_read_states_controller.ex
@@ -5,12 +5,12 @@ defmodule SkateWeb.NotificationReadStatesController do
   alias SkateWeb.AuthManager
 
   def update(conn, %{"new_state" => new_read_state, "notification_ids" => notification_ids}) do
-    username = AuthManager.Plug.current_resource(conn)
+    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
 
     new_read_state = String.to_existing_atom(new_read_state)
     notification_ids = String.split(notification_ids, ",")
 
-    Notification.update_read_states(username, notification_ids, new_read_state)
+    Notification.update_read_states(user_id, notification_ids, new_read_state)
 
     send_resp(conn, 200, "")
   end

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -9,12 +9,12 @@ defmodule SkateWeb.PageController do
   plug(:laboratory_features)
 
   def index(conn, _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    %{username: username, user_id: user_id} = AuthManager.Plug.current_resource(conn)
     _ = Logger.info("uid=#{username}")
 
-    user = User.get(username)
-    user_settings = UserSettings.get_or_create(username)
-    route_tabs = RouteTab.get_all_for_user(username)
+    user = User.get(user_id)
+    user_settings = UserSettings.get_or_create(user_id)
+    route_tabs = RouteTab.get_all_for_user(user_id)
 
     dispatcher_flag =
       conn |> Guardian.Plug.current_claims() |> AuthManager.claims_grant_dispatcher_access?()

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -9,7 +9,9 @@ defmodule SkateWeb.PageController do
   plug(:laboratory_features)
 
   def index(conn, _params) do
-    %{username: username, user_id: user_id} = AuthManager.Plug.current_resource(conn)
+    username = AuthManager.Plug.current_resource(conn)
+    user_id = get_session(conn, :user_id)
+
     _ = Logger.info("uid=#{username}")
 
     user = User.get(user_id)

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -5,9 +5,9 @@ defmodule SkateWeb.RouteTabsController do
   alias Skate.Settings.RouteTab
 
   def update(conn, %{"route_tabs" => route_tabs} = _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
 
-    new_route_tabs = RouteTab.update_all_for_user!(username, format_tabs_for_update(route_tabs))
+    new_route_tabs = RouteTab.update_all_for_user!(user_id, format_tabs_for_update(route_tabs))
     json(conn, %{data: new_route_tabs})
   end
 

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -1,11 +1,10 @@
 defmodule SkateWeb.RouteTabsController do
   use SkateWeb, :controller
 
-  alias SkateWeb.AuthManager
   alias Skate.Settings.RouteTab
 
   def update(conn, %{"route_tabs" => route_tabs} = _params) do
-    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
+    user_id = get_session(conn, :user_id)
 
     new_route_tabs = RouteTab.update_all_for_user!(user_id, format_tabs_for_update(route_tabs))
     json(conn, %{data: new_route_tabs})

--- a/lib/skate_web/controllers/user_settings_controller.ex
+++ b/lib/skate_web/controllers/user_settings_controller.ex
@@ -6,13 +6,13 @@ defmodule SkateWeb.UserSettingsController do
   alias SkateWeb.AuthManager
 
   def update(conn, %{"field" => field, "value" => value} = _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
     field = field(field)
     value = value(field, value)
 
     case {field, value} do
       {field, {:ok, value}} when not is_nil(field) ->
-        UserSettings.set(username, field, value)
+        UserSettings.set(user_id, field, value)
         send_resp(conn, 200, "")
 
       _ ->

--- a/lib/skate_web/controllers/user_settings_controller.ex
+++ b/lib/skate_web/controllers/user_settings_controller.ex
@@ -3,10 +3,9 @@ defmodule SkateWeb.UserSettingsController do
   alias Skate.Settings.UserSettings
   alias Skate.Settings.VehicleLabel
   alias Skate.Settings.VehicleAdherenceColor
-  alias SkateWeb.AuthManager
 
   def update(conn, %{"field" => field, "value" => value} = _params) do
-    %{user_id: user_id} = AuthManager.Plug.current_resource(conn)
+    user_id = get_session(conn, :user_id)
     field = field(field)
     value = value(field, value)
 

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -266,8 +266,8 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["39"]
         })
 
-      User.upsert("fake_uid", "fakeemail@test.com")
-      RouteTab.update_all_for_user!("fake_uid", [route_tab1])
+      %{id: id} = User.upsert("fake_uid", "fakeemail@test.com")
+      RouteTab.update_all_for_user!(id, [route_tab1])
       :ok
     end
 
@@ -341,8 +341,8 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["1", "83", "77"]
         })
 
-      User.upsert("fake_uid", "fakeemail@test.com")
-      RouteTab.update_all_for_user!("fake_uid", [route_tab1])
+      %{id: id} = User.upsert("fake_uid", "fakeemail@test.com")
+      RouteTab.update_all_for_user!(id, [route_tab1])
 
       set_log_level(:info)
 
@@ -433,8 +433,8 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid, "#{uid}@test.com")
-        RouteTab.update_all_for_user!(uid, [route_tab1])
+        %{id: id} = User.upsert(uid, "#{uid}@test.com")
+        RouteTab.update_all_for_user!(id, [route_tab1])
       end
 
       start_time = DateTime.utc_now() |> DateTime.to_unix()
@@ -474,8 +474,8 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid, "#{uid}@test.com")
-        RouteTab.update_all_for_user!(uid, [route_tab1])
+        %{id: id} = User.upsert(uid, "#{uid}@test.com")
+        RouteTab.update_all_for_user!(id, [route_tab1])
       end
 
       NotificationServer.subscribe("fake_uid0", server)
@@ -520,8 +520,8 @@ defmodule Notifications.NotificationServerTest do
           selected_route_ids: ["1", "83", "77"]
         })
 
-      User.upsert("fake_uid", "fake_uid@test.com")
-      RouteTab.update_all_for_user!("fake_uid", [route_tab1])
+      %{id: id} = User.upsert("fake_uid", "fake_uid@test.com")
+      RouteTab.update_all_for_user!(id, [route_tab1])
 
       set_log_level(:info)
 
@@ -564,8 +564,8 @@ defmodule Notifications.NotificationServerTest do
             selected_route_ids: ["#{route_id}"]
           })
 
-        User.upsert(uid, "#{uid}@test.com")
-        RouteTab.update_all_for_user!(uid, [route_tab1])
+        %{id: id} = User.upsert(uid, "#{uid}@test.com")
+        RouteTab.update_all_for_user!(id, [route_tab1])
       end
 
       NotificationServer.subscribe("fake_uid0", server)

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -14,9 +14,9 @@ defmodule Notifications.NotificationTest do
 
   describe "get_or_create_from_block_waiver/1" do
     test "associates a new notification with users subscribed to an affected route" do
-      user1 = User.upsert("user1", "user1@test.com")
-      user2 = User.upsert("user2", "user2@test.com")
-      User.upsert("user3", "user3@test.com")
+      %{id: user_id_1} = User.upsert("user1", "user1@test.com")
+      %{id: user_id_2} = User.upsert("user2", "user2@test.com")
+      %{id: user_id_3} = User.upsert("user3", "user3@test.com")
 
       route_tab1 =
         build(:route_tab, %{
@@ -24,7 +24,7 @@ defmodule Notifications.NotificationTest do
           selected_route_ids: ["4", "1"]
         })
 
-      RouteTab.update_all_for_user!("user1", [route_tab1])
+      RouteTab.update_all_for_user!(user_id_1, [route_tab1])
 
       route_tab2 =
         build(:route_tab, %{
@@ -32,7 +32,7 @@ defmodule Notifications.NotificationTest do
           selected_route_ids: ["2"]
         })
 
-      RouteTab.update_all_for_user!("user2", [route_tab2])
+      RouteTab.update_all_for_user!(user_id_2, [route_tab2])
 
       route_tab3 =
         build(:route_tab, %{
@@ -40,7 +40,7 @@ defmodule Notifications.NotificationTest do
           selected_route_ids: ["4", "5", "6", "7"]
         })
 
-      RouteTab.update_all_for_user!("user3", [route_tab3])
+      RouteTab.update_all_for_user!(user_id_3, [route_tab3])
 
       notification_values = %{
         created_at: 12345,
@@ -63,15 +63,15 @@ defmodule Notifications.NotificationTest do
 
       assert(
         notification_users |> Enum.map(& &1.user_id) |> Enum.sort() ==
-          [user1.id, user2.id] |> Enum.sort()
+          [user_id_1, user_id_2] |> Enum.sort()
       )
     end
   end
 
   describe "unexpired_notifications_for_user/2" do
     test "returns all unexpired notifications for the given user, in chronological order by creation timestamp" do
-      User.upsert("user1", "user1@test.com")
-      User.upsert("user2", "user2@test.com")
+      %{id: user_id_1} = User.upsert("user1", "user1@test.com")
+      %{id: user_id_2} = User.upsert("user2", "user2@test.com")
       baseline_time = 1_000_000_000
       now_fn = fn -> baseline_time end
       naive_now_fn = fn -> baseline_time |> DateTime.from_unix!() |> DateTime.to_naive() end
@@ -84,7 +84,7 @@ defmodule Notifications.NotificationTest do
           selected_route_ids: ["1", "2", "112"]
         })
 
-      RouteTab.update_all_for_user!("user1", [route_tab1])
+      RouteTab.update_all_for_user!(user_id_1, [route_tab1])
 
       route_tab2 =
         build(:route_tab, %{
@@ -92,7 +92,7 @@ defmodule Notifications.NotificationTest do
           selected_route_ids: ["1", "3", "743"]
         })
 
-      RouteTab.update_all_for_user!("user2", [route_tab2])
+      RouteTab.update_all_for_user!(user_id_2, [route_tab2])
 
       route_1_unexpired =
         Notification.get_or_create_from_block_waiver(%{

--- a/test/skate/settings/route_tab_test.exs
+++ b/test/skate/settings/route_tab_test.exs
@@ -18,11 +18,11 @@ defmodule Skate.Settings.RouteTabTest do
       route_tab1 = build_test_tab()
       route_tab2 = build_test_tab()
 
-      User.upsert("user1", "user1@test.com")
-      User.upsert("user2", "user2@test.com")
+      %{id: user_id_1} = User.upsert("user1", "user1@test.com")
+      %{id: user_id_2} = User.upsert("user2", "user2@test.com")
 
-      RouteTab.update_all_for_user!("user1", [route_tab1])
-      RouteTab.update_all_for_user!("user2", [route_tab2])
+      RouteTab.update_all_for_user!(user_id_1, [route_tab1])
+      RouteTab.update_all_for_user!(user_id_2, [route_tab2])
 
       assert [
                %RouteTab{
@@ -31,17 +31,17 @@ defmodule Skate.Settings.RouteTabTest do
                  ladder_directions: %{"28" => "1"},
                  ladder_crowding_toggles: %{"1" => true}
                }
-             ] = RouteTab.get_all_for_user("user1")
+             ] = RouteTab.get_all_for_user(user_id_1)
     end
   end
 
   describe "update_all_for_user!/2" do
     setup do
-      User.upsert("charlie", "charlie@test.com")
-      :ok
+      %{id: user_id} = User.upsert("charlie", "charlie@test.com")
+      {:ok, %{user_id: user_id}}
     end
 
-    test "adds a new tab entry" do
+    test "adds a new tab entry", %{user_id: user_id} do
       route_tab = build_test_tab()
 
       assert [
@@ -51,7 +51,7 @@ defmodule Skate.Settings.RouteTabTest do
                  ladder_directions: %{"28" => "1"},
                  ladder_crowding_toggles: %{"1" => true}
                }
-             ] = RouteTab.update_all_for_user!("charlie", [route_tab])
+             ] = RouteTab.update_all_for_user!(user_id, [route_tab])
 
       assert [
                %RouteTab{
@@ -60,19 +60,19 @@ defmodule Skate.Settings.RouteTabTest do
                  ladder_directions: %{"28" => "1"},
                  ladder_crowding_toggles: %{"1" => true}
                }
-             ] = RouteTab.get_all_for_user("charlie")
+             ] = RouteTab.get_all_for_user(user_id)
     end
 
-    test "updates an existing tab entry" do
+    test "updates an existing tab entry", %{user_id: user_id} do
       route_tab1 = build_test_tab()
       route_tab1_uuid = route_tab1.uuid
       route_tab2 = build_test_tab()
       route_tab2_uuid = route_tab2.uuid
 
-      [persisted_route_tab1] = RouteTab.update_all_for_user!("charlie", [route_tab1])
+      [persisted_route_tab1] = RouteTab.update_all_for_user!(user_id, [route_tab1])
 
       update_results =
-        RouteTab.update_all_for_user!("charlie", [
+        RouteTab.update_all_for_user!(user_id, [
           %{
             persisted_route_tab1
             | preset_name: "some other name",
@@ -96,7 +96,7 @@ defmodule Skate.Settings.RouteTabTest do
                uuid: ^route_tab2_uuid
              } = Enum.find(update_results, fn route_tab -> route_tab.uuid == route_tab2_uuid end)
 
-      get_all_results = RouteTab.get_all_for_user("charlie")
+      get_all_results = RouteTab.get_all_for_user(user_id)
 
       assert Enum.count(get_all_results) == 2
 
@@ -114,14 +114,14 @@ defmodule Skate.Settings.RouteTabTest do
              } = Enum.find(get_all_results, fn route_tab -> route_tab.uuid == route_tab2_uuid end)
     end
 
-    test "deletes a removed tab entry" do
+    test "deletes a removed tab entry", %{user_id: user_id} do
       route_tab = build_test_tab()
 
-      [_persisted_route_tab] = RouteTab.update_all_for_user!("charlie", [route_tab])
+      [_persisted_route_tab] = RouteTab.update_all_for_user!(user_id, [route_tab])
 
-      RouteTab.update_all_for_user!("charlie", [])
+      RouteTab.update_all_for_user!(user_id, [])
 
-      assert [] == RouteTab.get_all_for_user("charlie")
+      assert [] == RouteTab.get_all_for_user(user_id)
     end
   end
 

--- a/test/skate/settings/user_settings_test.exs
+++ b/test/skate/settings/user_settings_test.exs
@@ -26,7 +26,7 @@ defmodule Skate.Settings.UserSettingsTest do
         returning: true
       )
 
-      result = UserSettings.get_or_create(@username)
+      result = UserSettings.get_or_create(user.id)
 
       assert result == %UserSettings{
                ladder_page_vehicle_label: :vehicle_id,
@@ -35,8 +35,8 @@ defmodule Skate.Settings.UserSettingsTest do
              }
     end
 
-    test "for a new user, initializes and stores the default settings" do
-      result = UserSettings.get_or_create(@username)
+    test "for a new user, initializes and stores the default settings", %{user: user} do
+      result = UserSettings.get_or_create(user.id)
 
       assert result == %UserSettings{
                ladder_page_vehicle_label: :run_id,
@@ -58,10 +58,10 @@ defmodule Skate.Settings.UserSettingsTest do
   end
 
   describe "set" do
-    test "can set a setting" do
-      UserSettings.get_or_create(@username)
-      UserSettings.set(@username, :ladder_page_vehicle_label, :vehicle_id)
-      result = UserSettings.get_or_create(@username)
+    test "can set a setting", %{user: user} do
+      UserSettings.get_or_create(user.id)
+      UserSettings.set(user.id, :ladder_page_vehicle_label, :vehicle_id)
+      result = UserSettings.get_or_create(user.id)
       assert result.ladder_page_vehicle_label == :vehicle_id
     end
   end

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -7,15 +7,16 @@ defmodule Skate.Settings.UserTest do
   @email "user@test.com"
 
   describe "get/1" do
-    test "gets user by username" do
-      Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: @username}))
+    test "gets user by user id" do
+      %{id: user_id_1} = Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: @username}))
+
       Skate.Repo.insert!(DbUser.changeset(%DbUser{}, %{username: "otheruser"}))
 
-      assert %DbUser{username: @username} = User.get(@username)
+      assert %DbUser{username: @username} = User.get(user_id_1)
     end
 
     test "raises if user not found" do
-      assert_raise Ecto.NoResultsError, fn -> User.get("missinguser") end
+      assert_raise Ecto.NoResultsError, fn -> User.get(1234) end
     end
   end
 

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -6,11 +6,12 @@ defmodule SkateWeb.AuthManagerTest do
 
   describe "username_from_socket!/1" do
     test "extracts the username from the given socket's token" do
-      {:ok, token, _claims} = AuthManager.encode_and_sign("charlie")
+      user = %{username: "charlie", user_id: 101}
+      {:ok, token, _claims} = AuthManager.encode_and_sign(user)
 
       {:ok, socket} =
         UserSocket
-        |> socket("charlie", %{})
+        |> socket(user, %{})
         |> Socket.authenticate(AuthManager, token)
 
       assert(AuthManager.username_from_socket!(socket) == "charlie")

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -6,12 +6,11 @@ defmodule SkateWeb.AuthManagerTest do
 
   describe "username_from_socket!/1" do
     test "extracts the username from the given socket's token" do
-      user = %{username: "charlie", user_id: 101}
-      {:ok, token, _claims} = AuthManager.encode_and_sign(user)
+      {:ok, token, _claims} = AuthManager.encode_and_sign("charlie")
 
       {:ok, socket} =
         UserSocket
-        |> socket(user, %{})
+        |> socket("charlie", %{})
         |> Socket.authenticate(AuthManager, token)
 
       assert(AuthManager.username_from_socket!(socket) == "charlie")

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -46,7 +46,8 @@ defmodule SkateWeb.AuthControllerTest do
       |> assign(:ueberauth_auth, mock_auth)
       |> get("/auth/cognito/callback")
 
-      assert %{username: "test_username", email: "test@mbta.com"} = User.get("test_username")
+      assert %{username: "test_username", email: "test@mbta.com"} =
+               User.get_by_email("test@mbta.com")
     end
 
     test "redirects home for an ueberauth failure", %{conn: conn} do

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -19,7 +19,7 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
     @tag :authenticated
     test "sets read state for a batch of notifications for the user", %{
       conn: conn,
-      user: %{user_id: user_id}
+      user: %{id: user_id}
     } do
       user = User.get(user_id)
       route_tab1 = build_test_tab()

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -19,15 +19,15 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
     @tag :authenticated
     test "sets read state for a batch of notifications for the user", %{
       conn: conn,
-      user: username
+      user: %{user_id: user_id}
     } do
-      user = User.get(username)
+      user = User.get(user_id)
       route_tab1 = build_test_tab()
-      RouteTab.update_all_for_user!(username, [route_tab1])
+      RouteTab.update_all_for_user!(user_id, [route_tab1])
 
-      User.upsert("otheruser", "other@email.com")
+      %{id: other_user_id} = User.upsert("otheruser", "other@email.com")
       route_tab2 = build_test_tab()
-      RouteTab.update_all_for_user!("otheruser", [route_tab2])
+      RouteTab.update_all_for_user!(other_user_id, [route_tab2])
 
       user_notification1 =
         Notification.get_or_create_from_block_waiver(%{

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -39,7 +39,7 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes route tabs in HTML", %{conn: conn, user: %{user_id: user_id}} do
+    test "includes route tabs in HTML", %{conn: conn, user: %{id: user_id}} do
       Skate.Settings.RouteTab.update_all_for_user!(user_id, [
         build(:route_tab, %{selected_route_ids: ["1"]})
       ])
@@ -98,7 +98,7 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes UUID in HTML", %{conn: conn, user: %{user_id: user_id}} do
+    test "includes UUID in HTML", %{conn: conn, user: %{id: user_id}} do
       user_struct = Skate.Settings.User.get(user_id)
 
       conn = get(conn, "/")

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -18,10 +18,10 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "assigns the username", %{conn: conn, user: user} do
+    test "assigns the username", %{conn: conn, user: %{username: username}} do
       conn = get(conn, "/")
 
-      assert conn.assigns.username == user
+      assert conn.assigns.username == username
     end
 
     @tag :authenticated
@@ -39,8 +39,8 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes route tabs in HTML", %{conn: conn, user: user} do
-      Skate.Settings.RouteTab.update_all_for_user!(user, [
+    test "includes route tabs in HTML", %{conn: conn, user: %{user_id: user_id}} do
+      Skate.Settings.RouteTab.update_all_for_user!(user_id, [
         build(:route_tab, %{selected_route_ids: ["1"]})
       ])
 
@@ -98,8 +98,8 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "includes UUID in HTML", %{conn: conn, user: user} do
-      user_struct = Skate.Settings.User.get(user)
+    test "includes UUID in HTML", %{conn: conn, user: %{user_id: user_id}} do
+      user_struct = Skate.Settings.User.get(user_id)
 
       conn = get(conn, "/")
 

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -5,7 +5,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
   describe "PUT /api/route_tabs" do
     @tag :authenticated
-    test "sets route tabs for logged-in user", %{conn: conn, user: %{user_id: user_id}} do
+    test "sets route tabs for logged-in user", %{conn: conn, user: %{id: user_id}} do
       conn =
         put(conn, "/api/route_tabs", %{
           "route_tabs" => [

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -5,7 +5,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
 
   describe "PUT /api/route_tabs" do
     @tag :authenticated
-    test "sets route tabs for logged-in user", %{conn: conn, user: user} do
+    test "sets route tabs for logged-in user", %{conn: conn, user: %{user_id: user_id}} do
       conn =
         put(conn, "/api/route_tabs", %{
           "route_tabs" => [
@@ -26,7 +26,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
                  selected_route_ids: ["1", "28"],
                  ordering: 12345
                }
-             ] = RouteTab.get_all_for_user(user)
+             ] = RouteTab.get_all_for_user(user_id)
     end
   end
 end

--- a/test/skate_web/controllers/user_settings_controller_test.exs
+++ b/test/skate_web/controllers/user_settings_controller_test.exs
@@ -4,13 +4,13 @@ defmodule SkateWeb.UserSettingsControllerTest do
   alias Skate.Settings.UserSettings
 
   describe "PUT /api/user_settings" do
-    setup %{user: username} do
-      UserSettings.get_or_create(username)
+    setup %{user: %{user_id: user_id}} do
+      UserSettings.get_or_create(user_id)
       :ok
     end
 
     @tag :authenticated
-    test "can set ladder_page_vehicle_label", %{conn: conn, user: username} do
+    test "can set ladder_page_vehicle_label", %{conn: conn, user: %{user_id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -19,12 +19,12 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user_id)
       assert result.ladder_page_vehicle_label == :vehicle_id
     end
 
     @tag :authenticated
-    test "can set shuttle_page_vehicle_label", %{conn: conn, user: username} do
+    test "can set shuttle_page_vehicle_label", %{conn: conn, user: %{user_id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -33,12 +33,12 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user_id)
       assert result.shuttle_page_vehicle_label == :run_id
     end
 
     @tag :authenticated
-    test "can set vehicle_adherence_colors", %{conn: conn, user: username} do
+    test "can set vehicle_adherence_colors", %{conn: conn, user: %{user_id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -47,7 +47,7 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user_id)
       assert result.vehicle_adherence_colors == :early_blue
     end
 

--- a/test/skate_web/controllers/user_settings_controller_test.exs
+++ b/test/skate_web/controllers/user_settings_controller_test.exs
@@ -4,13 +4,13 @@ defmodule SkateWeb.UserSettingsControllerTest do
   alias Skate.Settings.UserSettings
 
   describe "PUT /api/user_settings" do
-    setup %{user: %{user_id: user_id}} do
+    setup %{user: %{id: user_id}} do
       UserSettings.get_or_create(user_id)
       :ok
     end
 
     @tag :authenticated
-    test "can set ladder_page_vehicle_label", %{conn: conn, user: %{user_id: user_id}} do
+    test "can set ladder_page_vehicle_label", %{conn: conn, user: %{id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -24,7 +24,7 @@ defmodule SkateWeb.UserSettingsControllerTest do
     end
 
     @tag :authenticated
-    test "can set shuttle_page_vehicle_label", %{conn: conn, user: %{user_id: user_id}} do
+    test "can set shuttle_page_vehicle_label", %{conn: conn, user: %{id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -38,7 +38,7 @@ defmodule SkateWeb.UserSettingsControllerTest do
     end
 
     @tag :authenticated
-    test "can set vehicle_adherence_colors", %{conn: conn, user: %{user_id: user_id}} do
+    test "can set vehicle_adherence_colors", %{conn: conn, user: %{id: user_id}} do
       conn =
         conn
         |> put("/api/user_settings", %{

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,38 +39,37 @@ defmodule SkateWeb.ConnCase do
       Sandbox.mode(Skate.Repo, {:shared, self()})
     end
 
-    %{id: user_id} = User.upsert(username, email)
-    user_resource = %{user_id: user_id, username: username}
+    %{id: user_id} = user = User.upsert(username, email)
 
     {conn, user} =
       cond do
         tags[:authenticated] ->
           conn =
             Phoenix.ConnTest.build_conn()
-            |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{})
+            |> init_test_session(%{user_id: user_id})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{})
 
-          {conn, user_resource}
+          {conn, user}
 
         tags[:authenticated_admin] ->
           conn =
             Phoenix.ConnTest.build_conn()
-            |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{
+            |> init_test_session(%{user_id: user_id})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
               "groups" => ["skate-admin"]
             })
 
-          {conn, user_resource}
+          {conn, user}
 
         tags[:authenticated_dispatcher] ->
           conn =
             Phoenix.ConnTest.build_conn()
-            |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{
+            |> init_test_session(%{user_id: user_id})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
               "groups" => ["skate-dispatcher"]
             })
 
-          {conn, user_resource}
+          {conn, user}
 
         true ->
           {Phoenix.ConnTest.build_conn(), nil}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,41 +39,38 @@ defmodule SkateWeb.ConnCase do
       Sandbox.mode(Skate.Repo, {:shared, self()})
     end
 
+    %{id: user_id} = User.upsert(username, email)
+    user_resource = %{user_id: user_id, username: username}
+
     {conn, user} =
       cond do
         tags[:authenticated] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{})
 
-          {conn, username}
+          {conn, user_resource}
 
         tags[:authenticated_admin] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{
               "groups" => ["skate-admin"]
             })
 
-          {conn, username}
+          {conn, user_resource}
 
         tags[:authenticated_dispatcher] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, user_resource, %{
               "groups" => ["skate-dispatcher"]
             })
 
-          {conn, username}
+          {conn, user_resource}
 
         true ->
           {Phoenix.ConnTest.build_conn(), nil}


### PR DESCRIPTION
ticket: https://app.asana.com/0/1152340551558956/1201646081199380/f

This ticket replaces places where user data is queried by username with the user's primary key: id. 

There are a few core places that username is still used which this PR does not address: 
* `notifications_channel`: This uses `AuthManager.username_for_socket!/1` to get the username, and which notifications to show the user are queried by username. It feels like there may be some consequences to changing this identifier used to subscribe to notifications that I don't fully understand yet. If there are no consequences, changing the notifications code still feels a bit riskier and can be addressed in a separate PR. 

* `AuthManager.reesource_for_claims` still returns `username`. The first commit in this PR modified that to return both username & user_id, but after reading the [Guardian docs](https://hexdocs.pm/guardian/introduction-implementation.html#basic-setup) I realized that would break all the existing user tokens and reverted from this PR and further developed in a separate draft PR [here](https://github.com/mbta/skate/pull/1790).
* FE user identification for 3rd party integrations

My inclination is to break those three out into separate tickets from this one since we know the `username` field will be sticking around a a while longer (at least until [this ticket](https://app.asana.com/0/1152340551558956/1203278600620523/f) is addressed)

In any case, I'm thinking there will be a few additional PRs needed to complete this current ticket (which could all be done before the above three bullets are addressed): 
1. `User.upsert` should take only email address, not email + username
2. Remove existing records from the DB where email is null
3. Add a not-null constraint to the email field

Please let me know if you have any concerns about that plan - any other PRs I'm missing?