### PR TITLE
fix(skate-web/channels): ensure token is authenticated when joining channels

### DIFF
--- a/lib/realtime/data_status_pub_sub.ex
+++ b/lib/realtime/data_status_pub_sub.ex
@@ -28,7 +28,9 @@ defmodule Realtime.DataStatusPubSub do
 
   @doc """
   The subscribing process will get a message when there's new data, with the form
+  ```
   {:new_data_status, data_status}
+  ```
   """
   @spec subscribe(GenServer.server()) :: DataStatus.t()
   def subscribe(server \\ default_name()) do

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -71,8 +71,10 @@ defmodule Realtime.Server do
 
   @doc """
   The subscribing process will get a message when there's new data, with the form
+  ```
   {:new_realtime_data, lookup_args}
-  Those lookup_args can be passed into Server.lookup(lookup_args) to get the data.
+  ```
+  Those `lookup_args` can be passed into `RealTime.Server.lookup(lookup_args)/1` to get the data.
   """
   @spec subscribe_to_route(Route.id(), GenServer.server()) :: [VehicleOrGhost.t()]
   def subscribe_to_route(route_id, server \\ default_name()) do

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -1,0 +1,24 @@
+defmodule SkateWeb.AuthenticatedChannel do
+  @doc """
+
+  """
+  @callback join_authenticated(any, any, Phoenix.Socket.t()) ::
+              {:error, :not_authenticated | %{message: <<_::64, _::_*8>>}}
+              | {:ok, %{data: any}, any}
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour SkateWeb.AuthenticatedChannel
+
+      @impl Phoenix.Channel
+
+      def join(topic, message, socket) do
+        if SkateWeb.ChannelAuth.valid_token?(socket) do
+          join_authenticated(topic, message, socket)
+        else
+          {:error, :not_authenticated}
+        end
+      end
+    end
+  end
+end

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -30,6 +30,7 @@ defmodule SkateWeb.AuthenticatedChannel do
   ```
   when the `socket` is not valid per `SkateWeb.ChannelAuth.valid_token?`.
   """
+  @moduledoc since: "https://github.com/mbta/skate/pull/1835"
 
   @doc """
   Handle __authenticated__ socket channel joins by topic.

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -11,7 +11,6 @@ defmodule SkateWeb.AuthenticatedChannel do
       @behaviour SkateWeb.AuthenticatedChannel
 
       @impl Phoenix.Channel
-
       def join(topic, message, socket) do
         if SkateWeb.ChannelAuth.valid_token?(socket) do
           join_authenticated(topic, message, socket)

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -1,19 +1,55 @@
 defmodule SkateWeb.AuthenticatedChannel do
-  @doc """
+  @moduledoc """
+  A `use` macro and `@behaviour` which implements `c:Phoenix.Channel.join/3` and
+  calls `c:SkateWeb.AuthenticatedChannel.join_authenticated/3` when socket is
+  authenticated.
 
+  This ensures that the token associated with the `socket` passed to
+  `c:Phoenix.Channel.join/3` is valid before forwarding the call to
+  `c:SkateWeb.AuthenticatedChannel.join_authenticated/3`.
+
+  ## Examples
+  Simple usage of `SkateWeb.AuthenticatedChannel`
+  ```
+  defmodule MyChannel do
+    use SkateWeb.AuthenticatedChannel
+
+    @impl SkateWeb.AuthenticatedChannel
+    def join_authenticated("room:lobby", payload, socket) do
+      # The token associated with this socket is valid within this function
+      {:ok, %{data: "payload"}, socket}
+    end
+  end
+  ```
   """
-  @callback join_authenticated(any, any, Phoenix.Socket.t()) ::
-              {:error, :not_authenticated | %{message: <<_::64, _::_*8>>}}
-              | {:ok, %{data: any}, any}
 
+  @doc """
+  Handle __authenticated__ socket channel joins by topic.
+
+  see: `c:Phoenix.Channel.join/3` for relevant docs.
+  """
+  @callback join_authenticated(
+              topic :: binary,
+              payload :: Phoenix.Channel.payload(),
+              socket :: Phoenix.Socket.t()
+            ) ::
+              {:ok, Phoenix.Socket.t()}
+              | {:ok, reply :: Phoenix.Channel.payload(), Phoenix.Socket.t()}
+              | {:error, reason :: map()}
+
+  @doc """
+  Macro which imports the `SkateWeb.AuthenticatedChannel` behaviour and
+  implements `c:Phoenix.Channel.join/3` for
+  `c:SkateWeb.AuthenticatedChannel.join_authenticated/3`
+  """
   defmacro __using__(_) do
     quote do
       @behaviour SkateWeb.AuthenticatedChannel
 
       @impl Phoenix.Channel
-      def join(topic, message, socket) do
+      def join(topic, payload, socket) do
         if SkateWeb.ChannelAuth.valid_token?(socket) do
-          join_authenticated(topic, message, socket)
+          join_authenticated(topic, payload, socket)
         else
           {:error, :not_authenticated}
         end

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -21,6 +21,14 @@ defmodule SkateWeb.AuthenticatedChannel do
     end
   end
   ```
