### PR TITLE
Retry failed Geonames requests

### DIFF
--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -12,8 +12,8 @@ defmodule Geonames do
     end
   end
 
-  @spec get(String.t(), String.t()) :: map() | nil
-  defp get(latitude, longitude) do
+  @spec get(String.t(), String.t(), boolean()) :: map() | nil
+  defp get(latitude, longitude, retry? \\ true) do
     geonames_url_base = Application.get_env(:skate, :geonames_url_base)
     geonames_token = Application.get_env(:skate, :geonames_token)
     token_param = if geonames_token, do: "&token=#{geonames_token}", else: ""
@@ -43,10 +43,14 @@ defmodule Geonames do
 
       response ->
         Logger.warn(
-          "#{__MODULE__} unexpected_response url=#{sanitized_url} response=#{inspect(response)} time=#{time_in_ms}"
+          "#{__MODULE__} unexpected_response url=#{sanitized_url} response=#{inspect(response)} time=#{time_in_ms} retry=#{retry?}"
         )
 
-        nil
+        if retry? do
+          get(latitude, longitude, false)
+        else
+          nil
+        end
     end
   end
 

--- a/lib/geonames.ex
+++ b/lib/geonames.ex
@@ -28,16 +28,22 @@ defmodule Geonames do
         url
       end
 
-    case HTTPoison.get(url) do
+    {time, result} = :timer.tc(HTTPoison, :get, [url])
+
+    time_in_ms = time / :timer.seconds(1)
+
+    case result do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        Logger.info("#{__MODULE__} got_intersection_response url=#{sanitized_url}")
+        Logger.info(
+          "#{__MODULE__} got_intersection_response url=#{sanitized_url} time=#{time_in_ms}"
+        )
 
         body
         |> Jason.decode!(strings: :copy)
 
       response ->
         Logger.warn(
-          "#{__MODULE__} unexpected_response url=#{sanitized_url} response=#{inspect(response)}"
+          "#{__MODULE__} unexpected_response url=#{sanitized_url} response=#{inspect(response)} time=#{time_in_ms}"
         )
 
         nil

--- a/test/geonames_test.exs
+++ b/test/geonames_test.exs
@@ -2,6 +2,7 @@ defmodule GeonamesTest do
   use ExUnit.Case, async: true
   import Test.Support.Helpers
   import ExUnit.CaptureLog
+  import Plug.Conn
 
   alias Geonames
 
@@ -77,6 +78,109 @@ defmodule GeonamesTest do
       assert log =~ "got_intersection_response"
     end
 
