### PR TITLE
chore: update hash of AWS certificate bundle for RDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /root
 
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     -o aws-cert-bundle.pem
-RUN echo "acaf8712f8d71c05f85503c6b90fd0127e95ff0091bf094a22a650119684a08e  aws-cert-bundle.pem" | sha256sum -c -
+RUN echo "6f99a8eac41b1b76bdc4f402c4a1f3d12d24fcae75ce08818ee3349bda075e93  aws-cert-bundle.pem" | sha256sum -c -
 
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static


### PR DESCRIPTION
No ticket, just a quick fix to make the deploy work again.