+
+  ## Implementation Details
+  `use`ing `SkateWeb.AuthenticatedChannel` will implement the
+  `c:Phoenix.Channel.join/3` callback to return
+  ```
+  {:error, %{reason: :not_authenticated}}
+  ```
+  when the `socket` is not valid per `SkateWeb.ChannelAuth.valid_token?`.
   """
 
   @doc """
@@ -51,7 +59,7 @@ defmodule SkateWeb.AuthenticatedChannel do
         if SkateWeb.ChannelAuth.valid_token?(socket) do
           join_authenticated(topic, payload, socket)
         else
-          {:error, :not_authenticated}
+          {:error, %{reason: :not_authenticated}}
         end
       end
     end

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -12,10 +12,7 @@ defmodule SkateWeb.AlertsChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_realtime_data, lookup_args}, socket) do
-    valid_token_fn =
-      Application.get_env(:skate, :valid_token_fn, &SkateWeb.ChannelAuth.valid_token?/1)
-
-    if valid_token_fn.(socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
       data = Server.lookup(lookup_args)
       :ok = push(socket, "alerts", %{data: data})
       {:noreply, socket}

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -4,8 +4,9 @@ defmodule SkateWeb.AlertsChannel do
   alias Realtime.Server
   alias Util.Duration
 
-  @impl Phoenix.Channel
-  def join("alerts:route:" <> route_id, _message, socket) do
+  use SkateWeb.AuthenticatedChannel
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated("alerts:route:" <> route_id, _message, socket) do
     alerts = Duration.log_duration(Server, :subscribe_to_alerts, [route_id])
     {:ok, %{data: alerts}, socket}
   end

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -1,10 +1,9 @@
 defmodule SkateWeb.AlertsChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
 
   alias Realtime.Server
   alias Util.Duration
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("alerts:route:" <> route_id, _message, socket) do

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -5,6 +5,7 @@ defmodule SkateWeb.AlertsChannel do
   alias Util.Duration
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("alerts:route:" <> route_id, _message, socket) do
     alerts = Duration.log_duration(Server, :subscribe_to_alerts, [route_id])

--- a/lib/skate_web/channels/channel_auth.ex
+++ b/lib/skate_web/channels/channel_auth.ex
@@ -14,12 +14,6 @@ defmodule SkateWeb.ChannelAuth do
   defp valid_socket_token?(socket) do
     token = Guardian.Phoenix.Socket.current_token(socket)
 
-    case AuthManager.decode_and_verify(token) do
-      {:ok, _claims} ->
-        true
-
-      _ ->
-        false
-    end
+    match?({:ok, _claims}, AuthManager.decode_and_verify(token))
   end
 end

--- a/lib/skate_web/channels/channel_auth.ex
+++ b/lib/skate_web/channels/channel_auth.ex
@@ -6,6 +6,12 @@ defmodule SkateWeb.ChannelAuth do
   """
   @spec valid_token?(Phoenix.Socket.t()) :: boolean()
   def valid_token?(socket) do
+    token_fn = Application.get_env(:skate, :valid_token_fn, &_valid_token?/1)
+    token_fn.(socket)
+  end
+
+  @spec _valid_token?(Phoenix.Socket.t()) :: boolean()
+  defp _valid_token?(socket) do
     token = Guardian.Phoenix.Socket.current_token(socket)
 
     case AuthManager.decode_and_verify(token) do

--- a/lib/skate_web/channels/channel_auth.ex
+++ b/lib/skate_web/channels/channel_auth.ex
@@ -6,12 +6,12 @@ defmodule SkateWeb.ChannelAuth do
   """
   @spec valid_token?(Phoenix.Socket.t()) :: boolean()
   def valid_token?(socket) do
-    token_fn = Application.get_env(:skate, :valid_token_fn, &_valid_token?/1)
+    token_fn = Application.get_env(:skate, :valid_token_fn, &valid_socket_token?/1)
     token_fn.(socket)
   end
 
-  @spec _valid_token?(Phoenix.Socket.t()) :: boolean()
-  defp _valid_token?(socket) do
+  @spec valid_socket_token?(Phoenix.Socket.t()) :: boolean()
+  defp valid_socket_token?(socket) do
     token = Guardian.Phoenix.Socket.current_token(socket)
 
     case AuthManager.decode_and_verify(token) do

--- a/lib/skate_web/channels/channel_auth.ex
+++ b/lib/skate_web/channels/channel_auth.ex
@@ -12,8 +12,9 @@ defmodule SkateWeb.ChannelAuth do
 
   @spec valid_socket_token?(Phoenix.Socket.t()) :: boolean()
   defp valid_socket_token?(socket) do
-    token = Guardian.Phoenix.Socket.current_token(socket)
-
-    match?({:ok, _claims}, AuthManager.decode_and_verify(token))
+    socket
+    |> Guardian.Phoenix.Socket.current_token()
+    |> AuthManager.decode_and_verify()
+    |> then(&match?({:ok, _claims}, &1))
   end
 end

--- a/lib/skate_web/channels/data_status_channel.ex
+++ b/lib/skate_web/channels/data_status_channel.ex
@@ -4,6 +4,7 @@ defmodule SkateWeb.DataStatusChannel do
   alias Realtime.DataStatusPubSub
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("data_status", _message, socket) do
     data_status = DataStatusPubSub.subscribe()

--- a/lib/skate_web/channels/data_status_channel.ex
+++ b/lib/skate_web/channels/data_status_channel.ex
@@ -3,13 +3,14 @@ defmodule SkateWeb.DataStatusChannel do
 
   alias Realtime.DataStatusPubSub
 
-  @impl Phoenix.Channel
-  def join("data_status", _message, socket) do
+  use SkateWeb.AuthenticatedChannel
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated("data_status", _message, socket) do
     data_status = DataStatusPubSub.subscribe()
     {:ok, %{data: data_status}, socket}
   end
 
-  def join(topic, _message, _socket) do
+  def join_authenticated(topic, _message, _socket) do
     {:error, %{message: "no such topic \"#{topic}\""}}
   end
 

--- a/lib/skate_web/channels/data_status_channel.ex
+++ b/lib/skate_web/channels/data_status_channel.ex
@@ -15,10 +15,7 @@ defmodule SkateWeb.DataStatusChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_data_status, data_status}, socket) do
-    valid_token? =
-      Application.get_env(:skate, :valid_token?, &SkateWeb.ChannelAuth.valid_token?/1)
-
-    if valid_token?.(socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
       :ok = push(socket, "data_status", %{data: data_status})
       {:noreply, socket}
     else

--- a/lib/skate_web/channels/data_status_channel.ex
+++ b/lib/skate_web/channels/data_status_channel.ex
@@ -1,9 +1,8 @@
 defmodule SkateWeb.DataStatusChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
 
   alias Realtime.DataStatusPubSub
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("data_status", _message, socket) do

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -3,10 +3,7 @@ defmodule SkateWeb.NotificationsChannel do
 
   @impl Phoenix.Channel
   def handle_info({:notification, notification}, socket) do
-    valid_token? =
-      Application.get_env(:skate, :valid_token?, &SkateWeb.ChannelAuth.valid_token?/1)
-
-    if valid_token?.(socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
       :ok = push(socket, "notification", %{data: notification})
       {:noreply, socket}
     else

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -1,5 +1,6 @@
 defmodule SkateWeb.NotificationsChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
 
   @impl Phoenix.Channel
   def handle_info({:notification, notification}, socket) do
@@ -11,8 +12,6 @@ defmodule SkateWeb.NotificationsChannel do
       {:stop, :normal, socket}
     end
   end
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("notifications", _message, socket) do

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -12,8 +12,9 @@ defmodule SkateWeb.NotificationsChannel do
     end
   end
 
-  @impl true
-  def join("notifications", _message, socket) do
+  use SkateWeb.AuthenticatedChannel
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated("notifications", _message, socket) do
     %{id: user_id} = Guardian.Phoenix.Socket.current_resource(socket)
 
     notification_fetch =

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -13,6 +13,7 @@ defmodule SkateWeb.NotificationsChannel do
   end
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("notifications", _message, socket) do
     %{id: user_id} = Guardian.Phoenix.Socket.current_resource(socket)

--- a/lib/skate_web/channels/train_vehicles_channel.ex
+++ b/lib/skate_web/channels/train_vehicles_channel.ex
@@ -4,6 +4,7 @@ defmodule SkateWeb.TrainVehiclesChannel do
   alias Realtime.TrainVehiclesPubSub
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("train_vehicles:" <> route_id, _message, socket) do
     train_vehicles_subscribe_fn =

--- a/lib/skate_web/channels/train_vehicles_channel.ex
+++ b/lib/skate_web/channels/train_vehicles_channel.ex
@@ -19,10 +19,7 @@ defmodule SkateWeb.TrainVehiclesChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_train_vehicles, train_vehicles}, socket) do
-    valid_token? =
-      Application.get_env(:skate, :valid_token?, &SkateWeb.ChannelAuth.valid_token?/1)
-
-    if valid_token?.(socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
       :ok = push(socket, "train_vehicles", %{data: train_vehicles})
       {:noreply, socket}
     else

--- a/lib/skate_web/channels/train_vehicles_channel.ex
+++ b/lib/skate_web/channels/train_vehicles_channel.ex
@@ -1,9 +1,8 @@
 defmodule SkateWeb.TrainVehiclesChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
 
   alias Realtime.TrainVehiclesPubSub
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("train_vehicles:" <> route_id, _message, socket) do

--- a/lib/skate_web/channels/train_vehicles_channel.ex
+++ b/lib/skate_web/channels/train_vehicles_channel.ex
@@ -3,8 +3,9 @@ defmodule SkateWeb.TrainVehiclesChannel do
 
   alias Realtime.TrainVehiclesPubSub
 
-  @impl Phoenix.Channel
-  def join("train_vehicles:" <> route_id, _message, socket) do
+  use SkateWeb.AuthenticatedChannel
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated("train_vehicles:" <> route_id, _message, socket) do
     train_vehicles_subscribe_fn =
       Application.get_env(
         :skate_web,

--- a/lib/skate_web/channels/vehicle_channel.ex
+++ b/lib/skate_web/channels/vehicle_channel.ex
@@ -1,5 +1,6 @@
 defmodule SkateWeb.VehicleChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
 
   alias Realtime.Server
 
@@ -10,8 +11,6 @@ defmodule SkateWeb.VehicleChannel do
 
     {:noreply, socket}
   end
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicle:run_ids:" <> run_ids, _message, socket) do

--- a/lib/skate_web/channels/vehicle_channel.ex
+++ b/lib/skate_web/channels/vehicle_channel.ex
@@ -11,8 +11,9 @@ defmodule SkateWeb.VehicleChannel do
     {:noreply, socket}
   end
 
-  @impl Phoenix.Channel
-  def join("vehicle:run_ids:" <> run_ids, _message, socket) do
+  use SkateWeb.AuthenticatedChannel
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated("vehicle:run_ids:" <> run_ids, _message, socket) do
     run_ids = String.split(run_ids, ",")
     vehicle_or_ghost = Realtime.Server.peek_at_vehicles_by_run_ids(run_ids) |> List.first()
 
@@ -23,8 +24,7 @@ defmodule SkateWeb.VehicleChannel do
     {:ok, %{data: vehicle_or_ghost}, socket}
   end
 
-  @impl Phoenix.Channel
-  def join("vehicle:id:" <> vehicle_or_ghost_id, _message, socket) do
+  def join_authenticated("vehicle:id:" <> vehicle_or_ghost_id, _message, socket) do
     vehicle_or_ghost = Realtime.Server.peek_at_vehicle_by_id(vehicle_or_ghost_id) |> List.first()
 
     if vehicle_or_ghost do

--- a/lib/skate_web/channels/vehicle_channel.ex
+++ b/lib/skate_web/channels/vehicle_channel.ex
@@ -12,6 +12,7 @@ defmodule SkateWeb.VehicleChannel do
   end
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicle:run_ids:" <> run_ids, _message, socket) do
     run_ids = String.split(run_ids, ",")

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -76,10 +76,8 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_realtime_data, lookup_args}, socket) do
-    valid_token_fn =
-      Application.get_env(:skate, :valid_token_fn, &SkateWeb.ChannelAuth.valid_token?/1)
 