+    test "retries request on failure" do
+      set_log_level(:info)
+
+      bypass = Bypass.open()
+      reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
+
+      json = %{
+        "credits" => "1.0",
+        "intersection" => %{
+          "mtfcc1" => "S1400",
+          "mtfcc2" => "S1400",
+          "adminCode1" => "CA",
+          "lng" => "-122.180842",
+          "distance" => "0.08",
+          "bearing" => "242",
+          "placename" => "Menlo Park",
+          "street1Bearing" => "213",
+          "street2Bearing" => "303",
+          "adminName2" => "San Mateo",
+          "postalcode" => "94025",
+          "countryCode" => "US",
+          "street1" => "Roble Ave",
+          "street2" => "Curtis St",
+          "adminName1" => "California",
+          "lat" => "37.450649"
+        }
+      }
+
+      {:ok, agent} = response_agent()
+
+      agent
+      |> add_response(fn conn ->
+        send_resp(conn, 500, "")
+      end)
+      |> add_response(fn conn ->
+        send_resp(conn, 200, Jason.encode!(json))
+      end)
+
+      log =
+        capture_log(
+          [level: :info],
+          fn ->
+            Bypass.expect(bypass, fn conn -> agent_response(agent, conn) end)
+
+            assert Geonames.nearest_intersection("40", "-70") == "Roble Ave & Curtis St"
+          end
+        )
+
+      assert log =~ "retry=true"
+      assert log =~ "got_intersection_response"
+    end
+
+    test "only retries request once" do
+      bypass = Bypass.open()
+      reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
+
+      json = %{
+        "credits" => "1.0",
+        "intersection" => %{
+          "mtfcc1" => "S1400",
+          "mtfcc2" => "S1400",
+          "adminCode1" => "CA",
+          "lng" => "-122.180842",
+          "distance" => "0.08",
+          "bearing" => "242",
+          "placename" => "Menlo Park",
+          "street1Bearing" => "213",
+          "street2Bearing" => "303",
+          "adminName2" => "San Mateo",
+          "postalcode" => "94025",
+          "countryCode" => "US",
+          "street1" => "Roble Ave",
+          "street2" => "Curtis St",
+          "adminName1" => "California",
+          "lat" => "37.450649"
+        }
+      }
+
+      {:ok, agent} = response_agent()
+
+      agent
+      |> add_response(fn conn ->
+        send_resp(conn, 500, "")
+      end)
+      |> add_response(fn conn ->
+        send_resp(conn, 500, "")
+      end)
+      |> add_response(fn conn ->
+        send_resp(conn, 200, Jason.encode!(json))
+      end)
+
+      log =
+        capture_log(fn ->
+          Bypass.expect(bypass, fn conn -> agent_response(agent, conn) end)
+
+          assert Geonames.nearest_intersection("40", "-70") == nil
+        end)
+
+      assert log =~ "unexpected_response"
+      assert log =~ "retry=true"
+      assert log =~ "retry=false"
+    end
+
     test "returns nil if there is no nearby intersection" do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
@@ -88,5 +192,28 @@ defmodule GeonamesTest do
       Bypass.expect(bypass, fn conn -> Plug.Conn.resp(conn, 200, Jason.encode!(json)) end)
       assert Geonames.nearest_intersection("40", "-70") == nil
     end
+  end
+
+  defp response_agent do
+    Agent.start_link(fn -> [] end)
+  end
+
+  defp add_response(agent, fun) do
+    :ok = Agent.update(agent, fn funs -> funs ++ [fun] end)
+    agent
+  end
+
+  defp agent_response(agent, conn) do
+    fun =
+      Agent.get_and_update(agent, fn
+        [] -> {&default_response/1, []}
+        [fun | funs] -> {fun, funs}
+      end)
+
+    fun.(conn)
+  end
+
+  defp default_response(conn) do
+    send_resp(conn, 200, "agent")
   end
 end

--- a/test/geonames_test.exs
+++ b/test/geonames_test.exs
@@ -6,6 +6,28 @@ defmodule GeonamesTest do
 
   alias Geonames
 
+  @json %{
+    "credits" => "1.0",
+    "intersection" => %{
+      "mtfcc1" => "S1400",
+      "mtfcc2" => "S1400",
+      "adminCode1" => "CA",
+      "lng" => "-122.180842",
+      "distance" => "0.08",
+      "bearing" => "242",
+      "placename" => "Menlo Park",
+      "street1Bearing" => "213",
+      "street2Bearing" => "303",
+      "adminName2" => "San Mateo",
+      "postalcode" => "94025",
+      "countryCode" => "US",
+      "street1" => "Roble Ave",
+      "street2" => "Curtis St",
+      "adminName1" => "California",
+      "lat" => "37.450649"
+    }
+  }
+
   describe "nearest_intersection" do
     test "returns nil if the request fails and logs" do
       bypass = Bypass.open()
@@ -44,33 +66,11 @@ defmodule GeonamesTest do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
 
-      json = %{
-        "credits" => "1.0",
-        "intersection" => %{
-          "mtfcc1" => "S1400",
-          "mtfcc2" => "S1400",
-          "adminCode1" => "CA",
-          "lng" => "-122.180842",
-          "distance" => "0.08",
-          "bearing" => "242",
-          "placename" => "Menlo Park",
-          "street1Bearing" => "213",
-          "street2Bearing" => "303",
-          "adminName2" => "San Mateo",
-          "postalcode" => "94025",
-          "countryCode" => "US",
-          "street1" => "Roble Ave",
-          "street2" => "Curtis St",
-          "adminName1" => "California",
-          "lat" => "37.450649"
-        }
-      }
-
       log =
         capture_log(
           [level: :info],
           fn ->
-            Bypass.expect(bypass, fn conn -> Plug.Conn.resp(conn, 200, Jason.encode!(json)) end)
+            Bypass.expect(bypass, fn conn -> Plug.Conn.resp(conn, 200, Jason.encode!(@json)) end)
             assert Geonames.nearest_intersection("40", "-70") == "Roble Ave & Curtis St"
           end
         )
