### PR TITLE
feat(SwingData): route ids no longer nullable

### DIFF
--- a/assets/src/models/swingsData.ts
+++ b/assets/src/models/swingsData.ts
@@ -1,12 +1,12 @@
-import { Infer, number, type, string, nullable } from "superstruct"
+import { Infer, number, type, string } from "superstruct"
 import { Swing } from "../schedule"
 
 export const SwingData = type({
   block_id: string(),
-  from_route_id: nullable(string()),
+  from_route_id: string(),
   from_run_id: string(),
   from_trip_id: string(),
-  to_route_id: nullable(string()),
+  to_route_id: string(),
   to_run_id: string(),
   to_trip_id: string(),
   time: number(),
@@ -16,10 +16,10 @@ export type SwingData = Infer<typeof SwingData>
 export const swingsFromData = (swingsData: SwingData[]): Swing[] =>
   swingsData.map((swingData) => ({
     blockId: swingData.block_id,
-    fromRouteId: swingData.from_route_id || "",
+    fromRouteId: swingData.from_route_id,
     fromRunId: swingData.from_run_id,
     fromTripId: swingData.from_trip_id,
-    toRouteId: swingData.to_route_id || "",
+    toRouteId: swingData.to_route_id,
     toRunId: swingData.to_run_id,
     toTripId: swingData.to_trip_id,
     time: swingData.time,

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -580,6 +580,25 @@ describe("fetchNearestIntersection", () => {
 })
 
 describe("fetchSwings", () => {
+  test("throws superstruct error if either route_id field is null", async () => {
+    const data: any = [
+      {
+        from_route_id: null,
+        to_route_id: null,
+        block_id: "A12-34",
+        from_run_id: "123-456",
+        from_trip_id: "1234",
+        to_run_id: "123-789",
+        to_trip_id: "5678",
+        time: 100,
+      },
+    ]
+
+    mockFetch(200, data)
+
+    await expect(fetchSwings([])).rejects.toThrowError(StructError)
+  })
+
   test("parses swings", (done) => {
     const swing = {
       block_id: "B1",


### PR DESCRIPTION
# Summary
> An issue discovered on dev after merging https://github.com/mbta/skate/pull/1776, namely that routes on swings can actually be null in some cases. It looks like there's an underlying data integrity issue [...] (and the fix should include removing the `nullable` on these fields as well)

https://github.com/mbta/skate/pull/1843 addresses the issue originally noted by Eddie in https://github.com/mbta/skate/pull/1781, and this PR reverts the `nullable` fields from the uperstruct definition.

And adds a test to check superstruct usage within the api.

## Acceptance Criteria from Asana Ticket
> 5. The Superstruct model in `models/swingsData.ts` should be updates to no longer allow the route fields to be nullable.

---

Deploy-after: https://github.com/mbta/skate/pull/1843
Addresses: https://github.com/mbta/skate/pull/1781
Asana Ticket: [⚙️ Investigate minischedule data issue](https://app.asana.com/0/1148853526253437/1203278600620513/f)
Asana Ticket: [⚙️ Check in on swings with missing to / from routes](https://app.asana.com/0/1148853526253437/1203587745391809/f)
Co-authored-by: Kayla Brady <kbrady@mbta.com>