-    if valid_token_fn.(socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
       event_name = event_name(lookup_args)
       data = Server.lookup(lookup_args)
       :ok = push(socket, event_name, %{data: data})

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -7,8 +7,12 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def join("vehicles:shuttle:all", _message, socket) do
-    shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
-    {:ok, %{data: shuttles}, socket}
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
+      shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
+      {:ok, %{data: shuttles}, socket}
+    else
+      {:error, "error"}
+    end
   end
 
   def join("vehicles:route:" <> route_id, _message, socket) do

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -1,11 +1,10 @@
 defmodule SkateWeb.VehiclesChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
   require Logger
 
   alias Realtime.Server
   alias Util.Duration
-
-  use SkateWeb.AuthenticatedChannel
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicles:shuttle:all", _message, socket) do

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -6,6 +6,7 @@ defmodule SkateWeb.VehiclesChannel do
   alias Util.Duration
 
   @impl Phoenix.Channel
+
   def join(topic, message, socket) do
     if SkateWeb.ChannelAuth.valid_token?(socket) do
       join_authenticated(topic, message, socket)
@@ -80,7 +81,6 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def handle_info({:new_realtime_data, lookup_args}, socket) do
-
     if SkateWeb.ChannelAuth.valid_token?(socket) do
       event_name = event_name(lookup_args)
       data = Server.lookup(lookup_args)

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -6,29 +6,37 @@ defmodule SkateWeb.VehiclesChannel do
   alias Util.Duration
 
   @impl Phoenix.Channel
-  def join("vehicles:shuttle:all", _message, socket) do
+  def join(topic, message, socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
+      join_authenticated(topic, message, socket)
+    else
+      {:error, :not_authenticated}
+    end
+  end
+
+  def join_authenticated("vehicles:shuttle:all", _message, socket) do
     shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
     {:ok, %{data: shuttles}, socket}
   end
 
-  def join("vehicles:route:" <> route_id, _message, socket) do
+  def join_authenticated("vehicles:route:" <> route_id, _message, socket) do
     vehicles_and_ghosts = Duration.log_duration(Server, :subscribe_to_route, [route_id])
     {:ok, %{data: vehicles_and_ghosts}, socket}
   end
 
-  def join("vehicles:run_ids:" <> run_ids, _message, socket) do
+  def join_authenticated("vehicles:run_ids:" <> run_ids, _message, socket) do
     run_ids = String.split(run_ids, ",")
     vehicles_and_ghosts = Duration.log_duration(Server, :subscribe_to_run_ids, [run_ids])
     {:ok, %{data: vehicles_and_ghosts}, socket}
   end
 
-  def join("vehicles:block_ids:" <> block_ids, _message, socket) do
+  def join_authenticated("vehicles:block_ids:" <> block_ids, _message, socket) do
     block_ids = String.split(block_ids, ",")
     vehicles_and_ghosts = Duration.log_duration(Server, :subscribe_to_block_ids, [block_ids])
     {:ok, %{data: vehicles_and_ghosts}, socket}
   end
 
-  def join(
+  def join_authenticated(
         "vehicles:search:" <> search_params,
         _message,
         socket
@@ -66,7 +74,7 @@ defmodule SkateWeb.VehiclesChannel do
     {:ok, %{data: vehicles}, socket}
   end
 
-  def join(topic, _message, _socket) do
+  def join_authenticated(topic, _message, _socket) do
     {:error, %{message: "no such topic \"#{topic}\""}}
   end
 

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -1,20 +1,12 @@
 defmodule SkateWeb.VehiclesChannel do
   use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
   require Logger
 
   alias Realtime.Server
   alias Util.Duration
 
-  @impl Phoenix.Channel
-
-  def join(topic, message, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      join_authenticated(topic, message, socket)
-    else
-      {:error, :not_authenticated}
-    end
-  end
-
+  @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicles:shuttle:all", _message, socket) do
     shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
     {:ok, %{data: shuttles}, socket}

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -7,12 +7,8 @@ defmodule SkateWeb.VehiclesChannel do
 
   @impl Phoenix.Channel
   def join("vehicles:shuttle:all", _message, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
-      {:ok, %{data: shuttles}, socket}
-    else
-      {:error, "error"}
-    end
+    shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])
+    {:ok, %{data: shuttles}, socket}
   end
 
   def join("vehicles:route:" <> route_id, _message, socket) do

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -1,11 +1,11 @@
 defmodule SkateWeb.VehiclesChannel do
   use SkateWeb, :channel
-  use SkateWeb.AuthenticatedChannel
   require Logger
 
   alias Realtime.Server
   alias Util.Duration
 
+  use SkateWeb.AuthenticatedChannel
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicles:shuttle:all", _message, socket) do
     shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -6,6 +6,7 @@ defmodule SkateWeb.VehiclesChannel do
   alias Util.Duration
 
   use SkateWeb.AuthenticatedChannel
+
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated("vehicles:shuttle:all", _message, socket) do
     shuttles = Duration.log_duration(Server, :subscribe_to_all_shuttles, [])

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -30,7 +30,7 @@ defmodule SkateWeb.AlertsChannelTest do
 
       for route <- [
             "alerts:route:",
-            "random:topic:",
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -25,7 +25,7 @@ defmodule SkateWeb.AlertsChannelTest do
                subscribe_and_join(socket, AlertsChannel, "alerts:route:" <> route_id)
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -28,11 +28,11 @@ defmodule SkateWeb.AlertsChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "alerts:route:"},
-            %{result: {:error, :not_authenticated}, route: "vehicles:route:"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:1"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "alerts:route:",
+            "vehicles:route:",
+            "random:topic:1",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -24,6 +24,18 @@ defmodule SkateWeb.AlertsChannelTest do
       assert {:ok, %{data: ["Some alert"]}, _socket} =
                subscribe_and_join(socket, AlertsChannel, "alerts:route:" <> route_id)
     end
+
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "alerts:route:"},
+            %{result: {:error, :not_authenticated}, route: "vehicles:route:"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:1"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, AlertsChannel, route))
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -30,9 +30,7 @@ defmodule SkateWeb.AlertsChannelTest do
 
       for route <- [
             "alerts:route:",
-            "vehicles:route:",
-            "random:topic:1",
-            "random:topic:2"
+            "random:topic:",
           ],
           do:
             assert(

--- a/test/skate_web/channels/alerts_channel_test.exs
+++ b/test/skate_web/channels/alerts_channel_test.exs
@@ -34,7 +34,11 @@ defmodule SkateWeb.AlertsChannelTest do
             %{result: {:error, :not_authenticated}, route: "random:topic:1"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, AlertsChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, AlertsChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -52,8 +52,5 @@ defmodule SkateWeb.ChannelAuthTest do
       reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
       assert ChannelAuth.valid_token?(socket) == true
     end
-
-    # test "when token expires, user should not be able to see data from skate", do end
-    # test "when token expires, user should not be able to subscribe to more topics", do end
   end
 end

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -2,7 +2,6 @@ defmodule SkateWeb.ChannelAuthTest do
   use SkateWeb.ChannelCase
   import Test.Support.Helpers
 
-
   alias SkateWeb.{AuthManager, ChannelAuth, UserSocket}
 
   setup do
@@ -41,7 +40,7 @@ defmodule SkateWeb.ChannelAuthTest do
       assert ChannelAuth.valid_token?(socket) == false
     end
 
-    test "uses :valid_token_fn when present in application env", %{ socket: socket } do
+    test "uses :valid_token_fn when present in application env", %{socket: socket} do
       assert ChannelAuth.valid_token?(socket) == false
 
       reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
@@ -53,6 +52,7 @@ defmodule SkateWeb.ChannelAuthTest do
       reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
       assert ChannelAuth.valid_token?(socket) == true
     end
+
     # test "when token expires, user should not be able to see data from skate", do end
     # test "when token expires, user should not be able to subscribe to more topics", do end
   end

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -1,5 +1,7 @@
 defmodule SkateWeb.ChannelAuthTest do
   use SkateWeb.ChannelCase
+  import Test.Support.Helpers
+
 
   alias SkateWeb.{AuthManager, ChannelAuth, UserSocket}
 
@@ -39,6 +41,18 @@ defmodule SkateWeb.ChannelAuthTest do
       assert ChannelAuth.valid_token?(socket) == false
     end
 
+    test "uses :valid_token_fn when present in application env", %{ socket: socket } do
+      assert ChannelAuth.valid_token?(socket) == false
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
+      assert ChannelAuth.valid_token?(socket) == true
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+      assert ChannelAuth.valid_token?(socket) == false
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
+      assert ChannelAuth.valid_token?(socket) == true
+    end
     # test "when token expires, user should not be able to see data from skate", do end
     # test "when token expires, user should not be able to subscribe to more topics", do end
   end

--- a/test/skate_web/channels/channel_auth_test.exs
+++ b/test/skate_web/channels/channel_auth_test.exs
@@ -38,5 +38,8 @@ defmodule SkateWeb.ChannelAuthTest do
 
       assert ChannelAuth.valid_token?(socket) == false
     end
+
+    # test "when token expires, user should not be able to see data from skate", do end
+    # test "when token expires, user should not be able to subscribe to more topics", do end
   end
 end

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -31,7 +31,7 @@ defmodule SkateWeb.DataStatusChannelTest do
                subscribe_and_join(socket, DataStatusChannel, "rooms:1")
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -36,7 +36,7 @@ defmodule SkateWeb.DataStatusChannelTest do
 
       for route <- [
             "data_status",
-            "random:topic:2"
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -38,7 +38,11 @@ defmodule SkateWeb.DataStatusChannelTest do
             %{result: {:error, :not_authenticated}, route: "data_status"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, DataStatusChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, DataStatusChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -56,9 +56,9 @@ defmodule SkateWeb.DataStatusChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-
       {:ok, _, socket} = subscribe_and_join(socket, DataStatusChannel, "data_status")
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       assert {:stop, :normal, _socket} =
                DataStatusChannel.handle_info(

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -30,6 +30,16 @@ defmodule SkateWeb.DataStatusChannelTest do
       assert {:error, %{message: "no such topic \"rooms:1\""}} =
                subscribe_and_join(socket, DataStatusChannel, "rooms:1")
     end
+
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "data_status"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, DataStatusChannel, route))
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -8,7 +8,7 @@ defmodule SkateWeb.DataStatusChannelTest do
   alias SkateWeb.UserSocket
 
   setup do
-    reassign_env(:skate, :valid_token?, fn _socket -> true end)
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
 
     socket = socket(UserSocket, "", %{})
 
@@ -46,7 +46,7 @@ defmodule SkateWeb.DataStatusChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token?, fn _socket -> false end)
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, DataStatusChannel, "data_status")
 

--- a/test/skate_web/channels/data_status_channel_test.exs
+++ b/test/skate_web/channels/data_status_channel_test.exs
@@ -34,9 +34,9 @@ defmodule SkateWeb.DataStatusChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "data_status"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "data_status",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -34,6 +34,16 @@ defmodule SkateWeb.NotificationsChannelTest do
                 data: %{initial_notifications: ["fake notification 1", "fake notification 2"]}
               }, %Socket{}} = subscribe_and_join(socket, NotificationsChannel, "notifications")
     end
+
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "notifications"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, NotificationsChannel, route))
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -38,9 +38,9 @@ defmodule SkateWeb.NotificationsChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "notifications"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "notifications",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -42,7 +42,11 @@ defmodule SkateWeb.NotificationsChannelTest do
             %{result: {:error, :not_authenticated}, route: "notifications"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, NotificationsChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, NotificationsChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -6,7 +6,7 @@ defmodule SkateWeb.NotificationsChannelTest do
   alias SkateWeb.{NotificationsChannel, UserSocket}
 
   setup do
-    reassign_env(:skate, :valid_token?, fn _socket -> true end)
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
 
     socket =
       UserSocket
@@ -50,7 +50,7 @@ defmodule SkateWeb.NotificationsChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token?, fn _socket -> false end)
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, NotificationsChannel, "notifications")
 

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -40,7 +40,7 @@ defmodule SkateWeb.NotificationsChannelTest do
 
       for route <- [
             "notifications",
-            "random:topic:2"
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -35,7 +35,7 @@ defmodule SkateWeb.NotificationsChannelTest do
               }, %Socket{}} = subscribe_and_join(socket, NotificationsChannel, "notifications")
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [

--- a/test/skate_web/channels/notifications_channel_test.exs
+++ b/test/skate_web/channels/notifications_channel_test.exs
@@ -60,9 +60,9 @@ defmodule SkateWeb.NotificationsChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-
       {:ok, _, socket} = subscribe_and_join(socket, NotificationsChannel, "notifications")
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       assert {:stop, :normal, _socket} =
                NotificationsChannel.handle_info(

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -17,7 +17,7 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
   ]
 
   setup do
-    reassign_env(:skate, :valid_token?, fn _socket -> true end)
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
 
     reassign_env(:skate_web, :train_vehicles_subscribe_fn, fn route_id ->
       case route_id do
@@ -59,7 +59,7 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token?, fn _socket -> false end)
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:ok, _, socket} = subscribe_and_join(socket, TrainVehiclesChannel, "train_vehicles:Red")
 

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -44,7 +44,7 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
       assert red_line_trains == @red_train_vehicles
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -47,11 +47,11 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "train_vehicles:Red"},
-            %{result: {:error, :not_authenticated}, route: "train_vehicles:Green"},
-            %{result: {:error, :not_authenticated}, route: "train_vehicles:Blue"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "train_vehicles:Red",
+            "train_vehicles:Green",
+            "train_vehicles:Blue",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -53,7 +53,11 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
             %{result: {:error, :not_authenticated}, route: "train_vehicles:Blue"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, TrainVehiclesChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, TrainVehiclesChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -43,6 +43,18 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
 
       assert red_line_trains == @red_train_vehicles
     end
+
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "train_vehicles:Red"},
+            %{result: {:error, :not_authenticated}, route: "train_vehicles:Green"},
+            %{result: {:error, :not_authenticated}, route: "train_vehicles:Blue"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, TrainVehiclesChannel, route))
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -71,9 +71,9 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
     end
 
     test "rejects sending vehicle data when socket is not authenticated", %{socket: socket} do
