### PR TITLE
chore(ci): bump version of upload-artifact to one that uses Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: elixir-lcov
           path: cover/


### PR DESCRIPTION
I upgraded some of the other GitHub Actions we used in #1759 but it looks like I forgot about this one.