### PR TITLE
chore: update AWS cert bundle sha256sum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /root
 
 RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     -o aws-cert-bundle.pem
-RUN echo "976de749e16140c2e91e2ea1daa508ef716be5decafbb9f0f77087abc879487b  aws-cert-bundle.pem" | sha256sum -c -
+RUN echo "fefac91d6800404461cece76724bc0a2383f4f556a1c9beb0813fac6f2e1e49f  aws-cert-bundle.pem" | sha256sum -c -
 
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static


### PR DESCRIPTION
No ticket, just a quick update to get deploys working again.