-      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-
       {:ok, _, socket} = subscribe_and_join(socket, TrainVehiclesChannel, "train_vehicles:Red")
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       assert {:stop, :normal, _socket} =
                TrainVehiclesChannel.handle_info(

--- a/test/skate_web/channels/train_vehicles_channel_test.exs
+++ b/test/skate_web/channels/train_vehicles_channel_test.exs
@@ -51,7 +51,7 @@ defmodule SkateWeb.TrainVehiclesChannelTest do
             "train_vehicles:Red",
             "train_vehicles:Green",
             "train_vehicles:Blue",
-            "random:topic:2"
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -77,7 +77,11 @@ defmodule SkateWeb.VehicleChannelTest do
             %{result: {:error, :not_authenticated}, route: "vehicle:run_ids:123-4567"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, VehicleChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, VehicleChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -75,7 +75,7 @@ defmodule SkateWeb.VehicleChannelTest do
 
       for route <- [
             "vehicle:run_ids:123-4567",
-            "random:topic:2"
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -70,7 +70,7 @@ defmodule SkateWeb.VehicleChannelTest do
                subscribe_and_join(socket, VehicleChannel, "vehicle:run_ids:123-4567")
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -69,6 +69,16 @@ defmodule SkateWeb.VehicleChannelTest do
       assert {:ok, ^expected_payload, %Socket{} = _socket} =
                subscribe_and_join(socket, VehicleChannel, "vehicle:run_ids:123-4567")
     end
+
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "vehicle:run_ids:123-4567"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, VehicleChannel, route))
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/vehicle_channel_test.exs
+++ b/test/skate_web/channels/vehicle_channel_test.exs
@@ -73,9 +73,9 @@ defmodule SkateWeb.VehicleChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "vehicle:run_ids:123-4567"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "vehicle:run_ids:123-4567",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -84,6 +84,12 @@ defmodule SkateWeb.VehiclesChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
       assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:")
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:run_ids:")
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:block_ids:")
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:search:")
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "random:topic:1")
+      assert {:error, %{ message: "no such topic" <> _}} = subscribe_and_join(socket, VehiclesChannel, "random:topic:2")
     end
   end
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -80,6 +80,10 @@ defmodule SkateWeb.VehiclesChannelTest do
       assert {:error, %{message: "no such topic \"rooms:1\""}} =
                subscribe_and_join(socket, VehiclesChannel, "rooms:1")
     end
