### PR TITLE
feat: setup for separate maps mode

### DIFF
--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -16,7 +16,6 @@ import useVehicles from "../hooks/useVehicles"
 import DataStatusBanner from "./dataStatusBanner"
 import LadderPage from "./ladderPage"
 import Modal from "./modal"
-import SearchPage from "./searchPage"
 import SettingsPage from "./settingsPage"
 import ShuttleMapPage from "./shuttleMapPage"
 import LateView from "./lateView"
@@ -24,8 +23,7 @@ import { OpenView } from "../state"
 import { allOpenRouteIds } from "../models/routeTab"
 import Nav from "./nav"
 import RightPanel from "./rightPanel"
-import inTestGroup from "../userTestGroups"
-import MapPage from "./mapPage"
+import { mapModeForUser } from "../util/mapMode"
 
 const AppRoutes = () => {
   useAppcues()
@@ -46,7 +44,7 @@ const AppRoutes = () => {
     vehiclesByRouteIdNeeded ? allOpenRouteIds(routeTabs) : []
   )
 
-  const hasMapMode = inTestGroup("map-beta")
+  const mapMode = mapModeForUser()
 
   return (
     <div className="m-app">
@@ -63,10 +61,7 @@ const AppRoutes = () => {
               <BrowserRoute path="/" element={<LadderPage />} />
               <BrowserRoute path="/shuttle-map" element={<ShuttleMapPage />} />
               <BrowserRoute path="/settings" element={<SettingsPage />} />
-              <BrowserRoute
-                path="/search"
-                element={hasMapMode ? <MapPage /> : <SearchPage />}
-              />
+              <BrowserRoute path={mapMode.path} element={mapMode.element} />
             </Routes>
             {openView === OpenView.Late ? <LateView /> : null}
             <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -24,6 +24,8 @@ import { OpenView } from "../state"
 import { allOpenRouteIds } from "../models/routeTab"
 import Nav from "./nav"
 import RightPanel from "./rightPanel"
+import inTestGroup from "../userTestGroups"
+import MapPage from "./mapPage"
 
 const AppRoutes = () => {
   useAppcues()
@@ -44,6 +46,8 @@ const AppRoutes = () => {
     vehiclesByRouteIdNeeded ? allOpenRouteIds(routeTabs) : []
   )
 
+  const hasMapMode = inTestGroup("map-beta")
+
   return (
     <div className="m-app">
       <div className="m-app__banner">
@@ -59,7 +63,10 @@ const AppRoutes = () => {
               <BrowserRoute path="/" element={<LadderPage />} />
               <BrowserRoute path="/shuttle-map" element={<ShuttleMapPage />} />
               <BrowserRoute path="/settings" element={<SettingsPage />} />
-              <BrowserRoute path="/search" element={<SearchPage />} />
+              <BrowserRoute
+                path="/search"
+                element={hasMapMode ? <MapPage /> : <SearchPage />}
+              />
             </Routes>
             {openView === OpenView.Late ? <LateView /> : null}
             <RightPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -212,7 +212,7 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
   ])
 
   return (
-    <>
+    <div data-testid="routeShape">
       <Polyline
         className="m-vehicle-map__route-shape"
         positions={positions}
@@ -228,7 +228,7 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
           <Popup className="m-vehicle-map__stop-tooltip">{stop.name}</Popup>
         </CircleMarker>
       ))}
-    </>
+    </div>
   )
 }
 

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -212,7 +212,7 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
   ])
 
   return (
-    <div data-testid="routeShape">
+    <>
       <Polyline
         className="m-vehicle-map__route-shape"
         positions={positions}
@@ -228,7 +228,7 @@ const LeafletShape = ({ shape }: { shape: Shape }) => {
           <Popup className="m-vehicle-map__stop-tooltip">{stop.name}</Popup>
         </CircleMarker>
       ))}
-    </div>
+    </>
   )
 }
 

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -105,7 +105,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
       <div className="m-search-page__map">
         <Map
           vehicles={onlyVehicles}
-          onPrimaryVehicleSelect={(vehicle) => setSelectedVehicle(vehicle)}
+          onPrimaryVehicleSelect={setSelectedVehicle}
           shapes={selectedVehicleShapes}
         />
       </div>

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -60,7 +60,9 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   )
   const onlyVehicles: Vehicle[] = filterVehicles(vehicles)
   const [mobileDisplay, setMobileDisplay] = useState(MobileDisplay.List)
