### PR TITLE
fix: do not display adherence info for shuttles

### DIFF
--- a/assets/src/components/scheduleAdherence.tsx
+++ b/assets/src/components/scheduleAdherence.tsx
@@ -1,12 +1,13 @@
 import React, { ComponentPropsWithoutRef, useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { className as classNames } from "../helpers/dom"
+import { isVehicle } from "../models/vehicle"
 import {
   drawnStatus,
   humanReadableScheduleAdherence,
   statusClasses,
 } from "../models/vehicleStatus"
-import { Vehicle } from "../realtime"
+import { Vehicle, VehicleOrGhost } from "../realtime"
 import { secondsToMinutes } from "../util/dateTime"
 
 const ScheduleAdherenceStatusIcon = () => (
@@ -59,7 +60,7 @@ const ScheduleAdherenceMetric = ({
 
 export interface ScheduleAdherenceProps
   extends ComponentPropsWithoutRef<"output"> {
-  vehicle: Vehicle
+  vehicle: VehicleOrGhost
   title?: string
 }
 
@@ -77,16 +78,20 @@ export const ScheduleAdherence = ({
   ])
   return (
     <output aria-label={title ?? "Schedule Adherence"} className={classes}>
-      <ScheduleAdherenceStatusIcon />
-      <ScheduleAdherenceDescription
-        vehicle={vehicle}
-        className="label font-xs-semi title-case"
-      />
-      &nbsp;
-      <ScheduleAdherenceMetric
-        vehicle={vehicle}
-        className="label font-xs-reg"
-      />
+      {isVehicle(vehicle) && !vehicle.isShuttle && (
+        <>
+          <ScheduleAdherenceStatusIcon />
+          <ScheduleAdherenceDescription
+            vehicle={vehicle}
+            className="label font-xs-semi title-case"
+          />
+          &nbsp;
+          <ScheduleAdherenceMetric
+            vehicle={vehicle}
+            className="label font-xs-reg"
+          />
+        </>
+      )}
     </output>
   )
 }

--- a/assets/src/components/vehicleRouteSummary.tsx
+++ b/assets/src/components/vehicleRouteSummary.tsx
@@ -87,7 +87,7 @@ export const VehicleRouteSummary = ({
       className="m-vehicle-route-summary__route-variant headsign font-m-semi"
     />
 
-    {isVehicle(vehicle) && (
+    {isVehicle(vehicle) && !vehicle.isShuttle && (
       <ScheduleAdherence
         vehicle={vehicle}
         title="Vehicle Schedule Adherence"

--- a/assets/src/components/vehicleRouteSummary.tsx
+++ b/assets/src/components/vehicleRouteSummary.tsx
@@ -4,7 +4,7 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import vehicleLabel from "../helpers/vehicleLabel"
 import { emptyLadderDirectionsByRouteId } from "../models/ladderDirection"
 import { currentRouteTab } from "../models/routeTab"
-import { directionName, isVehicle } from "../models/vehicle"
+import { directionName } from "../models/vehicle"
 import { drawnStatus } from "../models/vehicleStatus"
 import { VehicleOrGhost } from "../realtime"
 import { RouteVariantName } from "./routeVariantName"
@@ -87,13 +87,11 @@ export const VehicleRouteSummary = ({
       className="m-vehicle-route-summary__route-variant headsign font-m-semi"
     />
 
-    {isVehicle(vehicle) && !vehicle.isShuttle && (
-      <ScheduleAdherence
-        vehicle={vehicle}
-        title="Vehicle Schedule Adherence"
-        className="m-vehicle-route-summary__adherence label font-xs-reg"
-      />
-    )}
+    <ScheduleAdherence
+      vehicle={vehicle}
+      title="Vehicle Schedule Adherence"
+      className="m-vehicle-route-summary__adherence label font-xs-reg"
+    />
 
     <VehicleStatusIcon
       vehicle={vehicle}

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -12,8 +12,9 @@ import { TrainVehicle, Vehicle } from "../../src/realtime"
 import { ByRouteId, Shape } from "../../src/schedule"
 import { initialState } from "../../src/state"
 import * as dateTime from "../../src/util/dateTime"
-import vehicleFactory from "../factories/vehicle"
+import { shuttleFactory } from "../factories/vehicle"
 import userEvent from "@testing-library/user-event"
+import shapeFactory from "../factories/shape"
 
 jest
   .spyOn(dateTime, "now")
@@ -46,51 +47,12 @@ afterAll(() => {
   global.scrollTo = originalScrollTo
 })
 
-const shuttle: Vehicle = vehicleFactory.build({
-  id: "y1818",
-  label: "1818",
-  runId: "999-0555",
-  timestamp: 1557160307,
-  latitude: 0,
-  longitude: 0,
-  directionId: 0,
-  routeId: "1",
-  tripId: "39914237",
-  headsign: "h1",
-  viaVariant: "4",
-  operatorId: "op1",
-  operatorFirstName: "PATTI",
-  operatorLastName: "SMITH",
-  operatorLogonTime: new Date("2018-08-15T13:38:21.000Z"),
-  bearing: 33,
-  blockId: "block-1",
-  previousVehicleId: "v2",
-  scheduleAdherenceSecs: 0,
-  isShuttle: true,
-  isOverload: false,
-  isOffCourse: false,
-  isRevenue: true,
-  layoverDepartureTime: null,
-  dataDiscrepancies: [],
-  stopStatus: {
-    stopId: "57",
-    stopName: "57",
-  },
-  timepointStatus: {
-    fractionUntilTimepoint: 0.5,
-    timepointId: "MATPN",
-  },
-  scheduledLocation: null,
-  routeStatus: "on_route",
-  endOfTripType: "another_trip",
-  blockWaivers: [],
-  crowding: null,
-})
+const shuttle: Vehicle = shuttleFactory.build({ label: "1818" })
 
-const shape: Shape = {
-  id: "shape",
+const shape: Shape = shapeFactory.build({
   points: [],
-}
+  stops: [],
+})
 
 describe("Shuttle Map Page", () => {
   test("renders", () => {

--- a/assets/tests/components/vehiclePropertiesCard.test.tsx
+++ b/assets/tests/components/vehiclePropertiesCard.test.tsx
@@ -2,13 +2,14 @@ import React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import * as dateTime from "../../src/util/dateTime"
-import vehicleFactory from "../factories/vehicle"
+import vehicleFactory, { shuttleFactory } from "../factories/vehicle"
 import routeFactory from "../factories/route"
 
 import userEvent from "@testing-library/user-event"
 import VehiclePropertiesCard from "../../src/components/vehiclePropertiesCard"
 import { useNearestIntersection } from "../../src/hooks/useNearestIntersection"
 import { RoutesProvider } from "../../src/contexts/routesContext"
+import { VehicleRouteSummary } from "../../src/components/vehicleRouteSummary"
 
 jest.mock("../../src/hooks/useNearestIntersection", () => ({
   __esModule: true,
@@ -193,6 +194,27 @@ describe("<VehiclePropertiesCard/>", () => {
       expect(
         screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
       ).toHaveTextContent(/invalid/i)
+
+      // Use correct icon // TODO: make accessible and ensure icon is correct
+      expect(
+        screen.getByRole("img", { name: /vehicle status icon/i })
+      ).toBeVisible()
+    })
+
+    test("vehicle is shuttle, should render shuttle text and no route or adherence info", () => {
+      const vehicle = shuttleFactory.build()
+
+      render(<VehicleRouteSummary vehicle={vehicle} />)
+
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent("Shuttle")
+      expect(
+        screen.getByRole("status", { name: /Route Direction/i })
+      ).toBeEmptyDOMElement()
+      expect(
+        screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
+      ).toBeEmptyDOMElement()
 
       // Use correct icon // TODO: make accessible and ensure icon is correct
       expect(

--- a/assets/tests/components/vehicleRouteSummary.test.tsx
+++ b/assets/tests/components/vehicleRouteSummary.test.tsx
@@ -1,0 +1,133 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import React from "react"
+
+import { VehicleRouteSummary } from "../../src/components/vehicleRouteSummary"
+import { RoutesProvider } from "../../src/contexts/routesContext"
+import ghostFactory from "../factories/ghost"
+import routeFactory from "../factories/route"
+import vehicleFactory, {
+  invalidVehicleFactory,
+  shuttleFactory,
+} from "../factories/vehicle"
+
+describe("<VehicleRouteSummary />", () => {
+  describe("when rendering", () => {
+    test("a valid vehicle on route, should render direction, route variant, headsign, adherence information, and icon", () => {
+      const route = routeFactory.build()
+      const vehicle = vehicleFactory.build({ routeId: route.id })
+
+      render(
+        <RoutesProvider routes={[route]}>
+          <VehicleRouteSummary vehicle={vehicle} />
+        </RoutesProvider>
+      )
+
+      expect(
+        screen.getByRole("status", { name: "Route Direction" })
+      ).toHaveTextContent(/outbound/i)
+
+      const routeVariantName = screen.getByRole("status", {
+        name: "Route Variant Name",
+      })
+      expect(routeVariantName).toHaveTextContent(route.name)
+      expect(routeVariantName).toHaveTextContent(vehicle.viaVariant!)
+      expect(routeVariantName).toHaveTextContent(vehicle.headsign!)
+
+      expect(
+        screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
+      ).toHaveTextContent(/on time \(0 min early\)/i)
+
+      expect(
+        screen.getByRole("img", { name: /vehicle status icon/i })
+      ).toBeVisible()
+    })
+
+    test("a shuttle, should show shuttle text, and should not show route or adherence info", () => {
+      const route = routeFactory.build()
+      const vehicle = shuttleFactory.build()
+
+      render(
+        <RoutesProvider routes={[route]}>
+          <VehicleRouteSummary vehicle={vehicle} />
+        </RoutesProvider>
+      )
+
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent("Shuttle")
+
+      expect(
+        screen.getByRole("status", { name: /Route Direction/i })
+      ).toBeEmptyDOMElement()
+      expect(
+        screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
+      ).toBeEmptyDOMElement()
+
+      expect(
+        screen.getByRole("img", { name: /vehicle status icon/i })
+      ).toBeVisible()
+    })
+
+    test("an off course vehicle, should show invalid in adherence info", () => {
+      const route = routeFactory.build()
+      const vehicle = invalidVehicleFactory.build({ routeId: route.id })
+
+      render(
+        <RoutesProvider routes={[route]}>
+          <VehicleRouteSummary vehicle={vehicle} />
+        </RoutesProvider>
+      )
+
+      // Show `invalid` in Adherence Info
+      expect(
+        screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
+      ).toHaveTextContent(/invalid/i)
+
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent(route.name)
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent(vehicle.headsign!)
+
+      expect(
+        screen.getByRole("status", { name: /Route Direction/i })
+      ).toHaveTextContent(/outbound/i)
+
+      expect(
+        screen.getByRole("img", { name: /vehicle status icon/i })
+      ).toBeVisible()
+    })
+
+    test("a ghost bus, should show direction and route variant name, should not show adherence", () => {
+      const route = routeFactory.build()
+      const ghost = ghostFactory.build({ routeId: route.id })
+
+      render(
+        <RoutesProvider routes={[route]}>
+          <VehicleRouteSummary vehicle={ghost} />
+        </RoutesProvider>
+      )
+
+      expect(
+        screen.getByRole("status", { name: /Vehicle Schedule Adherence/i })
+      ).toBeEmptyDOMElement()
+
+      expect(
+        screen.getByRole("img", { name: /vehicle status icon/i })
+      ).toHaveTextContent("N/A")
+
+      expect(
+        screen.getByRole("status", { name: /Route Direction/i })
+      ).toHaveTextContent(/outbound/i)
+
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent(route.name)
+      expect(
+        screen.getByRole("status", { name: /Route Variant Name/i })
+      ).toHaveTextContent(ghost.headsign!)
+    })
+  })
+})

--- a/assets/tests/factories/ghost.ts
+++ b/assets/tests/factories/ghost.ts
@@ -1,7 +1,7 @@
 import { Factory } from "fishery"
 import { Ghost } from "../../src/realtime"
 
-export default Factory.define<Ghost>(({ sequence }) => ({
+const ghostFactory = Factory.define<Ghost>(({ sequence }) => ({
   id: `ghost-trip-${sequence}`,
   directionId: 0,
   routeId: "1",
@@ -22,3 +22,4 @@ export default Factory.define<Ghost>(({ sequence }) => ({
   currentPieceStartPlace: "garage",
   currentPieceFirstRoute: "route",
 }))
+export default ghostFactory

--- a/assets/tests/factories/vehicle.ts
+++ b/assets/tests/factories/vehicle.ts
@@ -6,7 +6,7 @@ import {
   buslocDataDiscrepancySourceFactory,
 } from "./dataDiscrepancy"
 
-export default Factory.define<Vehicle>(({ sequence }) => ({
+const vehicleFactory = Factory.define<Vehicle>(({ sequence }) => ({
   id: `v${sequence}`,
   label: `v${sequence}-label`,
   runId: `run-${sequence}`,
@@ -76,3 +76,21 @@ export default Factory.define<Vehicle>(({ sequence }) => ({
   blockWaivers: [],
   crowding: null,
 }))
+
+export default vehicleFactory
+
+export const shuttleFactory = vehicleFactory.params({
+  isShuttle: true,
+
+  runId: "999-0555",
+  tripId: "BL-10987654321",
+  routeId: "Shuttle-Generic",
+
+  crowding: null,
+
+  dataDiscrepancies: [],
+})
+
+export const invalidVehicleFactory = vehicleFactory.params({
+  isOffCourse: true,
+})


### PR DESCRIPTION
# Summary
This slipped through #1873 

This is the simplest fix for this, but I think this logic should be pushed down further into the components used so that they can be used in more contexts. 
So looking for thoughts on if it's worth perusing allowing `ScheduleAdherence` to handle `Ghosts` and `Shuttles` by returning `null` to disable rendering instead of handling that within `VehicleRouteSummary`.

I kinda feel that the `output` element returned by `VehicleRouteSummary` should always be returned (and this thought currently applies to sub elements which create elements in the accessibility tree) and the text content within the accessibility nodes should be removed instead.

---

Related: #1873 
Asana Ticket: https://app.asana.com/0/1200180014510248/1203502925530262/f