### PR TITLE
Detour alerts backend

### DIFF
--- a/lib/concentrate/consumer/vehicle_positions.ex
+++ b/lib/concentrate/consumer/vehicle_positions.ex
@@ -42,7 +42,7 @@ defmodule Concentrate.Consumer.VehiclePositions do
     by_route = Vehicles.group_by_route(all_vehicles, timepoint_names_by_id)
     shuttles = Enum.filter(all_vehicles, & &1.is_shuttle)
 
-    _ = Server.update({by_route, shuttles})
+    _ = Server.update_vehicles({by_route, shuttles})
 
     {:noreply, [], state}
   end

--- a/lib/realtime/alerts_fetcher.ex
+++ b/lib/realtime/alerts_fetcher.ex
@@ -1,0 +1,133 @@
+defmodule Realtime.AlertsFetcher do
+  use GenServer
+  require Logger
+  alias Schedule.Route
+
+  @default_poll_interval_ms 3 * 60 * 1_000
+
+  @type state :: %{
+          update_fn: Route.by_id([String.t()]),
+          poll_interval_ms: integer(),
+          api_url: String.t(),
+          api_key: String.t()
+        }
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    update_fn = Keyword.get(opts, :update_fn, &Realtime.Server.update_alerts/1)
+
+    poll_interval_ms = Keyword.get(opts, :poll_interval_ms, @default_poll_interval_ms)
+
+    {:ok, _} = :timer.send_interval(poll_interval_ms, self(), :query_api)
+
+    {:ok,
+     %{
+       update_fn: update_fn,
+       poll_interval_ms: poll_interval_ms,
+       api_url: Application.get_env(:skate, :api_url),
+       api_key: Application.get_env(:skate, :api_key)
+     }, {:continue, :initial_poll}}
+  end
+
+  @impl true
+  def handle_continue(:initial_poll, state) do
+    do_poll(state)
+  end
+
+  @impl true
+  def handle_info(:query_api, state) do
+    do_poll(state)
+  end
+
+  @spec do_poll(state()) :: {:noreply, state()}
+  defp do_poll(%{update_fn: update_fn, api_url: api_url, api_key: api_key} = state) do
+    headers =
+      if api_key do
+        [{"x-api-key", api_key}]
+      else
+        []
+      end
+
+    url =
+      api_url
+      |> URI.merge(
+        "/alerts?" <>
+          URI.encode_query([{"filter[route_type]", "3,11"}, {"filter[datetime]", "NOW"}])
+      )
+      |> URI.to_string()
+
+    case HTTPoison.get(url, headers) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        case parse_and_update_alerts(body, update_fn) do
+          :ok ->
+            Logger.info("#{__MODULE__}: updated_alerts url=#{inspect(url)}")
+
+          {:error, error} ->
+            Logger.warn(
+              "#{__MODULE__}: unable_to_parse_alerts url=#{inspect(url)} error=#{inspect(error)}"
+            )
+        end
+
+      response ->
+        Logger.warn(
+          "#{__MODULE__}: unexpected_response url=#{inspect(url)} response=#{inspect(response)}"
+        )
+    end
+
+    {:noreply, state}
+  end
+
+  @spec parse_and_update_alerts(binary(), (Route.by_id([String.t()]) -> term())) ::
+          :ok | {:error, any()}
+  defp parse_and_update_alerts(body, update_fn) do
+    case JsonApi.parse(body) do
+      %JsonApi{data: data} ->
+        alerts =
+          Enum.reduce(data, %{}, fn alert, acc ->
+            is_detour? = alert.attributes["effect"] == "DETOUR"
+
+            if is_detour? do
+              route_ids =
+                Enum.reduce(alert.attributes["informed_entity"], [], fn informed_entity,
+                                                                        route_ids ->
+                  if informed_entity["route"] && informed_entity["route"] not in route_ids do
+                    [informed_entity["route"] | route_ids]
+                  else
+                    route_ids
+                  end
+                end)
+
+              alert_text = alert.attributes["service_effect"]
+
+              Enum.reduce(route_ids, acc, fn route_id, acc ->
+                {_old_value, acc} =
+                  Map.get_and_update(acc, route_id, fn alerts_for_route ->
+                    case alerts_for_route do
+                      nil -> {alerts_for_route, [alert_text]}
+                      alerts -> {alerts_for_route, [alert_text | alerts]}
+                    end
+                  end)
+
+                acc
+              end)
+            else
+              acc
+            end
+          end)
+
+        update_fn.(alerts)
+
+        :ok
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lib/realtime/alerts_fetcher.ex
+++ b/lib/realtime/alerts_fetcher.ex
@@ -3,7 +3,7 @@ defmodule Realtime.AlertsFetcher do
   require Logger
   alias Schedule.Route
 
