### PR TITLE
feat(RouteShape): Tooltip + updated selected, hover states

### DIFF
--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -103,7 +103,7 @@
   stroke: $color-mbta-red;
 }
 
-.m-vehicle-map__route-shape:hover,
+.m-vehicle-map__route-shape:not(.m-vehicle-map__route-shape--no-hover):hover,
 .m-vehicle-map__route-shape--selected {
   stroke-width: 7;
 }

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -72,8 +72,40 @@
   }
 }
 
-.m-vehicle-map__route-shape:hover {
+.m-vehicle-map__route-shape {
+  stroke: $color-kiwi-500;
+  stroke-opacity: 0.5;
+  stroke-width: 5;
+}
+
+.m-vehicle-map__route-shape:focus {
+  outline: none;
+}
+
+.route-shape--rail {
   stroke-opacity: 1;
+  stroke-width: 4;
+}
+
+.m-vehicle-map__route-shape.route-shape--blue {
+  stroke: $color-mbta-blue;
+}
+
+.m-vehicle-map__route-shape.route-shape--green {
+  stroke: $color-mbta-green;
+}
+
+.m-vehicle-map__route-shape.route-shape--orange {
+  stroke: $color-mbta-orange;
+}
+
+.m-vehicle-map__route-shape.route-shape--red {
+  stroke: $color-mbta-red;
+}
+
+.m-vehicle-map__route-shape:hover,
+.m-vehicle-map__route-shape--selected {
+  stroke-width: 7;
 }
 
 .m-vehicle-map__stop {
@@ -101,7 +133,8 @@
   }
 }
 
