### PR TITLE
fix(ts/components/mapPage): ghost card implementation and fixes

### DIFF
--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -72,7 +72,7 @@
   .m-vehicle-route-summary__separator {
     justify-self: center;
     align-self: center;
-    height: 80%;
+    height: 100%;
     background-color: $color-gray-300;
     width: 1px;
   }

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -38,6 +38,7 @@
     justify-self: end;
   }
 
+  .m-vehicle-route-summary__icon,
   .m-vehicle-route-summary__separator {
     justify-self: center;
     align-self: center;

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -2,7 +2,7 @@
 // #region Layout
 .m-vehicle-route-summary {
   display: grid;
-  grid-template-rows: 1fr 2fr;
+  grid-template-rows: 3fr 8fr;
   grid-template-columns: min-content 1fr 6fr 12fr;
   grid-template-areas:
     "icon separator direction  adherence"

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -8,7 +8,7 @@
     "icon separator direction  adherence"
     "icon separator route-name route-name";
 
-  align-items: center; // center element vertically within cell
+  align-items: start; // align element vertically within cell
   justify-items: start; // align element horizontally within the cell
 
   // assign element grid locations
@@ -57,9 +57,7 @@
   }
 
   // route variant name should not move when text gets longer
-  // so also align
   .m-route-variant-name {
-    align-self: start;
 
     --line-height: 1.5;
     line-height: var(--line-height);

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -38,13 +38,15 @@
     justify-self: end;
   }
 
-  .m-schedule-adherence * {
-    display: inline-block;
-  }
-
   .m-vehicle-route-summary__separator {
     justify-self: center;
     align-self: center;
+  }
+
+  .m-schedule-adherence {
+    & > * {
+      display: inline-block;
+    }
   }
 
   // route variant name should not move when text gets longer

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -55,7 +55,7 @@
   .m-route-variant-name {
     align-self: start;
 
-    --line-height: 1.25;
+    --line-height: 1.5;
     line-height: var(--line-height);
     max-height: calc(var(--line-height) * 2em);
     height: 100%;

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -38,6 +38,12 @@
     justify-self: end;
   }
 
+  // Adherence and direction should hug the top of the container
+  .m-schedule-adherence,
+  .m-vehicle-route-direction {
+    line-height: 1;
+  }
+
   .m-vehicle-route-summary__icon,
   .m-vehicle-route-summary__separator {
     justify-self: center;

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -11,7 +11,7 @@
   align-items: start; // align element vertically within cell
   justify-items: start; // align element horizontally within the cell
 
-  // assign element grid locations
+  // #region element grid locations
   .m-vehicle-route-summary__icon {
     grid-area: icon;
   }
@@ -31,17 +31,12 @@
   .m-route-variant-name {
     grid-area: route-name;
   }
+  // #endregion
 
-  // Bespoke alignment within cells
-  // adherence sticks to the right side of the card
+  // #region Bespoke alignment within cells
+  // adherence should stick to the right side of the card
   .m-schedule-adherence {
     justify-self: end;
-  }
-
-  // Adherence and direction should hug the top of the container
-  .m-schedule-adherence,
-  .m-vehicle-route-direction {
-    line-height: 1;
   }
 
   .m-vehicle-route-summary__icon,
@@ -50,6 +45,14 @@
     align-self: center;
   }
 
+  // Adherence and direction should hug the top of the container
+  .m-schedule-adherence,
+  .m-vehicle-route-direction {
+    line-height: 1;
+  }
+  // #endregion
+
+  // #region component layout
   .m-schedule-adherence {
     & > * {
       display: inline-block;
@@ -58,12 +61,13 @@
 
   // route variant name should not move when text gets longer
   .m-route-variant-name {
+    // Fill grid container
+    height: 100%;
+    width: 100%;
 
     --line-height: 1.5;
     line-height: var(--line-height);
     max-height: calc(var(--line-height) * 2em);
-    height: 100%;
-    width: 100%;
 
     text-overflow: ellipsis; // doesn't work on multiline text
     overflow: hidden;

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -285,7 +285,7 @@ const MapDisplay = ({
           <>
             {showVpc && (
               <VehiclePropertiesCard
-                vehicle={selectedVehicleOrGhost}
+                vehicleOrGhost={selectedVehicleOrGhost}
                 onClose={deleteSelection}
               />
             )}

--- a/assets/src/components/vehiclePropertiesCard.tsx
+++ b/assets/src/components/vehiclePropertiesCard.tsx
@@ -91,13 +91,11 @@ const VehicleWorkInfo = ({ vehicle }: VehicleProp): React.ReactElement => (
         <TrNameValue name="run">{vehicle.runId ?? "N/A"}</TrNameValue>
         <TrNameValue name="vehicle">{vehicle.label ?? "N/A"}</TrNameValue>
         <TrNameValue name="operator" sensitivity={HideSensitiveInfo.All}>
-          <span className="title-case">
-            {joinTruthy([
-              vehicle.operatorFirstName,
-              vehicle.operatorLastName,
-              vehicle.operatorId && `#${vehicle.operatorId}`,
-            ]).toLowerCase() || "N/A"}
-          </span>
+          {joinTruthy([
+            vehicle.operatorFirstName,
+            vehicle.operatorLastName,
+            vehicle.operatorId && `#${vehicle.operatorId}`,
+          ]) || "N/A"}
         </TrNameValue>
       </tbody>
     </table>

--- a/assets/src/components/vehiclePropertiesCard.tsx
+++ b/assets/src/components/vehiclePropertiesCard.tsx
@@ -25,18 +25,18 @@ const DataStaleTime = ({
   timestamp: number
 }): React.ReactElement => {
   const epochNowInSeconds = useCurrentTimeSeconds()
-  return (
-    <output
-      aria-label="Time Since Last Update Received"
-      className="data-stale-time label font-xs-reg"
-    >
-      Updated {epochNowInSeconds - timestamp} sec ago
-    </output>
-  )
+  return <>Updated {epochNowInSeconds - timestamp} sec ago</>
 }
 
-const VehicleDataStaleTime = ({ vehicle }: VehicleProp): React.ReactElement => (
-  <DataStaleTime timestamp={vehicle.timestamp} />
+const VehicleDataStaleTime = ({
+  vehicle,
+}: VehicleProp): React.ReactElement => (
+  <output
+    aria-label="Time Since Last Update Received"
+    className="data-stale-time label font-xs-reg"
+  >
+    <DataStaleTime timestamp={vehicle.timestamp} />
+  </output>
 )
 // #endregion
 

--- a/assets/src/components/vehiclePropertiesCard.tsx
+++ b/assets/src/components/vehiclePropertiesCard.tsx
@@ -10,9 +10,7 @@ import { useNearestIntersection } from "../hooks/useNearestIntersection"
 import { isGhost, isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleOrGhost } from "../realtime"
 import { CloseButton } from "./closeButton"
-import StreetViewButton, {
-  GeographicCoordinateBearing,
-} from "./streetViewButton"
+import StreetViewButton from "./streetViewButton"
 import { VehicleRouteSummary } from "./vehicleRouteSummary"
 
 interface VehicleProp {
@@ -149,6 +147,14 @@ const VehicleNearestIntersection = ({
   )
 }
 
+const VehicleLocationStreetViewButton = ({ vehicle }: { vehicle: Vehicle }) => (
+  <StreetViewButton
+    aria-label="Go to Street View"
+    latitude={vehicle.latitude}
+    longitude={vehicle.longitude}
+    bearing={vehicle.bearing}
+  />
+)
 // #endregion
 
 // #region Vehicle Properties Card
@@ -200,10 +206,9 @@ const VehiclePropertiesCard = ({
         hidden={isGhost(vehicle)}
       >
         <VehicleNearestIntersection vehicle={vehicle} />
-        <StreetViewButton
-          aria-label="Go to Street View"
-          {...(vehicle as GeographicCoordinateBearing)}
-        />
+        {isVehicle(vehicle) && (
+          <VehicleLocationStreetViewButton vehicle={vehicle} />
+        )}
       </div>
     </div>
   </div>

--- a/assets/src/components/vehiclePropertiesCard.tsx
+++ b/assets/src/components/vehiclePropertiesCard.tsx
@@ -17,7 +17,7 @@ interface VehicleProp {
   vehicle: Vehicle
 }
 interface VehicleOrGhostProp {
-  vehicle: VehicleOrGhost
+  vehicleOrGhost: VehicleOrGhost
 }
 
 // #region Card Title Bar
@@ -31,14 +31,14 @@ const DataStaleTime = ({
 }
 
 const VehicleDataStaleTime = ({
-  vehicle,
+  vehicleOrGhost,
 }: VehicleOrGhostProp): React.ReactElement => (
   <output
     aria-label="Time Since Last Update Received"
     className="data-stale-time label font-xs-reg"
   >
-    {isVehicle(vehicle) ? (
-      <DataStaleTime timestamp={vehicle.timestamp} />
+    {isVehicle(vehicleOrGhost) ? (
+      <DataStaleTime timestamp={vehicleOrGhost.timestamp} />
     ) : (
       <>Ghost bus or dropped trip</>
     )}
@@ -91,21 +91,21 @@ const TrNameValue = ({
 }
 
 const VehicleWorkInfo = ({
-  vehicle,
+  vehicleOrGhost,
 }: VehicleOrGhostProp): React.ReactElement => (
   <>
     <table className="m-vehicle-work-info">
       <tbody className="m-vehicle-work-info__items">
-        <TrNameValue name="run">{vehicle.runId || "N/A"}</TrNameValue>
+        <TrNameValue name="run">{vehicleOrGhost.runId || "N/A"}</TrNameValue>
         <TrNameValue name="vehicle">
-          {(isVehicle(vehicle) && vehicle.label) || "N/A"}
+          {(isVehicle(vehicleOrGhost) && vehicleOrGhost.label) || "N/A"}
         </TrNameValue>
         <TrNameValue name="operator" sensitivity={HideSensitiveInfo.All}>
-          {(isVehicle(vehicle) &&
+          {(isVehicle(vehicleOrGhost) &&
             joinTruthy([
-              vehicle.operatorFirstName,
-              vehicle.operatorLastName,
-              vehicle.operatorId && `#${vehicle.operatorId}`,
+              vehicleOrGhost.operatorFirstName,
+              vehicleOrGhost.operatorLastName,
+              vehicleOrGhost.operatorId && `#${vehicleOrGhost.operatorId}`,
             ])) ||
             "N/A"}
         </TrNameValue>
@@ -125,7 +125,7 @@ const CurrentLocation = ({ vehicle }: VehicleProp): React.ReactElement => {
 }
 
 const VehicleNearestIntersection = ({
-  vehicle,
+  vehicleOrGhost,
 }: VehicleOrGhostProp): React.ReactElement => {
   const id = `current-location-${useId()}`
   return (
@@ -137,8 +137,8 @@ const VehicleNearestIntersection = ({
         Current Location
       </label>
       <output className="m-current-location__value label font-s-semi" id={id}>
-        {isVehicle(vehicle) ? (
-          <CurrentLocation vehicle={vehicle} />
+        {isVehicle(vehicleOrGhost) ? (
+          <CurrentLocation vehicle={vehicleOrGhost} />
         ) : (
           "Exact location cannot be determined"
         )}
@@ -172,7 +172,7 @@ const keepUserInputFromLeaflet: ComponentPropsWithoutRef<"div"> = {
 // #endregion
 
 const VehiclePropertiesCard = ({
-  vehicle,
+  vehicleOrGhost,
   onClose,
 }: VehicleOrGhostProp & {
   onClose: () => void
@@ -189,25 +189,25 @@ const VehiclePropertiesCard = ({
         aria-label="Close Vehicle Properties Card"
       />
 
-      <VehicleDataStaleTime vehicle={vehicle} />
+      <VehicleDataStaleTime vehicleOrGhost={vehicleOrGhost} />
     </div>
 
     <div className="m-vehicle-properties-card__summary">
-      <VehicleRouteSummary vehicle={vehicle} />
+      <VehicleRouteSummary vehicle={vehicleOrGhost} />
     </div>
 
     <div className="m-vehicle-properties-card__body">
       <div className="m-vehicle-properties-card__properties m-info-section">
-        <VehicleWorkInfo vehicle={vehicle} />
+        <VehicleWorkInfo vehicleOrGhost={vehicleOrGhost} />
       </div>
 
       <div
         className="m-vehicle-properties-card__location-info m-info-section"
-        hidden={isGhost(vehicle)}
+        hidden={isGhost(vehicleOrGhost)}
       >
-        <VehicleNearestIntersection vehicle={vehicle} />
-        {isVehicle(vehicle) && (
-          <VehicleLocationStreetViewButton vehicle={vehicle} />
+        <VehicleNearestIntersection vehicleOrGhost={vehicleOrGhost} />
+        {isVehicle(vehicleOrGhost) && (
+          <VehicleLocationStreetViewButton vehicle={vehicleOrGhost} />
         )}
       </div>
     </div>

--- a/assets/src/components/vehicleRouteSummary.tsx
+++ b/assets/src/components/vehicleRouteSummary.tsx
@@ -10,7 +10,7 @@ import { VehicleOrGhost } from "../realtime"
 import { RouteVariantName } from "./routeVariantName"
 import { ScheduleAdherence } from "./scheduleAdherence"
 import { Size, VehicleIcon, vehicleOrientation } from "./vehicleIcon"
-// import { VehicleProp } from "./vehiclePropertiesCard";
+
 interface VehicleOrGhostProp {
   vehicle: VehicleOrGhost
 }

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1299,11 +1299,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                       aria-labelledby="operator:r5:"
                       class="kv-value font-s-reg fs-mask"
                     >
-                      <span
-                        class="title-case"
-                      >
-                        will smith #op1
-                      </span>
+                      WILL SMITH #op1
                     </td>
                   </tr>
                 </tbody>

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -843,15 +843,15 @@ describe("<MapPage />", () => {
       describe("selection is a ghost", () => {
         test("the map should be unpopulated and centered on default location", () => {
           const changeApplicationState = jest.fn()
-          const vehicle = ghostFactory.build()
-          mockUseVehicleForId([vehicle])
-          mockUseVehiclesForRouteMap({ [vehicle.routeId!]: [vehicle] })
+          const ghost = ghostFactory.build()
+          mockUseVehicleForId([ghost])
+          mockUseVehiclesForRouteMap({ [ghost.routeId!]: [ghost] })
 
           render(
             <StateDispatchProvider
               state={stateFactory.build({
                 searchPageState: {
-                  selectedVehicleId: vehicle.id,
+                  selectedVehicleId: ghost.id,
                 },
               })}
               dispatch={changeApplicationState}
@@ -863,6 +863,7 @@ describe("<MapPage />", () => {
           expect(
             screen.queryAllByRole("button", { name: /^run/ })
           ).toHaveLength(0)
+          expect(getVehiclePropertiesCard()).toBeVisible()
           expect(changeApplicationState).not.toBeCalled()
         })
       })

--- a/assets/tests/components/vehiclePropertiesCard.test.tsx
+++ b/assets/tests/components/vehiclePropertiesCard.test.tsx
@@ -24,7 +24,7 @@ describe("<VehiclePropertiesCard/>", () => {
       const onClose = jest.fn()
       render(
         <VehiclePropertiesCard
-          vehicle={vehicleFactory.build()}
+          vehicleOrGhost={vehicleFactory.build()}
           onClose={onClose}
         />
       )
@@ -43,7 +43,7 @@ describe("<VehiclePropertiesCard/>", () => {
         .mockReturnValueOnce(intersection2)
 
       const { rerender } = render(
-        <VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />
+        <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
       )
       const locationElement = screen.getByRole("status", {
         name: "Current Location",
@@ -51,7 +51,9 @@ describe("<VehiclePropertiesCard/>", () => {
 
       expect(locationElement).toHaveTextContent(intersection)
 
-      rerender(<VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />)
+      rerender(
+        <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
+      )
 
       expect(locationElement).toHaveTextContent(intersection2)
     })
@@ -60,7 +62,7 @@ describe("<VehiclePropertiesCard/>", () => {
       const [vehicle, vehicle2] = vehicleFactory.buildList(2)
 
       const { rerender } = render(
-        <VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />
+        <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
       )
       const runCell = screen.getByRole("cell", { name: /run/i })
       const vehicleCell = screen.getByRole("cell", { name: /vehicle/i })
@@ -68,7 +70,9 @@ describe("<VehiclePropertiesCard/>", () => {
       expect(runCell).toHaveTextContent(vehicle.runId!)
       expect(vehicleCell).toHaveTextContent(vehicle.label)
 
-      rerender(<VehiclePropertiesCard vehicle={vehicle2} onClose={jest.fn()} />)
+      rerender(
+        <VehiclePropertiesCard vehicleOrGhost={vehicle2} onClose={jest.fn()} />
+      )
 
       expect(vehicleCell).toHaveTextContent(vehicle2.label)
       expect(runCell).toHaveTextContent(vehicle2.runId!)
@@ -94,7 +98,10 @@ describe("<VehiclePropertiesCard/>", () => {
 
         render(
           <RoutesProvider routes={[route]}>
-            <VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />
+            <VehiclePropertiesCard
+              vehicleOrGhost={vehicle}
+              onClose={jest.fn()}
+            />
           </RoutesProvider>
         )
 
@@ -156,7 +163,9 @@ describe("<VehiclePropertiesCard/>", () => {
         const vehicle = vehicleFactory.build()
         ;(useNearestIntersection as jest.Mock).mockReturnValueOnce(null)
 
-        render(<VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />)
+        render(
+          <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
+        )
 
         expect(
           screen.getByRole("status", { name: "Current Location" })
@@ -170,7 +179,9 @@ describe("<VehiclePropertiesCard/>", () => {
           .mockReturnValueOnce(undefined)
           .mockReturnValueOnce(intersection)
 
-        render(<VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />)
+        render(
+          <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
+        )
         const currentLocation = screen.getByRole("status", {
           name: "Current Location",
         })
@@ -190,7 +201,9 @@ describe("<VehiclePropertiesCard/>", () => {
     test("vehicle is off course, should render invalid bus design", () => {
       const vehicle = vehicleFactory.build({ isOffCourse: true })
 
-      render(<VehiclePropertiesCard vehicle={vehicle} onClose={jest.fn()} />)
+      render(
+        <VehiclePropertiesCard vehicleOrGhost={vehicle} onClose={jest.fn()} />
+      )
 
       // Show `invalid` in Adherence Info
       expect(
@@ -244,7 +257,7 @@ describe("<VehiclePropertiesCard/>", () => {
 
       render(
         <RoutesProvider routes={[route]}>
-          <VehiclePropertiesCard vehicle={ghost} onClose={jest.fn()} />
+          <VehiclePropertiesCard vehicleOrGhost={ghost} onClose={jest.fn()} />
         </RoutesProvider>
       )
 

--- a/assets/tests/components/vehiclePropertiesCard.test.tsx
+++ b/assets/tests/components/vehiclePropertiesCard.test.tsx
@@ -297,8 +297,8 @@ describe("<VehiclePropertiesCard/>", () => {
         screen.getByRole("status", { name: "Current Location", hidden: true })
       ).not.toBeVisible()
       expect(
-        screen.getByRole("link", { name: /street view/i, hidden: true })
-      ).not.toBeVisible()
+        screen.queryByRole("link", { name: /street view/i, hidden: true })
+      ).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
This does the final work allowing the VPC to also handle ghost types. Additionally, there were a few easy style changes that I ran by design and added as well. 

I see the biggest issue being around where to put type boundaries for components. I felt it was best to have a component handle as many relevant types as possible (within reason) until a final verdict is reached where only a single type can pass. 
This is why the current location component can accept a `VehicleOrGhost` argument, despite always returning the same string for a ghost, this is made type safe by the component which is used which can only display a location if the type is a `Vehicle`.

---

Asana Ticket: https://app.asana.com/0/1200180014510248/1203641819945189/f