### PR TITLE
fix(Logger): Filter socket logs too

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -120,6 +120,14 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+# "code" is the secret value returned by AWS to /auth/cognito/callback
+log_filter_params =
+  ~w(password code token guardian_default_claims guardian_default_resource guardian_default_token)
+
+config :logster, :filter_parameters, log_filter_params
+
+config :phoenix, :filter_parameters, log_filter_params
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -47,11 +47,6 @@ config :logger, :console,
   format: "$time $metadata[$level] node=$node $message\n",
   metadata: [:request_id]
 
-# "code" is the secret value returned by AWS to /auth/cognito/callback
-config :logster,
-       :filter_parameters,
-       ~w(password code, token guardian_default_claims guardian_default_resource guardian_default_token)
-
 # Configure Ueberauth to use Cognito
 config :ueberauth, Ueberauth,
   providers: [

--- a/test/skate_web/channels/user_socket_test.exs
+++ b/test/skate_web/channels/user_socket_test.exs
@@ -3,6 +3,10 @@ defmodule SkateWeb.UserSocketTest do
 
   alias SkateWeb.{AuthManager, UserSocket}
 
+  import Test.Support.Helpers
+
+  import ExUnit.CaptureLog
+
   setup do
     %{socket: socket(UserSocket), resource: %{id: 1}}
   end
@@ -31,6 +35,18 @@ defmodule SkateWeb.UserSocketTest do
 
     test "doesn't authenticate without a token", %{socket: socket} do
       assert UserSocket.connect(%{"token" => nil}, socket, %{}) == :error
+    end
+
+    test "doesn't log user token", %{resource: resource} do
+      set_log_level(:info)
+
+      current_time = System.system_time(:second)
+      expiration_time = current_time + 500
+
+      {:ok, token, _claims} = AuthManager.encode_and_sign(resource, %{"exp" => expiration_time})
+
+      log = capture_log(fn -> connect(UserSocket, %{"token" => token}) end)
+      assert log =~ "%{\"token\" => \"[FILTERED]\"}"
     end
   end
 end

--- a/test/skate_web/channels/user_socket_test.exs
+++ b/test/skate_web/channels/user_socket_test.exs
@@ -4,7 +4,6 @@ defmodule SkateWeb.UserSocketTest do
   alias SkateWeb.{AuthManager, UserSocket}
 
   import Test.Support.Helpers
-
   import ExUnit.CaptureLog
 
   setup do


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1200180014510248/1203412139193191/f

Phoenix Sockets use the Phoenix Logger, so we need to configure its filter parameters too.
