### PR TITLE
chore: Update AWS certificate bundle hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /root
 
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     -o aws-cert-bundle.pem
-RUN echo "6f99a8eac41b1b76bdc4f402c4a1f3d12d24fcae75ce08818ee3349bda075e93  aws-cert-bundle.pem" | sha256sum -c -
+RUN echo "4ce3510fcdc7ebd281c45a7f9dfafe3354acd0f504cf7ca35afbbc956b7ed06c  aws-cert-bundle.pem" | sha256sum -c -
 
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static


### PR DESCRIPTION
to fix failing deploys: https://github.com/mbta/skate/actions/runs/3489790242