-  const [selectedVehicle, setSelectedVehicle] = useState<Vehicle | null>(null)
+  const [selectedVehicle, setSelectedVehicle] = useState<VehicleOrGhost | null>(
+    null
+  )
   const selectedVehicleShapes = useTripShape(selectedVehicle?.tripId || null)
 
   const toggleMobileDisplay = () => {
@@ -95,7 +97,11 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
 
         <div className="m-search-display">
           {thereIsAnActiveSearch(vehicles, searchPageState) ? (
-            <SearchResults vehicles={vehicles as VehicleOrGhost[]} />
+            <SearchResults
+              vehicles={vehicles as VehicleOrGhost[]}
+              selectedVehicleId={selectedVehicle?.id || null}
+              onClick={setSelectedVehicle}
+            />
           ) : (
             <RecentSearches />
           )}

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -81,6 +81,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   return (
     <div
       className={`c-page m-search-page ${mobileDisplayClass} ${mobileMenuClass}`}
+      data-testid="map-page"
     >
       <div className="m-search-page__input-and-results">
         <div className="m-search-page__input">

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -3,9 +3,9 @@ import React, { ReactElement, useContext, useState } from "react"
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import useSearchResults from "../hooks/useSearchResults"
+import { useTripShape } from "../hooks/useShapes"
 import { isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleOrGhost } from "../realtime"
-import { selectVehicle } from "../state"
 import { SearchPageState } from "../state/searchPageState"
 import Map from "./map"
 import RecentSearches from "./recentSearches"
@@ -49,8 +49,8 @@ const ToggleMobileDisplayButton = ({
   )
 }
 
-const SearchPage = (): ReactElement<HTMLDivElement> => {
-  const [{ searchPageState, mobileMenuIsOpen }, dispatch] =
+const MapPage = (): ReactElement<HTMLDivElement> => {
+  const [{ searchPageState, mobileMenuIsOpen }] =
     useContext(StateDispatchContext)
 
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
@@ -60,6 +60,9 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
   )
   const onlyVehicles: Vehicle[] = filterVehicles(vehicles)
   const [mobileDisplay, setMobileDisplay] = useState(MobileDisplay.List)
+  const [selectedVehicle, setSelectedVehicle] = useState<Vehicle | null>(null)
+  const selectedVehicleShapes = useTripShape(selectedVehicle?.tripId || null)
+
   const toggleMobileDisplay = () => {
     setMobileDisplay(
       mobileDisplay === MobileDisplay.List
@@ -101,11 +104,12 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
       <div className="m-search-page__map">
         <Map
           vehicles={onlyVehicles}
-          onPrimaryVehicleSelect={(vehicle) => dispatch(selectVehicle(vehicle))}
+          onPrimaryVehicleSelect={(vehicle) => setSelectedVehicle(vehicle)}
+          shapes={selectedVehicleShapes}
         />
       </div>
     </div>
   )
 }
 
-export default SearchPage
+export default MapPage

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -65,6 +65,10 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   )
   const selectedVehicleShapes = useTripShape(selectedVehicle?.tripId || null)
 
+  const onSearchCallback = () => {
+    setSelectedVehicle(null)
+  }
+
   const toggleMobileDisplay = () => {
     setMobileDisplay(
       mobileDisplay === MobileDisplay.List
@@ -87,7 +91,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
     >
       <div className="m-search-page__input-and-results">
         <div className="m-search-page__input">
-          <SearchForm />
+          <SearchForm onSubmit={onSearchCallback} onClear={onSearchCallback} />
 
           <ToggleMobileDisplayButton
             mobileDisplay={mobileDisplay}

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -25,9 +25,7 @@ const thereIsAnActiveSearch = (
 const filterVehicles = (
   vehiclesOrGhosts: VehicleOrGhost[] | null
 ): Vehicle[] => {
-  return vehiclesOrGhosts === null
-    ? []
-    : (vehiclesOrGhosts.filter((vog) => isVehicle(vog)) as Vehicle[])
+  return vehiclesOrGhosts === null ? [] : vehiclesOrGhosts.filter(isVehicle)
 }
 
 const ToggleMobileDisplayButton = ({
@@ -100,9 +98,10 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
         </div>
 
         <div className="m-search-display">
-          {thereIsAnActiveSearch(vehicles, searchPageState) ? (
+          {vehicles !== null &&
+          thereIsAnActiveSearch(vehicles, searchPageState) ? (
             <SearchResults
-              vehicles={vehicles as VehicleOrGhost[]}
+              vehicles={vehicles}
               selectedVehicleId={selectedVehicle?.id || null}
               onClick={setSelectedVehicle}
             />

--- a/assets/src/components/nav/bottomNavMobile.tsx
+++ b/assets/src/components/nav/bottomNavMobile.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { ladderIcon, mapIcon, searchIcon, swingIcon } from "../../helpers/icon"
 import { NavLink } from "react-router-dom"
 import { tagManagerEvent } from "../../helpers/googleTagManager"
+import { mapModeForUser } from "../../util/mapMode"
 
 interface Props {
   mobileMenuIsOpen: boolean
@@ -11,69 +12,72 @@ interface Props {
 const BottomNavMobile: React.FC<Props> = ({
   mobileMenuIsOpen,
   openSwingsView,
-}) => (
-  <div
-    data-testid="bottom-nav-mobile"
-    className={
-      "m-bottom-nav-mobile" + (mobileMenuIsOpen ? " blurred-mobile" : "")
-    }
-  >
-    <ul className="m-bottom-nav-mobile__links">
-      <li>
-        <NavLink
-          className={({ isActive }) =>
-            "m-bottom-nav-mobile__link" +
-            (isActive ? " m-bottom-nav-mobile__link--active" : "")
-          }
-          title="Route Ladders"
-          to="/"
-        >
-          {ladderIcon("m-bottom-nav-mobile__icon")}
-        </NavLink>
-      </li>
+}) => {
+  const mapMode = mapModeForUser()
+  return (
+    <div
+      data-testid="bottom-nav-mobile"
+      className={
+        "m-bottom-nav-mobile" + (mobileMenuIsOpen ? " blurred-mobile" : "")
+      }
+    >
+      <ul className="m-bottom-nav-mobile__links">
+        <li>
+          <NavLink
+            className={({ isActive }) =>
+              "m-bottom-nav-mobile__link" +
+              (isActive ? " m-bottom-nav-mobile__link--active" : "")
+            }
+            title="Route Ladders"
+            to="/"
+          >
+            {ladderIcon("m-bottom-nav-mobile__icon")}
+          </NavLink>
+        </li>
 
-      <li>
-        <NavLink
-          className={({ isActive }) =>
-            "m-bottom-nav-mobile__link" +
-            (isActive ? " m-bottom-nav-mobile__link--active" : "")
-          }
-          title="Shuttle Map"
-          to="/shuttle-map"
-        >
-          {mapIcon("m-bottom-nav-mobile__icon")}
-        </NavLink>
-      </li>
+        <li>
+          <NavLink
+            className={({ isActive }) =>
+              "m-bottom-nav-mobile__link" +
+              (isActive ? " m-bottom-nav-mobile__link--active" : "")
+            }
+            title="Shuttle Map"
+            to="/shuttle-map"
+          >
+            {mapIcon("m-bottom-nav-mobile__icon")}
+          </NavLink>
+        </li>
 
-      <li>
-        <NavLink
-          className={({ isActive }) =>
-            "m-bottom-nav-mobile__link" +
-            (isActive ? " m-bottom-nav-mobile__link--active" : "")
-          }
-          title="Search"
-          to="/search"
-        >
-          {searchIcon("m-bottom-nav-mobile__icon")}
-        </NavLink>
-      </li>
+        <li>
+          <NavLink
+            className={({ isActive }) =>
+              "m-bottom-nav-mobile__link" +
+              (isActive ? " m-bottom-nav-mobile__link--active" : "")
+            }
+            title={mapMode.title}
+            to={mapMode.path}
+          >
+            {searchIcon("m-bottom-nav-mobile__icon")}
+          </NavLink>
+        </li>
 
-      <li>
-        <button
-          className="m-bottom-nav-mobile__button"
-          onClick={() => {
-            tagManagerEvent("swings_view_toggled")
-            openSwingsView()
-          }}
-          title="Swings View"
-        >
-          {swingIcon(
-            "m-bottom-nav-mobile__icon m-bottom-nav-mobile__icon--swings-view"
-          )}
-        </button>
-      </li>
-    </ul>
-  </div>
-)
+        <li>
+          <button
+            className="m-bottom-nav-mobile__button"
+            onClick={() => {
+              tagManagerEvent("swings_view_toggled")
+              openSwingsView()
+            }}
+            title="Swings View"
+          >
+            {swingIcon(
+              "m-bottom-nav-mobile__icon m-bottom-nav-mobile__icon--swings-view"
+            )}
+          </button>
+        </li>
+      </ul>
+    </div>
+  )
+}
 
 export default BottomNavMobile

--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -27,6 +27,7 @@ import {
   togglePickerContainer,
 } from "../../state"
 import NavMenu from "./navMenu"
+import { mapModeForUser } from "../../util/mapMode"
 
 interface Props {
   toggleMobileMenu?: () => void
@@ -45,6 +46,7 @@ const LeftNav = ({
     useContext(StateDispatchContext)
   const [collapsed, setCollapsed] = useState<boolean>(defaultToCollapsed)
   const location = useLocation()
+  const mapMode = mapModeForUser()
 
   const bellIconClasses =
     openView == OpenView.NotificationDrawer
@@ -106,11 +108,11 @@ const LeftNav = ({
                 "m-left-nav__link" +
                 (isActive ? " m-left-nav__link--active" : "")
               }
-              title="Search"
-              to="/search"
+              title={mapMode.title}
+              to={mapMode.path}
             >
               {searchIcon("m-left-nav__icon")}
-              {collapsed ? null : "Search"}
+              {collapsed ? null : mapMode.title}
             </NavLink>
           </li>
           <li>

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -10,7 +10,13 @@ import {
 
 const SEARCH_PROPERTIES = ["all", "run", "vehicle", "operator"]
 
-const SearchForm = () => {
+const SearchForm = ({
+  onSubmit,
+  onClear,
+}: {
+  onSubmit?: () => void
+  onClear?: () => void
+}) => {
   const [
     {
       searchPageState: { query },
@@ -25,6 +31,9 @@ const SearchForm = () => {
   const clearTextInput = (event: React.FormEvent<EventTarget>): void => {
     event.preventDefault()
     dispatch(setSearchText(""))
+    if (onClear) {
+      onClear()
+    }
   }
 
   const handlePropertyChange = (
@@ -38,6 +47,9 @@ const SearchForm = () => {
     event.preventDefault()
 
     dispatch(submitSearch())
+    if (onSubmit) {
+      onSubmit()
+    }
   }
 
   return (

--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -25,9 +25,7 @@ const thereIsAnActiveSearch = (
 const filterVehicles = (
   vehiclesOrGhosts: VehicleOrGhost[] | null
 ): Vehicle[] => {
-  return vehiclesOrGhosts === null
-    ? []
-    : (vehiclesOrGhosts.filter((vog) => isVehicle(vog)) as Vehicle[])
+  return vehiclesOrGhosts === null ? [] : vehiclesOrGhosts.filter(isVehicle)
 }
 
 const ToggleMobileDisplayButton = ({
@@ -92,9 +90,10 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
         </div>
 
         <div className="m-search-display">
-          {thereIsAnActiveSearch(vehicles, searchPageState) ? (
+          {vehicles != null &&
+          thereIsAnActiveSearch(vehicles, searchPageState) ? (
             <SearchResults
-              vehicles={vehicles as VehicleOrGhost[]}
+              vehicles={vehicles}
               onClick={(vehicleOrGhost) => {
                 dispatch(selectVehicle(vehicleOrGhost))
               }}

--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -50,8 +50,10 @@ const ToggleMobileDisplayButton = ({
 }
 
 const SearchPage = (): ReactElement<HTMLDivElement> => {
-  const [{ searchPageState, mobileMenuIsOpen }, dispatch] =
-    useContext(StateDispatchContext)
+  const [
+    { searchPageState, mobileMenuIsOpen, selectedVehicleOrGhost },
+    dispatch,
+  ] = useContext(StateDispatchContext)
 
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
   const vehicles: VehicleOrGhost[] | null = useSearchResults(
@@ -91,7 +93,13 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
 
         <div className="m-search-display">
           {thereIsAnActiveSearch(vehicles, searchPageState) ? (
-            <SearchResults vehicles={vehicles as VehicleOrGhost[]} />
+            <SearchResults
+              vehicles={vehicles as VehicleOrGhost[]}
+              onClick={(vehicleOrGhost) => {
+                dispatch(selectVehicle(vehicleOrGhost))
+              }}
+              selectedVehicleId={selectedVehicleOrGhost?.id || null}
+            />
           ) : (
             <RecentSearches />
           )}

--- a/assets/src/hooks/useShapes.ts
+++ b/assets/src/hooks/useShapes.ts
@@ -55,6 +55,8 @@ export const useTripShape = (tripId: TripId | null): Shape[] => {
       fetchShapeForTrip(tripId).then((shapeResult: Shape | null) =>
         setShape(shapeResult)
       )
+    } else {
+      setShape(null)
     }
   }, [tripId])
 

--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -4,6 +4,8 @@ import appData from "./appData"
 const TestGroups = array(string())
 type TestGroups = Infer<typeof TestGroups>
 
+export const MAP_BETA_GROUP_NAME = "map-beta"
+
 const getTestGroups = (): string[] => {
   const testGroupsJson = appData()?.userTestGroups
 

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { ReactElement } from "react"
+import MapPage from "../components/mapPage"
+import SearchPage from "../components/searchPage"
+import inTestGroup, { MAP_BETA_GROUP_NAME } from "../userTestGroups"
+
+export interface NavMode {
+  path: string
+  title: string
+  element: ReactElement
+}
+
+export const mapModeForUser = (): any =>
+  inTestGroup(MAP_BETA_GROUP_NAME)
+    ? { path: "/search", title: "Map", element: <MapPage /> }
+    : { path: "/search", title: "Search", element: <SearchPage /> }

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -12,5 +12,5 @@ export interface NavMode {
 
 export const mapModeForUser = (): NavMode =>
   inTestGroup(MAP_BETA_GROUP_NAME)
-    ? { path: "/search", title: "Map", element: <MapPage /> }
+    ? { path: "/map", title: "Map", element: <MapPage /> }
     : { path: "/search", title: "Search", element: <SearchPage /> }

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -10,7 +10,7 @@ export interface NavMode {
   element: ReactElement
 }
 
-export const mapModeForUser = (): any =>
+export const mapModeForUser = (): NavMode =>
   inTestGroup(MAP_BETA_GROUP_NAME)
     ? { path: "/search", title: "Map", element: <MapPage /> }
     : { path: "/search", title: "Search", element: <SearchPage /> }

--- a/assets/src/util/streetViewUrl.ts
+++ b/assets/src/util/streetViewUrl.ts
@@ -1,0 +1,12 @@
+export const streetViewUrl = ({
+  latitude,
+  longitude,
+  bearing,
+}: {
+  latitude: number
+  longitude: number
+  bearing?: number
+}): string =>
+  `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${latitude}%2C${longitude}&heading=${
+    bearing || 0
+  }&pitch=0&fov=80`

--- a/assets/src/util/streetViewUrl.ts
+++ b/assets/src/util/streetViewUrl.ts
@@ -7,6 +7,6 @@ export const streetViewUrl = ({
   longitude: number
   bearing?: number
 }): string =>
-  `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${latitude}%2C${longitude}&heading=${
-    bearing || 0
+  `https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=${latitude}%2C${longitude}${
+    bearing ? `&heading=${bearing}` : ""
   }&pitch=0&fov=80`

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1,0 +1,684 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MapPage renders the empty state 1`] = `
+<DocumentFragment>
+  <div
+    class="c-page m-search-page m-search-page--show-list "
+  >
+    <div
+      class="m-search-page__input-and-results"
+    >
+      <div
+        class="m-search-page__input"
+      >
+        <form
+          class="m-search-form"
+        >
+          <div
+            class="m-search-form__row"
+          >
+            <div
+              class="m-search-form__text"
+            >
+              <input
+                class="m-search-form__input"
+                placeholder="Search"
+                type="text"
+                value=""
+              />
+              <button
+                class="m-search-form__clear"
+                title="Clear"
+                type="reset"
+              >
+                <span
+                  class=""
+                >
+                  SVG
+                </span>
+              </button>
+            </div>
+            <button
+              class="m-search-form__submit"
+              disabled=""
+              title="Submit"
+              type="submit"
+            >
+              <span
+                class=""
+              >
+                SVG
+              </span>
+            </button>
+          </div>
+          <div
+            class="m-search-form__row"
+          >
+            <ul
+              class="m-search-form__property-buttons"
+            >
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  checked=""
+                  class="m-search-form__property-input"
+                  id="property-all"
+                  name="property"
+                  type="radio"
+                  value="all"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-all"
+                >
+                  all
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-run"
+                  name="property"
+                  type="radio"
+                  value="run"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-run"
+                >
+                  run
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-vehicle"
+                  name="property"
+                  type="radio"
+                  value="vehicle"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-vehicle"
+                >
+                  vehicle
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-operator"
+                  name="property"
+                  type="radio"
+                  value="operator"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-operator"
+                >
+                  operator
+                </label>
+              </li>
+            </ul>
+          </div>
+        </form>
+        <button
+          class="m-search-page__toggle-mobile-display-button"
+        >
+          Show map instead
+        </button>
+      </div>
+      <div
+        class="m-search-display"
+      >
+        <div
+          class="m-recent-searches"
+        >
+          <div
+            class="m-recent-searches__heading"
+          >
+            Recent Searches
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="m-search-page__map"
+    >
+      <div
+        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        id="id-vehicle-map"
+        style="position: relative;"
+        tabindex="0"
+      >
+        <div
+          class="leaflet-pane leaflet-map-pane"
+          style="left: 0px; top: 0px;"
+        >
+          <div
+            class="leaflet-pane leaflet-tile-pane"
+          >
+            <div
+              class="leaflet-layer "
+              style="z-index: 1;"
+            >
+              <div
+                class="leaflet-tile-container leaflet-zoom-animated"
+                style="z-index: 18; left: 0px; top: 0px;"
+              >
+                <img
+                  alt=""
+                  class="leaflet-tile"
+                  src="/13/2479/3029.png"
+                  style="width: 256px; height: 256px; left: -4px; top: -239px;"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="leaflet-pane leaflet-overlay-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-shadow-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-marker-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-tooltip-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-popup-pane"
+          />
+        </div>
+        <div
+          class="leaflet-control-container"
+        >
+          <div
+            class="leaflet-top leaflet-left"
+          />
+          <div
+            class="leaflet-top leaflet-right"
+          >
+            <div
+              class="leaflet-control-zoom leaflet-bar leaflet-control"
+            >
+              <a
+                aria-disabled="false"
+                aria-label="Zoom in"
+                class="leaflet-control-zoom-in"
+                href="#"
+                role="button"
+                title="Zoom in"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  +
+                </span>
+              </a>
+              <a
+                aria-disabled="false"
+                aria-label="Zoom out"
+                class="leaflet-control-zoom-out"
+                href="#"
+                role="button"
+                title="Zoom out"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  −
+                </span>
+              </a>
+            </div>
+            <div
+              class="leaflet-bar leaflet-control"
+            >
+              <a
+                aria-label="Full Screen"
+                class="leaflet-control-zoom-fullscreen fullscreen-icon"
+                href="#"
+                role="button"
+                title="Full Screen"
+              />
+            </div>
+            <div
+              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+            >
+              
+        
+              <a
+                aria-label="Recenter Map"
+                href="#"
+                role="button"
+                title="Recenter Map"
+              >
+                
+          
+                <svg
+                  height="26"
+                  viewBox="-5 -5 32 32"
+                  width="26"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  
+            
+                  <path
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="rotate(60, 12, 12)"
+                  />
+                  
+          
+                </svg>
+                
+        
+              </a>
+            </div>
+          </div>
+          <div
+            class="leaflet-bottom leaflet-left"
+          />
+          <div
+            class="leaflet-bottom leaflet-right"
+          >
+            <div
+              class="leaflet-control-attribution leaflet-control"
+            >
+              © 
+              <a
+                href="http://osm.org/copyright"
+              >
+                OpenStreetMap
+              </a>
+               contributors
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`MapPage renders vehicle data 1`] = `
+<DocumentFragment>
+  <div
+    class="c-page m-search-page m-search-page--show-list "
+  >
+    <div
+      class="m-search-page__input-and-results"
+    >
+      <div
+        class="m-search-page__input"
+      >
+        <form
+          class="m-search-form"
+        >
+          <div
+            class="m-search-form__row"
+          >
+            <div
+              class="m-search-form__text"
+            >
+              <input
+                class="m-search-form__input"
+                placeholder="Search"
+                type="text"
+                value=""
+              />
+              <button
+                class="m-search-form__clear"
+                title="Clear"
+                type="reset"
+              >
+                <span
+                  class=""
+                >
+                  SVG
+                </span>
+              </button>
+            </div>
+            <button
+              class="m-search-form__submit"
+              disabled=""
+              title="Submit"
+              type="submit"
+            >
+              <span
+                class=""
+              >
+                SVG
+              </span>
+            </button>
+          </div>
+          <div
+            class="m-search-form__row"
+          >
+            <ul
+              class="m-search-form__property-buttons"
+            >
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  checked=""
+                  class="m-search-form__property-input"
+                  id="property-all"
+                  name="property"
+                  type="radio"
+                  value="all"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-all"
+                >
+                  all
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-run"
+                  name="property"
+                  type="radio"
+                  value="run"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-run"
+                >
+                  run
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-vehicle"
+                  name="property"
+                  type="radio"
+                  value="vehicle"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-vehicle"
+                >
+                  vehicle
+                </label>
+              </li>
+              <li
+                class="m-search-form__property-button"
+              >
+                <input
+                  class="m-search-form__property-input"
+                  id="property-operator"
+                  name="property"
+                  type="radio"
+                  value="operator"
+                />
+                <label
+                  class="m-search-form__property-label"
+                  for="property-operator"
+                >
+                  operator
+                </label>
+              </li>
+            </ul>
+          </div>
+        </form>
+        <button
+          class="m-search-page__toggle-mobile-display-button"
+        >
+          Show map instead
+        </button>
+      </div>
+      <div
+        class="m-search-display"
+      >
+        <div
+          class="m-recent-searches"
+        >
+          <div
+            class="m-recent-searches__heading"
+          >
+            Recent Searches
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="m-search-page__map"
+    >
+      <div
+        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+      />
+      <div
+        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        id="id-vehicle-map"
+        style="position: relative;"
+        tabindex="0"
+      >
+        <div
+          class="leaflet-pane leaflet-map-pane"
+          style="left: 0px; top: 0px;"
+        >
+          <div
+            class="leaflet-pane leaflet-tile-pane"
+          >
+            <div
+              class="leaflet-layer "
+              style="z-index: 1;"
+            >
+              <div
+                class="leaflet-tile-container leaflet-zoom-animated"
+                style="z-index: 18; left: 0px; top: 0px;"
+              >
+                <img
+                  alt=""
+                  class="leaflet-tile"
+                  src="/16/20061/24522.png"
+                  style="width: 256px; height: 256px; left: -77px; top: -215px;"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="leaflet-pane leaflet-overlay-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-shadow-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-marker-pane"
+          >
+            <div
+              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+              role="button"
+              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 3252915px; top: 2110761px; z-index: 2112761;"
+              tabindex="0"
+            >
+              <svg
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+        
+                <path
+                  class="on-time early-red"
+                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                  transform="scale(1) rotate(33) translate(-12, -12)"
+                />
+                
+      
+              </svg>
+            </div>
+            <div
+              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+              role="button"
+              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 3252915px; top: 2110761px; z-index: 2112761;"
+              tabindex="0"
+            >
+              <svg
+                height="16"
+                viewBox="0 0 40 16"
+                width="40"
+              >
+                
+            
+                <rect
+                  class="m-vehicle-icon__label-background"
+                  height="100%"
+                  rx="5.5px"
+                  ry="5.5px"
+                  width="100%"
+                />
+                
+            
+                <text
+                  class="m-vehicle-icon__label"
+                  dominant-baseline="central"
+                  text-anchor="middle"
+                  x="50%"
+                  y="50%"
+                >
+                  
+              1
+            
+                </text>
+                
+          
+              </svg>
+            </div>
+          </div>
+          <div
+            class="leaflet-pane leaflet-tooltip-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-popup-pane"
+          />
+        </div>
+        <div
+          class="leaflet-control-container"
+        >
+          <div
+            class="leaflet-top leaflet-left"
+          />
+          <div
+            class="leaflet-top leaflet-right"
+          >
+            <div
+              class="leaflet-control-zoom leaflet-bar leaflet-control"
+            >
+              <a
+                aria-disabled="false"
+                aria-label="Zoom in"
+                class="leaflet-control-zoom-in"
+                href="#"
+                role="button"
+                title="Zoom in"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  +
+                </span>
+              </a>
+              <a
+                aria-disabled="false"
+                aria-label="Zoom out"
+                class="leaflet-control-zoom-out"
+                href="#"
+                role="button"
+                title="Zoom out"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  −
+                </span>
+              </a>
+            </div>
+            <div
+              class="leaflet-bar leaflet-control"
+            >
+              <a
+                aria-label="Full Screen"
+                class="leaflet-control-zoom-fullscreen fullscreen-icon"
+                href="#"
+                role="button"
+                title="Full Screen"
+              />
+            </div>
+            <div
+              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+            >
+              
+        
+              <a
+                aria-label="Recenter Map"
+                href="#"
+                role="button"
+                title="Recenter Map"
+              >
+                
+          
+                <svg
+                  height="26"
+                  viewBox="-5 -5 32 32"
+                  width="26"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  
+            
+                  <path
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="rotate(60, 12, 12)"
+                  />
+                  
+          
+                </svg>
+                
+        
+              </a>
+            </div>
+          </div>
+          <div
+            class="leaflet-bottom leaflet-left"
+          />
+          <div
+            class="leaflet-bottom leaflet-right"
+          >
+            <div
+              class="leaflet-control-attribution leaflet-control"
+            >
+              © 
+              <a
+                href="http://osm.org/copyright"
+              >
+                OpenStreetMap
+              </a>
+               contributors
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`MapPage renders the empty state 1`] = `
 <DocumentFragment>
   <div
     class="c-page m-search-page m-search-page--show-list "
+    data-testid="map-page"
   >
     <div
       class="m-search-page__input-and-results"
@@ -315,6 +316,7 @@ exports[`MapPage renders vehicle data 1`] = `
 <DocumentFragment>
   <div
     class="c-page m-search-page m-search-page--show-list "
+    data-testid="map-page"
   >
     <div
       class="m-search-page__input-and-results"

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -1397,6 +1397,9 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
             </div>
           </div>
         </div>
+        <div
+          data-testid="routeShape"
+        />
       </div>
     </div>
   </div>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -1397,9 +1397,6 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
             </div>
           </div>
         </div>
-        <div
-          data-testid="routeShape"
-        />
       </div>
     </div>
   </div>

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -103,7 +103,7 @@ describe("App", () => {
     ;(appData as jest.Mock).mockImplementationOnce(() => ({
       userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
     }))
-    window.history.pushState({}, "", "/search")
+    window.history.pushState({}, "", "/map")
 
     const result = render(<App />)
 

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -10,6 +10,8 @@ import { initialState, State } from "../../src/state"
 import routeTabFactory from "../factories/routeTab"
 import useVehicles from "../../src/hooks/useVehicles"
 import vehicle from "../factories/vehicle"
+import appData from "../../src/appData"
+import { MAP_BETA_GROUP_NAME } from "../../src/userTestGroups"
 
 jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
@@ -19,6 +21,8 @@ jest.mock("../../src/hooks/useVehicles", () => ({
   __esModule: true,
   default: jest.fn(),
 }))
+
+jest.mock("appData")
 
 describe("App", () => {
   test("renders", () => {
@@ -85,5 +89,24 @@ describe("App", () => {
     )
 
     expect(result.getByText("Vehicles")).toBeInTheDocument()
+  })
+
+  test("renders old search page for users not in map test group", () => {
+    window.history.pushState({}, "", "/search")
+
+    const result = render(<App />)
+
+    expect(result.queryByTestId("map-page")).not.toBeInTheDocument()
+  })
+
+  test("renders new map page for users in map test group", () => {
+    ;(appData as jest.Mock).mockImplementationOnce(() => ({
+      userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
+    }))
+    window.history.pushState({}, "", "/search")
+
+    const result = render(<App />)
+
+    expect(result.getByTestId("map-page")).toBeInTheDocument()
   })
 })

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import App from "../../src/components/app"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
@@ -94,9 +94,9 @@ describe("App", () => {
   test("renders old search page for users not in map test group", () => {
     window.history.pushState({}, "", "/search")
 
-    const result = render(<App />)
+    render(<App />)
 
-    expect(result.queryByTestId("map-page")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("map-page")).not.toBeInTheDocument()
   })
 
   test("renders new map page for users in map test group", () => {
@@ -105,8 +105,8 @@ describe("App", () => {
     }))
     window.history.pushState({}, "", "/map")
 
-    const result = render(<App />)
+    render(<App />)
 
-    expect(result.getByTestId("map-page")).toBeInTheDocument()
+    expect(screen.getByTestId("map-page")).toBeInTheDocument()
   })
 })

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import { LatLng } from "leaflet"
 import React, { MutableRefObject } from "react"
@@ -117,23 +117,21 @@ describe("map", () => {
 
   test("performs onPrimaryVehicleSelected function when primary vehicle selected", async () => {
     const onClick = jest.fn()
-    const result = render(
-      <Map vehicles={[vehicle]} onPrimaryVehicleSelect={onClick} />
-    )
-    await userEvent.click(result.getByText(runIdToLabel(vehicle.runId!)))
+    render(<Map vehicles={[vehicle]} onPrimaryVehicleSelect={onClick} />)
+    await userEvent.click(screen.getByText(runIdToLabel(vehicle.runId!)))
     expect(onClick).toHaveBeenCalledWith(expect.objectContaining(vehicle))
   })
 
-  test("does not onPrimaryVehicleSelected function when secondary vehicle selected", async () => {
+  test("does not perform onPrimaryVehicleSelected function when secondary vehicle selected", async () => {
     const onClick = jest.fn()
-    const result = render(
+    render(
       <Map
         vehicles={[]}
         secondaryVehicles={[vehicle]}
         onPrimaryVehicleSelect={onClick}
       />
     )
-    await userEvent.click(result.getByText(runIdToLabel(vehicle.runId!)))
+    await userEvent.click(screen.getByText(runIdToLabel(vehicle.runId!)))
     expect(onClick).not.toHaveBeenCalled()
   })
 })

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -13,6 +13,7 @@ import { TrainVehicle, Vehicle } from "../../src/realtime"
 import { Shape } from "../../src/schedule"
 import vehicleFactory from "../factories/vehicle"
 import userEvent from "@testing-library/user-event"
+import { runIdToLabel } from "../../src/helpers/vehicleLabel"
 
 const vehicle: Vehicle = vehicleFactory.build({
   id: "y1818",
@@ -112,6 +113,28 @@ describe("map", () => {
     const result = render(<Map vehicles={[]} shapes={[shape]} />)
     expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
     expect(result.container.innerHTML).toContain("m-vehicle-map__stop")
+  })
+
+  test("performs onPrimaryVehicleSelected function when primary vehicle selected", async () => {
+    const onClick = jest.fn()
+    const result = render(
+      <Map vehicles={[vehicle]} onPrimaryVehicleSelect={onClick} />
+    )
+    await userEvent.click(result.getByText(runIdToLabel(vehicle.runId!)))
+    expect(onClick).toHaveBeenCalledWith(expect.objectContaining(vehicle))
+  })
+
+  test("does not onPrimaryVehicleSelected function when secondary vehicle selected", async () => {
+    const onClick = jest.fn()
+    const result = render(
+      <Map
+        vehicles={[]}
+        secondaryVehicles={[vehicle]}
+        onPrimaryVehicleSelect={onClick}
+      />
+    )
+    await userEvent.click(result.getByText(runIdToLabel(vehicle.runId!)))
+    expect(onClick).not.toHaveBeenCalled()
   })
 })
 

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -13,6 +13,7 @@ import vehicleFactory from "../factories/vehicle"
 import ghostFactory from "../factories/ghost"
 import userEvent from "@testing-library/user-event"
 import { useTripShape } from "../../src/hooks/useShapes"
+import { SearchPageState } from "../../src/state/searchPageState"
 jest
   .spyOn(dateTime, "now")
   .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
@@ -127,6 +128,62 @@ describe("MapPage", () => {
 
     await userEvent.click(result.getByText(runId))
     expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
+  })
+
+  test("clicking a vehicle from a search result displays the route shape", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const activeSearch: SearchPageState = {
+      query: { text: "clickMe", property: "run" },
+      isActive: true,
+      savedQueries: [],
+    }
+    const mockDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{ ...initialState, searchPageState: activeSearch }}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByRole("button", { name: /run/i }))
+    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
+  })
+
+  test("submitting a new search clears the previously selected route shape", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const activeSearch: SearchPageState = {
+      query: { text: "clickMe", property: "run" },
+      isActive: true,
+      savedQueries: [],
+    }
+    const mockDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{ ...initialState, searchPageState: activeSearch }}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByRole("button", { name: /run/i }))
+    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
+    await userEvent.click(result.getByTitle("Submit"))
+    expect(result.container.innerHTML).not.toContain(
+      "m-vehicle-map__route-shape"
+    )
   })
 
   test("on mobile, allows you to toggle to the map view and back again", async () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -13,6 +13,7 @@ import vehicleFactory from "../factories/vehicle"
 import ghostFactory from "../factories/ghost"
 import userEvent from "@testing-library/user-event"
 import { useTripShape } from "../../src/hooks/useShapes"
+import { SearchPageState } from "../../src/state/searchPageState"
 jest
   .spyOn(dateTime, "now")
   .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
@@ -127,6 +128,60 @@ describe("MapPage", () => {
 
     await userEvent.click(screen.getByText(runId))
     expect(container.innerHTML).toContain("m-vehicle-map__route-shape")
+  })
+
+  test("clicking a vehicle from a search result displays the route shape", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const activeSearch: SearchPageState = {
+      query: { text: "clickMe", property: "run" },
+      isActive: true,
+      savedQueries: [],
+    }
+    const mockDispatch = jest.fn()
+    const { container } = render(
+      <StateDispatchProvider
+        state={{ ...initialState, searchPageState: activeSearch }}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /run/i }))
+    expect(container.innerHTML).toContain("m-vehicle-map__route-shape")
+  })
+
+  test("submitting a new search clears the previously selected route shape", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const activeSearch: SearchPageState = {
+      query: { text: "clickMe", property: "run" },
+      isActive: true,
+      savedQueries: [],
+    }
+    const mockDispatch = jest.fn()
+    const { container } = render(
+      <StateDispatchProvider
+        state={{ ...initialState, searchPageState: activeSearch }}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /run/i }))
+    expect(container.innerHTML).toContain("m-vehicle-map__route-shape")
+    await userEvent.click(screen.getByTitle("Submit"))
+    expect(container.innerHTML).not.toContain("m-vehicle-map__route-shape")
   })
 
   test("on mobile, allows you to toggle to the map view and back again", async () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -1,0 +1,151 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import { BrowserRouter } from "react-router-dom"
+import "@testing-library/jest-dom"
+import MapPage from "../../src/components/mapPage"
+import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import useSearchResults from "../../src/hooks/useSearchResults"
+import { Ghost, Vehicle, VehicleOrGhost } from "../../src/realtime"
+import { initialState } from "../../src/state"
+import * as dateTime from "../../src/util/dateTime"
+
+import vehicleFactory from "../factories/vehicle"
+import ghostFactory from "../factories/ghost"
+import userEvent from "@testing-library/user-event"
+import { useTripShape } from "../../src/hooks/useShapes"
+jest
+  .spyOn(dateTime, "now")
+  .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
+
+jest.spyOn(Date, "now").mockImplementation(() => 234000)
+
+const vehicle: Vehicle = vehicleFactory.build()
+
+const ghost: Ghost = ghostFactory.build({
+  id: "ghost-trip",
+  directionId: 0,
+  routeId: "39",
+  tripId: "trip",
+  headsign: "headsign",
+  blockId: "block",
+  runId: "123-0123",
+  viaVariant: "X",
+  layoverDepartureTime: null,
+  scheduledTimepointStatus: {
+    timepointId: "t0",
+    fractionUntilTimepoint: 0.0,
+  },
+  scheduledLogonTime: null,
+  routeStatus: "on_route",
+  blockWaivers: [],
+})
+jest.mock("../../src/hooks/useSearchResults", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock("../../src/hooks/useShapes", () => ({
+  __esModule: true,
+  useTripShape: jest.fn(() => null),
+}))
+
+describe("MapPage", () => {
+  test("renders the empty state", () => {
+    ;(useSearchResults as jest.Mock).mockImplementationOnce(() => null)
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.asFragment()).toMatchSnapshot()
+  })
+
+  test("renders vehicle data", () => {
+    const searchResults: VehicleOrGhost[] = [vehicle, ghost]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.asFragment()).toMatchSnapshot()
+  })
+
+  test("on mobile, shows the results list initially", () => {
+    const result = render(
+      <BrowserRouter>
+        <MapPage />
+      </BrowserRouter>
+    )
+
+    expect(result.container.firstChild).toHaveClass("m-search-page--show-list")
+  })
+
+  test("clicking a vehicle on the map displays the route shape", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    ;(useTripShape as jest.Mock).mockImplementation((tripId) =>
+      tripId === vehicle.tripId
+        ? [
+            {
+              id: "shape",
+              points: [
+                { lat: 0, lon: 0 },
+                { lat: 0, lon: 0 },
+              ],
+              stops: [
+                {
+                  id: "stop",
+                  name: "stop",
+                  lat: 0,
+                  lon: 0,
+                },
+              ],
+            },
+          ]
+        : null
+    )
+
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const mockDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    expect(result.queryByTestId("routeShape")).toBeNull()
+
+    await userEvent.click(result.getByText(runId))
+    expect(result.getByTestId("routeShape")).toBeInTheDocument()
+  })
+
+  test("on mobile, allows you to toggle to the map view and back again", async () => {
+    const result = render(
+      <BrowserRouter>
+        <MapPage />
+      </BrowserRouter>
+    )
+
+    await userEvent.click(
+      result.getByRole("button", { name: "Show map instead" })
+    )
+
+    expect(result.container.firstChild).toHaveClass("m-search-page--show-map")
+
+    await userEvent.click(
+      result.getByRole("button", { name: "Show list instead" })
+    )
+
+    expect(result.container.firstChild).toHaveClass("m-search-page--show-list")
+  })
+})

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -126,7 +126,7 @@ describe("MapPage", () => {
     expect(result.queryByTestId("routeShape")).toBeNull()
 
     await userEvent.click(result.getByText(runId))
-    expect(result.getByTestId("routeShape")).toBeInTheDocument()
+    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
   })
 
   test("on mobile, allows you to toggle to the map view and back again", async () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import MapPage from "../../src/components/mapPage"
@@ -13,7 +13,6 @@ import vehicleFactory from "../factories/vehicle"
 import ghostFactory from "../factories/ghost"
 import userEvent from "@testing-library/user-event"
 import { useTripShape } from "../../src/hooks/useShapes"
-import { SearchPageState } from "../../src/state/searchPageState"
 jest
   .spyOn(dateTime, "now")
   .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
@@ -53,7 +52,7 @@ jest.mock("../../src/hooks/useShapes", () => ({
 describe("MapPage", () => {
   test("renders the empty state", () => {
     ;(useSearchResults as jest.Mock).mockImplementationOnce(() => null)
-    const result = render(
+    const { asFragment } = render(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
         <BrowserRouter>
           <MapPage />
@@ -61,13 +60,13 @@ describe("MapPage", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   test("renders vehicle data", () => {
     const searchResults: VehicleOrGhost[] = [vehicle, ghost]
     ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
-    const result = render(
+    const { asFragment } = render(
       <StateDispatchProvider state={initialState} dispatch={jest.fn()}>
         <BrowserRouter>
           <MapPage />
@@ -75,17 +74,17 @@ describe("MapPage", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   test("on mobile, shows the results list initially", () => {
-    const result = render(
+    const { container } = render(
       <BrowserRouter>
         <MapPage />
       </BrowserRouter>
     )
 
-    expect(result.container.firstChild).toHaveClass("m-search-page--show-list")
+    expect(container.firstChild).toHaveClass("m-search-page--show-list")
   })
 
   test("clicking a vehicle on the map displays the route shape", async () => {
@@ -116,7 +115,7 @@ describe("MapPage", () => {
     const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
     ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
     const mockDispatch = jest.fn()
-    const result = render(
+    const { container } = render(
       <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
         <BrowserRouter>
           <MapPage />
@@ -124,85 +123,29 @@ describe("MapPage", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.queryByTestId("routeShape")).toBeNull()
+    expect(screen.queryByTestId("routeShape")).toBeNull()
 
-    await userEvent.click(result.getByText(runId))
-    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
-  })
-
-  test("clicking a vehicle from a search result displays the route shape", async () => {
-    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
-    const runId = "clickMe"
-    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
-    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
-    const activeSearch: SearchPageState = {
-      query: { text: "clickMe", property: "run" },
-      isActive: true,
-      savedQueries: [],
-    }
-    const mockDispatch = jest.fn()
-    const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, searchPageState: activeSearch }}
-        dispatch={mockDispatch}
-      >
-        <BrowserRouter>
-          <MapPage />
-        </BrowserRouter>
-      </StateDispatchProvider>
-    )
-
-    await userEvent.click(result.getByRole("button", { name: /run/i }))
-    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
-  })
-
-  test("submitting a new search clears the previously selected route shape", async () => {
-    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
-    const runId = "clickMe"
-    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
-    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
-    const activeSearch: SearchPageState = {
-      query: { text: "clickMe", property: "run" },
-      isActive: true,
-      savedQueries: [],
-    }
-    const mockDispatch = jest.fn()
-    const result = render(
-      <StateDispatchProvider
-        state={{ ...initialState, searchPageState: activeSearch }}
-        dispatch={mockDispatch}
-      >
-        <BrowserRouter>
-          <MapPage />
-        </BrowserRouter>
-      </StateDispatchProvider>
-    )
-
-    await userEvent.click(result.getByRole("button", { name: /run/i }))
-    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
-    await userEvent.click(result.getByTitle("Submit"))
-    expect(result.container.innerHTML).not.toContain(
-      "m-vehicle-map__route-shape"
-    )
+    await userEvent.click(screen.getByText(runId))
+    expect(container.innerHTML).toContain("m-vehicle-map__route-shape")
   })
 
   test("on mobile, allows you to toggle to the map view and back again", async () => {
-    const result = render(
+    const { container } = render(
       <BrowserRouter>
         <MapPage />
       </BrowserRouter>
     )
 
     await userEvent.click(
-      result.getByRole("button", { name: "Show map instead" })
+      screen.getByRole("button", { name: "Show map instead" })
     )
 
-    expect(result.container.firstChild).toHaveClass("m-search-page--show-map")
+    expect(container.firstChild).toHaveClass("m-search-page--show-map")
 
     await userEvent.click(
-      result.getByRole("button", { name: "Show list instead" })
+      screen.getByRole("button", { name: "Show list instead" })
     )
 
-    expect(result.container.firstChild).toHaveClass("m-search-page--show-list")
+    expect(container.firstChild).toHaveClass("m-search-page--show-list")
   })
 })

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import Nav from "../../src/components/nav"
@@ -75,7 +75,7 @@ describe("Nav", () => {
       userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
     }))
 
-    const result = render(
+    render(
       <BrowserRouter>
         <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
           Hello, world!
@@ -83,8 +83,8 @@ describe("Nav", () => {
       </BrowserRouter>
     )
 
-    expect(result.queryByTitle("Search")).toBeNull()
-    expect(result.queryByTitle("Map")).toBeInTheDocument()
+    expect(screen.queryByTitle("Search")).toBeNull()
+    expect(screen.queryByTitle("Map")).toBeInTheDocument()
   })
 
   test("renders desktop nav content", () => {

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -1,14 +1,26 @@
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { render } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
 import Nav from "../../src/components/nav"
 import { OpenView } from "../../src/state"
 import useDeviceType from "../../src/hooks/useDeviceType"
+import appData from "../../src/appData"
+import { MAP_BETA_GROUP_NAME } from "../../src/userTestGroups"
 
 jest.mock("../../src/hooks/useDeviceType", () => ({
   __esModule: true,
   default: jest.fn(() => "desktop"),
 }))
+
+jest.mock("appData")
+
+beforeEach(() => {
+  ;(appData as jest.Mock).mockImplementation(() => ({
+    userTestGroups: JSON.stringify([]),
+  }))
+})
 
 describe("Nav", () => {
   test("renders mobile nav content", () => {
@@ -56,6 +68,23 @@ describe("Nav", () => {
 
     expect(result.queryByTitle("Route Ladders")).not.toBeNull()
     expect(result.queryByText("Route Ladders")).toBeNull()
+  })
+
+  test("renders nav item with title 'Map' if in map test group", () => {
+    ;(appData as jest.Mock).mockImplementation(() => ({
+      userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
+    }))
+
+    const result = render(
+      <BrowserRouter>
+        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+          Hello, world!
+        </Nav>
+      </BrowserRouter>
+    )
+
+    expect(result.queryByTitle("Search")).toBeNull()
+    expect(result.queryByTitle("Map")).toBeInTheDocument()
   })
 
   test("renders desktop nav content", () => {

--- a/assets/tests/components/nav/bottomNavMobile.test.tsx
+++ b/assets/tests/components/nav/bottomNavMobile.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import BottomNavMobile from "../../../src/components/nav/bottomNavMobile"
 import userEvent from "@testing-library/user-event"
@@ -40,7 +40,7 @@ describe("BottomNavMobile", () => {
       userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
     }))
 
-    const result = render(
+    render(
       <BrowserRouter>
         <BottomNavMobile
           mobileMenuIsOpen={initialState.mobileMenuIsOpen}
@@ -49,7 +49,7 @@ describe("BottomNavMobile", () => {
       </BrowserRouter>
     )
 
-    expect(result.queryByTitle("Search")).toBeNull()
-    expect(result.queryByTitle("Map")).toBeInTheDocument()
+    expect(screen.queryByTitle("Search")).toBeNull()
+    expect(screen.queryByTitle("Map")).toBeInTheDocument()
   })
 })

--- a/assets/tests/components/nav/bottomNavMobile.test.tsx
+++ b/assets/tests/components/nav/bottomNavMobile.test.tsx
@@ -1,15 +1,20 @@
 import React from "react"
 import { render } from "@testing-library/react"
+import "@testing-library/jest-dom"
 import BottomNavMobile from "../../../src/components/nav/bottomNavMobile"
 import userEvent from "@testing-library/user-event"
 import { initialState } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
+import appData from "../../../src/appData"
+import { MAP_BETA_GROUP_NAME } from "../../../src/userTestGroups"
 
 jest.mock("../../../src/helpers/googleTagManager", () => ({
   __esModule: true,
   tagManagerEvent: jest.fn(),
 }))
+
+jest.mock("appData")
 
 describe("BottomNavMobile", () => {
   test("clicking swings view button toggles swing view", async () => {
@@ -28,5 +33,23 @@ describe("BottomNavMobile", () => {
 
     expect(openSwingsView).toHaveBeenCalled()
     expect(tagManagerEvent).toHaveBeenCalledWith("swings_view_toggled")
+  })
+
+  test("renders nav item with title 'Map' if in map test group", () => {
+    ;(appData as jest.Mock).mockImplementationOnce(() => ({
+      userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
+    }))
+
+    const result = render(
+      <BrowserRouter>
+        <BottomNavMobile
+          mobileMenuIsOpen={initialState.mobileMenuIsOpen}
+          openSwingsView={jest.fn()}
+        />
+      </BrowserRouter>
+    )
+
+    expect(result.queryByTitle("Search")).toBeNull()
+    expect(result.queryByTitle("Map")).toBeInTheDocument()
   })
 })

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -16,6 +16,8 @@ import {
 import { openDrift } from "../../../src/helpers/drift"
 import { displayHelp } from "../../../src/helpers/appCue"
 import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
+import appData from "../../../src/appData"
+import { MAP_BETA_GROUP_NAME } from "../../../src/userTestGroups"
 
 jest.mock("../../../src/helpers/drift", () => ({
   __esModule: true,
@@ -30,6 +32,8 @@ jest.mock("../../../src/helpers/googleTagManager", () => ({
   __esModule: true,
   tagManagerEvent: jest.fn(),
 }))
+
+jest.mock("appData")
 
 describe("LeftNav", () => {
   test("renders non-collapsed state", () => {
@@ -75,6 +79,21 @@ describe("LeftNav", () => {
     expect(result.queryByTitle("Settings")).not.toBeNull()
     expect(result.queryByText("Expand")).toBeNull()
     expect(result.queryByTitle("Expand")).not.toBeNull()
+  })
+
+  test("renders nav item with title 'Map' if in map test group", () => {
+    ;(appData as jest.Mock).mockImplementationOnce(() => ({
+      userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
+    }))
+
+    const result = render(
+      <BrowserRouter>
+        <LeftNav defaultToCollapsed={true} dispatcherFlag={true} />
+      </BrowserRouter>
+    )
+
+    expect(result.queryByTitle("Search")).toBeNull()
+    expect(result.getByTitle("Map")).toBeInTheDocument()
   })
 
   test("can toggle nav menu on tablet layout", async () => {

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import LeftNav from "../../../src/components/nav/leftNav"
 import userEvent from "@testing-library/user-event"
@@ -86,14 +86,14 @@ describe("LeftNav", () => {
       userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
     }))
 
-    const result = render(
+    render(
       <BrowserRouter>
         <LeftNav defaultToCollapsed={true} dispatcherFlag={true} />
       </BrowserRouter>
     )
 
-    expect(result.queryByTitle("Search")).toBeNull()
-    expect(result.getByTitle("Map")).toBeInTheDocument()
+    expect(screen.queryByTitle("Search")).toBeNull()
+    expect(screen.getByTitle("Map")).toBeInTheDocument()
   })
 
   test("can toggle nav menu on tablet layout", async () => {

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -91,6 +91,29 @@ describe("SearchForm", () => {
     expect(testDispatch).toHaveBeenCalledWith(submitSearch())
   })
 
+  test("clicking the submit button also calls onSubmit when set", async () => {
+    const testDispatch = jest.fn()
+    const onSubmit = jest.fn()
+    const validSearch: SearchPageState = {
+      query: { text: "12", property: "run" },
+      isActive: false,
+      savedQueries: [],
+    }
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    const result = render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <SearchForm onSubmit={onSubmit} />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByTitle("Submit"))
+    expect(testDispatch).toHaveBeenCalledWith(submitSearch())
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
   test("entering text sets it as the search text", async () => {
     const validSearch: SearchPageState = {
       query: { text: "12", property: "run" },
@@ -135,6 +158,30 @@ describe("SearchForm", () => {
     await userEvent.click(result.getByTitle("Clear"))
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
+  })
+
+  test("clicking the clear button also calls onClear when set", async () => {
+    const testDispatch = jest.fn()
+    const onClear = jest.fn()
+    const validSearch: SearchPageState = {
+      query: { text: "12", property: "run" },
+      isActive: false,
+      savedQueries: [],
+    }
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    const result = render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <SearchForm onClear={onClear} />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByTitle("Clear"))
+
+    expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
+    expect(onClear).toHaveBeenCalledTimes(1)
   })
 
   test("clicking a search property selects it", async () => {

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React from "react"
 import renderer from "react-test-renderer"
@@ -103,13 +103,13 @@ describe("SearchForm", () => {
       ...initialState,
       searchPageState: validSearch,
     }
-    const result = render(
+    render(
       <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
         <SearchForm onSubmit={onSubmit} />
       </StateDispatchProvider>
     )
 
-    await userEvent.click(result.getByTitle("Submit"))
+    await userEvent.click(screen.getByTitle("Submit"))
     expect(testDispatch).toHaveBeenCalledWith(submitSearch())
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
@@ -172,13 +172,13 @@ describe("SearchForm", () => {
       ...initialState,
       searchPageState: validSearch,
     }
-    const result = render(
+    render(
       <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
         <SearchForm onClear={onClear} />
       </StateDispatchProvider>
     )
 
-    await userEvent.click(result.getByTitle("Clear"))
+    await userEvent.click(screen.getByTitle("Clear"))
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
     expect(onClear).toHaveBeenCalledTimes(1)

--- a/assets/tests/components/searchPage.test.tsx
+++ b/assets/tests/components/searchPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom"
 import SearchPage from "../../src/components/searchPage"
@@ -113,7 +113,7 @@ describe("SearchPage", () => {
       savedQueries: [],
     }
     const mockDispatch = jest.fn()
-    const result = render(
+    render(
       <StateDispatchProvider
         state={{ ...initialState, searchPageState: activeSearch }}
         dispatch={mockDispatch}
@@ -124,7 +124,7 @@ describe("SearchPage", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(result.getByRole("button", { name: /run/i }))
+    await userEvent.click(screen.getByRole("button", { name: /run/i }))
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: "SELECT_VEHICLE" })
     )

--- a/assets/tests/components/searchPage.test.tsx
+++ b/assets/tests/components/searchPage.test.tsx
@@ -12,6 +12,7 @@ import * as dateTime from "../../src/util/dateTime"
 import vehicleFactory from "../factories/vehicle"
 import ghostFactory from "../factories/ghost"
 import userEvent from "@testing-library/user-event"
+import { SearchPageState } from "../../src/state/searchPageState"
 jest
   .spyOn(dateTime, "now")
   .mockImplementation(() => new Date("2018-08-15T17:41:21.000Z"))
@@ -96,6 +97,34 @@ describe("SearchPage", () => {
     )
 
     await userEvent.click(result.getByText(runId))
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "SELECT_VEHICLE" })
+    )
+  })
+
+  test("clicking a search result selects that vehicle", async () => {
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    const runId = "clickMe"
+    const searchResults: VehicleOrGhost[] = [{ ...vehicle, runId: runId }]
+    ;(useSearchResults as jest.Mock).mockImplementation(() => searchResults)
+    const activeSearch: SearchPageState = {
+      query: { text: "clickMe", property: "run" },
+      isActive: true,
+      savedQueries: [],
+    }
+    const mockDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider
+        state={{ ...initialState, searchPageState: activeSearch }}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <SearchPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByRole("button", { name: /run/i }))
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: "SELECT_VEHICLE" })
     )

--- a/assets/tests/components/searchResults.test.tsx
+++ b/assets/tests/components/searchResults.test.tsx
@@ -7,7 +7,7 @@ import SearchResults, {
 } from "../../src/components/searchResults"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { Ghost, Vehicle } from "../../src/realtime"
-import { initialState, selectVehicle, State } from "../../src/state"
+import { initialState, State } from "../../src/state"
 import { setSearchText } from "../../src/state/searchPageState"
 import * as dateTime from "../../src/util/dateTime"
 
@@ -32,7 +32,11 @@ describe("SearchResults", () => {
     const tree = renderer
       .create(
         <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <SearchResults vehicles={[]} />
+          <SearchResults
+            vehicles={[]}
+            onClick={jest.fn()}
+            selectedVehicleId={null}
+          />
         </StateDispatchProvider>
       )
       .toJSON()
@@ -117,7 +121,11 @@ describe("SearchResults", () => {
     const tree = renderer
       .create(
         <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <SearchResults vehicles={[vehicle, ghost]} />
+          <SearchResults
+            vehicles={[vehicle, ghost]}
+            onClick={jest.fn()}
+            selectedVehicleId={null}
+          />
         </StateDispatchProvider>
       )
       .toJSON()
@@ -184,7 +192,11 @@ describe("SearchResults", () => {
     const tree = renderer
       .create(
         <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <SearchResults vehicles={[vehicle]} />
+          <SearchResults
+            vehicles={[vehicle]}
+            onClick={jest.fn()}
+            selectedVehicleId={null}
+          />
         </StateDispatchProvider>
       )
       .toJSON()
@@ -323,7 +335,11 @@ describe("SearchResults", () => {
     const tree = renderer
       .create(
         <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <SearchResults vehicles={[oldVehicle, newVehicle, ghost]} />
+          <SearchResults
+            vehicles={[oldVehicle, newVehicle, ghost]}
+            onClick={jest.fn()}
+            selectedVehicleId={null}
+          />
         </StateDispatchProvider>
       )
       .toJSON()
@@ -339,15 +355,14 @@ describe("SearchResults", () => {
     })
     const ghost: Ghost = ghostFactory.build({ runId: "123-0123" })
 
-    const stateWithSelected = {
-      ...state,
-      selectedVehicleOrGhost: vehicle,
-    }
-
     const tree = renderer
       .create(
-        <StateDispatchProvider state={stateWithSelected} dispatch={jest.fn()}>
-          <SearchResults vehicles={[vehicle, ghost]} />
+        <StateDispatchProvider state={state} dispatch={jest.fn()}>
+          <SearchResults
+            vehicles={[vehicle, ghost]}
+            onClick={jest.fn()}
+            selectedVehicleId={vehicle.id}
+          />
         </StateDispatchProvider>
       )
       .toJSON()
@@ -358,22 +373,31 @@ describe("SearchResults", () => {
   test("clicking a result card selects that vehicle", async () => {
     const testDispatch = jest.fn()
     const vehicle: Vehicle = vehicleFactory.build({ runId: "12345" })
+    const mockOnClick = jest.fn()
     const result = render(
       <StateDispatchProvider state={state} dispatch={testDispatch}>
-        <SearchResults vehicles={[vehicle]} />
+        <SearchResults
+          vehicles={[vehicle]}
+          onClick={mockOnClick}
+          selectedVehicleId={null}
+        />
       </StateDispatchProvider>
     )
 
     await userEvent.click(result.getByText("12345"))
 
-    expect(testDispatch).toHaveBeenCalledWith(selectVehicle(vehicle))
+    expect(mockOnClick).toHaveBeenCalledWith(vehicle)
   })
 
   test("clicking the clear search button empties the search text", async () => {
     const testDispatch = jest.fn()
     const result = render(
       <StateDispatchProvider state={state} dispatch={testDispatch}>
-        <SearchResults vehicles={[]} />
+        <SearchResults
+          vehicles={[]}
+          onClick={jest.fn()}
+          selectedVehicleId={null}
+        />
       </StateDispatchProvider>
     )
 

--- a/assets/tests/hooks/useShapes.test.ts
+++ b/assets/tests/hooks/useShapes.test.ts
@@ -158,4 +158,23 @@ describe("useTripShape", () => {
     rerender("2")
     expect(mockFetchShape).toHaveBeenCalledTimes(2)
   })
+
+  test("returns null when trip id changes to null", () => {
+    const shape: Shape = {
+      id: "shape",
+      points: [{ lat: 42.41356, lon: -70.99211 }],
+    }
+    const mockFetchShape: jest.Mock = Api.fetchShapeForTrip as jest.Mock
+    mockFetchShape.mockImplementationOnce(() => instantPromise(shape))
+    const { rerender, result } = renderHook<Shape[], string | null>(
+      (tripId) => useTripShape(tripId),
+      {
+        initialProps: "1",
+      }
+    )
+    expect(result.current).toEqual([shape])
+
+    rerender(null)
+    expect(result.current).toEqual([])
+  })
 })

--- a/assets/tests/util/mapMode.test.tsx
+++ b/assets/tests/util/mapMode.test.tsx
@@ -13,7 +13,7 @@ describe("mapModeForUser", () => {
       userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
     }))
     expect(mapModeForUser()).toEqual({
-      path: "/search",
+      path: "/map",
       title: "Map",
       element: <MapPage />,
     })

--- a/assets/tests/util/mapMode.test.tsx
+++ b/assets/tests/util/mapMode.test.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import appData from "../../src/appData"
+import MapPage from "../../src/components/mapPage"
+import SearchPage from "../../src/components/searchPage"
+import { MAP_BETA_GROUP_NAME } from "../../src/userTestGroups"
+import { mapModeForUser } from "../../src/util/mapMode"
+
+jest.mock("appData")
+
+describe("mapModeForUser", () => {
+  test("returns new map mode when a part of new map test group", () => {
+    ;(appData as jest.Mock).mockImplementationOnce(() => ({
+      userTestGroups: JSON.stringify([MAP_BETA_GROUP_NAME]),
+    }))
+    expect(mapModeForUser()).toEqual({
+      path: "/search",
+      title: "Map",
+      element: <MapPage />,
+    })
+  })
+
+  test("returns old search mode when not a part of new map test group", () => {
+    ;(appData as jest.Mock).mockImplementationOnce(() => ({
+      userTestGroups: JSON.stringify([]),
+    }))
+    expect(mapModeForUser()).toEqual({
+      path: "/search",
+      title: "Search",
+      element: <SearchPage />,
+    })
+  })
+})

--- a/assets/tests/util/streetViewUrl.test.ts
+++ b/assets/tests/util/streetViewUrl.test.ts
@@ -20,7 +20,7 @@ describe("streetViewUrl", () => {
         longitude: -71.09505978,
       })
     ).toEqual(
-      "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=42.36014757%2C-71.09505978&heading=0&pitch=0&fov=80"
+      "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=42.36014757%2C-71.09505978&pitch=0&fov=80"
     )
   })
 })

--- a/assets/tests/util/streetViewUrl.test.ts
+++ b/assets/tests/util/streetViewUrl.test.ts
@@ -1,0 +1,26 @@
+import { streetViewUrl } from "../../src/util/streetViewUrl"
+
+describe("streetViewUrl", () => {
+  test("returns a url with the given lat, lon, and bearing", () => {
+    expect(
+      streetViewUrl({
+        latitude: 42.36014757,
+        longitude: -71.09505978,
+        bearing: 131,
+      })
+    ).toEqual(
+      "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=42.36014757%2C-71.09505978&heading=131&pitch=0&fov=80"
+    )
+  })
+
+  test("returns with default heading of 0 when no bearing given", () => {
+    expect(
+      streetViewUrl({
+        latitude: 42.36014757,
+        longitude: -71.09505978,
+      })
+    ).toEqual(
+      "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=42.36014757%2C-71.09505978&heading=0&pitch=0&fov=80"
+    )
+  })
+})

--- a/assets/tests/util/streetViewUrl.test.ts
+++ b/assets/tests/util/streetViewUrl.test.ts
@@ -13,7 +13,7 @@ describe("streetViewUrl", () => {
     )
   })
 
-  test("returns with default heading of 0 when no bearing given", () => {
+  test("returns without heading param when no bearing given", () => {
     expect(
       streetViewUrl({
         latitude: 42.36014757,

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -60,6 +60,7 @@ defmodule SkateWeb.Router do
     get "/", PageController, :index
     get "/shuttle-map", PageController, :index
     get "/search", PageController, :index
+    get "/map", PageController, :index
     get "/settings", PageController, :index
     get "/unauthorized", UnauthorizedController, :index
   end


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203329634351702
There are some minor comments in the thread for that ticket, but I don't think they should block an initial review.

My general approach for this ticket was to create a new `MapPage` component as a copy of the existing `SearchPage` so that it is easy to make changes to the component without affecting the old `SearchPage` that all users should currently still see. The `MapPage.test.tsx` file is a copy of `SearchPage.test.tsx` as well, with only the relevant click interaction tests changed.