+
+    test "returns an error when trying to join with expired token", %{} do
+      assert false
+    end
   end
 
   describe "handle_info/2" do

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -84,14 +84,14 @@ defmodule SkateWeb.VehiclesChannelTest do
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
-      for %{result: result, route: route} <- [
-            %{result: {:error, :not_authenticated}, route: "vehicles:shuttle:all"},
-            %{result: {:error, :not_authenticated}, route: "vehicles:route:"},
-            %{result: {:error, :not_authenticated}, route: "vehicles:run_ids:"},
-            %{result: {:error, :not_authenticated}, route: "vehicles:block_ids:"},
-            %{result: {:error, :not_authenticated}, route: "vehicles:search:"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:1"},
-            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+      for route <- [
+            "vehicles:shuttle:all",
+            "vehicles:route:",
+            "vehicles:run_ids:",
+            "vehicles:block_ids:",
+            "vehicles:search:",
+            "random:topic:1",
+            "random:topic:2"
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -160,9 +160,9 @@ defmodule SkateWeb.VehiclesChannelTest do
       ets: ets
     } do
       assert Realtime.Server.update_vehicles({%{"1" => [@vehicle]}, []}) == :ok
-      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-
       {:ok, _, socket} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:1")
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       {:stop, :normal, _socket} =
         VehiclesChannel.handle_info(

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -83,13 +83,13 @@ defmodule SkateWeb.VehiclesChannelTest do
 
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:")
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:run_ids:")
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:block_ids:")
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:search:")
-      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "random:topic:1")
-      assert {:error, %{ message: "no such topic" <> _}} = subscribe_and_join(socket, VehiclesChannel, "random:topic:2")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:run_ids:")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:block_ids:")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:search:")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "random:topic:1")
+      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "random:topic:2")
     end
   end
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -90,8 +90,7 @@ defmodule SkateWeb.VehiclesChannelTest do
             "vehicles:run_ids:",
             "vehicles:block_ids:",
             "vehicles:search:",
