### PR TITLE
feat: Add endpoint for getting all stations

### DIFF
--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -1,4 +1,7 @@
 defmodule Schedule do
+  @moduledoc """
+  A repository for accessing and updating static schedule data stored in memory
+  """
   require Logger
 
   alias Schedule.{

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -149,7 +149,7 @@ defmodule Schedule do
   end
 
   def stations(persistent_term_key \\ __MODULE__) do
-    call_with_data(persistent_term_key, [], :shape_with_stops_for_trip, [])
+    call_with_data(persistent_term_key, [], :stations, [])
   end
 
   @spec first_route_pattern_for_route_and_direction(Route.id(), Direction.id()) ::

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -148,6 +148,10 @@ defmodule Schedule do
     call_with_data(persistent_term_key, [trip_id], :shape_with_stops_for_trip, nil)
   end
 
+  def stations(persistent_term_key \\ __MODULE__) do
+    call_with_data(persistent_term_key, [], :shape_with_stops_for_trip, [])
+  end
+
   @spec first_route_pattern_for_route_and_direction(Route.id(), Direction.id()) ::
           RoutePattern.t() | nil
   @spec first_route_pattern_for_route_and_direction(

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -1,6 +1,6 @@
 defmodule Schedule.Data do
   @moduledoc """
-  GTFS Data management
+  Combined static GTFS and HASTUS schedule data.
   """
   require Logger
 

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -264,7 +264,9 @@ defmodule Schedule.Data do
   end
 
   @spec stations(t()) :: [Stop.t()]
-  def stations(%__MODULE__{stations: stations}), do: stations
+  def stations(%__MODULE__{stations: stations}) do
+    stations
+  end
 
   @spec stops_for_trip(t(), Schedule.Trip.id()) :: [Stop.t()]
   defp stops_for_trip(%__MODULE__{stops: stops_by_id, trips: trips}, trip_id) do

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -35,7 +35,6 @@ defmodule Schedule.Data do
           timepoint_names_by_id: Timepoint.timepoint_names_by_id(),
           shapes: shapes_by_route_id(),
           stops: stops_by_id(),
-          stations: [Stop.t()],
           trips: Schedule.Trip.by_id(),
           blocks: Block.by_id(),
           calendar: Calendar.t(),
@@ -57,7 +56,6 @@ defmodule Schedule.Data do
             timepoint_names_by_id: %{},
             shapes: %{},
             stops: %{},
-            stations: [],
             trips: %{},
             blocks: %{},
             calendar: %{},
@@ -264,8 +262,10 @@ defmodule Schedule.Data do
   end
 
   @spec stations(t()) :: [Stop.t()]
-  def stations(%__MODULE__{stations: stations}) do
-    stations
+  def stations(%__MODULE__{stops: stops}) do
+    stops
+    |> Map.values()
+    |> Enum.filter(&Stop.is_station?/1)
   end
 
   @spec stops_for_trip(t(), Schedule.Trip.id()) :: [Stop.t()]
@@ -388,10 +388,6 @@ defmodule Schedule.Data do
       timepoint_names_by_id: timepoint_names_by_id,
       shapes: gtfs_data.bus_only.shapes,
       stops: stops,
-      stations:
-        stops
-        |> Map.values()
-        |> Enum.filter(&Stop.is_station?/1),
       trips: schedule_trips_by_id,
       blocks: blocks,
       calendar: gtfs_data.all_modes.calendar,

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -671,8 +671,7 @@ defmodule Schedule.Data do
   @spec all_stops_by_id(binary()) :: stops_by_id()
   defp all_stops_by_id(stops_data) do
     stops_data
-    # TODO perf: filter out non-stop or station rows
-    |> Csv.parse(parse: &Stop.from_csv_row/1)
+    |> Stop.parse()
     |> Map.new(fn stop -> {stop.id, stop} end)
   end
 end

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -35,6 +35,7 @@ defmodule Schedule.Data do
           timepoint_names_by_id: Timepoint.timepoint_names_by_id(),
           shapes: shapes_by_route_id(),
           stops: stops_by_id(),
+          stations: [Stop.t()],
           trips: Schedule.Trip.by_id(),
           blocks: Block.by_id(),
           calendar: Calendar.t(),
@@ -56,6 +57,7 @@ defmodule Schedule.Data do
             timepoint_names_by_id: %{},
             shapes: %{},
             stops: %{},
+            stations: [],
             trips: %{},
             blocks: %{},
             calendar: %{},
@@ -261,6 +263,9 @@ defmodule Schedule.Data do
     end
   end
 
+  @spec stations(t()) :: [Stop.t()]
+  def stations(%__MODULE__{stations: stations}), do: stations
+
   @spec stops_for_trip(t(), Schedule.Trip.id()) :: [Stop.t()]
   defp stops_for_trip(%__MODULE__{stops: stops_by_id, trips: trips}, trip_id) do
     case Map.get(trips, trip_id) do
@@ -361,6 +366,14 @@ defmodule Schedule.Data do
 
     bus_routes = Garage.add_garages_to_routes(gtfs_data.bus_only.routes, schedule_trips_by_id)
 
+    stops =
+      Stop.stops_with_connections(
+        gtfs_data.all_modes.stops_by_id,
+        gtfs_data.all_modes.routes,
+        gtfs_data.all_modes.route_patterns,
+        gtfs_data.all_modes.stop_times_by_trip_id
+      )
+
     %__MODULE__{
       routes: bus_routes,
       route_patterns: gtfs_data.bus_only.route_patterns,
@@ -372,13 +385,11 @@ defmodule Schedule.Data do
         ),
       timepoint_names_by_id: timepoint_names_by_id,
       shapes: gtfs_data.bus_only.shapes,
-      stops:
-        Stop.stops_with_connections(
-          gtfs_data.all_modes.stops_by_id,
-          gtfs_data.all_modes.routes,
-          gtfs_data.all_modes.route_patterns,
-          gtfs_data.all_modes.stop_times_by_trip_id
-        ),
+      stops: stops,
+      stations:
+        stops
+        |> Map.values()
+        |> Enum.filter(&Stop.is_station?/1),
       trips: schedule_trips_by_id,
       blocks: blocks,
       calendar: gtfs_data.all_modes.calendar,

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -671,6 +671,7 @@ defmodule Schedule.Data do
   @spec all_stops_by_id(binary()) :: stops_by_id()
   defp all_stops_by_id(stops_data) do
     stops_data
+    # TODO perf: filter out non-stop or station rows
     |> Csv.parse(parse: &Stop.from_csv_row/1)
     |> Map.new(fn stop -> {stop.id, stop} end)
   end

--- a/lib/schedule/gtfs/stop.ex
+++ b/lib/schedule/gtfs/stop.ex
@@ -41,18 +41,21 @@ defmodule Schedule.Gtfs.Stop do
   def from_csv_row(row) do
     parent_station_id = if row["parent_station"] == "", do: nil, else: row["parent_station"]
 
-    location_type =
-      if row["location_type"] == "", do: 0, else: String.to_integer(row["location_type"])
-
     %__MODULE__{
       id: row["stop_id"],
       name: row["stop_name"],
       parent_station_id: parent_station_id,
       latitude: parse_lat_lon(row["stop_lat"]),
       longitude: parse_lat_lon(row["stop_lon"]),
-      location_type: location_type
+      location_type: parse_location_type(row["location_type"])
     }
   end
+
+  @doc """
+  Returns true when the stop is a station.
+  """
+  @spec is_station?(t()) :: boolean()
+  def is_station?(stop), do: stop.location_type == 1
 
   @doc """
   Remove any stop connections with the given route_id
@@ -147,4 +150,9 @@ defmodule Schedule.Gtfs.Stop do
   @spec parse_lat_lon(String.t()) :: float() | nil
   defp parse_lat_lon(""), do: nil
   defp parse_lat_lon(s), do: String.to_float(s)
+
+  @spec parse_location_type(String.t() | nil) :: integer()
+  defp parse_location_type(""), do: 0
+  defp parse_location_type(nil), do: 0
+  defp parse_location_type(location_type), do: String.to_integer(location_type)
 end

--- a/lib/schedule/gtfs/stop.ex
+++ b/lib/schedule/gtfs/stop.ex
@@ -10,7 +10,8 @@ defmodule Schedule.Gtfs.Stop do
           parent_station_id: id() | nil,
           latitude: float() | nil,
           longitude: float() | nil,
-          connections: [Route.t()]
+          connections: [Route.t()],
+          location_type: integer()
         }
   @type by_id :: %{id() => t()}
 
@@ -27,7 +28,8 @@ defmodule Schedule.Gtfs.Stop do
     :parent_station_id,
     :latitude,
     :longitude,
-    connections: []
+    connections: [],
+    location_type: 0
   ]
 
   @spec parent_station_id(t() | nil) :: id() | nil
@@ -39,12 +41,16 @@ defmodule Schedule.Gtfs.Stop do
   def from_csv_row(row) do
     parent_station_id = if row["parent_station"] == "", do: nil, else: row["parent_station"]
 
+    location_type =
+      if row["location_type"] == "", do: 0, else: String.to_integer(row["location_type"])
+
     %__MODULE__{
       id: row["stop_id"],
       name: row["stop_name"],
       parent_station_id: parent_station_id,
       latitude: parse_lat_lon(row["stop_lat"]),
-      longitude: parse_lat_lon(row["stop_lon"])
+      longitude: parse_lat_lon(row["stop_lon"]),
+      location_type: location_type
     }
   end
 

--- a/lib/schedule/gtfs/stop.ex
+++ b/lib/schedule/gtfs/stop.ex
@@ -82,7 +82,7 @@ defmodule Schedule.Gtfs.Stop do
   Returns true when the stop is a station.
   """
   @spec is_station?(t()) :: boolean()
-  def is_station?(stop), do: stop.location_type == 1
+  def is_station?(stop), do: stop.location_type == :station
 
   @doc """
   Remove any stop connections with the given route_id

--- a/lib/schedule/gtfs/stop.ex
+++ b/lib/schedule/gtfs/stop.ex
@@ -20,8 +20,6 @@ defmodule Schedule.Gtfs.Stop do
     :name
   ]
 
-  @derive Jason.Encoder
-
   defstruct [
     :id,
     :name,
@@ -31,6 +29,18 @@ defmodule Schedule.Gtfs.Stop do
     connections: [],
     location_type: 0
   ]
+
+  defimpl Jason.Encoder do
+    def encode(stop, opts) do
+      %{latitude: latitude, longitude: longitude} = stop
+
+      stop
+      |> Map.from_struct()
+      |> Map.drop([:latitude, :longitude, :parent_station_id])
+      |> Map.merge(%{lat: latitude, lon: longitude})
+      |> Jason.Encode.map(opts)
+    end
+  end
 
   @spec parent_station_id(t() | nil) :: id() | nil
   def parent_station_id(nil), do: nil

--- a/lib/schedule/shape_with_stops.ex
+++ b/lib/schedule/shape_with_stops.ex
@@ -18,28 +18,7 @@ defmodule Schedule.ShapeWithStops do
     :stops
   ]
 
-  defimpl Jason.Encoder do
-    def encode(shape_with_stops, opts) do
-      stops_to_encode =
-        shape_with_stops
-        |> Map.get(:stops, [])
-        |> Enum.map(
-          &%{
-            id: &1.id,
-            name: &1.name,
-            lat: &1.latitude,
-            lon: &1.longitude,
-            connections: &1.connections
-          }
-        )
-
-      Jason.Encode.map(
-        %{id: shape_with_stops.id, points: shape_with_stops.points, stops: stops_to_encode},
-        opts
-      )
-    end
-  end
-
+  @derive Jason.Encoder
   defstruct [
     :id,
     points: [],

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -6,7 +6,8 @@ defmodule SkateWeb.StopController do
   Get all stations
   """
   def stations(conn, _params) do
-    stations = Application.get_env(:skate_web, :stations_fn, &Schedule.stations/1)
+    # TODO fix in original PR
+    stations = Application.get_env(:skate_web, :stations_fn, &Schedule.stations/0)
     stations = stations.()
 
     json(conn, %{data: stations})

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -6,7 +6,7 @@ defmodule SkateWeb.StopController do
   Get all stations
   """
   def stations(conn, _params) do
-    stations = Application.get_env(:skate_web, :shapes_fn, &Schedule.stations/1)
+    stations = Application.get_env(:skate_web, :stations_fn, &Schedule.stations/1)
     stations = stations.()
 
     json(conn, %{data: stations})

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -1,0 +1,14 @@
+defmodule SkateWeb.StopController do
+  use SkateWeb, :controller
+
+  @spec stations(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @doc """
+  Get all stations
+  """
+  def stations(conn, _params) do
+    stations = Application.get_env(:skate_web, :shapes_fn, &Schedule.stations/1)
+    stations = stations.()
+
+    json(conn, %{data: stations})
+  end
+end

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -6,9 +6,8 @@ defmodule SkateWeb.StopController do
   Get all stations
   """
   def stations(conn, _params) do
-    # TODO fix in original PR
-    stations = Application.get_env(:skate_web, :stations_fn, &Schedule.stations/0)
-    stations = stations.()
+    stations_fn = Application.get_env(:skate_web, :stations_fn, &Schedule.stations/0)
+    stations = stations_fn.()
 
     json(conn, %{data: stations})
   end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -93,6 +93,7 @@ defmodule SkateWeb.Router do
     get "/routes/:route_id", RouteController, :show
     get "/shapes/route/:route_id", ShapeController, :route
     get "/shapes/trip/:trip_id", ShapeController, :trip
+    get "/stops/stations", StopController, :stations
     get "/shuttles", ShuttleController, :index
     get "/schedule/run", ScheduleController, :run
     get "/schedule/block", ScheduleController, :block

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -631,12 +631,20 @@ defmodule Schedule.DataTest do
   end
 
   describe "stations/1" do
-    stations = [
-      %Stop{id: "station-1", name: "station 1"},
-      %Stop{id: "station-2", name: "station 2"}
-    ]
+    test "returns only stations" do
+      [station_1, station_2] = [
+        %Stop{id: "station-1", name: "station 1", location_type: :station},
+        %Stop{id: "station-2", name: "station 2", location_type: :station}
+      ]
 
-    assert stations == Data.stations(%Data{stations: stations})
+      stops = %{
+        station_1.id => station_1,
+        station_2.id => station_2,
+        "stop-1" => build(:gtfs_stop, %{id: "stop-1", location_type: :stop})
+      }
+
+      assert [station_1, station_2] == Data.stations(%Data{stops: stops})
+    end
   end
 
   describe "first_route_pattern_for_route_and_direction/3" do

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -630,6 +630,15 @@ defmodule Schedule.DataTest do
     end
   end
 
+  describe "stations/1" do
+    stations = [
+      %Stop{id: "station-1", name: "station 1"},
+      %Stop{id: "station-2", name: "station 2"}
+    ]
+
+    assert stations == Data.stations(%Data{stations: stations})
+  end
+
   describe "first_route_pattern_for_route_and_direction/3" do
     setup do
       route_patterns = [

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -633,8 +633,8 @@ defmodule Schedule.DataTest do
   describe "stations/1" do
     test "returns only stations" do
       [station_1, station_2] = [
-        %Stop{id: "station-1", name: "station 1", location_type: :station},
-        %Stop{id: "station-2", name: "station 2", location_type: :station}
+        build(:gtfs_stop, %{id: "station-1", location_type: :station}),
+        build(:gtfs_stop, %{id: "station-2", location_type: :station})
       ]
 
       stops = %{

--- a/test/schedule/gtfs/stop_test.exs
+++ b/test/schedule/gtfs/stop_test.exs
@@ -21,6 +21,47 @@ defmodule Schedule.Gtfs.StopTest do
     "wheelchair_boarding" => "1"
   }
 
+  describe "parse/1" do
+    test "returns only stops and stations" do
+      file =
+        Enum.join(
+          [
+            "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type",
+            "stop-1,No Location Type,1.0,1.5,,",
+            "stop-2,Stop,2.0,2.5,,0",
+            "stop-3,Platform,2.0,2.5,stop-4,0",
+            "stop-4,Station,2.0,2.5,,1",
+            "stop-5,Enterance,2.0,2.5,,2",
+            "stop-6,Generic Node,2.0,2.5,,3",
+            "stop-7,Boarding Area,2.0,2.5,,4"
+          ],
+          "\n"
+        )
+
+      assert [
+               %Stop{
+                 id: "stop-1",
+                 name: "No Location Type",
+                 location_type: :stop,
+                 parent_station_id: nil
+               },
+               %Stop{id: "stop-2", name: "Stop", location_type: :stop, parent_station_id: nil},
+               %Stop{
+                 id: "stop-3",
+                 name: "Platform",
+                 location_type: :stop,
+                 parent_station_id: "stop-4"
+               },
+               %Stop{
+                 id: "stop-4",
+                 name: "Station",
+                 location_type: :station,
+                 parent_station_id: nil
+               }
+             ] = Stop.parse(file)
+    end
+  end
+
   describe "parent_station_id/1" do
     test "returns the parent_station_id if the stop has one" do
       stop = %Stop{
@@ -55,7 +96,7 @@ defmodule Schedule.Gtfs.StopTest do
                parent_station_id: "place-asmnl",
                latitude: 42.330957,
                longitude: -71.082754,
-               location_type: 1
+               location_type: :station
              }
     end
 
@@ -72,7 +113,7 @@ defmodule Schedule.Gtfs.StopTest do
                parent_station_id: nil,
                latitude: nil,
                longitude: nil,
-               location_type: 0
+               location_type: :stop
              }
     end
   end

--- a/test/schedule/gtfs/stop_test.exs
+++ b/test/schedule/gtfs/stop_test.exs
@@ -16,7 +16,7 @@ defmodule Schedule.Gtfs.StopTest do
     "stop_address" => "",
     "stop_url" => "https://www.mbta.com/stops/1",
     "level_id" => "",
-    "location_type" => "0",
+    "location_type" => "1",
     "parent_station" => "place-asmnl",
     "wheelchair_boarding" => "1"
   }
@@ -54,7 +54,8 @@ defmodule Schedule.Gtfs.StopTest do
                name: "Washington St opp Ruggles St",
                parent_station_id: "place-asmnl",
                latitude: 42.330957,
-               longitude: -71.082754
+               longitude: -71.082754,
+               location_type: 1
              }
     end
 
