### PR TITLE
refactor(Data.parse_files/2): Only filter to bus data when needed to support accessing subway data

### DIFF
--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -326,7 +326,14 @@ defmodule Schedule.Data do
     |> FeedInfo.parse()
     |> FeedInfo.log_gtfs_version()
 
-    directions_by_route_id = directions_by_route_id(gtfs_files["directions.txt"])
+    %{
+      calendar: calendar,
+      stops: stops,
+      timepoints_by_id: timepoints_by_id,
+      directions_by_route_id: directions_by_route_id
+    } = parse_gtfs_all_modes(gtfs_files)
+
+    timepoint_names_by_id = timepoint_names_for_ids(timepoints_by_id)
 
     bus_routes =
       Csv.parse(
@@ -347,9 +354,6 @@ defmodule Schedule.Data do
       |> Hastus.Trip.expand_through_routed_trips(gtfs_trip_ids)
 
     route_patterns = bus_route_patterns(gtfs_files["route_patterns.txt"], bus_route_ids)
-
-    timepoints_by_id = all_timepoints_by_id(gtfs_files["checkpoints.txt"])
-    timepoint_names_by_id = timepoint_names_for_ids(timepoints_by_id)
 
     stop_times_by_id = StopTime.parse(gtfs_files["stop_times.txt"], gtfs_trip_ids)
 
@@ -383,12 +387,21 @@ defmodule Schedule.Data do
         ),
       timepoint_names_by_id: timepoint_names_by_id,
       shapes: shapes_by_route_id(gtfs_files["shapes.txt"], gtfs_trips),
-      stops: all_stops_by_id(gtfs_files["stops.txt"]),
+      stops: stops,
       trips: schedule_trips_by_id,
       blocks: blocks,
-      calendar: Calendar.from_files(gtfs_files["calendar.txt"], gtfs_files["calendar_dates.txt"]),
+      calendar: calendar,
       runs: runs,
       swings: Swing.from_blocks(blocks, schedule_trips_by_id)
+    }
+  end
+
+  def parse_gtfs_all_modes(gtfs_files) do
+    %{
+      calendar: Calendar.from_files(gtfs_files["calendar.txt"], gtfs_files["calendar_dates.txt"]),
+      stops: all_stops_by_id(gtfs_files["stops.txt"]),
+      timepoints_by_id: all_timepoints_by_id(gtfs_files["checkpoints.txt"]),
+      directions_by_route_id: directions_by_route_id(gtfs_files["directions.txt"])
     }
   end
 

--- a/lib/schedule/gtfs/route.ex
+++ b/lib/schedule/gtfs/route.ex
@@ -80,15 +80,13 @@ defmodule Schedule.Gtfs.Route do
     short_name
   end
 
-  @spec bus_route?(t()) :: boolean
-  def bus_route?(route) do
-    route.type == @bus_route_type
-  end
-
   @spec bus_route_mbta?(t()) :: boolean
+  @doc """
+  Is this an mbta bus route?
+  """
   def bus_route_mbta?(route) do
     # Verify that route number is not one of the private carriers: 710, 712, 713, 714, 716
-    bus_route?(route) && route.id not in ["710", "712", "713", "714", "716"]
+    route.type == @bus_route_type && route.id not in ["710", "712", "713", "714", "716"]
   end
 
   @spec shuttle_route?(t) :: boolean

--- a/lib/schedule/gtfs/route_pattern.ex
+++ b/lib/schedule/gtfs/route_pattern.ex
@@ -38,6 +38,13 @@ defmodule Schedule.Gtfs.RoutePattern do
     :representative_trip_id
   ]
 
+  def from_file(file_binary) do
+    Csv.parse(
+      file_binary,
+      parse: &from_csv_row/1
+    )
+  end
+
   @spec from_csv_row(Csv.row()) :: t()
   def from_csv_row(row) do
     %__MODULE__{

--- a/lib/schedule/gtfs/route_pattern.ex
+++ b/lib/schedule/gtfs/route_pattern.ex
@@ -38,13 +38,6 @@ defmodule Schedule.Gtfs.RoutePattern do
     :representative_trip_id
   ]
 
-  def from_file(file_binary) do
-    Csv.parse(
-      file_binary,
-      parse: &from_csv_row/1
-    )
-  end
-
   @spec from_csv_row(Csv.row()) :: t()
   def from_csv_row(row) do
     %__MODULE__{

--- a/lib/schedule/gtfs/trip.ex
+++ b/lib/schedule/gtfs/trip.ex
@@ -40,23 +40,6 @@ defmodule Schedule.Gtfs.Trip do
     :shape_id
   ]
 
