### PR TITLE
feat(AuthManager): Remove support for old username-only resource/subject

### DIFF
--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -15,18 +15,8 @@ defmodule SkateWeb.AuthManager do
     {:ok, "#{@v2_resource_prefix}#{user_id}"}
   end
 
-  def subject_for_token(resource, _claims) do
-    Logger.info("old_pattern_matched function=subject_for_token")
-    {:ok, resource}
-  end
-
   def resource_from_claims(%{"sub" => @v2_resource_prefix <> user_id}) do
     {:ok, %{id: String.to_integer(user_id)}}
-  end
-
-  def resource_from_claims(%{"sub" => username}) do
-    Logger.info("old_pattern_matched function=resource_from_claims")
-    {:ok, username}
   end
 
   def resource_from_claims(_), do: {:error, :invalid_claims}
@@ -43,11 +33,6 @@ defmodule SkateWeb.AuthManager do
 
   def username_from_resource(%{id: user_id}) do
     User.get_by_id!(user_id).username
-  end
-
-  def username_from_resource(username) when is_binary(username) do
-    Logger.info("old_pattern_matched function=username_from_resource")
-    username
   end
 
   defp decode_and_verify!(token) do

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -4,30 +4,32 @@ defmodule SkateWeb.ChannelAuthTest do
   alias SkateWeb.{AuthManager, ChannelAuth, UserSocket}
 
   setup do
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
-    {:ok, socket: socket}
+    {:ok, %{socket: socket, resource: %{id: 1}}}
   end
 
   describe "valid_token?/1" do
     test "returns true when socket is authenticated", %{
-      socket: socket
+      socket: socket,
+      resource: resource
     } do
       {:ok, token, claims} =
-        AuthManager.encode_and_sign("test-authed@mbta.com", %{
+        AuthManager.encode_and_sign(resource, %{
           "exp" => System.system_time(:second) + 500
         })
 
-      socket = Guardian.Phoenix.Socket.assign_rtc(socket, "test-authed@mbta.com", token, claims)
+      socket = Guardian.Phoenix.Socket.assign_rtc(socket, resource, token, claims)
 
       assert ChannelAuth.valid_token?(socket) == true
     end
 
     test "returns false when socket is not authenticated", %{
-      socket: socket
+      socket: socket,
+      resource: resource
     } do
       {:ok, token, claims} =
-        AuthManager.encode_and_sign("test-not-authed@mbta.com", %{
+        AuthManager.encode_and_sign(resource, %{
           "exp" => System.system_time(:second) - 100
         })
 

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -10,7 +10,7 @@ defmodule SkateWeb.DataStatusChannelTest do
   setup do
     reassign_env(:skate, :valid_token?, fn _socket -> true end)
 
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
     start_supervised({Registry, keys: :duplicate, name: Realtime.Supervisor.registry_name()})
     start_supervised({Realtime.DataStatusPubSub, name: Realtime.DataStatusPubSub.default_name()})

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -9,7 +9,7 @@ defmodule SkateWeb.NotificationsChannelTest do
     reassign_env(:skate, :valid_token?, fn _socket -> true end)
     reassign_env(:skate, :username_from_socket!, fn _socket -> "test_uid" end)
 
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
     start_supervised({Registry, keys: :duplicate, name: Notifications.Supervisor.registry_name()})
 

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -29,7 +29,7 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
       end
     end)
 
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
     {:ok, socket: socket}
   end

--- a/test/skate_web/channels/user_socket_test.exs
+++ b/test/skate_web/channels/user_socket_test.exs
@@ -4,26 +4,27 @@ defmodule SkateWeb.UserSocketTest do
   alias SkateWeb.{AuthManager, UserSocket}
 
   setup do
-    %{socket: socket(UserSocket)}
+    %{socket: socket(UserSocket), resource: %{id: 1}}
   end
 
   describe "connect/2" do
-    test "authenticates when a valid token is given", %{socket: socket} do
+    test "authenticates when a valid token is given", %{socket: socket, resource: resource} do
       current_time = System.system_time(:second)
       expiration_time = current_time + 500
 
-      {:ok, token, _claims} =
-        AuthManager.encode_and_sign("foo@mbta.com", %{"exp" => expiration_time})
+      {:ok, token, _claims} = AuthManager.encode_and_sign(resource, %{"exp" => expiration_time})
 
       assert {:ok, _authed_socket} = UserSocket.connect(%{"token" => token}, socket, %{})
     end
 
-    test "doesn't authenticate when an expired token is given", %{socket: socket} do
+    test "doesn't authenticate when an expired token is given", %{
+      socket: socket,
+      resource: resource
+    } do
       current_time = System.system_time(:second)
       expiration_time = current_time - 100
 
-      {:ok, token, _claims} =
-        AuthManager.encode_and_sign("foo@mbta.com", %{"exp" => expiration_time})
+      {:ok, token, _claims} = AuthManager.encode_and_sign(resource, %{"exp" => expiration_time})
 
       assert UserSocket.connect(%{"token" => token}, socket, %{}) == :error
     end

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -49,7 +49,7 @@ defmodule SkateWeb.VehicleChannelTest do
   setup do
     reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
 
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
     start_supervised({Registry, keys: :duplicate, name: Realtime.Supervisor.registry_name()})
     start_supervised({Realtime.Server, name: Realtime.Server.default_name()})

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -13,7 +13,7 @@ defmodule SkateWeb.VehiclesChannelTest do
     reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
     reassign_env(:skate, :username_from_socket!, fn _socket -> "test_uid" end)
 
-    socket = socket(UserSocket, "", %{guardian_default_resource: "test_uid"})
+    socket = socket(UserSocket, "", %{})
 
     start_supervised({Registry, keys: :duplicate, name: Realtime.Supervisor.registry_name()})
     start_supervised({Realtime.Server, name: Realtime.Server.default_name()})


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203331355829267/f

This must be deployed 60+ minutes after https://github.com/mbta/skate/pull/1790 to ensure that there are no valid tokens with the old format out in the wild. Confirm no more logs of `old_pattern_matched` before deploying. 