-  @default_poll_interval_ms 3 * 60 * 1_000
+  @default_poll_interval_ms 60 * 1_000
 
   @type state :: %{
           update_fn: Route.by_id([String.t()]),

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -27,7 +27,8 @@ defmodule Realtime.Server do
   defstruct ets: nil,
             active_route_ids: [],
             active_run_ids: [],
-            active_block_ids: []
+            active_block_ids: [],
+            active_alert_route_ids: []
 
   @type subscription_key ::
           {:route_id, Route.id()}
@@ -37,6 +38,7 @@ defmodule Realtime.Server do
           | {:vehicle, String.t()}
           | {:run_ids, [Run.id()]}
           | {:block_ids, [Block.id()]}
+          | {:alerts, Route.id()}
 
   @type search_params :: %{
           text: String.t(),
@@ -53,7 +55,8 @@ defmodule Realtime.Server do
            ets: :ets.tid(),
            active_route_ids: [Route.id()],
            active_run_ids: [Run.id()],
-           active_block_ids: [Block.id()]
+           active_block_ids: [Block.id()],
+           active_alert_route_ids: [Route.id()]
          }
 
   # Client functions
@@ -110,6 +113,11 @@ defmodule Realtime.Server do
     subscribe(server, {:block_ids, block_ids})
   end
 
+  @spec subscribe_to_alerts(Route.id(), GenServer.server()) :: [String.t()]
+  def subscribe_to_alerts(route_id, server \\ default_name()) do
+    subscribe(server, {:alerts, route_id})
+  end
+
   def peek_at_vehicles_by_run_ids(run_ids, server \\ default_name()) do
     {_registry_key, ets} = GenServer.call(server, :subscription_info)
     lookup({ets, {:run_ids, run_ids}})
@@ -127,6 +135,7 @@ defmodule Realtime.Server do
   @spec subscribe(GenServer.server(), {:vehicle, String.t()}) :: [VehicleOrGhost.t()]
   @spec subscribe(GenServer.server(), {:run_ids, [Run.id()]}) :: [VehicleOrGhost.t()]
   @spec subscribe(GenServer.server(), {:block_ids, [Block.id()]}) :: [VehicleOrGhost.t()]
+  @spec subscribe(GenServer.server(), {:alerts, Route.id()}) :: [String.t()]
   defp subscribe(server, subscription_key) do
     {registry_key, ets} = GenServer.call(server, :subscription_info)
     Registry.register(Realtime.Registry, registry_key, subscription_key)
@@ -141,7 +150,12 @@ defmodule Realtime.Server do
   def update_vehicles(update_term, server \\ __MODULE__)
 
   def update_vehicles({vehicles_by_route_id, shuttles}, server) do
-    GenServer.cast(server, {:update, vehicles_by_route_id, shuttles})
+    GenServer.cast(server, {:update_vehicles, vehicles_by_route_id, shuttles})
+  end
+
+  @spec update_alerts(Route.by_id([String.t()]), GenServer.server()) :: term()
+  def update_alerts(alerts_by_route_id, server \\ __MODULE__) do
+    GenServer.cast(server, {:update_alerts, alerts_by_route_id})
   end
 
   @spec lookup({:ets.tid(), {:route_id, Route.id()}}) :: [VehicleOrGhost.t()]
@@ -151,6 +165,7 @@ defmodule Realtime.Server do
   @spec lookup({:ets.tid(), {:vehicle, String.t()}}) :: [VehicleOrGhost.t()]
   @spec lookup({:ets.tid(), {:run_ids, [Run.id()]}}) :: [VehicleOrGhost.t()]
   @spec lookup({:ets.tid(), {:block_ids, [Block.id()]}}) :: [VehicleOrGhost.t()]
+  @spec lookup({:ets.tid(), {:alerts, Route.id()}}) :: [String.t()]
   def lookup({table, {:search, search_params}}) do
     {table, :all_vehicles}
     |> lookup()
@@ -242,7 +257,7 @@ defmodule Realtime.Server do
 
   @impl true
   def handle_cast(
-        {:update, vehicles_by_route_id, shuttles},
+        {:update_vehicles, vehicles_by_route_id, shuttles},
         %__MODULE__{} = state
       ) do
     new_active_route_ids = Map.keys(vehicles_by_route_id)
@@ -282,6 +297,27 @@ defmodule Realtime.Server do
     _ = broadcast(new_state)
 
     {:noreply, new_state}
+  end
+
+  def handle_cast(
+        {:update_alerts, alerts_by_route_id},
+        %__MODULE__{active_alert_route_ids: active_alert_route_ids, ets: ets} = state
+      ) do
+    new_active_route_ids = Map.keys(alerts_by_route_id)
+
+    removed_route_ids = active_alert_route_ids -- new_active_route_ids
+
+    for route_id <- removed_route_ids do
+      :ets.delete(ets, {:alerts, route_id})
+    end
+
+    Enum.each(alerts_by_route_id, fn {route_id, alerts} ->
+      :ets.insert(ets, {{:alerts, route_id}, alerts})
+    end)
+
+    _ = broadcast(state)
+
+    {:noreply, %{state | active_alert_route_ids: new_active_route_ids}}
   end
 
   defp update_vehicle_positions(

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -133,14 +133,14 @@ defmodule Realtime.Server do
     lookup({ets, subscription_key})
   end
 
-  @spec update({Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]}) :: term()
-  @spec update(
+  @spec update_vehicles({Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]}) :: term()
+  @spec update_vehicles(
           {Route.by_id([VehicleOrGhost.t()]), [Vehicle.t()]},
           GenServer.server()
         ) :: term()
-  def update(update_term, server \\ __MODULE__)
+  def update_vehicles(update_term, server \\ __MODULE__)
 
-  def update({vehicles_by_route_id, shuttles}, server) do
+  def update_vehicles({vehicles_by_route_id, shuttles}, server) do
     GenServer.cast(server, {:update, vehicles_by_route_id, shuttles})
   end
 

--- a/lib/realtime/supervisor.ex
+++ b/lib/realtime/supervisor.ex
@@ -24,7 +24,8 @@ defmodule Realtime.Supervisor do
            Application.get_env(:skate, :swiftly_realtime_vehicles_url),
          trip_updates_url: Application.get_env(:skate, :trip_updates_url)
        ]},
