### PR TITLE
feat(AuthManager): Accept user_id as token subject

### DIFF
--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -28,6 +28,14 @@ defmodule Skate.Settings.User do
     Skate.Repo.get(DbUser, id)
   end
 
+  @spec get_by_id!(integer()) :: DbUser.t()
+  @doc """
+  Get a user by ID or raise an error if none found.
+  """
+  def get_by_id!(id) do
+    Skate.Repo.get!(DbUser, id)
+  end
+
   @spec get_all() :: [DbUser.t()]
   def get_all() do
     Skate.Repo.all(DbUser)

--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -17,6 +17,7 @@ defmodule SkateWeb.AuthManager do
   end
 
   def subject_for_token(resource, _claims) do
+    Logger.info("old pattern matched: subject_for_token")
     {:ok, resource}
   end
 
@@ -28,6 +29,7 @@ defmodule SkateWeb.AuthManager do
   end
 
   def resource_from_claims(%{"sub" => username}) do
+    Logger.info("old pattern matched: resource_from_claims")
     {:ok, username}
   end
 
@@ -48,7 +50,7 @@ defmodule SkateWeb.AuthManager do
   end
 
   def username_from_resource(username) when is_binary(username) do
-    Logger.info("old username resource pattern matched")
+    Logger.info("old pattern matched: username_from_resource")
     username
   end
 

--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -1,6 +1,5 @@
 defmodule SkateWeb.AuthManager do
   use Guardian, otp_app: :skate
-  alias Skate.Settings.Db.User, as: DbUser
   alias Skate.Settings.User
   require Logger
 
@@ -12,24 +11,21 @@ defmodule SkateWeb.AuthManager do
 
   def v2_resource_prefix, do: @v2_resource_prefix
 
-  def subject_for_token(%DbUser{id: user_id}, _claims) do
+  def subject_for_token(%{id: user_id}, _claims) do
     {:ok, "#{@v2_resource_prefix}#{user_id}"}
   end
 
   def subject_for_token(resource, _claims) do
-    Logger.info("old pattern matched: subject_for_token")
+    Logger.info("old_pattern_matched function=subject_for_token")
     {:ok, resource}
   end
 
   def resource_from_claims(%{"sub" => @v2_resource_prefix <> user_id}) do
-    case User.get_by_id(String.to_integer(user_id)) do
-      nil -> {:error, :user_not_found}
-      user -> {:ok, user}
-    end
+    {:ok, %{id: String.to_integer(user_id)}}
   end
 
   def resource_from_claims(%{"sub" => username}) do
-    Logger.info("old pattern matched: resource_from_claims")
+    Logger.info("old_pattern_matched function=resource_from_claims")
     {:ok, username}
   end
 
@@ -45,12 +41,12 @@ defmodule SkateWeb.AuthManager do
     username_from_resource(resource)
   end
 
-  def username_from_resource(%DbUser{username: username}) do
-    username
+  def username_from_resource(%{id: user_id}) do
+    User.get_by_id!(user_id).username
   end
 
   def username_from_resource(username) when is_binary(username) do
-    Logger.info("old pattern matched: username_from_resource")
+    Logger.info("old_pattern_matched function=username_from_resource")
     username
   end
 

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -31,8 +31,17 @@ defmodule SkateWeb.VehiclesChannel do
   def join(
         "vehicles:search:" <> search_params,
         _message,
-        %{assigns: %{guardian_default_resource: username}} = socket
+        socket
       ) do
+    username_from_socket! =
+      Application.get_env(
+        :skate,
+        :username_from_socket!,
+        &SkateWeb.AuthManager.username_from_socket!/1
+      )
+
+    username = username_from_socket!.(socket)
+
     subscribe_args =
       case search_params do
         "all:" <> text ->

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -14,12 +14,12 @@ defmodule SkateWeb.AuthController do
 
     current_time = System.system_time(:second)
 