-            "random:topic:1",
-            "random:topic:2"
+            "random:topic:",
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -83,13 +83,17 @@ defmodule SkateWeb.VehiclesChannelTest do
 
     test "returns an error when trying to join with expired token", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:route:")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:run_ids:")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:block_ids:")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "vehicles:search:")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "random:topic:1")
-      assert {:error, :not_authenticated} = subscribe_and_join(socket, VehiclesChannel, "random:topic:2")
+
+      for %{result: result, route: route} <- [
+            %{result: {:error, :not_authenticated}, route: "vehicles:shuttle:all"},
+            %{result: {:error, :not_authenticated}, route: "vehicles:route:"},
+            %{result: {:error, :not_authenticated}, route: "vehicles:run_ids:"},
+            %{result: {:error, :not_authenticated}, route: "vehicles:block_ids:"},
+            %{result: {:error, :not_authenticated}, route: "vehicles:search:"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:1"},
+            %{result: {:error, :not_authenticated}, route: "random:topic:2"}
+          ],
+          do: assert(^result = subscribe_and_join(socket, VehiclesChannel, route))
     end
   end
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -93,7 +93,11 @@ defmodule SkateWeb.VehiclesChannelTest do
             %{result: {:error, :not_authenticated}, route: "random:topic:1"},
             %{result: {:error, :not_authenticated}, route: "random:topic:2"}
           ],