-      {Realtime.DataStatusAlerter, []}
+      {Realtime.DataStatusAlerter, []},
+      {Realtime.AlertsFetcher, []}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -1,0 +1,27 @@
+defmodule SkateWeb.AlertsChannel do
+  use SkateWeb, :channel
+
+  alias Realtime.Server
+  alias Util.Duration
+
+  @impl Phoenix.Channel
+  def join("alerts:route:" <> route_id, _message, socket) do
+    alerts = Duration.log_duration(Server, :subscribe_to_alerts, [route_id])
+    {:ok, %{data: alerts}, socket}
+  end
+
+  @impl Phoenix.Channel
+  def handle_info({:new_realtime_data, lookup_args}, socket) do
+    valid_token_fn =
+      Application.get_env(:skate, :valid_token_fn, &SkateWeb.ChannelAuth.valid_token?/1)
+
+    if valid_token_fn.(socket) do
+      data = Server.lookup(lookup_args)
+      :ok = push(socket, "alerts", %{data: data})
+      {:noreply, socket}
+    else
+      :ok = push(socket, "auth_expired", %{})
+      {:stop, :normal, socket}
+    end
+  end
+end

--- a/lib/skate_web/channels/user_socket.ex
+++ b/lib/skate_web/channels/user_socket.ex
@@ -7,6 +7,7 @@ defmodule SkateWeb.UserSocket do
   channel("vehicles:*", SkateWeb.VehiclesChannel)
   channel("train_vehicles:*", SkateWeb.TrainVehiclesChannel)
   channel("notifications", SkateWeb.NotificationsChannel)