-    User.upsert(username, email)
+    %{id: user_id} = User.upsert(username, email)
 
     conn
     |> Guardian.Plug.sign_in(
       AuthManager,
-      %{username: username, user_id: user_id},
+      "#{AuthManager.v2_resource_prefix()}#{user_id}",
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -23,7 +23,6 @@ defmodule SkateWeb.AuthController do
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )
-    |> Plug.Conn.put_session(:username, username)
     |> redirect(to: Helpers.page_path(conn, :index))
   end
 

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -19,7 +19,7 @@ defmodule SkateWeb.AuthController do
     conn
     |> Guardian.Plug.sign_in(
       AuthManager,
-      "#{AuthManager.v2_resource_prefix()}#{user_id}",
+      %{id: user_id},
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -19,7 +19,7 @@ defmodule SkateWeb.AuthController do
     conn
     |> Guardian.Plug.sign_in(
       AuthManager,
-      username,
+      %{username: username, user_id: user_id},
       %{groups: credentials.other[:groups]},
       ttl: {expiration - current_time, :seconds}
     )

--- a/lib/skate_web/controllers/notification_read_states_controller.ex
+++ b/lib/skate_web/controllers/notification_read_states_controller.ex
@@ -5,7 +5,10 @@ defmodule SkateWeb.NotificationReadStatesController do
   alias SkateWeb.AuthManager
 
   def update(conn, %{"new_state" => new_read_state, "notification_ids" => notification_ids}) do
-    username = AuthManager.Plug.current_resource(conn)
+    username =
+      conn
+      |> AuthManager.Plug.current_resource()
+      |> AuthManager.username_from_resource()
 
     new_read_state = String.to_existing_atom(new_read_state)
     notification_ids = String.split(notification_ids, ",")

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -9,7 +9,11 @@ defmodule SkateWeb.PageController do
   plug(:laboratory_features)
 
   def index(conn, _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    username =
+      conn
+      |> AuthManager.Plug.current_resource()
+      |> AuthManager.username_from_resource()
+
     _ = Logger.info("uid=#{username}")
 
     user = username |> User.get() |> Skate.Repo.preload(:test_groups)

--- a/lib/skate_web/controllers/route_tabs_controller.ex
+++ b/lib/skate_web/controllers/route_tabs_controller.ex
@@ -5,7 +5,10 @@ defmodule SkateWeb.RouteTabsController do
   alias Skate.Settings.RouteTab
 
   def update(conn, %{"route_tabs" => route_tabs} = _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    username =
+      conn
+      |> AuthManager.Plug.current_resource()
+      |> AuthManager.username_from_resource()
 
     new_route_tabs = RouteTab.update_all_for_user!(username, format_tabs_for_update(route_tabs))
     json(conn, %{data: new_route_tabs})

--- a/lib/skate_web/controllers/user_settings_controller.ex
+++ b/lib/skate_web/controllers/user_settings_controller.ex
@@ -6,7 +6,11 @@ defmodule SkateWeb.UserSettingsController do
   alias SkateWeb.AuthManager
 
   def update(conn, %{"field" => field, "value" => value} = _params) do
-    username = AuthManager.Plug.current_resource(conn)
+    username =
+      conn
+      |> AuthManager.Plug.current_resource()
+      |> AuthManager.username_from_resource()
+
     field = field(field)
     value = value(field, value)
 

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -39,6 +39,28 @@ defmodule Skate.Settings.UserTest do
     end
   end
 
+  describe "get_by_id/1" do
+    test "returns user if one is found" do
+      %{id: id} = user = User.upsert(@username, @email)
+      assert user == User.get_by_id(id)
+    end
+
+    test "returns nil if no user found" do
+      assert is_nil(User.get_by_id(1))
+    end
+  end
+
+  describe "get_by_id!/1" do
+    test "returns user if one is found" do
+      %{id: id} = user = User.upsert(@username, @email)
+      assert user == User.get_by_id!(id)
+    end
+
+    test "raises exception if no user found" do
+      assert_raise Ecto.NoResultsError, fn -> User.get_by_id!(1) end
+    end
+  end
+
   describe "get_all/0" do
     test "returns all users" do
       user1 = User.upsert("user1", "user1@test.com")

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -3,6 +3,46 @@ defmodule SkateWeb.AuthManagerTest do
   alias Guardian.Phoenix.Socket
   alias SkateWeb.AuthManager
   alias SkateWeb.UserSocket
+  alias Skate.Settings.Db.User, as: DbUser
+  alias Skate.Settings.User
+
+  @username "username1"
+  @user_id 1
+
+  describe "subject_for_token/2" do
+    test "returns username string" do
+      assert {:ok, @username} == AuthManager.subject_for_token(@username, %{})
+    end
+
+    test "returns v2 formatted user id when given user struct" do
+      assert {:ok, "v2:#{@user_id}"} ==
+               AuthManager.subject_for_token(%DbUser{username: @username, id: @user_id}, %{})
+    end
+  end
+
+  describe "resource_from_claims/2" do
+    test "returns user struct when given v2 formatted user id for a user that exists" do
+      %{id: user_id} = User.upsert(@username, "email@test.com")
+
+      assert {:ok, %DbUser{username: @username, id: ^user_id}} =
+               AuthManager.resource_from_claims(%{
+                 "sub" => "v2:#{user_id}"
+               })
+    end
+
+    test "returns error when given v2 formatted user id for a user that doesn't exist" do
+      non_existent_id = 1234
+
+      assert {:error, :user_not_found} =
+               AuthManager.resource_from_claims(%{
+                 "sub" => "v2:#{non_existent_id}"
+               })
+    end
+
+    test "returns username as string when given only username" do
+      assert {:ok, @username} == AuthManager.resource_from_claims(%{"sub" => @username})
+    end
+  end
 
   describe "username_from_socket!/1" do
     test "extracts the username from the given socket's token" do
@@ -14,6 +54,17 @@ defmodule SkateWeb.AuthManagerTest do
         |> Socket.authenticate(AuthManager, token)
 
       assert(AuthManager.username_from_socket!(socket) == "charlie")
+    end
+  end
+
+  describe "username_from_resource/1" do
+    test "returns username from user struct" do
+      assert @username =
+               AuthManager.username_from_resource(%DbUser{username: @username, id: @user_id})
+    end
+
+    test "returns string when only given username as string" do
+      assert @username = AuthManager.username_from_resource(@username)
     end
   end
 

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -3,7 +3,6 @@ defmodule SkateWeb.AuthManagerTest do
   alias Guardian.Phoenix.Socket
   alias SkateWeb.AuthManager
   alias SkateWeb.UserSocket
-  alias Skate.Settings.Db.User, as: DbUser
   alias Skate.Settings.User
 
   @username "username1"
@@ -16,26 +15,17 @@ defmodule SkateWeb.AuthManagerTest do
 
     test "returns v2 formatted user id when given user struct" do
       assert {:ok, "v2:#{@user_id}"} ==
-               AuthManager.subject_for_token(%DbUser{username: @username, id: @user_id}, %{})
+               AuthManager.subject_for_token(%{id: @user_id}, %{})
     end
   end
 
   describe "resource_from_claims/2" do
-    test "returns user struct when given v2 formatted user id for a user that exists" do
+    test "returns struct when given v2 formatted user id" do
       %{id: user_id} = User.upsert(@username, "email@test.com")
 
-      assert {:ok, %DbUser{username: @username, id: ^user_id}} =
+      assert {:ok, %{id: ^user_id}} =
                AuthManager.resource_from_claims(%{
                  "sub" => "v2:#{user_id}"
-               })
-    end
-
-    test "returns error when given v2 formatted user id for a user that doesn't exist" do
-      non_existent_id = 1234
-
-      assert {:error, :user_not_found} =
-               AuthManager.resource_from_claims(%{
-                 "sub" => "v2:#{non_existent_id}"
                })
     end
 
@@ -59,8 +49,8 @@ defmodule SkateWeb.AuthManagerTest do
 
   describe "username_from_resource/1" do
     test "returns username from user struct" do
-      assert @username =
-               AuthManager.username_from_resource(%DbUser{username: @username, id: @user_id})
+      %{id: user_id} = User.upsert(@username, "test@email.com")
+      assert @username = AuthManager.username_from_resource(%{id: user_id})
     end
 
     test "returns string when only given username as string" do

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -1,6 +1,5 @@
 defmodule SkateWeb.NotificationsChannelTest do
   use SkateWeb.ChannelCase
-  use Skate.DataCase
   import Test.Support.Helpers
 
   alias Phoenix.Socket

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -11,6 +11,7 @@ defmodule SkateWeb.VehiclesChannelTest do
 
   setup do
     reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
+    reassign_env(:skate, :username_from_socket!, fn _socket -> "test_uid" end)
 
     socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
 

--- a/test/skate_web/controllers/notification_read_states_controller_test.exs
+++ b/test/skate_web/controllers/notification_read_states_controller_test.exs
@@ -19,11 +19,10 @@ defmodule SkateWeb.NotificationReadStatesControllerTest do
     @tag :authenticated
     test "sets read state for a batch of notifications for the user", %{
       conn: conn,
-      user: username
+      user: user
     } do
-      user = User.get(username)
       route_tab1 = build_test_tab()
-      RouteTab.update_all_for_user!(username, [route_tab1])
+      RouteTab.update_all_for_user!(user.username, [route_tab1])
 
       User.upsert("otheruser", "other@email.com")
       route_tab2 = build_test_tab()

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -21,7 +21,7 @@ defmodule SkateWeb.PageControllerTest do
     test "assigns the username", %{conn: conn, user: user} do
       conn = get(conn, "/")
 
-      assert conn.assigns.username == user
+      assert conn.assigns.username == user.username
     end
 
     @tag :authenticated
@@ -40,7 +40,7 @@ defmodule SkateWeb.PageControllerTest do
 
     @tag :authenticated
     test "includes route tabs in HTML", %{conn: conn, user: user} do
-      Skate.Settings.RouteTab.update_all_for_user!(user, [
+      Skate.Settings.RouteTab.update_all_for_user!(user.username, [
         build(:route_tab, %{selected_route_ids: ["1"]})
       ])
 
@@ -54,14 +54,12 @@ defmodule SkateWeb.PageControllerTest do
 
     @tag :authenticated
     test "includes user test groups in HTML", %{conn: conn, user: user} do
-      user_struct = user |> Skate.Settings.User.get()
-
       Skate.Settings.TestGroup.update(%{
         Skate.Settings.TestGroup.create("html-test-group")
-        | users: [user_struct]
+        | users: [user]
       })
 
-      user_struct = user |> Skate.Settings.User.get() |> Skate.Repo.preload(:test_groups)
+      user_struct = user.username |> Skate.Settings.User.get() |> Skate.Repo.preload(:test_groups)
 
       conn = get(conn, "/")
 
@@ -124,7 +122,7 @@ defmodule SkateWeb.PageControllerTest do
 
     @tag :authenticated
     test "includes UUID in HTML", %{conn: conn, user: user} do
-      user_struct = Skate.Settings.User.get(user)
+      user_struct = Skate.Settings.User.get(user.username)
 
       conn = get(conn, "/")
 

--- a/test/skate_web/controllers/route_tabs_controller_test.exs
+++ b/test/skate_web/controllers/route_tabs_controller_test.exs
@@ -26,7 +26,7 @@ defmodule SkateWeb.RouteTabsControllerTest do
                  selected_route_ids: ["1", "28"],
                  ordering: 12345
                }
-             ] = RouteTab.get_all_for_user(user)
+             ] = RouteTab.get_all_for_user(user.username)
     end
   end
 end

--- a/test/skate_web/controllers/test_group_controller_test.exs
+++ b/test/skate_web/controllers/test_group_controller_test.exs
@@ -13,9 +13,7 @@ defmodule SkateWeb.TestGroupControllerTest do
     end
 
     @tag :authenticated_admin
-    test "returns page with test groups listed", %{conn: conn, user: user_name} do
-      user = User.get(user_name)
-
+    test "returns page with test groups listed", %{conn: conn, user: user} do
       test_group = TestGroup.create("test group name")
 
       TestGroup.update(%{test_group | users: [user]})
@@ -56,9 +54,8 @@ defmodule SkateWeb.TestGroupControllerTest do
     end
 
     @tag :authenticated_admin
-    test "renders a test group", %{conn: conn, user: user_name} do
+    test "renders a test group", %{conn: conn, user: user} do
       test_group = TestGroup.create("group to show")
-      user = User.get(user_name)
       test_group_with_user = TestGroup.update(%TestGroup{test_group | users: [user]})
 
       html =

--- a/test/skate_web/controllers/user_settings_controller_test.exs
+++ b/test/skate_web/controllers/user_settings_controller_test.exs
@@ -4,13 +4,13 @@ defmodule SkateWeb.UserSettingsControllerTest do
   alias Skate.Settings.UserSettings
 
   describe "PUT /api/user_settings" do
-    setup %{user: username} do
-      UserSettings.get_or_create(username)
+    setup %{user: user} do
+      UserSettings.get_or_create(user.username)
       :ok
     end
 
     @tag :authenticated
-    test "can set ladder_page_vehicle_label", %{conn: conn, user: username} do
+    test "can set ladder_page_vehicle_label", %{conn: conn, user: user} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -19,12 +19,12 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user.username)
       assert result.ladder_page_vehicle_label == :vehicle_id
     end
 
     @tag :authenticated
-    test "can set shuttle_page_vehicle_label", %{conn: conn, user: username} do
+    test "can set shuttle_page_vehicle_label", %{conn: conn, user: user} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -33,12 +33,12 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user.username)
       assert result.shuttle_page_vehicle_label == :run_id
     end
 
     @tag :authenticated
