### PR TITLE
refactor(ts/components/map): separate Autocenterer from map to allow configuration through composition

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -300,10 +300,12 @@ interface AutoCenterMapOnProps {
   setShouldAutoCenter: Dispatch<SetStateAction<boolean>>
 }
 
-const AutoCenterMapOn = (props: AutoCenterMapOnProps) => {
-  const { shouldAutoCenter, setShouldAutoCenter, isAutoCentering, latLngs } =
-    props
-
+const AutoCenterMapOn = ({
+  shouldAutoCenter,
+  setShouldAutoCenter,
+  isAutoCentering,
+  latLngs,
+}: AutoCenterMapOnProps) => {
   useMapEvents({
     // If the user drags or zooms, they want manual control of the map.
 

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -311,7 +311,7 @@ const Autocenterer = ({
   return <></>
 }
 
-const Map = (props: Props): ReactElement<HTMLDivElement> => {
+const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
   const mapRef: MutableRefObject<LeafletMap | null> =
     // this prop is only for tests, and is consistent between renders, so the hook call is consistent
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -430,4 +430,5 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
   )
 }
 
+const Map = BaseMap
 export default Map

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -244,7 +244,7 @@ export const autoCenter = (
   }
 }
 
-const Autocenterer = ({
+const AutoCenter = ({
   latLngs,
   shouldAutoCenter,
   isAutoCentering,
@@ -282,7 +282,7 @@ const Autocenterer = ({
   return <></>
 }
 
-const useCenterOnState = () => {
+const useAutoCenterState = () => {
   const [shouldAutoCenter, setShouldAutoCenter] = useState<boolean>(true)
   const isAutoCentering: MutableRefObject<boolean> = useRef(false)
 
@@ -293,14 +293,14 @@ const useCenterOnState = () => {
   }
 }
 
-interface CenterMapOnProps {
+interface AutoCenterMapOnProps {
   latLngs: LatLng[]
   isAutoCentering: MutableRefObject<boolean>
   shouldAutoCenter: boolean
   setShouldAutoCenter: Dispatch<SetStateAction<boolean>>
 }
 
-const CenterMapOn = (props: CenterMapOnProps) => {
+const AutoCenterMapOn = (props: AutoCenterMapOnProps) => {
   const { shouldAutoCenter, setShouldAutoCenter, isAutoCentering, latLngs } =
     props
 
@@ -337,7 +337,7 @@ const CenterMapOn = (props: CenterMapOnProps) => {
 
   return (
     <>
-      <Autocenterer
+      <AutoCenter
         shouldAutoCenter={shouldAutoCenter}
         isAutoCentering={isAutoCentering}
         latLngs={latLngs}
@@ -454,14 +454,14 @@ const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
   )
 }
 
-const AutoCenteringMap = (props: Props): ReactElement<HTMLDivElement> => {
-  const state = useCenterOnState(),
+const AutoCenteringMap = (props: Props) => {
+  const state = useAutoCenterState(),
     { shouldAutoCenter } = state
 
   const latLngs: LatLng[] = props.vehicles.map(({ latitude, longitude }) =>
     Leaflet.latLng(latitude, longitude)
   )
-  const centerOnProps: CenterMapOnProps = {
+  const centerOnProps: AutoCenterMapOnProps = {
     ...state,
     latLngs,
   }
@@ -474,7 +474,7 @@ const AutoCenteringMap = (props: Props): ReactElement<HTMLDivElement> => {
       }
     >
       <>
-        <CenterMapOn {...centerOnProps} />
+        <AutoCenterMapOn {...centerOnProps} />
         {props.children}
       </>
     </BaseMap>

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -178,23 +178,6 @@ export const FullscreenControl = createControlComponent(
   Leaflet.control.fullscreen
 )
 
-export const autoCenter = (
-  map: LeafletMap,
-  latLngs: LatLngExpression[],
-  pickerContainerIsVisible: boolean
-): void => {
-  if (latLngs.length === 0) {
-    map.setView(defaultCenter, 13)
-  } else if (latLngs.length === 1) {
-    map.setView(latLngs[0], 16)
-  } else if (latLngs.length > 1) {
-    map.fitBounds(Leaflet.latLngBounds(latLngs), {
-      paddingBottomRight: [20, 50],
-      paddingTopLeft: [pickerContainerIsVisible ? 220 : 20, 20],
-    })
-  }
-}
-
 const tilesetUrl = (): string => appData()?.tilesetUrl || ""
 
 const EventAdder = ({
@@ -273,6 +256,24 @@ const EventAdder = ({
   return <></>
 }
 
+// #region Auto Center Functionality
+export const autoCenter = (
+  map: LeafletMap,
+  latLngs: LatLngExpression[],
+  pickerContainerIsVisible: boolean
+): void => {
+  if (latLngs.length === 0) {
+    map.setView(defaultCenter, 13)
+  } else if (latLngs.length === 1) {
+    map.setView(latLngs[0], 16)
+  } else if (latLngs.length > 1) {
+    map.fitBounds(Leaflet.latLngBounds(latLngs), {
+      paddingBottomRight: [20, 50],
+      paddingTopLeft: [pickerContainerIsVisible ? 220 : 20, 20],
+    })
+  }
+}
+
 const Autocenterer = ({
   latLngs,
   shouldAutoCenter,
@@ -310,6 +311,7 @@ const Autocenterer = ({
 
   return <></>
 }
+// #endregion
 
 const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
   const mapRef: MutableRefObject<LeafletMap | null> =


### PR DESCRIPTION
This does an initial refactor to <Map/> needed to be able to have a separate implementation and more control over the autocentering function needed to complete the asana ticket.
Looking for feedback related to feasibility and if this seems like the right direction to go in to allow autocenterer to be wielded with more specificity.

This does not change any functionality of the autocenterer or the map and does it's best to preserve existing tests and features. Tests have been used to ensure that functionality remains the same as it did before this PR so that it may be iterated on in the future.

If I were to spend more time on this, I would convert the RecenterButton control to be a `input[checkbox] role=switch` and change tests to use `toBeChecked()` instead of the existing tests which test for if a class is present on the map status classes div.

---

Asana Ticket: https://app.asana.com/0/1203014709808707/1203641439240315