-          do: assert(^result = subscribe_and_join(socket, VehiclesChannel, route))
+          do:
+            assert(
+              {:error, %{reason: :not_authenticated}} =
+                subscribe_and_join(socket, VehiclesChannel, route)
+            )
     end
   end
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -81,8 +81,9 @@ defmodule SkateWeb.VehiclesChannelTest do
                subscribe_and_join(socket, VehiclesChannel, "rooms:1")
     end
 
-    test "returns an error when trying to join with expired token", %{} do
-      assert false
+    test "returns an error when trying to join with expired token", %{socket: socket} do
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+      assert {:error, _} = subscribe_and_join(socket, VehiclesChannel, "vehicles:shuttle:all")
     end
   end
 

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -90,7 +90,7 @@ defmodule SkateWeb.VehiclesChannelTest do
             "vehicles:run_ids:",
             "vehicles:block_ids:",
             "vehicles:search:",
-            "random:topic:",
+            "random:topic:"
           ],
           do:
             assert(

--- a/test/skate_web/channels/vehicles_channel_test.exs
+++ b/test/skate_web/channels/vehicles_channel_test.exs
@@ -81,7 +81,7 @@ defmodule SkateWeb.VehiclesChannelTest do
                subscribe_and_join(socket, VehiclesChannel, "rooms:1")
     end
 
-    test "returns an error when trying to join with expired token", %{socket: socket} do
+    test "deny topic subscription when socket token validation fails", %{socket: socket} do
       reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
 
       for route <- [


### PR DESCRIPTION
# Summary
When initiating a connection to the server the token is validated, but when joining a channel the socket is not checked to be authenticated.

[Phoenix.Channel Documentation on Authorization](https://hexdocs.pm/phoenix/Phoenix.Channel.html#module-authorization) says that 
> Your channels must implement a join/3 callback that authorizes the socket for the given topic.

So this PR modifies all channel `join/3` callbacks to instead be `join_authenticated/3` which is wrapped by `SkateWeb.AuthenticatedChannel` (name and file location not final) so that authentication code does not need to be manually written and managed for new topics, and should make implementing new channels safer.

## Implementation Details
Use of `SkateWeb.AuthenticatedChannel` shims a `Phoenix.Channel` `@callback join/3` into the module, which firsts checks if the socket is authenticated, which delegates to `join_authenticated/3` if the socket token is valid; and returns `{:error, :not_authenticated}` if the token is invalid.
`join_authenticated/3` is defined as a callback matching the `Phoenix.Channel.join/3` spec so that calls made to `join/3` can be transparently passed to `join_authenticated/3`.

## Notes
I've decided to add a macro which inserts a `join/3` callback for `Phoenix.Channel` which wraps calls to `join_authenticated`, the idea being that if you're getting a callback at `join_authenticated` then you should be able to expect that the request has been authenticated already for you.

I'm unsure if this is the way we should do it or if there's a better way I could've approached this, so I'm really interested in feedback.

Adding `SkateWeb.AuthenticatedChannel` to other channels in SkateWeb showed that some tests are also returning false from `valid_token?/1` too soon, but this may need further review.

In addition, I also moved `:valid_token_fn` and `:valid_token?` into the `ChannelAuth` module and consolidated them to a single atom, which can be updated if we prefer a certain atom name.

I've also realized that I could possibly get rid of `AuthenticatedChannel` and instead do the same work within `lib/skate_web.ex`'s `__using__` macro.

# Todo
- [x] Every new thing needs docs
- [ ] Add frontend tests and "response"(refresh)
- [ ] add `AuthenticatedChannel` specific tests
- [ ] Find edge cases to add more elixir tests for
- [ ] (hopefully) find ways to make tests for `join_authenticated` automatically find all the topics that need to be tested.
- [x] Change elixir test names to be more descriptive 


---

Asana Ticket: https://app.asana.com/0/0/1203412139193187