### PR TITLE
fix: position children in the same spot under Nav in all variants

### DIFF
--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -18,7 +18,12 @@ const Nav: React.FC<Props> = ({ children, allowViews }) => {
 
   switch (deviceType) {
     case "mobile":
-      return <MobilePortraitNav>{children}</MobilePortraitNav>
+      return (
+        <div className="m-nav--narrow">
+          <div className="m-nav__app-content">{children}</div>
+          <MobilePortraitNav />
+        </div>
+      )
     case "mobile_landscape_tablet_portrait":
       return (
         <div className="m-nav--medium">

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -22,6 +22,7 @@ const Nav: React.FC<Props> = ({ children, allowViews }) => {
     case "mobile_landscape_tablet_portrait":
       return (
         <div className="m-nav--medium">
+          <div className="m-nav__app-content">{children}</div>
           <div className="m-nav__nav-bar m-nav__nav-bar--left">
             <LeftNav
               toggleMobileMenu={() => dispatch(toggleMobileMenu())}
@@ -31,12 +32,12 @@ const Nav: React.FC<Props> = ({ children, allowViews }) => {
               allowViews={allowViews}
             />
           </div>
-          <div className="m-nav__app-content">{children}</div>
         </div>
       )
     case "tablet":
       return (
         <div className="m-nav--medium">
+          <div className="m-nav__app-content">{children}</div>
           <div className="m-nav__nav-bar m-nav__nav-bar--left">
             <LeftNav
               toggleMobileMenu={() => dispatch(toggleMobileMenu())}
@@ -45,12 +46,12 @@ const Nav: React.FC<Props> = ({ children, allowViews }) => {
               allowViews={allowViews}
             />
           </div>
-          <div className="m-nav__app-content">{children}</div>
         </div>
       )
     default:
       return (
         <div className="m-nav--wide">
+          <div className="m-nav__app-content">{children}</div>
           <div className="m-nav__nav-bar m-nav__nav-bar--top">
             <TopNav />
           </div>
@@ -61,7 +62,6 @@ const Nav: React.FC<Props> = ({ children, allowViews }) => {
               allowViews={allowViews}
             />
           </div>
-          <div className="m-nav__app-content">{children}</div>
         </div>
       )
   }

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -9,11 +9,7 @@ import {
 import BottomNavMobile from "./bottomNavMobile"
 import TopNavMobile from "./topNavMobile"
 
-const MobilePortraitNav = ({
-  children,
-}: {
-  children?: React.ReactNode | undefined
-}): JSX.Element => {
+const MobilePortraitNav = (): JSX.Element => {
   const [state, dispatch] = useContext(StateDispatchContext)
 
   const { mobileMenuIsOpen, routeTabs, openView, selectedVehicleOrGhost } =
@@ -24,9 +20,7 @@ const MobilePortraitNav = ({
   const navVisibilityStyle = isViewOpen ? "hidden" : "visible"
 
   return (
-    <div className="m-nav--narrow">
-      <div className="m-nav__app-content">{children}</div>
-
+    <>
       <div
         className="m-nav__nav-bar m-nav__nav-bar--top"
         style={{ visibility: navVisibilityStyle }}
@@ -48,7 +42,7 @@ const MobilePortraitNav = ({
           openSwingsView={() => dispatch(openSwingsView())}
         />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/assets/src/components/nav/mobilePortraitNav.tsx
+++ b/assets/src/components/nav/mobilePortraitNav.tsx
@@ -25,6 +25,8 @@ const MobilePortraitNav = ({
 
   return (
     <div className="m-nav--narrow">
+      <div className="m-nav__app-content">{children}</div>
+
       <div
         className="m-nav__nav-bar m-nav__nav-bar--top"
         style={{ visibility: navVisibilityStyle }}
@@ -36,8 +38,6 @@ const MobilePortraitNav = ({
           mobileMenuIsOpen={mobileMenuIsOpen}
         />
       </div>
-
-      <div className="m-nav__app-content">{children}</div>
 
       <div
         className="m-nav__nav-bar m-nav__nav-bar--bottom"

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -15,6 +15,125 @@ exports[`App renders 1`] = `
         class="m-nav--wide"
       >
         <div
+          class="m-nav__app-content"
+        >
+          <div
+            class="m-ladder-page m-ladder-page--picker-container-visible "
+          >
+            <div
+              class="m-notifications"
+            />
+            <div
+              class="m-picker-container visible"
+              data-testid="picker-container"
+            >
+              <div
+                class="c-drawer-tab"
+              >
+                <button
+                  class="c-drawer-tab__tab-button"
+                  title="Collapse"
+                >
+                  <span>
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="m-ladder-page__routes-presets-toggle"
+              >
+                <button
+                  class="m-ladder-page__routes_picker_button_selected"
+                  id="m-ladder-page__routes_picker_button"
+                >
+                  Routes
+                </button>
+                <button
+                  class="m-ladder-page__routes_picker_button_unselected"
+                  id="m-ladder-page__presets_picker_button"
+                >
+                  Presets
+                </button>
+              </div>
+              <div
+                class="m-route-picker"
+              >
+                <div
+                  class="m-route-filter"
+                >
+                  <div
+                    class="m-route-filter__text"
+                  >
+                    <input
+                      class="m-route-filter__input"
+                      placeholder="Search routes"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  class="m-garage-filter"
+                >
+                  <button
+                    class="m-garage-filter__show-hide-button"
+                    title="Toggle Garage Filter"
+                  >
+                    <div
+                      class="m-garage-filter__header"
+                    >
+                      Filter garages
+                    </div>
+                    <div
+                      class="m-garage-filter__show-hide-icon"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </div>
+                  </button>
+                </div>
+                <div
+                  class="m-route-picker__routes-container"
+                >
+                  loading...
+                  <p>
+                    Selected routes will show up here…
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="m-picker-container-overlay"
+              data-testid="picker-container-overlay"
+            />
+            <div
+              class="m-ladder-page__tab-bar-and-ladders"
+            >
+              <div
+                class="m-ladder-page__route-tab-bar"
+                role="tablist"
+              >
+                <button
+                  class="m-ladder-page__add-tab-button"
+                  title="Add Tab"
+                >
+                  <span
+                    class="m-ladder-page__add-tab-icon"
+                  >
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="m-route-ladders"
+                data-testid="route-ladders-div"
+              />
+            </div>
+          </div>
+        </div>
+        <div
           class="m-nav__nav-bar m-nav__nav-bar--top"
         >
           <div
@@ -193,125 +312,6 @@ exports[`App renders 1`] = `
                   </button>
                 </li>
               </ul>
-            </div>
-          </div>
-        </div>
-        <div
-          class="m-nav__app-content"
-        >
-          <div
-            class="m-ladder-page m-ladder-page--picker-container-visible "
-          >
-            <div
-              class="m-notifications"
-            />
-            <div
-              class="m-picker-container visible"
-              data-testid="picker-container"
-            >
-              <div
-                class="c-drawer-tab"
-              >
-                <button
-                  class="c-drawer-tab__tab-button"
-                  title="Collapse"
-                >
-                  <span>
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="m-ladder-page__routes-presets-toggle"
-              >
-                <button
-                  class="m-ladder-page__routes_picker_button_selected"
-                  id="m-ladder-page__routes_picker_button"
-                >
-                  Routes
-                </button>
-                <button
-                  class="m-ladder-page__routes_picker_button_unselected"
-                  id="m-ladder-page__presets_picker_button"
-                >
-                  Presets
-                </button>
-              </div>
-              <div
-                class="m-route-picker"
-              >
-                <div
-                  class="m-route-filter"
-                >
-                  <div
-                    class="m-route-filter__text"
-                  >
-                    <input
-                      class="m-route-filter__input"
-                      placeholder="Search routes"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  class="m-garage-filter"
-                >
-                  <button
-                    class="m-garage-filter__show-hide-button"
-                    title="Toggle Garage Filter"
-                  >
-                    <div
-                      class="m-garage-filter__header"
-                    >
-                      Filter garages
-                    </div>
-                    <div
-                      class="m-garage-filter__show-hide-icon"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="m-route-picker__routes-container"
-                >
-                  loading...
-                  <p>
-                    Selected routes will show up here…
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="m-picker-container-overlay"
-              data-testid="picker-container-overlay"
-            />
-            <div
-              class="m-ladder-page__tab-bar-and-ladders"
-            >
-              <div
-                class="m-ladder-page__route-tab-bar"
-                role="tablist"
-              >
-                <button
-                  class="m-ladder-page__add-tab-button"
-                  title="Add Tab"
-                >
-                  <span
-                    class="m-ladder-page__add-tab-icon"
-                  >
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="m-route-ladders"
-                data-testid="route-ladders-div"
-              />
             </div>
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -15,6 +15,157 @@ exports[`renders 1`] = `
         class="m-nav--wide"
       >
         <div
+          class="m-nav__app-content"
+        >
+          <div
+            class="m-ladder-page m-ladder-page--picker-container-visible "
+          >
+            <div
+              class="m-notifications"
+            />
+            <div
+              class="m-picker-container visible"
+              data-testid="picker-container"
+            >
+              <div
+                class="c-drawer-tab"
+              >
+                <button
+                  class="c-drawer-tab__tab-button"
+                  title="Collapse"
+                >
+                  <span>
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="m-ladder-page__routes-presets-toggle"
+              >
+                <button
+                  class="m-ladder-page__routes_picker_button_selected"
+                  id="m-ladder-page__routes_picker_button"
+                >
+                  Routes
+                </button>
+                <button
+                  class="m-ladder-page__routes_picker_button_unselected"
+                  id="m-ladder-page__presets_picker_button"
+                >
+                  Presets
+                </button>
+              </div>
+              <div
+                class="m-route-picker"
+              >
+                <div
+                  class="m-route-filter"
+                >
+                  <div
+                    class="m-route-filter__text"
+                  >
+                    <input
+                      class="m-route-filter__input"
+                      placeholder="Search routes"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  class="m-garage-filter"
+                >
+                  <button
+                    class="m-garage-filter__show-hide-button"
+                    title="Toggle Garage Filter"
+                  >
+                    <div
+                      class="m-garage-filter__header"
+                    >
+                      Filter garages
+                    </div>
+                    <div
+                      class="m-garage-filter__show-hide-icon"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </div>
+                  </button>
+                </div>
+                <div
+                  class="m-route-picker__routes-container"
+                >
+                  loading...
+                  <p>
+                    Selected routes will show up here…
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="m-picker-container-overlay"
+              data-testid="picker-container-overlay"
+            />
+            <div
+              class="m-ladder-page__tab-bar-and-ladders"
+            >
+              <div
+                class="m-ladder-page__route-tab-bar"
+                role="tablist"
+              >
+                <div
+                  class="m-ladder-page__tab m-ladder-page__tab-current"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <div
+                    class="m-ladder-page__tab-contents"
+                  >
+                    <div
+                      class="m-ladder-page__tab-title"
+                    >
+                      Untitled
+                    </div>
+                    <button
+                      class="m-ladder-page__tab-save-button"
+                      title="Save"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </button>
+                    <button
+                      class="m-old-close-button"
+                      data-testid="close-button"
+                      title="Close"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  class="m-ladder-page__add-tab-button"
+                  title="Add Tab"
+                >
+                  <span
+                    class="m-ladder-page__add-tab-icon"
+                  >
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="m-route-ladders"
+                data-testid="route-ladders-div"
+              />
+            </div>
+          </div>
+        </div>
+        <div
           class="m-nav__nav-bar m-nav__nav-bar--top"
         >
           <div
@@ -193,157 +344,6 @@ exports[`renders 1`] = `
                   </button>
                 </li>
               </ul>
-            </div>
-          </div>
-        </div>
-        <div
-          class="m-nav__app-content"
-        >
-          <div
-            class="m-ladder-page m-ladder-page--picker-container-visible "
-          >
-            <div
-              class="m-notifications"
-            />
-            <div
-              class="m-picker-container visible"
-              data-testid="picker-container"
-            >
-              <div
-                class="c-drawer-tab"
-              >
-                <button
-                  class="c-drawer-tab__tab-button"
-                  title="Collapse"
-                >
-                  <span>
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="m-ladder-page__routes-presets-toggle"
-              >
-                <button
-                  class="m-ladder-page__routes_picker_button_selected"
-                  id="m-ladder-page__routes_picker_button"
-                >
-                  Routes
-                </button>
-                <button
-                  class="m-ladder-page__routes_picker_button_unselected"
-                  id="m-ladder-page__presets_picker_button"
-                >
-                  Presets
-                </button>
-              </div>
-              <div
-                class="m-route-picker"
-              >
-                <div
-                  class="m-route-filter"
-                >
-                  <div
-                    class="m-route-filter__text"
-                  >
-                    <input
-                      class="m-route-filter__input"
-                      placeholder="Search routes"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  class="m-garage-filter"
-                >
-                  <button
-                    class="m-garage-filter__show-hide-button"
-                    title="Toggle Garage Filter"
-                  >
-                    <div
-                      class="m-garage-filter__header"
-                    >
-                      Filter garages
-                    </div>
-                    <div
-                      class="m-garage-filter__show-hide-icon"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="m-route-picker__routes-container"
-                >
-                  loading...
-                  <p>
-                    Selected routes will show up here…
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="m-picker-container-overlay"
-              data-testid="picker-container-overlay"
-            />
-            <div
-              class="m-ladder-page__tab-bar-and-ladders"
-            >
-              <div
-                class="m-ladder-page__route-tab-bar"
-                role="tablist"
-              >
-                <div
-                  class="m-ladder-page__tab m-ladder-page__tab-current"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <div
-                    class="m-ladder-page__tab-contents"
-                  >
-                    <div
-                      class="m-ladder-page__tab-title"
-                    >
-                      Untitled
-                    </div>
-                    <button
-                      class="m-ladder-page__tab-save-button"
-                      title="Save"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </button>
-                    <button
-                      class="m-old-close-button"
-                      data-testid="close-button"
-                      title="Close"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  class="m-ladder-page__add-tab-button"
-                  title="Add Tab"
-                >
-                  <span
-                    class="m-ladder-page__add-tab-icon"
-                  >
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="m-route-ladders"
-                data-testid="route-ladders-div"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Asana ticket: [⚙️🐞 Better Maps | Investigate how to not re-render components when breakpoint changes ](https://app.asana.com/0/1148853526253437/1203180633835795/f)

This just reorders the children of `<Nav />` so that, regardless of which variant of the nav is rendered, the children end up under a `<div>` which is the first child of the main `<div>` of the overall nav component. This keeps the children in the same place in the UI tree and therefore causes React to preserve their state. The React documentation on [Preserving and Resetting State](https://beta.reactjs.org/learn/preserving-and-resetting-state) was a useful reference here (kudos to @firestack for pointing me to it).