### PR TITLE
Disable views on search map

### DIFF
--- a/assets/css/nav/_left_nav.scss
+++ b/assets/css/nav/_left_nav.scss
@@ -123,7 +123,7 @@
     }
   }
 
-  &:disabled {
+  &.m-left-nav__view--disabled {
     cursor: not-allowed;
     background-color: $color-gray-300;
     color: $color-gray-500;

--- a/assets/css/nav/_left_nav.scss
+++ b/assets/css/nav/_left_nav.scss
@@ -123,6 +123,13 @@
     }
   }
 
+  &:disabled {
+    cursor: not-allowed;
+    background-color: $color-gray-300;
+    color: $color-gray-500;
+    font-weight: var(--font-weight-reg);
+  }
+
   .m-left-nav__icon {
     svg {
       fill: $color-gray-50;

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -30,9 +30,8 @@ import { mapModeForUser } from "../util/mapMode"
 export const AppRoutes = () => {
   useAppcues()
 
-  const [
-    { pickerContainerIsVisible, openView, routeTabs, selectedVehicleOrGhost },
-  ] = useContext(StateDispatchContext)
+  const [{ openView, routeTabs, selectedVehicleOrGhost }] =
+    useContext(StateDispatchContext)
 
   const { socket }: { socket: Socket | undefined } = useContext(SocketContext)
 
@@ -56,8 +55,6 @@ export const AppRoutes = () => {
       <VehiclesByRouteIdProvider vehiclesByRouteId={vehiclesByRouteId}>
         <div className="m-app__main">
           <Nav
-            pickerContainerIsVisible={pickerContainerIsVisible}
-            openView={openView}
             allowViews={
               location.pathname !== mapMode.path || mapMode.supportsRightPanel
             }

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -58,6 +58,9 @@ export const AppRoutes = () => {
           <Nav
             pickerContainerIsVisible={pickerContainerIsVisible}
             openView={openView}
+            allowViews={
+              location.pathname !== mapMode.path || mapMode.supportsRightPanel
+            }
           >
             <Routes>
               <Route

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -19,7 +19,7 @@ import useVehiclesForRoute from "../hooks/useVehiclesForRoute"
 import { filterVehicles, isGhost, isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleId, VehicleOrGhost } from "../realtime"
 import { RouteId } from "../schedule"
-import { closeView } from "../state"
+import { closeView, OpenView } from "../state"
 import { SearchPageState, setSelectedVehicle } from "../state/searchPageState"
 import DrawerTab from "./drawerTab"
 import {
@@ -320,13 +320,16 @@ const MapDisplay = ({
 // #endregion
 
 const MapPage = (): ReactElement<HTMLDivElement> => {
-  const [{ searchPageState, mobileMenuIsOpen }, dispatch] =
+  const [{ searchPageState, mobileMenuIsOpen, openView }, dispatch] =
       useContext(StateDispatchContext),
     { selectedVehicleId = null } = searchPageState
 
   useEffect(() => {
-    dispatch(closeView())
-  }, [dispatch])
+    // don't dispatch closeView if the VPP is open
+    if (openView !== OpenView.None) {
+      dispatch(closeView())
+    }
+  }, [dispatch, openView])
 
   // #region Search Drawer Logic
   const [searchOpen, setSearchOpen] = useState<boolean>(

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -19,6 +19,7 @@ import useVehiclesForRoute from "../hooks/useVehiclesForRoute"
 import { filterVehicles, isGhost, isVehicle } from "../models/vehicle"
 import { Vehicle, VehicleId, VehicleOrGhost } from "../realtime"
 import { RouteId } from "../schedule"
+import { closeView } from "../state"
 import { SearchPageState, setSelectedVehicle } from "../state/searchPageState"
 import DrawerTab from "./drawerTab"
 import {
@@ -322,6 +323,10 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   const [{ searchPageState, mobileMenuIsOpen }, dispatch] =
       useContext(StateDispatchContext),
     { selectedVehicleId = null } = searchPageState
+
+  useEffect(() => {
+    dispatch(closeView())
+  }, [dispatch])
 
   // #region Search Drawer Logic
   const [searchOpen, setSearchOpen] = useState<boolean>(

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react"
-import { OpenView, toggleMobileMenu } from "../state"
+import { toggleMobileMenu } from "../state"
 import appData from "../appData"
 import useScreenSize from "../hooks/useScreenSize"
 import LeftNav from "./nav/leftNav"
@@ -9,8 +9,6 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 
 interface Props {
   children?: React.ReactNode
-  pickerContainerIsVisible: boolean
-  openView: OpenView
   allowViews: boolean
 }
 

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -11,6 +11,7 @@ interface Props {
   children?: React.ReactNode
   pickerContainerIsVisible: boolean
   openView: OpenView
+  allowViews: boolean
 }
 
 const Nav: React.FC<Props> = ({ children }) => {

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -12,7 +12,7 @@ interface Props {
   allowViews: boolean
 }
 
-const Nav: React.FC<Props> = ({ children }) => {
+const Nav: React.FC<Props> = ({ children, allowViews }) => {
   const [, dispatch] = useContext(StateDispatchContext)
   const deviceType = useScreenSize()
 
@@ -28,6 +28,7 @@ const Nav: React.FC<Props> = ({ children }) => {
               defaultToCollapsed={true}
               dispatcherFlag={readDispatcherFlag()}
               closePickerOnViewOpen={true}
+              allowViews={allowViews}
             />
           </div>
           <div className="m-nav__app-content">{children}</div>
@@ -41,6 +42,7 @@ const Nav: React.FC<Props> = ({ children }) => {
               toggleMobileMenu={() => dispatch(toggleMobileMenu())}
               defaultToCollapsed={true}
               dispatcherFlag={readDispatcherFlag()}
+              allowViews={allowViews}
             />
           </div>
           <div className="m-nav__app-content">{children}</div>
@@ -56,6 +58,7 @@ const Nav: React.FC<Props> = ({ children }) => {
             <LeftNav
               defaultToCollapsed={false}
               dispatcherFlag={readDispatcherFlag()}
+              allowViews={allowViews}
             />
           </div>
           <div className="m-nav__app-content">{children}</div>

--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../state"
 import NavMenu from "./navMenu"
 import { mapModeForUser } from "../../util/mapMode"
+import Tippy from "@tippyjs/react"
 
 interface Props {
   toggleMobileMenu?: () => void
@@ -249,20 +250,31 @@ const ViewToggle = ({
   collapsed: boolean
   disabled?: boolean
 }): JSX.Element => {
-  return (
+  const buttonContent = (
     <button
       className={
         "m-left-nav__link m-left-nav__view" +
-        (viewIsOpen ? " m-left-nav__view--active" : "")
+        (viewIsOpen ? " m-left-nav__view--active" : "") +
+        (disabled ? " m-left-nav__view--disabled" : "")
       }
       onClick={toggleView}
       title={name}
-      disabled={disabled}
+      aria-disabled={disabled}
     >
       {icon}
       {collapsed ? null : name}
     </button>
   )
+
+  if (disabled) {
+    return (
+      <Tippy content="Not available in Search Map" placement="right">
+        {buttonContent}
+      </Tippy>
+    )
+  }
+
+  return buttonContent
 }
 
 export default LeftNav

--- a/assets/src/components/nav/leftNav.tsx
+++ b/assets/src/components/nav/leftNav.tsx
@@ -32,6 +32,7 @@ interface Props {
   toggleMobileMenu?: () => void
   defaultToCollapsed: boolean
   dispatcherFlag: boolean
+  allowViews: boolean
   closePickerOnViewOpen?: boolean
 }
 
@@ -39,6 +40,7 @@ const LeftNav = ({
   toggleMobileMenu,
   defaultToCollapsed,
   dispatcherFlag,
+  allowViews,
   closePickerOnViewOpen,
 }: Props): JSX.Element => {
   const [{ openView, mobileMenuIsOpen, pickerContainerIsVisible }, dispatch] =
@@ -134,6 +136,7 @@ const LeftNav = ({
                   }
                 }}
                 collapsed={collapsed}
+                disabled={!allowViews}
               />
             </li>
           ) : null}
@@ -153,6 +156,7 @@ const LeftNav = ({
                 }
               }}
               collapsed={collapsed}
+              disabled={!allowViews}
             />
           </li>
           <li>
@@ -170,6 +174,7 @@ const LeftNav = ({
               }}
               name="Notifications"
               collapsed={collapsed}
+              disabled={!allowViews}
             />
           </li>
         </ul>
@@ -235,12 +240,14 @@ const ViewToggle = ({
   viewIsOpen,
   toggleView,
   collapsed,
+  disabled,
 }: {
   icon: JSX.Element
   name: string
   viewIsOpen: boolean
   toggleView: () => void
   collapsed: boolean
+  disabled?: boolean
 }): JSX.Element => {
   return (
     <button
@@ -250,6 +257,7 @@ const ViewToggle = ({
       }
       onClick={toggleView}
       title={name}
+      disabled={disabled}
     >
       {icon}
       {collapsed ? null : name}

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`App renders 1`] = `
                 </li>
                 <li>
                   <button
+                    aria-disabled="false"
                     class="m-left-nav__link m-left-nav__view"
                     title="Swings View"
                   >
@@ -122,6 +123,7 @@ exports[`App renders 1`] = `
                 </li>
                 <li>
                   <button
+                    aria-disabled="false"
                     class="m-left-nav__link m-left-nav__view"
                     title="Notifications"
                   >

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -109,6 +109,7 @@ exports[`renders 1`] = `
                 </li>
                 <li>
                   <button
+                    aria-disabled="false"
                     class="m-left-nav__link m-left-nav__view"
                     title="Swings View"
                   >
@@ -122,6 +123,7 @@ exports[`renders 1`] = `
                 </li>
                 <li>
                   <button
+                    aria-disabled="false"
                     class="m-left-nav__link m-left-nav__view"
                     title="Notifications"
                   >

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -13,6 +13,7 @@ import vehicleFactory from "../factories/vehicle"
 import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
 import getTestGroups from "../../src/userTestGroups"
 import { MemoryRouter } from "react-router-dom"
+import appData from "../../src/appData"
 
 jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
@@ -22,11 +23,17 @@ jest.mock("../../src/hooks/useVehicles", () => ({
   __esModule: true,
   default: jest.fn(),
 }))
-
 jest.mock("userTestGroups", () => ({
   __esModule: true,
   default: jest.fn(() => []),
 }))
+jest.mock("../../src/appData", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    userSettings: JSON.stringify({}),
+  })),
+}))
+
 describe("App", () => {
   test("renders", () => {
     const result = render(<App />)
@@ -179,6 +186,25 @@ describe("App", () => {
         screen.queryByRole("heading", { name: expectedPanelTitle })
       ).not.toBeInTheDocument()
     })
+  })
+
+  test("disables view nav entries on search map page", () => {
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(appData as jest.Mock).mockImplementationOnce(() => {
+      return {
+        dispatcherFlag: "true",
+      }
+    })
+
+    render(
+      <MemoryRouter initialEntries={["/map"]}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole("button", { name: "Late View" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Swings View" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Notifications" })).toBeDisabled()
   })
 
   test("renders old search page for users not in map test group", () => {

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -202,9 +202,17 @@ describe("App", () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByRole("button", { name: "Late View" })).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Swings View" })).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Notifications" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Late View" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Swings View" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(
+      screen.getByRole("button", { name: "Notifications" })
+    ).toHaveAttribute("aria-disabled", "true")
   })
 
   test("renders old search page for users not in map test group", () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -38,7 +38,7 @@ import routeFactory from "../factories/route"
 import { RealDispatchWrapper } from "../testHelpers/wrappers"
 import { VehicleId, VehicleOrGhost } from "../../src/realtime"
 import { RouteId, Shape, TripId } from "../../src/schedule"
-import { closeView } from "../../src/state"
+import { closeView, OpenView } from "../../src/state"
 
 jest.mock("../../src/hooks/useSearchResults", () => ({
   __esModule: true,
@@ -194,12 +194,31 @@ describe("<MapPage />", () => {
     const dispatch = jest.fn()
 
     render(
-      <StateDispatchProvider state={stateFactory.build()} dispatch={dispatch}>
+      <StateDispatchProvider
+        state={stateFactory.build({ openView: OpenView.Swings })}
+        dispatch={dispatch}
+      >
         <MapPage />
       </StateDispatchProvider>
     )
 
     expect(dispatch).toHaveBeenCalledWith(closeView())
+  })
+
+  test("doesn't close VPP if open", () => {
+    const selectedVehicle = vehicleFactory.build()
+    const dispatch = jest.fn()
+
+    render(
+      <StateDispatchProvider
+        state={stateFactory.build({ selectedVehicleOrGhost: selectedVehicle })}
+        dispatch={dispatch}
+      >
+        <MapPage />
+      </StateDispatchProvider>
+    )
+
+    expect(dispatch).not.toHaveBeenCalledWith(closeView())
   })
 
   test("renders stations on zoom", async () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -38,6 +38,7 @@ import routeFactory from "../factories/route"
 import { RealDispatchWrapper } from "../testHelpers/wrappers"
 import { VehicleId, VehicleOrGhost } from "../../src/realtime"
 import { RouteId, Shape, TripId } from "../../src/schedule"
+import { closeView } from "../../src/state"
 
 jest.mock("../../src/hooks/useSearchResults", () => ({
   __esModule: true,
@@ -187,6 +188,18 @@ describe("<MapPage />", () => {
 
       expect(asFragment()).toMatchSnapshot()
     })
+  })
+
+  test("closes any open views on page render", () => {
+    const dispatch = jest.fn()
+
+    render(
+      <StateDispatchProvider state={stateFactory.build()} dispatch={dispatch}>
+        <MapPage />
+      </StateDispatchProvider>
+    )
+
+    expect(dispatch).toHaveBeenCalledWith(closeView())
   })
 
   test("renders stations on zoom", async () => {
@@ -598,7 +611,6 @@ describe("<MapPage />", () => {
         expect(
           screen.queryAllByRole("button", { name: /^vehicle #/ })
         ).toHaveLength(0)
-        expect(changeApplicationState).not.toBeCalled()
       })
     })
 
@@ -633,7 +645,6 @@ describe("<MapPage />", () => {
         expect(screen.queryAllByRole("button", { name: /^run/ })).toHaveLength(
           0
         )
-        expect(changeApplicationState).not.toBeCalled()
       })
 
       test("when a search is made, the map should be unpopulated until search result is selected", async () => {
@@ -746,7 +757,6 @@ describe("<MapPage />", () => {
           expect(
             screen.getAllByRole("button", { name: selectedVehicle.runId! })
           ).toHaveLength(selectedRouteVehicles.length)
-          expect(changeApplicationState).not.toBeCalled()
         })
 
         describe("and vehicle is a regular bus", () => {
@@ -789,8 +799,6 @@ describe("<MapPage />", () => {
             expect(
               container.querySelector(".m-vehicle-map__route-shape")
             ).toBeInTheDocument()
-
-            expect(changeApplicationState).not.toHaveBeenCalled()
           })
         })
 
@@ -835,8 +843,6 @@ describe("<MapPage />", () => {
               name: /route variant name/i,
             })
           ).toHaveTextContent("Shuttle")
-
-          expect(changeApplicationState).not.toHaveBeenCalled()
         })
       })
 
@@ -864,7 +870,6 @@ describe("<MapPage />", () => {
             screen.queryAllByRole("button", { name: /^run/ })
           ).toHaveLength(0)
           expect(getVehiclePropertiesCard()).toBeVisible()
-          expect(changeApplicationState).not.toBeCalled()
         })
       })
     })

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 
 import Nav from "../../src/components/nav"
-import { OpenView } from "../../src/state"
 import useScreenSize from "../../src/hooks/useScreenSize"
 import getTestGroups from "../../src/userTestGroups"
 import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
@@ -29,13 +28,7 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav
-          pickerContainerIsVisible={true}
-          openView={OpenView.None}
-          allowViews={true}
-        >
-          Hello, world!
-        </Nav>
+        <Nav allowViews={true}>Hello, world!</Nav>
       </BrowserRouter>
     )
 
@@ -50,13 +43,7 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav
-          pickerContainerIsVisible={true}
-          openView={OpenView.None}
-          allowViews={true}
-        >
-          Hello, world!
-        </Nav>
+        <Nav allowViews={true}>Hello, world!</Nav>
       </BrowserRouter>
     )
 
@@ -69,13 +56,7 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav
-          pickerContainerIsVisible={true}
-          openView={OpenView.None}
-          allowViews={true}
-        >
-          Hello, world!
-        </Nav>
+        <Nav allowViews={true}>Hello, world!</Nav>
       </BrowserRouter>
     )
 
@@ -88,13 +69,7 @@ describe("Nav", () => {
 
     render(
       <BrowserRouter>
-        <Nav
-          pickerContainerIsVisible={true}
-          openView={OpenView.None}
-          allowViews={true}
-        >
-          Hello, world!
-        </Nav>
+        <Nav allowViews={true}>Hello, world!</Nav>
       </BrowserRouter>
     )
 
@@ -105,13 +80,7 @@ describe("Nav", () => {
   test("renders desktop nav content", () => {
     const result = render(
       <BrowserRouter>
-        <Nav
-          pickerContainerIsVisible={true}
-          openView={OpenView.None}
-          allowViews={true}
-        >
-          Hello, world!
-        </Nav>
+        <Nav allowViews={true}>Hello, world!</Nav>
       </BrowserRouter>
     )
 

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -29,7 +29,11 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+        <Nav
+          pickerContainerIsVisible={true}
+          openView={OpenView.None}
+          allowViews={true}
+        >
           Hello, world!
         </Nav>
       </BrowserRouter>
@@ -46,7 +50,11 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+        <Nav
+          pickerContainerIsVisible={true}
+          openView={OpenView.None}
+          allowViews={true}
+        >
           Hello, world!
         </Nav>
       </BrowserRouter>
@@ -61,7 +69,11 @@ describe("Nav", () => {
 
     const result = render(
       <BrowserRouter>
-        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+        <Nav
+          pickerContainerIsVisible={true}
+          openView={OpenView.None}
+          allowViews={true}
+        >
           Hello, world!
         </Nav>
       </BrowserRouter>
@@ -76,7 +88,11 @@ describe("Nav", () => {
 
     render(
       <BrowserRouter>
-        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+        <Nav
+          pickerContainerIsVisible={true}
+          openView={OpenView.None}
+          allowViews={true}
+        >
           Hello, world!
         </Nav>
       </BrowserRouter>
@@ -89,7 +105,11 @@ describe("Nav", () => {
   test("renders desktop nav content", () => {
     const result = render(
       <BrowserRouter>
-        <Nav pickerContainerIsVisible={true} openView={OpenView.None}>
+        <Nav
+          pickerContainerIsVisible={true}
+          openView={OpenView.None}
+          allowViews={true}
+        >
           Hello, world!
         </Nav>
       </BrowserRouter>

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -42,7 +42,11 @@ describe("LeftNav", () => {
   test("renders non-collapsed state", () => {
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={false} dispatcherFlag={true} />
+        <LeftNav
+          defaultToCollapsed={false}
+          dispatcherFlag={true}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -60,7 +64,11 @@ describe("LeftNav", () => {
   test("renders collapsed state", () => {
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={true} dispatcherFlag={true} />
+        <LeftNav
+          defaultToCollapsed={true}
+          dispatcherFlag={true}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -89,7 +97,11 @@ describe("LeftNav", () => {
 
     render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={true} dispatcherFlag={true} />
+        <LeftNav
+          defaultToCollapsed={true}
+          dispatcherFlag={true}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -106,6 +118,7 @@ describe("LeftNav", () => {
           toggleMobileMenu={toggleMobileMenu}
           defaultToCollapsed={false}
           dispatcherFlag={false}
+          allowViews={true}
         />
       </BrowserRouter>
     )
@@ -119,7 +132,11 @@ describe("LeftNav", () => {
     const user = userEvent.setup()
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+        <LeftNav
+          defaultToCollapsed={false}
+          dispatcherFlag={false}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -135,7 +152,11 @@ describe("LeftNav", () => {
   test("does not render late view option when dispatcher flag is false", () => {
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+        <LeftNav
+          defaultToCollapsed={false}
+          dispatcherFlag={false}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -148,7 +169,11 @@ describe("LeftNav", () => {
     const result = render(
       <StateDispatchProvider state={initialState} dispatch={dispatch}>
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={true} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={true}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -172,6 +197,7 @@ describe("LeftNav", () => {
             defaultToCollapsed={true}
             dispatcherFlag={true}
             closePickerOnViewOpen={true}
+            allowViews={true}
           />
         </BrowserRouter>
       </StateDispatchProvider>
@@ -188,7 +214,11 @@ describe("LeftNav", () => {
     const result = render(
       <StateDispatchProvider state={initialState} dispatch={dispatch}>
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={false}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -212,6 +242,7 @@ describe("LeftNav", () => {
             defaultToCollapsed={true}
             dispatcherFlag={true}
             closePickerOnViewOpen={true}
+            allowViews={true}
           />
         </BrowserRouter>
       </StateDispatchProvider>
@@ -230,7 +261,11 @@ describe("LeftNav", () => {
         dispatch={dispatch}
       >
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={true} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={true}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -244,7 +279,11 @@ describe("LeftNav", () => {
     const user = userEvent.setup()
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+        <LeftNav
+          defaultToCollapsed={false}
+          dispatcherFlag={false}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -257,7 +296,11 @@ describe("LeftNav", () => {
     const user = userEvent.setup()
     const result = render(
       <BrowserRouter>
-        <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+        <LeftNav
+          defaultToCollapsed={false}
+          dispatcherFlag={false}
+          allowViews={true}
+        />
       </BrowserRouter>
     )
 
@@ -272,7 +315,11 @@ describe("LeftNav", () => {
     const result = render(
       <StateDispatchProvider state={initialState} dispatch={dispatch}>
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={false}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -296,6 +343,7 @@ describe("LeftNav", () => {
             defaultToCollapsed={true}
             dispatcherFlag={true}
             closePickerOnViewOpen={true}
+            allowViews={true}
           />
         </BrowserRouter>
       </StateDispatchProvider>
@@ -314,7 +362,11 @@ describe("LeftNav", () => {
         dispatch={dispatch}
       >
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={false}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -332,7 +384,11 @@ describe("LeftNav", () => {
         dispatch={dispatch}
       >
         <BrowserRouter>
-          <LeftNav defaultToCollapsed={false} dispatcherFlag={false} />
+          <LeftNav
+            defaultToCollapsed={false}
+            dispatcherFlag={false}
+            allowViews={true}
+          />
         </BrowserRouter>
       </StateDispatchProvider>
     )
@@ -340,5 +396,21 @@ describe("LeftNav", () => {
     expect(result.getByTitle("Notifications").children[0]).not.toHaveClass(
       "m-left-nav__icon--notifications-view--active"
     )
+  })
+
+  test("views are disabled when allowViews prop is set to false", () => {
+    render(
+      <BrowserRouter>
+        <LeftNav
+          defaultToCollapsed={true}
+          dispatcherFlag={true}
+          allowViews={false}
+        />
+      </BrowserRouter>
+    )
+
+    expect(screen.getByRole("button", { name: "Late View" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Swings View" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Notifications" })).toBeDisabled()
   })
 })

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -409,8 +409,16 @@ describe("LeftNav", () => {
       </BrowserRouter>
     )
 
-    expect(screen.getByRole("button", { name: "Late View" })).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Swings View" })).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Notifications" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Late View" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(screen.getByRole("button", { name: "Swings View" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+    expect(
+      screen.getByRole("button", { name: "Notifications" })
+    ).toHaveAttribute("aria-disabled", "true")
   })
 })


### PR DESCRIPTION
Asana ticket: [⚙️ Better Maps | Disabled Left Nav View Buttons](https://app.asana.com/0/1200180014510248/1203641819945181/f)

This should address all of the acceptance criteria aside from the tooltip. The issue with the tooltip is that, if we set `disabled` on the button, the various events that might trigger the tooltip, like mousing over it, don't fire. It would probably be possible to work around this somehow, for instance by not actually using the `disabled` attribute, that would result in less standard HTML and presumably break web conventions. We'll revisit this and decide whether it's worth somehow including. A couple of other minor things:

1. I may revisit some of the styling of the SVG icons themselves in the disabled state based on design feedback.
2. After discussion on Slack we agreed to disable the notifications drawer in addition to swings view and late view.
3. One of the acceptance criteria is to disable notifications on the map page, but it looks like we already don't render the `Notifications` component there, so it should be taken care of.
4. For closing the open view when going to the map page, I opted to fire a dispatch to the state reducer inside of a `useEffect` hook from the page component. This is perhaps the part that I'm technically least sure about, so I'm open to feedback on better ways to do it.