+  channel("alerts:*", SkateWeb.AlertsChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/test/realtime/alerts_fetcher_test.exs
+++ b/test/realtime/alerts_fetcher_test.exs
@@ -1,0 +1,218 @@
+defmodule Realtime.AlertsFetcherTest do
+  use ExUnit.Case
+  import Test.Support.Helpers
+  import ExUnit.CaptureLog
+  alias Realtime.AlertsFetcher
+
+  @api_response %{
+    "data" => [
+      %{
+        "attributes" => %{
+          "informed_entity" => [
+            %{"route" => "1"}
+          ],
+          "effect" => "DETOUR",
+          "service_effect" => "Route 1 detour"
+        },
+        "type" => "alert",
+        "id" => 123
+      }
+    ]
+  }
+
+  @complex_api_response %{
+    "data" => [
+      %{
+        "attributes" => %{
+          "informed_entity" => [
+            %{"route" => "1"},
+            %{"route" => "1"},
+            %{"route" => "2"}
+          ],
+          "effect" => "DETOUR",
+          "service_effect" => "Route 1 and 2 detour"
+        },
+        "type" => "alert",
+        "id" => 123
+      },
+      %{
+        "attributes" => %{
+          "informed_entity" => [
+            %{"route" => "2"}
+          ],
+          "effect" => "DETOUR",
+          "service_effect" => "Different route 2 detour"
+        },
+        "type" => "alert",
+        "id" => 456
+      },
+      %{
+        "attributes" => %{
+          "informed_entity" => [
+            %{"route" => "1"}
+          ],
+          "effect" => "UNKNOWN_EFFECT",
+          "service_effect" => "Non-detour alert"
+        },
+        "type" => "alert",
+        "id" => 789
+      }
+    ]
+  }
+
+  describe "start_link/1" do
+    test "starts GenServer" do
+      assert {:ok, _pid} = AlertsFetcher.start_link(update_fn: fn _ -> :ok end)
+    end
+  end
+
+  describe "init/1" do
+    test "sets state and queues up initial check" do
+      api_url = "https://test.com/"
+      api_key = "test_key"
+      reassign_env(:skate, :api_url, api_url)
+      reassign_env(:skate, :api_key, api_key)
+
+      update_fn = fn _ -> :ok end
+
+      assert {:ok,
+              %{
+                update_fn: ^update_fn,
+                poll_interval_ms: 500,
+                api_url: ^api_url,
+                api_key: ^api_key
+              },
+              {:continue, :initial_poll}} =
+               AlertsFetcher.init(update_fn: update_fn, poll_interval_ms: 500)
+    end
+  end
+
+  describe "handle_continue/2" do
+    test "fetches alerts" do
+      bypass = Bypass.open()
+      api_url = "http://localhost:#{bypass.port}/"
+      reassign_env(:skate, :api_url, api_url)
+      test_pid = self()
+
+      update_fn = fn alerts ->
+        GenServer.cast(test_pid, alerts)
+        :ok
+      end
+
+      {:ok, state, _} = AlertsFetcher.init(update_fn: update_fn)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(@api_response))
+      end)
+
+      assert {:noreply, _state} = AlertsFetcher.handle_continue(:initial_poll, state)
+
+      assert_receive {:"$gen_cast", %{"1" => ["Route 1 detour"]}}, 5000
+    end
+  end
+
+  describe "handle_info/2" do
+    test "fetches alerts and logs on success" do
+      set_log_level(:info)
+      bypass = Bypass.open()
+      api_url = "http://localhost:#{bypass.port}/"
+      reassign_env(:skate, :api_url, api_url)
+      test_pid = self()
+
+      update_fn = fn alerts ->
+        GenServer.cast(test_pid, alerts)
+        :ok
+      end
+
+      {:ok, state, _} = AlertsFetcher.init(update_fn: update_fn)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(@api_response))
+      end)
+
+      log =
+        capture_log([level: :info], fn ->
+          assert {:noreply, _state} = AlertsFetcher.handle_info(:query_api, state)
+        end)
+
+      assert_receive {:"$gen_cast", %{"1" => ["Route 1 detour"]}}, 5000
+
+      assert log =~ "updated_alerts"
+    end
+
+    test "handles unsuccessful HTTP request" do
+      bypass = Bypass.open()
+      api_url = "http://localhost:#{bypass.port}/"
+      reassign_env(:skate, :api_url, api_url)
+
+      update_fn = fn _ -> :ok end
+
+      {:ok, state, _} = AlertsFetcher.init(update_fn: update_fn)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 500, "server error")
+      end)
+
+      log =
+        capture_log([level: :warn], fn ->
+          assert {:noreply, _state} = AlertsFetcher.handle_info(:query_api, state)
+        end)
+
+      assert log =~ "unexpected_response"
+    end
+
+    test "handles malformed response" do
+      bypass = Bypass.open()
+      api_url = "http://localhost:#{bypass.port}/"
+      reassign_env(:skate, :api_url, api_url)
+
+      update_fn = fn _ -> :ok end
+
+      {:ok, state, _} = AlertsFetcher.init(update_fn: update_fn)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, "bad json")
+      end)
+
+      log =
+        capture_log([level: :warn], fn ->
+          assert {:noreply, _state} = AlertsFetcher.handle_info(:query_api, state)
+        end)
+
+      assert log =~ "unable_to_parse_alerts"
+    end
+
+    test "handles multiple alerts per route, multiple routes per alert, and non-detour alerts" do
+      set_log_level(:info)
+      bypass = Bypass.open()
+      api_url = "http://localhost:#{bypass.port}/"
+      reassign_env(:skate, :api_url, api_url)
+      test_pid = self()
+
+      update_fn = fn alerts ->
+        GenServer.cast(test_pid, alerts)
+        :ok
+      end
+
+      {:ok, state, _} = AlertsFetcher.init(update_fn: update_fn)
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(@complex_api_response))
+      end)
+
+      log =
+        capture_log([level: :info], fn ->
+          assert {:noreply, _state} = AlertsFetcher.handle_info(:query_api, state)
+        end)
+
+      assert_receive {:"$gen_cast",
+                      %{
+                        "1" => ["Route 1 and 2 detour"],
+                        "2" => ["Different route 2 detour", "Route 1 and 2 detour"]
+                      }},
+                     5000
+
+      assert log =~ "updated_alerts"
+    end
+  end
+end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -46,7 +46,7 @@ defmodule Realtime.ServerTest do
     :ok
   end
 