@@ -64,12 +65,14 @@ defmodule Schedule.Gtfs.StopTest do
                |> Map.put("parent_station", "")
                |> Map.put("stop_lat", "")
                |> Map.put("stop_lon", "")
+               |> Map.put("location_type", "")
              ) == %Stop{
                id: "1",
                name: "Washington St opp Ruggles St",
                parent_station_id: nil,
                latitude: nil,
-               longitude: nil
+               longitude: nil,
+               location_type: 0
              }
     end
   end

--- a/test/schedule/gtfs/stop_test.exs
+++ b/test/schedule/gtfs/stop_test.exs
@@ -118,6 +118,16 @@ defmodule Schedule.Gtfs.StopTest do
     end
   end
 
+  describe "is_station?/1" do
+    test "true when location_type is :station" do
+      assert Stop.is_station?(%Stop{id: "stop-1", name: "Station", location_type: :station})
+    end
+
+    test "false when location_type is :stop" do
+      refute Stop.is_station?(%Stop{id: "stop-1", name: "Stop", location_type: :stop})
+    end
+  end
+
   describe "reject_connections_for_route/2" do
     test "only rejects connections with the matching route id " do
       matching_route = %Route{

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -353,6 +353,29 @@ defmodule ScheduleTest do
     end
   end
 
+  describe "stations/1" do
+    test "returns only stations" do
+      pid =
+        Schedule.start_mocked(%{
+          gtfs: %{
+            "stops.txt" => [
+              "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type",
+              "stop-1,No Location Type,1.0,1.5,,",
+              "stop-2,Stop,2.0,2.5,,0",
+              "stop-3,Platform,2.0,2.5,stop-4,0",
+              "stop-4,Station,2.0,2.5,,1",
+              "stop-5,Enterance,2.0,2.5,,2",
+              "stop-6,Generic Node,2.0,2.5,,3",
+              "stop-7,Boarding Area,2.0,2.5,,4"
+            ]
+          }
+        })
+
+      assert [%Stop{id: "stop-4", name: "Station", location_type: :station}] =
+               Schedule.stations(pid)
+    end
+  end
+
   describe "trip" do
     test "returns the trip, including stop_times" do
       pid =

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -325,6 +325,32 @@ defmodule ScheduleTest do
         ]
       } = Schedule.stop("stop1_id", pid)
     end