-  @spec parse(binary()) :: [t()]
-  def parse(file_binary) do
-    Csv.parse(
-      file_binary,
-      parse: &from_csv_row/1
-    )
-  end
-
-  @spec parse(binary() | nil, MapSet.t(Route.id())) :: [t()]
-  def parse(file_binary, route_ids) do
-    Csv.parse(
-      file_binary,
-      filter: &row_in_route_id_set?(&1, route_ids),
-      parse: &from_csv_row/1
-    )
-  end
-
   @spec from_csv_row(Csv.row()) :: t()
   def from_csv_row(row) do
     route_pattern_id =
@@ -76,7 +59,4 @@ defmodule Schedule.Gtfs.Trip do
       shape_id: row["shape_id"]
     }
   end
-
-  @spec row_in_route_id_set?(Csv.row(), MapSet.t(Route.id())) :: boolean
-  defp row_in_route_id_set?(row, route_id_set), do: MapSet.member?(route_id_set, row["route_id"])
 end

--- a/lib/schedule/gtfs/trip.ex
+++ b/lib/schedule/gtfs/trip.ex
@@ -40,6 +40,14 @@ defmodule Schedule.Gtfs.Trip do
     :shape_id
   ]
 
+  @spec parse(binary()) :: [t()]
+  def parse(file_binary) do
+    Csv.parse(
+      file_binary,
+      parse: &from_csv_row/1
+    )
+  end
+
   @spec parse(binary() | nil, MapSet.t(Route.id())) :: [t()]
   def parse(file_binary, route_ids) do
     Csv.parse(

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -50,10 +50,6 @@ defmodule Schedule.Gtfs.RouteTest do
     end
   end
 
-  # TEST: test from_file/1 pulled out to Route
-  # * parses all routes (including non-bus)
-  # * raises error if route_type is missing on a route
-
   describe "shuttle_route?/1" do
     test "returns true if this route is a 'Rail Replacement Bus'" do
       shuttle_route = %Route{

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -1,5 +1,6 @@
 defmodule Schedule.Gtfs.RouteTest do
   use ExUnit.Case, async: true
+  import Skate.Factory
 
   alias Schedule.Gtfs.{Direction, Route}
 
@@ -47,6 +48,64 @@ defmodule Schedule.Gtfs.RouteTest do
       }
 
       assert Route.from_csv_row(csv_row, directions_by_route_id) == expected
+    end
+  end
+
+  describe "row_has_route_type?/1" do
+    test "true when route type present" do
+      bus_route_csv_row = %{
+        "route_id" => "39",
+        "agency_id" => "1",
+        "route_short_name" => "39",
+        "route_long_name" => "Forest Hills - Back Bay Station",
+        "route_desc" => "Key Bus",
+        "route_type" => "3",
+        "route_url" => "https://www.mbta.com/schedules/39",
+        "route_color" => "FFC72C",
+        "route_text_color" => "000000",
+        "route_sort_order" => "50390",
+        "route_fare_class" => "Local Bus",
+        "line_id" => "line-39",
+        "listed_route" => ""
+      }
+
+      assert Route.row_has_route_type?(bus_route_csv_row)
+    end
+
+    test "ensures a `route_type` property" do
+      bad_route_csv_row = %{
+        "route_id" => "39",
+        "agency_id" => "1",
+        "route_short_name" => "39",
+        "route_long_name" => "Forest Hills - Back Bay Station",
+        "route_desc" => "Key Bus",
+        "route_type" => nil,
+        "route_url" => "https://www.mbta.com/schedules/39",
+        "route_color" => "FFC72C",
+        "route_text_color" => "000000",
+        "route_sort_order" => "50390",
+        "route_fare_class" => "Local Bus",
+        "line_id" => "line-39",
+        "listed_route" => ""
+      }
+
+      assert_raise ArgumentError, fn ->
+        Route.row_has_route_type?(bad_route_csv_row)
+      end
+    end
+  end
+
+  describe "bus_route_mbta?/1" do
+    test "true for bus route" do
+      assert Route.bus_route_mbta?(build(:gtfs_route, %{id: "1", type: 3}))
+    end
+
+    test "false for non-mbta bus route" do
+      refute Route.bus_route_mbta?(build(:gtfs_route, %{id: "710", type: 3}))
+    end
+
+    test "false for  subway route" do
+      refute Route.bus_route_mbta?(build(:gtfs_route, %{id: "RL", type: 1}))
     end
   end
 

--- a/test/schedule/gtfs/route_test.exs
+++ b/test/schedule/gtfs/route_test.exs
@@ -50,83 +50,9 @@ defmodule Schedule.Gtfs.RouteTest do
     end
   end
 
-  describe "bus_route_valid_row?/1" do
-    test "returns whether or not this row represents a bus route" do
-      bus_csv_row = %{
-        "route_id" => "39",
-        "agency_id" => "1",
-        "route_short_name" => "39",
-        "route_long_name" => "Forest Hills - Back Bay Station",
-        "route_desc" => "Key Bus",
-        "route_type" => "3",
-        "route_url" => "https://www.mbta.com/schedules/39",
-        "route_color" => "FFC72C",
-        "route_text_color" => "000000",
-        "route_sort_order" => "50390",
-        "route_fare_class" => "Local Bus",
-        "line_id" => "line-39",
-        "listed_route" => ""
-      }
-
-      subway_csv_row = %{
-        "route_id" => "Red",
-        "agency_id" => "1",
-        "route_short_name" => "",
-        "route_long_name" => "Red Line",
-        "route_desc" => "Rapid Transit",
-        "route_type" => "1",
-        "route_url" => "https://www.mbta.com/schedules/Red",
-        "route_color" => "DA291C",
-        "route_text_color" => "FFFFFF",
-        "route_sort_order" => "10010",
-        "route_fare_class" => "Rapid Transit",
-        "line_id" => "line-Red",
-        "listed_route" => ""
-      }
-
-      private_carrier_csv_row = %{
-        "route_id" => "710",
-        "agency_id" => "1",
-        "route_short_name" => "710",
-        "route_long_name" => "North Medford - Wellington Station",
-        "route_desc" => "Local Bus",
-        "route_type" => "3",
-        "route_url" => "https://www.mbta.com/schedules/710",
-        "route_color" => "FFC72C",
-        "route_text_color" => "000000",
-        "route_sort_order" => "57100",
-        "route_fare_class" => "Local Bus",
-        "line_id" => "line-710",
-        "listed_route" => ""
-      }
-
-      assert Route.bus_route_valid_row?(bus_csv_row)
-      refute Route.bus_route_valid_row?(subway_csv_row)
-      refute Route.bus_route_valid_row?(private_carrier_csv_row)
-    end
-
-    test "ensures a `route_type` property" do
-      bad_csv_row = %{
-        "route_id" => "39",
-        "agency_id" => "1",
-        "route_short_name" => "39",
-        "route_long_name" => "Forest Hills - Back Bay Station",
-        "route_desc" => "Key Bus",
-        "route_type" => nil,
-        "route_url" => "https://www.mbta.com/schedules/39",
-        "route_color" => "FFC72C",
-        "route_text_color" => "000000",
-        "route_sort_order" => "50390",
-        "route_fare_class" => "Local Bus",
-        "line_id" => "line-39",
-        "listed_route" => ""
-      }
-
-      assert_raise ArgumentError, fn ->
-        Route.bus_route_valid_row?(bad_csv_row)
-      end
-    end
-  end
+  # TEST: test from_file/1 pulled out to Route
+  # * parses all routes (including non-bus)
+  # * raises error if route_type is missing on a route
 
   describe "shuttle_route?/1" do
     test "returns true if this route is a 'Rail Replacement Bus'" do

--- a/test/schedule/gtfs/trip_test.exs
+++ b/test/schedule/gtfs/trip_test.exs
@@ -3,20 +3,6 @@ defmodule Schedule.Gtfs.TripTest do
 
   alias Schedule.Gtfs.Trip
 
-  describe "parse" do
-    test "filters out other routes" do
-      binary =
-        [
-          "route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,shape_id,wheelchair_accessible,trip_route_type,route_pattern_id,bikes_allowed",
-          "1,service,trip1,headsign,,0,block,shape,1,,1-_-0,1",
-          "2,service,trip2,headsign,,0,block,shape,1,,1-_-0,1"
-        ]
-        |> Enum.join("\n")
-
-      assert [%Trip{id: "trip1"}] = Trip.parse(binary, MapSet.new(["1"]))
-    end
-  end
-
   describe "from_csv_row" do
     test "builds a Trip struct from a csv row" do
       csv_row = %{


### PR DESCRIPTION
Refactor to support https://app.asana.com/0/1200180014510248/1203520428951853/f.

Currently, for many gtfs files, non-bus data is immediately filtered during the parsing process. This PR pushes that filtering to a later stage for the files we'll need in order to calculate all route connections for bus stops: 
* route_patterns
* trips

I attempted to keep this refactor as small as possible to reduce the risk of unintended regressions for this core flow. 
Added:
There may be additional refactoring in `parse_files` to come, but this is the core chunk of it. If it would be preferable to review this refactor in the context of all changes to expose stop connection data, I can close this PR.