-  describe "update" do
+  describe "update_vehicles/2" do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
@@ -54,7 +54,7 @@ defmodule Realtime.ServerTest do
     end
 
     test "accepts vehicle positions", %{server_pid: server_pid} do
-      assert Server.update({@vehicles_by_route_id, []}, server_pid) == :ok
+      assert Server.update_vehicles({@vehicles_by_route_id, []}, server_pid) == :ok
     end
   end
 
@@ -62,7 +62,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -75,7 +75,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to a route get data pushed to them", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -89,7 +89,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to a route get repeated messages", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, _},
@@ -97,7 +97,7 @@ defmodule Realtime.ServerTest do
         "Client didn't receive vehicle positions the first time"
       )
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -111,7 +111,7 @@ defmodule Realtime.ServerTest do
     test "inactive routes have all their vehicle data removed", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({%{}, []}, server_pid)
+      Server.update_vehicles({%{}, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -125,7 +125,7 @@ defmodule Realtime.ServerTest do
     test "vehicles on inactive blocks are removed", %{server_pid: server_pid} do
       Server.subscribe_to_route("1", server_pid)
 
-      Server.update({%{"1" => [@vehicle_on_inactive_block]}, []}, server_pid)
+      Server.update_vehicles({%{"1" => [@vehicle_on_inactive_block]}, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -141,7 +141,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -161,7 +161,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to a route get data pushed to them", %{server_pid: server_pid} do
       Server.subscribe_to_block_ids([@vehicle.block_id], server_pid)
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -175,7 +175,7 @@ defmodule Realtime.ServerTest do
     test "clients subscribed to block IDs get repeated messages", %{server_pid: server_pid} do
       Server.subscribe_to_block_ids([@vehicle.block_id], server_pid)
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, _},
@@ -183,7 +183,7 @@ defmodule Realtime.ServerTest do
         "Client didn't receive vehicle positions the first time"
       )
 
-      Server.update({@vehicles_by_route_id, []}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -197,7 +197,7 @@ defmodule Realtime.ServerTest do
     test "inactive blocks have all their vehicle data removed", %{server_pid: server_pid} do
       Server.subscribe_to_block_ids([@vehicle.block_id], server_pid)
 
-      Server.update({%{}, []}, server_pid)
+      Server.update_vehicles({%{}, []}, server_pid)
 
       assert_receive(
         {:new_realtime_data, lookup_args},
@@ -213,7 +213,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      :ok = Server.update({%{}, [@shuttle]}, server_pid)
+      :ok = Server.update_vehicles({%{}, [@shuttle]}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -225,7 +225,7 @@ defmodule Realtime.ServerTest do
     test "clients get updated data pushed to them", %{server_pid: pid} do
       Server.subscribe_to_all_shuttles(pid)
 
-      Server.update({%{}, [@shuttle, @shuttle]}, pid)
+      Server.update_vehicles({%{}, [@shuttle, @shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle, @shuttle]
@@ -236,7 +236,7 @@ defmodule Realtime.ServerTest do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
-      :ok = Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)
+      :ok = Server.update_vehicles({@vehicles_by_route_id, [@shuttle]}, server_pid)
 
       %{server_pid: server_pid}
     end
@@ -252,7 +252,7 @@ defmodule Realtime.ServerTest do
     test "clients get updated search results pushed to them", %{server_pid: pid} do
       Server.subscribe_to_search("90", :all, pid)
 
-      Server.update({%{}, [@shuttle]}, pid)
+      Server.update_vehicles({%{}, [@shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle]
@@ -261,7 +261,7 @@ defmodule Realtime.ServerTest do
     test "does not receive duplicate vehicles", %{server_pid: pid} do
       Server.subscribe_to_search("90", :all, pid)
 
-      Server.update({%{}, [@shuttle, @shuttle]}, pid)
+      Server.update_vehicles({%{}, [@shuttle, @shuttle]}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == [@shuttle]
@@ -270,7 +270,7 @@ defmodule Realtime.ServerTest do
     test "vehicles on inactive blocks are included", %{server_pid: pid} do
       Server.subscribe_to_search("v2-label", :vehicle, pid)
 
-      Server.update({%{"1" => [@vehicle_on_inactive_block]}, []}, pid)
+      Server.update_vehicles({%{"1" => [@vehicle_on_inactive_block]}, []}, pid)
 
       assert_receive {:new_realtime_data, lookup_args}
 
@@ -411,7 +411,7 @@ defmodule Realtime.ServerTest do
   describe "peek_at_vehicles_by_run_ids/2" do
     test "looks up vehicles active on the given trip IDs" do
       {:ok, server_pid} = Server.start_link([])
-      Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, [@shuttle]}, server_pid)
 
       assert Server.peek_at_vehicles_by_run_ids([], server_pid) == []
       assert Server.peek_at_vehicles_by_run_ids(["no_such_run"], server_pid) == []
@@ -436,7 +436,7 @@ defmodule Realtime.ServerTest do
   describe "peek_at_vehicles_by_id/2" do
     test "looks up the vehicle or ghost with given ID" do
       {:ok, server_pid} = Server.start_link([])
-      Server.update({@vehicles_by_route_id, [@shuttle]}, server_pid)
+      Server.update_vehicles({@vehicles_by_route_id, [@shuttle]}, server_pid)
 
       assert Server.peek_at_vehicle_by_id("no_such_vehicle", server_pid) == []
       assert Server.peek_at_vehicle_by_id("v1", server_pid) == [@vehicle]

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -315,6 +315,16 @@ defmodule Realtime.ServerTest do
       assert_receive {:new_realtime_data, lookup_args}
       assert Server.lookup(lookup_args) == []
     end
+
+    test "clients subscribed to vehicles don't get updated data pushed to them", %{
+      server_pid: pid
+    } do
+      Server.subscribe_to_route("1", pid)
+
+      Server.update_alerts(%{"1" => ["Totally different alert"]}, pid)
+
+      refute_receive {:new_realtime_data, _lookup_args}
+    end
   end
 
   describe "lookup/2" do

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -1,0 +1,69 @@
+defmodule SkateWeb.AlertsChannelTest do
+  use SkateWeb.ChannelCase
+  import Test.Support.Helpers
+
+  alias SkateWeb.{UserSocket, AlertsChannel}
+
+  setup do
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
+
+    socket = socket(UserSocket)
+
+    start_supervised({Registry, keys: :duplicate, name: Realtime.Supervisor.registry_name()})
+    start_supervised({Realtime.Server, name: Realtime.Server.default_name()})
+
+    {:ok, socket: socket}
+  end
+
+  describe "join/3" do
+    test "subscribes to alerts for a route and returns the current alerts", %{socket: socket} do
+      route_id = "1"
+
+      :ok = Realtime.Server.update_alerts(%{route_id => ["Some alert"]})
+
+      assert {:ok, %{data: ["Some alert"]}, _socket} =
+               subscribe_and_join(socket, AlertsChannel, "alerts:route:" <> route_id)
+    end
+  end
+
+  describe "handle_info/2" do
+    setup do
+      ets = GenServer.call(Realtime.Server.default_name(), :ets)
+
+      {:ok, ets: ets}
+    end
+
+    test "pushes new alert data onto the socket", %{socket: socket, ets: ets} do
+      {:ok, _, socket} = subscribe_and_join(socket, AlertsChannel, "alerts:route:1")
+
+      :ok = assert Realtime.Server.update_alerts(%{"1" => ["Some alert"]})
+
+      assert {:noreply, _socket} =
+               AlertsChannel.handle_info(
+                 {:new_realtime_data, {ets, {:alerts, "1"}}},
+                 socket
+               )
+
+      assert_push("alerts", %{data: ["Some alert"]})
+    end
+
+    test "rejects sending vehicle data when socket is not authenticated", %{
+      socket: socket,
+      ets: ets
+    } do
+      {:ok, _, socket} = subscribe_and_join(socket, AlertsChannel, "alerts:route:1")
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      :ok = Realtime.Server.update_alerts(%{"1" => ["Some alert"]})
+
+      assert {:stop, :normal, _socket} =
+               AlertsChannel.handle_info(
+                 {:new_realtime_data, {ets, {:alerts, "1"}}},
+                 socket
+               )
+
+      assert_push("auth_expired", _)
+    end
+  end
+end

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -61,7 +61,7 @@ defmodule SkateWeb.VehicleChannelTest do
     test "subscribes to the active vehicle for given run IDs and returns that vehicle", %{
       socket: socket
     } do
-      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update_vehicles({%{"1" => [@vehicle]}, []}) == :ok
       assert Realtime.Server.peek_at_vehicles_by_run_ids(["123-4567"]) == [@vehicle]
 
       expected_payload = %{data: @vehicle}
@@ -76,7 +76,7 @@ defmodule SkateWeb.VehicleChannelTest do
       socket: socket
     } do
       ets = GenServer.call(Realtime.Server.default_name(), :ets)
-      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update_vehicles({%{"1" => [@vehicle]}, []}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehicleChannel, "vehicle:run_ids:123-4567")
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -93,7 +93,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update_vehicles({%{"1" => [@vehicle]}, []}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")
 
@@ -111,7 +111,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({%{}, [@vehicle]}) == :ok
+      assert Realtime.Server.update_vehicles({%{}, [@vehicle]}) == :ok
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
 
@@ -129,7 +129,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({%{}, [@vehicle]}) == :ok
+      assert Realtime.Server.update_vehicles({%{}, [@vehicle]}) == :ok
 
       {:ok, _, socket} =
         subscribe_and_join(socket, VehiclesChannel, "vehicles:search:all:" <> @vehicle.label)
@@ -148,7 +148,7 @@ defmodule SkateWeb.VehiclesChannelTest do
       socket: socket,
       ets: ets
     } do
-      assert Realtime.Server.update({%{"1" => [@vehicle]}, []}) == :ok
+      assert Realtime.Server.update_vehicles({%{"1" => [@vehicle]}, []}) == :ok
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")


### PR DESCRIPTION
Asana ticket: [🎨⚙️ Show existing diversions on route ladder](https://app.asana.com/0/1200180014510248/1203142766477809/f)

This is exclusively the back-end code for the ticket. The front-end will follow in another PR, and we'll want to release the back-end first so that the channel is available when the front-end code is deployed.

There were a few possible ways to pull this alert data in and make it available to the channel. It may have been advantageous to use [Server Sent Event-based streaming](https://www.mbta.com/developers/v3-api/streaming), both for reducing latency and conserving bandwidth. However, that would involve managing the alerts on a by-ID basis, whereas we prefer to keep them grouped by route ID for internal purposes. This wasn't an insurmountable barrier but it would have made the code somewhat messier. Furthermore, the size of the data isn't too large (the API query specifically only gets currently-active alerts and only for bus), and the latency isn't a huge issue for our use case.

Finally, there was a bit of a question as to whether to use `Realtime.Server` (like most of our real-time bus data) or the Phoenix PubSub (like the live train data). I opted for the former simply because that's how most of our real-time data works but I'd be curious as to whether or not `Realtime.Server` should just be migrated to use `Phoenix.Pubsub` someday.