+
+    test "filters stops that aren't stops or stations" do
+      pid =
+        Schedule.start_mocked(%{
+          gtfs: %{
+            "stops.txt" => [
+              "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type",
+              "stop-1,No Location Type,1.0,1.5,,",
+              "stop-2,Stop,2.0,2.5,,0",
+              "stop-3,Platform,2.0,2.5,stop-4,0",
+              "stop-4,Station,2.0,2.5,,1",
+              "stop-5,Enterance,2.0,2.5,,2",
+              "stop-6,Generic Node,2.0,2.5,,3",
+              "stop-7,Boarding Area,2.0,2.5,,4"
+            ]
+          }
+        })
+
+      assert %Stop{id: "stop-1", location_type: :stop} = Schedule.stop("stop-1", pid)
+      assert %Stop{id: "stop-2", location_type: :stop} = Schedule.stop("stop-2", pid)
+      assert %Stop{id: "stop-3", location_type: :stop} = Schedule.stop("stop-3", pid)
+      assert %Stop{id: "stop-4", location_type: :station} = Schedule.stop("stop-4", pid)
+      refute Schedule.stop("stop-5", pid)
+      refute Schedule.stop("stop-6", pid)
+      refute Schedule.stop("stop-7", pid)
+    end
   end
 
   describe "trip" do

