### PR TITLE
feat(map-stops): tap targets selection state and style+size updates

### DIFF
--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -139,7 +139,7 @@ $color-line-gapped: #00c6ed;
 $color-line-gapped-light: #75e8ff;
 
 $color-stop-fill: $white;
-$color-stop-stroke: $black;
+$color-stop-stroke: $color-gray-700;
 
 $color-tooltip-background: #333333;
 

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -79,12 +79,27 @@
 .m-vehicle-map__stop {
   fill: $color-stop-fill;
   fill-opacity: 1;
-  stroke: $color-stop-stroke;
-  stroke-width: 1;
-}
 
-.m-vehicle-map__stop:focus {
-  outline: 0;
+  stroke: $color-stop-stroke;
+  stroke-width: 2px;
+
+  &:hover {
+    stroke-width: 4px;
+  }
+
+  &:focus {
+    stroke-width: 4px;
+    box-shadow: 0px 0px 0px 1px #514f55;
+    filter: drop-shadow(0 0 2px #514f55);
+    outline: 0;
+  }
+
+  &.selected {
+    stroke-width: 4px;
+
+    fill: $color-eggplant-200;
+    stroke: $color-eggplant-700;
+  }
 }
 
 .leaflet-tooltip.m-vehicle-map__mobile-friendly-tooltip {

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -89,7 +89,6 @@
 
   &:focus {
     stroke-width: 4px;
-    box-shadow: 0px 0px 0px 1px #514f55;
     filter: drop-shadow(0 0 2px #514f55);
     outline: 0;
   }

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -26,6 +26,7 @@ import ReactDOM from "react-dom"
 import {
   AttributionControl,
   MapContainer,
+  Pane,
   TileLayer,
   useMap,
   useMapEvents,
@@ -431,18 +432,33 @@ export const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
           url={`${tilesetUrl()}/{z}/{x}/{y}.png`}
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         />
-        {props.vehicles.map((vehicle: Vehicle) => (
-          <VehicleMarker
-            key={vehicle.id}
-            vehicle={vehicle}
-            isPrimary={true}
-            isSelected={props.selectedVehicleId === vehicle.id}
-            onSelect={props.onPrimaryVehicleSelect}
-          />
-        ))}
-        {(props.secondaryVehicles || []).map((vehicle: Vehicle) => (
-          <VehicleMarker key={vehicle.id} vehicle={vehicle} isPrimary={false} />
-        ))}
+
+        <Pane name="primaryVehicles" pane="markerPane" style={{ zIndex: 499 }}>
+          {props.vehicles.map((vehicle: Vehicle) => (
+            <VehicleMarker
+              key={vehicle.id}
+              vehicle={vehicle}
+              isPrimary={true}
+              isSelected={props.selectedVehicleId === vehicle.id}
+              onSelect={props.onPrimaryVehicleSelect}
+            />
+          ))}
+        </Pane>
+
+        <Pane
+          name="secondaryVehicles"
+          pane="markerPane"
+          style={{ zIndex: 400 }}
+        >
+          {(props.secondaryVehicles || []).map((vehicle: Vehicle) => (
+            <VehicleMarker
+              key={vehicle.id}
+              vehicle={vehicle}
+              isPrimary={false}
+            />
+          ))}
+        </Pane>
+
         {(props.trainVehicles || []).map((trainVehicle: TrainVehicle) => (
           <TrainVehicleMarker
             key={trainVehicle.id}
@@ -457,24 +473,37 @@ export const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
           {(zoomLevel) => (
             <>
               {stops.length > 0 && (
-                <RouteStopMarkers
-                  stops={stops}
-                  zoomLevel={zoomLevel}
-                  direction={props.stopCardDirection}
-                  includeStopCard={
-                    props.includeStopCard && inTestGroup(MAP_BETA_GROUP_NAME)
-                  }
-                />
-              )}
-              {zoomLevel >= 15 &&
-                props.stations?.map((station) => (
-                  <StationMarker
-                    key={station.id}
-                    station={station}
+                <Pane
+                  name="routeStopMarkers"
+                  pane="markerPane"
+                  style={{ zIndex: 450 }} // should be above other non-interactive elements
+                >
+                  <RouteStopMarkers
+                    stops={stops}
                     zoomLevel={zoomLevel}
+                    direction={props.stopCardDirection}
+                    includeStopCard={
+                      props.includeStopCard && inTestGroup(MAP_BETA_GROUP_NAME)
+                    }
                   />
-                ))}
-              {zoomLevel >= 15 && <GarageMarkers zoomLevel={zoomLevel} />}
+                </Pane>
+              )}
+
+              <Pane
+                name="notableLocationMarkers"
+                pane="markerPane"
+                style={{ zIndex: 410 }}
+              >
+                {zoomLevel >= 15 &&
+                  props.stations?.map((station) => (
+                    <StationMarker
+                      key={station.id}
+                      station={station}
+                      zoomLevel={zoomLevel}
+                    />
+                  ))}
+                {zoomLevel >= 15 && <GarageMarkers zoomLevel={zoomLevel} />}
+              </Pane>
             </>
           )}
         </ZoomLevelWrapper>

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -3,7 +3,7 @@ import Leaflet, {
   LatLngExpression,
 } from "leaflet"
 import "leaflet-defaulticon-compatibility" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
-import React, { useContext, useEffect, useRef, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { CircleMarker, Marker, Polyline, Popup, Tooltip } from "react-leaflet"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { className } from "../helpers/dom"
@@ -240,18 +240,25 @@ export const StopIcon = ({
   selected = false,
   ...props
 }: StopIconProps) => {
-  const ref = useRef<null | LeafletCircleMarker>(null)
-  const element = ref.current?.getElement()
+  const [marker, setMarker] = useState<null | LeafletCircleMarker>(null)
+
   useEffect(() => {
-    if (element) {
-      element.classList.toggle("selected", selected)
+    if (marker == null) {
+      return
     }
-  }, [selected, element])
+
+    const element = marker.getElement()
+    if (!element) {
+      return
+    }
+
+    element.classList.toggle("selected", selected)
+  }, [selected, marker])
 
   return (
     <CircleMarker
       {...props}
-      ref={ref}
+      ref={setMarker}
       className={className(["m-vehicle-map__stop"])}
       center={[stop.lat, stop.lon]}
       radius={radius}

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -117,7 +117,12 @@ export const VehicleMarker = ({
     userSettings,
     isSelected
   )
-  const zIndexOffset = (isPrimary ? 2000 : 0) + (isSelected ? 100 : 0)
+
+  // https://leafletjs.com/reference.html#marker-zindexoffset
+  // > By default, marker images zIndex is set automatically based on its latitude
+  // > [...] if you want to put the marker on top of all others,
+  // > [specify] a high value like 1000 [...]
+  const zIndexOffset = isSelected ? 1000 : 0
   return (
     <>
       <Marker

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -203,6 +203,7 @@ const MobileFriendlyTooltip = ({
 
   return supportsHover ? (
     <Tooltip
+      pane="tooltipPane"
       className={fullClassName}
       direction={"top"}
       offset={[0, -(markerRadius + 8)]}
@@ -211,6 +212,7 @@ const MobileFriendlyTooltip = ({
     </Tooltip>
   ) : (
     <Popup
+      pane="popupPane"
       autoPan={false}
       // style popup as tooltip for consistency
       className={`leaflet-tooltip ${fullClassName} leaflet-tooltip-top`}

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -49,7 +49,12 @@ const StopCard = ({
     : []
 
   return (
-    <Popup className="m-stop-card" closeButton={false} offset={[-125, 7]}>
+    <Popup
+      pane="popupPane"
+      className="m-stop-card"
+      closeButton={false}
+      offset={[-125, 7]}
+    >
       <div className="m-stop-card__stop-info">
         <div className="m-stop-card__stop-name">{stop.name}</div>
         {direction !== undefined && (

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -207,7 +207,20 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
           />
           <div
             class="leaflet-pane leaflet-marker-pane"
-          />
+          >
+            <div
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
+            />
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
+            <div
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
+            />
+          </div>
           <div
             class="leaflet-pane leaflet-tooltip-pane"
           />
@@ -554,7 +567,20 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
           />
           <div
             class="leaflet-pane leaflet-marker-pane"
-          />
+          >
+            <div
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
+            />
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
+            <div
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
+            />
+          </div>
           <div
             class="leaflet-pane leaflet-tooltip-pane"
           />
@@ -903,9 +929,283 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
+            />
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
+            <div
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
+            >
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -57px; top: 1268px; z-index: 1268;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -57px; top: 1268px; z-index: 1268;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2115px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2115px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 273px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 273px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -456px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -456px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1173px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1173px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 4158px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 4158px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3032px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3032px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2539px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2539px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -65px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -65px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
+            </div>
+            <div
               class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
               role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 2100;"
+              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 1000;"
               tabindex="0"
             >
               <svg
@@ -928,7 +1228,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             <div
               class="leaflet-marker-icon m-vehicle-map__label primary selected leaflet-zoom-hide leaflet-interactive"
               role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 2100;"
+              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 1000;"
               tabindex="0"
             >
               <svg
@@ -960,267 +1260,6 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </text>
                 
           
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -57px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -57px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2115px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2115px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Arborway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 273px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 273px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -456px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -456px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Charlestown and Somerville
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1173px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1173px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 4158px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 4158px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Lynn
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3032px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3032px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2539px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2539px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Quincy
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -65px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -65px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
-              >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Southampton
-                </text>
-                
-				
               </svg>
             </div>
           </div>

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -192,7 +192,20 @@ exports[`SearchPage renders the empty state 1`] = `
           />
           <div
             class="leaflet-pane leaflet-marker-pane"
-          />
+          >
+            <div
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
+            />
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
+            <div
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
+            />
+          </div>
           <div
             class="leaflet-pane leaflet-tooltip-pane"
           />
@@ -504,325 +517,339 @@ exports[`SearchPage renders vehicle data 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
             >
-              <svg
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
               >
-                
-        
-                <path
-                  class="on-time early-red"
-                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-                  transform="scale(1) rotate(33) translate(-12, -12)"
-                />
-                
-      
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
-            >
-              <svg
-                height="16"
-                viewBox="0 0 40 16"
-                width="40"
-              >
-                
-            
-                <rect
-                  class="m-vehicle-icon__label-background"
-                  height="100%"
-                  rx="5.5px"
-                  ry="5.5px"
-                  width="100%"
-                />
-                
-            
-                <text
-                  class="m-vehicle-icon__label"
-                  dominant-baseline="central"
-                  text-anchor="middle"
-                  x="50%"
-                  y="50%"
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   
+        
+                  <path
+                    class="on-time early-red"
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="scale(1) rotate(33) translate(-12, -12)"
+                  />
+                  
+      
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 40 16"
+                  width="40"
+                >
+                  
+            
+                  <rect
+                    class="m-vehicle-icon__label-background"
+                    height="100%"
+                    rx="5.5px"
+                    ry="5.5px"
+                    width="100%"
+                  />
+                  
+            
+                  <text
+                    class="m-vehicle-icon__label"
+                    dominant-baseline="central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    
               1
             
-                </text>
-                
+                  </text>
+                  
           
-              </svg>
+                </svg>
+              </div>
             </div>
             <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
             <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
             >
-              <svg
-                height="30"
-                width="200"
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Arborway
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Charlestown and Somerville
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Lynn
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Quincy
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Southampton
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
 				
-              </svg>
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
             </div>
           </div>
           <div

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -208,325 +208,339 @@ exports[`Shuttle Map Page renders 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
             >
-              <svg
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
               >
-                
-        
-                <path
-                  class=""
-                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-                  transform="scale(1) rotate(33) translate(-12, -12)"
-                />
-                
-      
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
-            >
-              <svg
-                height="16"
-                viewBox="0 0 40 16"
-                width="40"
-              >
-                
-            
-                <rect
-                  class="m-vehicle-icon__label-background"
-                  height="100%"
-                  rx="5.5px"
-                  ry="5.5px"
-                  width="100%"
-                />
-                
-            
-                <text
-                  class="m-vehicle-icon__label"
-                  dominant-baseline="central"
-                  text-anchor="middle"
-                  x="50%"
-                  y="50%"
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   
+        
+                  <path
+                    class=""
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="scale(1) rotate(33) translate(-12, -12)"
+                  />
+                  
+      
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 40 16"
+                  width="40"
+                >
+                  
+            
+                  <rect
+                    class="m-vehicle-icon__label-background"
+                    height="100%"
+                    rx="5.5px"
+                    ry="5.5px"
+                    width="100%"
+                  />
+                  
+            
+                  <text
+                    class="m-vehicle-icon__label"
+                    dominant-baseline="central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    
               1818
             
-                </text>
-                
+                  </text>
+                  
           
-              </svg>
+                </svg>
+              </div>
             </div>
             <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
             <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
             >
-              <svg
-                height="30"
-                width="200"
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Arborway
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Charlestown and Somerville
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Lynn
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Quincy
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Southampton
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
 				
-              </svg>
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
             </div>
           </div>
           <div
@@ -854,325 +868,339 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
             >
-              <svg
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
               >
-                
-        
-                <path
-                  class=""
-                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-                  transform="scale(1) rotate(33) translate(-12, -12)"
-                />
-                
-      
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
-            >
-              <svg
-                height="16"
-                viewBox="0 0 40 16"
-                width="40"
-              >
-                
-            
-                <rect
-                  class="m-vehicle-icon__label-background"
-                  height="100%"
-                  rx="5.5px"
-                  ry="5.5px"
-                  width="100%"
-                />
-                
-            
-                <text
-                  class="m-vehicle-icon__label"
-                  dominant-baseline="central"
-                  text-anchor="middle"
-                  x="50%"
-                  y="50%"
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   
+        
+                  <path
+                    class=""
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="scale(1) rotate(33) translate(-12, -12)"
+                  />
+                  
+      
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 40 16"
+                  width="40"
+                >
+                  
+            
+                  <rect
+                    class="m-vehicle-icon__label-background"
+                    height="100%"
+                    rx="5.5px"
+                    ry="5.5px"
+                    width="100%"
+                  />
+                  
+            
+                  <text
+                    class="m-vehicle-icon__label"
+                    dominant-baseline="central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    
               1818
             
-                </text>
-                
+                  </text>
+                  
           
-              </svg>
+                </svg>
+              </div>
             </div>
             <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
             <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
             >
-              <svg
-                height="30"
-                width="200"
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Arborway
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Charlestown and Somerville
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Lynn
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Quincy
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Southampton
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
 				
-              </svg>
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
             </div>
           </div>
           <div
@@ -1500,325 +1528,339 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
             >
-              <svg
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
               >
-                
-        
-                <path
-                  class=""
-                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-                  transform="scale(1) rotate(33) translate(-12, -12)"
-                />
-                
-      
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
-            >
-              <svg
-                height="16"
-                viewBox="0 0 40 16"
-                width="40"
-              >
-                
-            
-                <rect
-                  class="m-vehicle-icon__label-background"
-                  height="100%"
-                  rx="5.5px"
-                  ry="5.5px"
-                  width="100%"
-                />
-                
-            
-                <text
-                  class="m-vehicle-icon__label"
-                  dominant-baseline="central"
-                  text-anchor="middle"
-                  x="50%"
-                  y="50%"
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   
+        
+                  <path
+                    class=""
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="scale(1) rotate(33) translate(-12, -12)"
+                  />
+                  
+      
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 40 16"
+                  width="40"
+                >
+                  
+            
+                  <rect
+                    class="m-vehicle-icon__label-background"
+                    height="100%"
+                    rx="5.5px"
+                    ry="5.5px"
+                    width="100%"
+                  />
+                  
+            
+                  <text
+                    class="m-vehicle-icon__label"
+                    dominant-baseline="central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    
               1818
             
-                </text>
-                
+                  </text>
+                  
           
-              </svg>
+                </svg>
+              </div>
             </div>
             <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
             <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
             >
-              <svg
-                height="30"
-                width="200"
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Arborway
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Charlestown and Somerville
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Lynn
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Quincy
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Southampton
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
 				
-              </svg>
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
             </div>
           </div>
           <div
@@ -2030,7 +2072,20 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
           />
           <div
             class="leaflet-pane leaflet-marker-pane"
-          />
+          >
+            <div
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
+            />
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
+            <div
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
+            />
+          </div>
           <div
             class="leaflet-pane leaflet-tooltip-pane"
           />
@@ -2356,65 +2411,74 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
             class="leaflet-pane leaflet-marker-pane"
           >
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
+              class="leaflet-pane leaflet-primaryVehicles-pane"
+              style="z-index: 499;"
             >
-              <svg
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
               >
-                
-        
-                <path
-                  class=""
-                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-                  transform="scale(1) rotate(33) translate(-12, -12)"
-                />
-                
-      
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
-              role="button"
-              style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 2000;"
-              tabindex="0"
-            >
-              <svg
-                height="16"
-                viewBox="0 0 40 16"
-                width="40"
-              >
-                
-            
-                <rect
-                  class="m-vehicle-icon__label-background"
-                  height="100%"
-                  rx="5.5px"
-                  ry="5.5px"
-                  width="100%"
-                />
-                
-            
-                <text
-                  class="m-vehicle-icon__label"
-                  dominant-baseline="central"
-                  text-anchor="middle"
-                  x="50%"
-                  y="50%"
+                <svg
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   
+        
+                  <path
+                    class=""
+                    d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                    transform="scale(1) rotate(33) translate(-12, -12)"
+                  />
+                  
+      
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                role="button"
+                style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
+                tabindex="0"
+              >
+                <svg
+                  height="16"
+                  viewBox="0 0 40 16"
+                  width="40"
+                >
+                  
+            
+                  <rect
+                    class="m-vehicle-icon__label-background"
+                    height="100%"
+                    rx="5.5px"
+                    ry="5.5px"
+                    width="100%"
+                  />
+                  
+            
+                  <text
+                    class="m-vehicle-icon__label"
+                    dominant-baseline="central"
+                    text-anchor="middle"
+                    x="50%"
+                    y="50%"
+                  >
+                    
               1818
             
-                </text>
-                
+                  </text>
+                  
           
-              </svg>
+                </svg>
+              </div>
             </div>
+            <div
+              class="leaflet-pane leaflet-secondaryVehicles-pane"
+              style="z-index: 400;"
+            />
             <div
               class="leaflet-marker-icon m-vehicle-map__train-icon leaflet-zoom-hide leaflet-interactive"
               role="button"
@@ -2445,265 +2509,270 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
               </svg>
             </div>
             <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
+              class="leaflet-pane leaflet-notableLocationMarkers-pane"
+              style="z-index: 410;"
             >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Albany
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Arborway
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Albany
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Cabot
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Charlestown and Somerville
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Arborway
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  Fellsway
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Lynn
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Cabot
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
-                >
-                  North Cambridge
-                </text>
-                
-				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Quincy
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Charlestown and Somerville
+                  </text>
+                  
 				
-              </svg>
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
-              role="button"
-              style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg />
-            </div>
-            <div
-              class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
-              role="button"
-              style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
-              tabindex="0"
-            >
-              <svg
-                height="30"
-                width="200"
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
               >
-                
-				    
-                <text
-                  y="15"
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
                 >
-                  Southampton
-                </text>
-                
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Fellsway
+                  </text>
+                  
 				
-              </svg>
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Lynn
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    North Cambridge
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Quincy
+                  </text>
+                  
+				
+                </svg>
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
+                class="leaflet-marker-icon m-garage-icon__label leaflet-zoom-hide"
+                role="button"
+                style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg
+                  height="30"
+                  width="200"
+                >
+                  
+				    
+                  <text
+                    y="15"
+                  >
+                    Southampton
+                  </text>
+                  
+				
+                </svg>
+              </div>
             </div>
           </div>
           <div

--- a/assets/tests/components/mapMarkers.test.tsx
+++ b/assets/tests/components/mapMarkers.test.tsx
@@ -96,7 +96,7 @@ describe("StopMarker", () => {
   })
 
   test("Stop name displayed on click when hover not supported", async () => {
-    ;(useDeviceSupportsHover as jest.Mock).mockReturnValueOnce(false)
+    ;(useDeviceSupportsHover as jest.Mock).mockReturnValue(false)
 
     const { container } = renderInMap(
       <StopMarker
@@ -119,11 +119,14 @@ describe("StopMarker", () => {
 
 describe("StationMarker", () => {
   test("Station icon with name on hover", async () => {
+    ;(useDeviceSupportsHover as jest.Mock).mockReturnValueOnce(true)
     const { container } = renderInMap(
       <StationMarker station={station} zoomLevel={13} />
     )
     expect(container.querySelector(".m-station-icon")).toBeInTheDocument()
+
     await userEvent.hover(container.querySelector(".m-station-icon")!)
+
     expect(screen.getByText(station.name)).toBeVisible()
   })
 


### PR DESCRIPTION
I grouped vehicles into panes to make debugging in devtools easier as well as making z-index/stacking context a little easier to manage, we could do this manually by setting z-index per item if that'd be preferred, but I liked the way that panes helped keep things grouped. A difficulty here is that I don't think `BaseMap` should have as many props as it does and provide as much default functionality as it does, mainly because we'd have to add more props to allow users of `BaseMap` to put things into the pane's that it reserves for itself.

I also dislike that pane's specify their z-index via the `style` attribute, but there wasn't a `zindexOffset` like there is for `Markers`. Leaflet seems to set z-index according via css which matches the [pane `z-index` values provided in the leaflet documentation](https://leafletjs.com/reference.html#map-tilepane)

### Implemented AC:
- [x] Deploy to all users 
  - [x] Implement hover states + styling outlined in the Figma file 
  - [x] Change the tap target size to 16x16  
  - [x] The z-index of the tap target should place it above some of the other non-interactive elements on the map (route shapes, other buses on the same route).
	  - This was applied to only the `BaseMap` for things like the `Search Page`, `MiniMap`, and `Shuttle Page`, because the `MapPage` manages it's own stacking context/order and does not have the ability to insert elements into the specific panes otherwise.

---

Asana Ticket: https://app.asana.com/0/1203014709808707/1203222524521880/f