@@ -84,28 +84,6 @@ defmodule GeonamesTest do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
 
-      json = %{
-        "credits" => "1.0",
-        "intersection" => %{
-          "mtfcc1" => "S1400",
-          "mtfcc2" => "S1400",
-          "adminCode1" => "CA",
-          "lng" => "-122.180842",
-          "distance" => "0.08",
-          "bearing" => "242",
-          "placename" => "Menlo Park",
-          "street1Bearing" => "213",
-          "street2Bearing" => "303",
-          "adminName2" => "San Mateo",
-          "postalcode" => "94025",
-          "countryCode" => "US",
-          "street1" => "Roble Ave",
-          "street2" => "Curtis St",
-          "adminName1" => "California",
-          "lat" => "37.450649"
-        }
-      }
-
       {:ok, agent} = response_agent()
 
       agent
@@ -113,7 +91,7 @@ defmodule GeonamesTest do
         send_resp(conn, 500, "")
       end)
       |> add_response(fn conn ->
-        send_resp(conn, 200, Jason.encode!(json))
+        send_resp(conn, 200, Jason.encode!(@json))
       end)
 
       log =
@@ -134,28 +112,6 @@ defmodule GeonamesTest do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
 
-      json = %{
-        "credits" => "1.0",
-        "intersection" => %{
-          "mtfcc1" => "S1400",
-          "mtfcc2" => "S1400",
-          "adminCode1" => "CA",
-          "lng" => "-122.180842",
-          "distance" => "0.08",
-          "bearing" => "242",
-          "placename" => "Menlo Park",
-          "street1Bearing" => "213",
-          "street2Bearing" => "303",
-          "adminName2" => "San Mateo",
-          "postalcode" => "94025",
-          "countryCode" => "US",
-          "street1" => "Roble Ave",
-          "street2" => "Curtis St",
-          "adminName1" => "California",
-          "lat" => "37.450649"
-        }
-      }
-
       {:ok, agent} = response_agent()
 
       agent
@@ -166,7 +122,7 @@ defmodule GeonamesTest do
         send_resp(conn, 500, "")
       end)
       |> add_response(fn conn ->
-        send_resp(conn, 200, Jason.encode!(json))
+        send_resp(conn, 200, Jason.encode!(@json))
       end)
 
       log =
@@ -185,11 +141,11 @@ defmodule GeonamesTest do
       bypass = Bypass.open()
       reassign_env(:skate, :geonames_url_base, "http://localhost:#{bypass.port}")
 
-      json = %{
+      empty_json = %{
         "credits" => "1.0"
       }
 
-      Bypass.expect(bypass, fn conn -> Plug.Conn.resp(conn, 200, Jason.encode!(json)) end)
+      Bypass.expect(bypass, fn conn -> Plug.Conn.resp(conn, 200, Jason.encode!(empty_json)) end)
       assert Geonames.nearest_intersection("40", "-70") == nil
     end
   end


### PR DESCRIPTION
Asana ticket: [⚙️ Investigate intermittent external API request errors](https://app.asana.com/0/1148853526253437/1203468822722733/f)

This adds some simple logic to retry Geonames API requests once if they fail. This is done synchronously in the request to `IntersectionController`, but since the front-end doesn't block on that request I'm not too worried about the latency. Also, failed requests take only ~50ms on average. In about an hour of testing on dev-blue we logged 44 failed requests and every one of them succeeded with the single retry, so I'm fairly confident that this will put a big dent in the number of user-visible failures.