--- a/test/skate_web/controllers/shape_controller_test.exs
+++ b/test/skate_web/controllers/shape_controller_test.exs
@@ -75,6 +75,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "name" => "One",
         "lat" => 42.01,
         "lon" => -71.01,
+        "location_type" => 0,
         "connections" => [
           %{
             "id" => "route_1",
@@ -91,6 +92,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "name" => "Two",
         "lat" => 42.02,
         "lon" => -71.02,
+        "location_type" => 0,
         "connections" => []
       }
     ]

--- a/test/skate_web/controllers/shape_controller_test.exs
+++ b/test/skate_web/controllers/shape_controller_test.exs
@@ -75,7 +75,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "name" => "One",
         "lat" => 42.01,
         "lon" => -71.01,
-        "location_type" => 0,
+        "location_type" => "stop",
         "connections" => [
           %{
             "id" => "route_1",
@@ -92,7 +92,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "name" => "Two",
         "lat" => 42.02,
         "lon" => -71.02,
-        "location_type" => 0,
+        "location_type" => "stop",
         "connections" => []
       }
     ]

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -4,11 +4,11 @@ defmodule SkateWeb.StopControllerTest do
   import Skate.Factory
 
   @stations [
-    build(:gtfs_stop, %{location_type: 1, connections: [build(:gtfs_route)]}),
+    build(:gtfs_stop, %{location_type: :station, connections: [build(:gtfs_route)]}),
     build(:gtfs_stop, %{
       id: "stop2",
       name: "Stop 2",
-      location_type: 1
+      location_type: :station
     })
   ]
   describe "GET /api/stops/stations" do