-    test "can set vehicle_adherence_colors", %{conn: conn, user: username} do
+    test "can set vehicle_adherence_colors", %{conn: conn, user: user} do
       conn =
         conn
         |> put("/api/user_settings", %{
@@ -47,7 +47,7 @@ defmodule SkateWeb.UserSettingsControllerTest do
         })
 
       response(conn, 200)
-      result = UserSettings.get_or_create(username)
+      result = UserSettings.get_or_create(user.username)
       assert result.vehicle_adherence_colors == :early_blue
     end
 

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -26,7 +26,14 @@ defmodule SkateWeb.ChannelCase do
     end
   end
 
-  setup _tags do
+  setup tags do
+    alias Ecto.Adapters.SQL.Sandbox
+    :ok = Sandbox.checkout(Skate.Repo)
+
+    unless tags[:async] do
+      Sandbox.mode(Skate.Repo, {:shared, self()})
+    end
+
     :ok
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,8 +39,8 @@ defmodule SkateWeb.ConnCase do
       Sandbox.mode(Skate.Repo, {:shared, self()})
     end
 
-    %{id: user_id} = user = User.upsert(username, email)
-    resource = "v2:#{user_id}"
+    user = User.upsert(username, email)
+    resource = %{id: user.id}
 
     {conn, user} =
       cond do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -39,6 +39,9 @@ defmodule SkateWeb.ConnCase do
       Sandbox.mode(Skate.Repo, {:shared, self()})
     end
 