-.leaflet-tooltip.m-vehicle-map__mobile-friendly-tooltip {
+.leaflet-tooltip.m-vehicle-map__mobile-friendly-tooltip,
+.leaflet-tooltip.route-shape__tooltip {
   background-color: $color-tooltip-background;
   color: $white;
   border-color: $color-tooltip-background;
@@ -139,7 +172,8 @@
 }
 
 // The tooltip triangle
-.leaflet-tooltip-top.m-vehicle-map__mobile-friendly-tooltip::before {
+.leaflet-tooltip-top.m-vehicle-map__mobile-friendly-tooltip::before,
+.leaflet-tooltip-top.route-shape__tooltip::before {
   border-top-color: $color-tooltip-background;
 }
 

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -167,19 +167,6 @@ export const TrainVehicleMarker = ({
   return <Marker position={position} icon={icon} />
 }
 
-export const shapeStrokeOptions = ({ color }: Shape): object =>
-  color
-    ? {
-        color,
-        opacity: 1.0,
-        weight: 4,
-      }
-    : {
-        color: "#4db6ac",
-        opacity: 0.6,
-        weight: 6,
-      }
-
 const stationLeafletIcon = ({ size }: { size: number }): Leaflet.DivIcon => {
   return Leaflet.divIcon({
     html: stationIcon,
@@ -385,18 +372,31 @@ export const RouteStopMarkers = ({
 }
 
 export const RouteShape = React.memo(
-  ({ shape, onClick }: { shape: Shape; onClick?: () => void }) => {
+  ({
+    shape,
+    isSelected,
+    onClick,
+    children,
+  }: {
+    shape: Shape
+    isSelected?: boolean
+    onClick?: () => void
+    children?: JSX.Element
+  }) => {
     const positions: LatLngExpression[] = shape.points.map((point) => [
       point.lat,
       point.lon,
     ])
     return (
       <Polyline
-        className="m-vehicle-map__route-shape"
+        className={`m-vehicle-map__route-shape ${shape.className || ""} ${
+          isSelected ? "m-vehicle-map__route-shape--selected" : ""
+        }`}
         positions={positions}
-        {...shapeStrokeOptions(shape)}
         eventHandlers={{ click: onClick }}
-      />
+      >
+        {children}
+      </Polyline>
     )
   }
 )

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -389,9 +389,11 @@ export const RouteShape = React.memo(
     ])
     return (
       <Polyline
-        className={`m-vehicle-map__route-shape ${shape.className || ""} ${
-          isSelected ? "m-vehicle-map__route-shape--selected" : ""
-        }`}
+        className={
+          `m-vehicle-map__route-shape ${shape.className || ""}` +
+          `${isSelected ? " m-vehicle-map__route-shape--selected" : ""}` +
+          `${onClick ? "" : " m-vehicle-map__route-shape--no-hover"}`
+        }
         positions={positions}
         eventHandlers={onClick ? { click: onClick } : {}}
       >

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -393,7 +393,7 @@ export const RouteShape = React.memo(
           isSelected ? "m-vehicle-map__route-shape--selected" : ""
         }`}
         positions={positions}
-        eventHandlers={{ click: onClick }}
+        eventHandlers={onClick ? { click: onClick } : {}}
       >
         {children}
       </Polyline>

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -272,9 +272,8 @@ const RoutePatternLayers = ({
                         sticky={true}
                         direction="top"
                       >
-                        <>
-                          {`Click to select route ${routePattern.routeId}${variantFormatted}.`}
-                        </>
+                        Click to select route {routePattern.routeId}
+                        {variantFormatted}.
                       </Tooltip>
                     ) : undefined}
                   </RouteShape>

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -252,6 +252,11 @@ const RoutePatternLayers = ({
     <>
       <ZoomLevelWrapper>
         {(zoomLevel) => {
+          const routePatternIdSplit = routePattern.id.split("-")
+          const variantFormatted =
+            routePatternIdSplit.length === 3 && routePatternIdSplit[1] !== "_"
+              ? "_" + routePatternIdSplit[1]
+              : ""
           return (
             <>
               {routePattern.shape && (
@@ -267,7 +272,9 @@ const RoutePatternLayers = ({
                         sticky={true}
                         direction="top"
                       >
-                        <>Click to select route {routePattern.id}.</>
+                        <>
+                          {`Click to select route ${routePattern.routeId}${variantFormatted}.`}
+                        </>
                       </Tooltip>
                     ) : undefined}
                   </RouteShape>

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -266,7 +266,7 @@ const RoutePatternLayers = ({
                     isSelected={isSelected}
                     onClick={onShapeClick}
                   >
-                    {zoomLevel >= 16 && !isSelected ? (
+                    {(zoomLevel >= 16 && !isSelected && (
                       <Tooltip
                         className="route-shape__tooltip"
                         sticky={true}
@@ -275,7 +275,8 @@ const RoutePatternLayers = ({
                         Click to select route {routePattern.routeId}
                         {variantFormatted}.
                       </Tooltip>
-                    ) : undefined}
+                    )) ||
+                      undefined}
                   </RouteShape>
                   <RouteStopMarkers
                     stops={routePattern.shape.stops || []}

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
+import { Tooltip } from "react-leaflet"
 import { SocketContext } from "../../contexts/socketContext"
 import useMostRecentVehicleById from "../../hooks/useMosRecentVehicleById"
 import usePatternsByIdForRoute from "../../hooks/usePatternsByIdForRoute"
@@ -240,25 +241,43 @@ const SelectionCardContainer = ({
 
 const RoutePatternLayers = ({
   routePattern,
+  isSelected,
   onShapeClick,
 }: {
   routePattern: RoutePattern
+  isSelected: boolean
   onShapeClick: () => void
 }): JSX.Element => {
   return routePattern.shape ? (
     <>
-      <RouteShape shape={routePattern.shape} onClick={onShapeClick} />
       <ZoomLevelWrapper>
         {(zoomLevel) => {
           return (
             <>
               {routePattern.shape && (
-                <RouteStopMarkers
-                  stops={routePattern.shape.stops || []}
-                  includeStopCard={true}
-                  direction={routePattern.directionId}
-                  zoomLevel={zoomLevel}
-                />
+                <>
+                  <RouteShape
+                    shape={routePattern.shape}
+                    isSelected={isSelected}
+                    onClick={onShapeClick}
+                  >
+                    {zoomLevel >= 16 && !isSelected ? (
+                      <Tooltip
+                        className="route-shape__tooltip"
+                        sticky={true}
+                        direction="top"
+                      >
+                        <>Click to select route {routePattern.id}.</>
+                      </Tooltip>
+                    ) : undefined}
+                  </RouteShape>
+                  <RouteStopMarkers
+                    stops={routePattern.shape.stops || []}
+                    includeStopCard={true}
+                    direction={routePattern.directionId}
+                    zoomLevel={zoomLevel}
+                  />
+                </>
               )}
             </>
           )
@@ -346,6 +365,7 @@ const SelectedVehicleDataLayers = ({
           {showShapeAndStops && routePatternForVehicle && (
             <RoutePatternLayers
               routePattern={routePatternForVehicle}
+              isSelected={false}
               onShapeClick={() => selectRoutePattern(routePatternForVehicle)}
             />
           )}
@@ -407,6 +427,7 @@ const SelectedRouteDataLayers = ({
       {selectedRoutePattern && (
         <RoutePatternLayers
           routePattern={selectedRoutePattern}
+          isSelected={true}
           onShapeClick={() => selectRoutePattern(selectedRoutePattern)}
         />
       )}

--- a/assets/src/data/shapesBlue.ts
+++ b/assets/src/data/shapesBlue.ts
@@ -3,7 +3,7 @@ import stopsBlue from "./stopsBlue"
 
 const blueLine60Shape: Shape = {
   id: "946_0013",
-  color: "#003DA5",
+  className: "route-shape--rail route-shape--blue",
   points: [
     { lat: 42.413638, lon: -70.991535 },
     { lat: 42.4127, lon: -70.992021 },
@@ -217,7 +217,7 @@ const blueLine60Shape: Shape = {
 
 const blueLine61Shape: Shape = {
   id: "946_0014",
-  color: "#003DA5",
+  className: "route-shape--rail route-shape--blue",
   points: [
     { lat: 42.36118, lon: -71.062395 },
     { lat: 42.361162, lon: -71.06215 },

--- a/assets/src/data/shapesGreen.ts
+++ b/assets/src/data/shapesGreen.ts
@@ -3,7 +3,7 @@ import stopsGreen from "./stopsGreen"
 
 const greenLineB30Shape: Shape = {
   id: "813_0006",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.356334, lon: -71.062193 },
     { lat: 42.356219, lon: -71.062336 },
@@ -279,7 +279,7 @@ const greenLineB30Shape: Shape = {
 
 const greenLineB31Shape: Shape = {
   id: "813_0007",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.340076, lon: -71.16681 },
     { lat: 42.34002, lon: -71.166556 },
@@ -555,7 +555,7 @@ const greenLineB31Shape: Shape = {
 
 const greenLineC10Shape: Shape = {
   id: "831_0008",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.365657, lon: -71.0606 },
     { lat: 42.363989, lon: -71.059097 },
@@ -773,7 +773,7 @@ const greenLineC10Shape: Shape = {
 
 const greenLineC11Shape: Shape = {
   id: "831_0009",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.336152, lon: -71.149186 },
     { lat: 42.336314, lon: -71.148435 },
@@ -991,7 +991,7 @@ const greenLineC11Shape: Shape = {
 
 const greenLineD11Shape: Shape = {
   id: "851_0008",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.337303, lon: -71.252372 },
     { lat: 42.337239, lon: -71.2522 },
@@ -1445,7 +1445,7 @@ const greenLineD11Shape: Shape = {
 
 const greenLineD20Shape: Shape = {
   id: "852_0013",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.359338, lon: -71.059393 },
     { lat: 42.359208, lon: -71.059508 },
@@ -1879,7 +1879,7 @@ const greenLineD20Shape: Shape = {
 
 const greenLineD21Shape: Shape = {
   id: "852_0012",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.337303, lon: -71.252372 },
     { lat: 42.337239, lon: -71.2522 },
@@ -2313,7 +2313,7 @@ const greenLineD21Shape: Shape = {
 
 const greenLineD51Shape: Shape = {
   id: "842_0007",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.334947, lon: -71.149078 },
     { lat: 42.335031, lon: -71.148726 },
@@ -2547,7 +2547,7 @@ const greenLineD51Shape: Shape = {
 
 const greenLineD60Shape: Shape = {
   id: "858_0002",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.321731, lon: -71.206113 },
     { lat: 42.321677, lon: -71.20616 },
@@ -2649,7 +2649,7 @@ const greenLineD60Shape: Shape = {
 
 const greenLineD61Shape: Shape = {
   id: "858_0001",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.337303, lon: -71.252372 },
     { lat: 42.337239, lon: -71.2522 },
@@ -2751,7 +2751,7 @@ const greenLineD61Shape: Shape = {
 
 const greenLineE00Shape: Shape = {
   id: "8000002",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.37712, lon: -71.09433 },
     { lat: 42.37708, lon: -71.09426 },
@@ -3023,7 +3023,7 @@ const greenLineE00Shape: Shape = {
 
 const greenLineE01Shape: Shape = {
   id: "8000001",
-  color: "#00843D",
+  className: "route-shape--rail route-shape--green",
   points: [
     { lat: 42.32834, lon: -71.1101 },
     { lat: 42.32836, lon: -71.11008 },

--- a/assets/src/data/shapesMattapan.ts
+++ b/assets/src/data/shapesMattapan.ts
@@ -3,7 +3,7 @@ import stopsMattapan from "./stopsMattapan"
 
 const mattapan00Shape: Shape = {
   id: "899_0005",
-  color: "#DA291C",
+  className: "route-shape--rail route-shape--red",
   points: [
     { lat: 42.284095, lon: -71.063303 },
     { lat: 42.283901, lon: -71.063183 },
@@ -136,7 +136,7 @@ const mattapan00Shape: Shape = {
 
 const mattapan10Shape: Shape = {
   id: "899_0008",
-  color: "#DA291C",
+  className: "route-shape--rail route-shape--red",
   points: [
     { lat: 42.267515, lon: -71.09199 },
     { lat: 42.267516, lon: -71.091986 },

--- a/assets/src/data/shapesOrange.ts
+++ b/assets/src/data/shapesOrange.ts
@@ -3,7 +3,7 @@ import stopsOrange from "./stopsOrange"
 
 const orangeLine30Shape: Shape = {
   id: "903_0018",
-  color: "#ED8B00",
+  className: "route-shape--rail route-shape--orange",
   points: [
     { lat: 42.436967, lon: -71.070867 },
     { lat: 42.436397, lon: -71.070961 },
@@ -313,7 +313,7 @@ const orangeLine30Shape: Shape = {
 
 const orangeLine31Shape: Shape = {
   id: "903_0017",
-  color: "#ED8B00",
+  className: "route-shape--rail route-shape--orange",
   points: [
     { lat: 42.300731, lon: -71.114102 },
     { lat: 42.301103, lon: -71.113837 },

--- a/assets/src/data/shapesRed.ts
+++ b/assets/src/data/shapesRed.ts
@@ -3,7 +3,7 @@ import stopsRed from "./stopsRed"
 
 const redLine10Shape: Shape = {
   id: "931_0009",
-  color: "#DA291C",
+  className: "route-shape--rail route-shape--red",
   points: [
     { lat: 42.396152, lon: -71.142079 },
     { lat: 42.396193, lon: -71.139553 },
@@ -305,7 +305,7 @@ const redLine10Shape: Shape = {
 
 const redLine30Shape: Shape = {
   id: "933_0009",
-  color: "#DA291C",
+  className: "route-shape--rail route-shape--red",
   points: [
     { lat: 42.396152, lon: -71.142079 },
     { lat: 42.396193, lon: -71.139553 },
@@ -721,7 +721,7 @@ const redLine30Shape: Shape = {
 
 const redLine31Shape: Shape = {
   id: "931_0010",
-  color: "#DA291C",
+  className: "route-shape--rail route-shape--red",
   points: [
     { lat: 42.284249, lon: -71.063556 },
     { lat: 42.284383, lon: -71.063627 },

--- a/assets/src/schedule.d.ts
+++ b/assets/src/schedule.d.ts
@@ -57,9 +57,9 @@ export interface RoutePattern {
 
 export interface Shape {
   id: ShapeId
-  color?: string
   points: ShapePoint[]
   stops?: Stop[]
+  className?: string
 }
 
 export type ShapeId = string

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -2058,11 +2058,11 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
                   class="m-vehicle-map__route-shape leaflet-interactive"
                   d="M0 0"
                   fill="none"
-                  stroke="#4db6ac"
+                  stroke="#3388ff"
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                  stroke-opacity="0.6"
-                  stroke-width="6"
+                  stroke-opacity="1"
+                  stroke-width="3"
                 />
               </g>
             </svg>

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -2055,7 +2055,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
             >
               <g>
                 <path
-                  class="m-vehicle-map__route-shape leaflet-interactive"
+                  class="m-vehicle-map__route-shape m-vehicle-map__route-shape--no-hover leaflet-interactive"
                   d="M0 0"
                   fill="none"
                   stroke="#3388ff"

--- a/assets/tests/components/mapMarkers.test.tsx
+++ b/assets/tests/components/mapMarkers.test.tsx
@@ -1,11 +1,9 @@
 import "@testing-library/jest-dom"
-import { Shape } from "../../src/schedule"
 import {
   GarageMarkers,
   RouteShape,
   RouteStopMarkers,
   StationMarker,
-  shapeStrokeOptions,
   TrainVehicleMarker,
   VehicleMarker,
   StopMarker,
@@ -54,36 +52,6 @@ describe("TrainVehicleMarker", () => {
     expect(
       container.querySelector(".m-vehicle-map__train-icon")
     ).toBeInTheDocument()
-  })
-})
-
-describe("strokeOptions", () => {
-  test("uses the color for a subway line, defaults to a thinner, opaque line", () => {
-    const subwayShape = {
-      color: "#DA291C",
-    } as Shape
-
-    const expected = {
-      color: "#DA291C",
-      opacity: 1.0,
-      weight: 4,
-    }
-
-    expect(shapeStrokeOptions(subwayShape)).toEqual(expected)
-  })
-
-  test("sets default color, width, and opacity settincgs for shuttle route lines", () => {
-    const shuttleShape = {
-      color: undefined,
-    } as Shape
-
-    const expected = {
-      color: "#4db6ac",
-      opacity: 0.6,
-      weight: 6,
-    }
-
-    expect(shapeStrokeOptions(shuttleShape)).toEqual(expected)
   })
 })
 
@@ -176,6 +144,33 @@ describe("RouteShape", () => {
     expect(
       container.querySelector(".m-vehicle-map__route-shape")
     ).toBeInTheDocument()
+  })
+
+  test("has selected class when isSelected is true", () => {
+    const { container } = renderInMap(
+      <RouteShape
+        shape={{ id: "shape1", points: [{ lat: 0, lon: 0 }] }}
+        isSelected={true}
+      />
+    )
+    expect(container.querySelector(".m-vehicle-map__route-shape")).toHaveClass(
+      "m-vehicle-map__route-shape--selected"
+    )
+  })
+
+  test("passes additional class names defined on the shape", () => {
+    const { container } = renderInMap(
+      <RouteShape
+        shape={{
+          id: "shape1",
+          points: [{ lat: 0, lon: 0 }],
+          className: "route-shape--red",
+        }}
+      />
+    )
+    expect(container.querySelector(".m-vehicle-map__route-shape")).toHaveClass(
+      "route-shape--red"
+    )
   })
 
   test("onClick called on click", async () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom"
-import { render, screen, within } from "@testing-library/react"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import MapPage from "../../src/components/mapPage"
@@ -651,11 +657,8 @@ describe("<MapPage />", () => {
       )
       expect(vehiclePropertiesCard.get()).toBeVisible()
 
-      await userEvent.click(
-        container.querySelector(".m-vehicle-map__route-shape")!
-      )
-      expect(routePropertiesCard.get()).toBeVisible()
-      expect(window.FS?.event).toHaveBeenCalledWith("RPC Opened")
+      fireEvent.click(container.querySelector(".m-vehicle-map__route-shape")!)
+      await waitFor(() => expect(routePropertiesCard.get()).toBeVisible())
       expect(vehiclePropertiesCard.query()).not.toBeInTheDocument()
     })
     test("clicking vehicle when RPC is open closes RPC and opens VPC", async () => {


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1203766403597552/f


**Note:  userEvent => fireEvent for some tests**
Adding a tooltip to shapes caused existing tests to fail where a route shape is clicked. Kudos to @firestack for helping me debug and pointing me to the fact that the `clientX` and `clientY` were undefined [here](https://github.com/Leaflet/Leaflet/blob/9c58fcdd0a61167bafc4496528aaece1e4fe44af/src/dom/DomEvent.js#L259), leading to an `Invalid LatLng object: (NaN, NaN)` error. 

Stepping into [here](https://github.com/Leaflet/Leaflet/blob/3f5ea5a271b41ec09147ea774fea90bc960a1ab2/src/map/Map.js#L1419), `clientX/Y` was not `in src` [here](https://github.com/Leaflet/Leaflet/blob/3f5ea5a271b41ec09147ea774fea90bc960a1ab2/src/core/Util.js#L14). This was not the case when stepping through the browser. I suspect it is because of the way the `MouseEvent` is created when using `userEvent.click`: `clientX/Y` are set using [`defineProperty`](https://github.com/testing-library/user-event/blob/7a305dee9ab833d6f338d567fc2e862b4838b76a/src/event/createEvent.ts#L81). From the defineProperty [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description):

> By default, properties added using Object.defineProperty() are not writable, not enumerable, and not configurable. 

Locally, I added `enumerable: true` to `defineProperty`  and confirmed the tests passed.

With the limitation of using the current rtl library (I'll likely open up a PR to address), I tried using `fireEvent.click` instead, which worked. Stepping through, I confirmed that `clientX/Y` were hit as expected. 