@@ -41,7 +41,7 @@ defmodule SkateWeb.StopControllerTest do
                    ],
                    "id" => "stop1",
                    "lat" => 42.01,
-                   "location_type" => 1,
+                   "location_type" => "station",
                    "lon" => -71.01,
                    "name" => "Stop 1"
                  },
@@ -49,7 +49,7 @@ defmodule SkateWeb.StopControllerTest do
                    "connections" => [],
                    "id" => "stop2",
                    "lat" => 42.01,
-                   "location_type" => 1,
+                   "location_type" => "station",
                    "lon" => -71.01,
                    "name" => "Stop 2"
                  }

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -1,0 +1,60 @@
+defmodule SkateWeb.StopControllerTest do
+  use SkateWeb.ConnCase
+  import Test.Support.Helpers
+  import Skate.Factory
+
+  @stations [
+    build(:gtfs_stop, %{location_type: 1, connections: [build(:gtfs_route)]}),
+    build(:gtfs_stop, %{
+      id: "stop2",
+      name: "Stop 2",
+      location_type: 1
+    })
+  ]
+  describe "GET /api/stops/stations" do
+    setup do
+      reassign_env(:skate_web, :stations_fn, fn -> @stations end)
+    end
+
+    test "when logged out, redirects you to cognito auth", %{conn: conn} do
+      conn = get(conn, SkateWeb.Router.Helpers.stop_path(conn, :stations))
+
+      assert redirected_to(conn) == "/auth/cognito"
+    end
+
+    @tag :authenticated
+    test "when logged in, returns all stations", %{conn: conn} do
+      conn = get(conn, SkateWeb.Router.Helpers.stop_path(conn, :stations))
+
+      assert %{
+               "data" => [
+                 %{
+                   "connections" => [
+                     %{
+                       "description" => "Key Bus",
+                       "direction_names" => %{"0" => "Outbound", "1" => "Inbound"},
+                       "garages" => [],
+                       "id" => "route",
+                       "type" => 3,
+                       "name" => "Point A - Point B"
+                     }
+                   ],
+                   "id" => "stop1",
+                   "lat" => 42.01,
+                   "location_type" => 1,
+                   "lon" => -71.01,
+                   "name" => "Stop 1"
+                 },
+                 %{
+                   "connections" => [],
+                   "id" => "stop2",
+                   "lat" => 42.01,
+                   "location_type" => 1,
+                   "lon" => -71.01,
+                   "name" => "Stop 2"
+                 }
+               ]
+             } == json_response(conn, 200)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -114,7 +114,7 @@ defmodule Skate.Factory do
     %Schedule.Gtfs.Stop{
       id: "stop1",
       name: "Stop 1",
-      location_type: 0,
+      location_type: :stop,
       latitude: 42.01,
       longitude: -71.01
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -110,6 +110,16 @@ defmodule Skate.Factory do
     }
   end
 
+  def gtfs_stop_factory do
+    %Schedule.Gtfs.Stop{
+      id: "stop1",
+      name: "Stop 1",
+      location_type: 0,
+      latitude: 42.01,
+      longitude: -71.01
+    }
+  end
+
   def gtfs_route_factory do
     %Schedule.Gtfs.Route{
       id: "route",


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203442408293386/f

This PR includes setting the `location_type` field on stops when parsing from GTFS and adding a new StopController for getting all stops where the `location_type` is `:station`.

To be used on the FE for adding stations to the map, see https://github.com/mbta/skate/pull/1872