+    %{id: user_id} = user = User.upsert(username, email)
+    resource = "v2:#{user_id}"
+
     {conn, user} =
       cond do
         tags[:authenticated] ->
@@ -47,9 +50,9 @@ defmodule SkateWeb.ConnCase do
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{})
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, resource, %{})
 
-          {conn, username}
+          {conn, user}
 
         tags[:authenticated_admin] ->
           User.upsert(username, email)
@@ -57,11 +60,11 @@ defmodule SkateWeb.ConnCase do
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, resource, %{
               "groups" => ["skate-admin"]
             })
 
-          {conn, username}
+          {conn, user}
 
         tags[:authenticated_dispatcher] ->
           User.upsert(username, email)
@@ -69,11 +72,11 @@ defmodule SkateWeb.ConnCase do
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
-            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, username, %{
+            |> Guardian.Plug.sign_in(SkateWeb.AuthManager, resource, %{
               "groups" => ["skate-dispatcher"]
             })
 
-          {conn, username}
+          {conn, user}
 
         true ->
           {Phoenix.ConnTest.build_conn(), nil}


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203331355829267/f

Followed the basic setup instructions from https://hexdocs.pm/guardian/introduction-implementation.html#basic-setup.

This allows us to move away from the AD username as the subject of the token to Skate's internal user id PK. The old username format is supported for backwards compatibility and can be removed once all the outstanding old tokens are expired (expected after 1 hour of deploying, will confirm with logs)

