### PR TITLE
feat(ts/components/stopCard): prevent stop card from being obscured

### DIFF
--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -25,6 +25,7 @@ import { UserSettings } from "../userSettings"
 import garages, { Garage } from "../data/garages"
 import useDeviceSupportsHover from "../hooks/useDeviceSupportsHover"
 import { LocationType } from "../models/stopData"
+import StopCard from "./stopCard"
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
@@ -32,7 +33,6 @@ import garageIcon from "../../static/images/icon-bus-garage.svg"
 // @ts-ignore
 import stationIcon from "../../static/images/icon-station.svg"
 /*  eslint-enable @typescript-eslint/ban-ts-comment */
-import { SafeAreaContextStopCard } from "./stopCard"
 
 const makeVehicleIcon = (
   vehicle: Vehicle,
@@ -291,7 +291,7 @@ export const StopMarker = React.memo(
         radius={markerRadius}
       >
         {includeStopCard ? (
-          <SafeAreaContextStopCard stop={stop} direction={direction} />
+          <StopCard.WithSafeArea stop={stop} direction={direction} />
         ) : (
           <MobileFriendlyTooltip
             className={"m-vehicle-map__stop-tooltip"}

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -3,8 +3,17 @@ import Leaflet, {
   LatLngExpression,
 } from "leaflet"
 import "leaflet-defaulticon-compatibility" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
+import "leaflet.fullscreen"
 import React, { useContext, useEffect, useState } from "react"
-import { CircleMarker, Marker, Polyline, Popup, Tooltip } from "react-leaflet"
+import {
+  CircleMarker,
+  CircleMarkerProps,
+  Marker,
+  Polyline,
+  Popup,
+  Tooltip,
+} from "react-leaflet"
+
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { className } from "../helpers/dom"
 import vehicleLabelString from "../helpers/vehicleLabel"
@@ -12,18 +21,17 @@ import { drawnStatus, statusClasses } from "../models/vehicleStatus"
 import { TrainVehicle, Vehicle } from "../realtime"
 import { DirectionId, Shape, Stop, StopId } from "../schedule"
 import { UserSettings } from "../userSettings"
-import "leaflet.fullscreen"
 
 import garages, { Garage } from "../data/garages"
+import useDeviceSupportsHover from "../hooks/useDeviceSupportsHover"
+import { LocationType } from "../models/stopData"
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-ignore
 import garageIcon from "../../static/images/icon-bus-garage.svg"
 // @ts-ignore
 import stationIcon from "../../static/images/icon-station.svg"
 /*  eslint-enable @typescript-eslint/ban-ts-comment */
-import { LocationType } from "../models/stopData"
-import useDeviceSupportsHover from "../hooks/useDeviceSupportsHover"
-import { CircleMarkerProps } from "react-leaflet"
 import { SafeAreaContextStopCard } from "./stopCard"
 
 const makeVehicleIcon = (

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -22,9 +22,9 @@ import garageIcon from "../../static/images/icon-bus-garage.svg"
 import stationIcon from "../../static/images/icon-station.svg"
 /*  eslint-enable @typescript-eslint/ban-ts-comment */
 import { LocationType } from "../models/stopData"
-import StopCard from "./stopCard"
 import useDeviceSupportsHover from "../hooks/useDeviceSupportsHover"
 import { CircleMarkerProps } from "react-leaflet"
+import { SafeAreaContextStopCard } from "./stopCard"
 
 const makeVehicleIcon = (
   vehicle: Vehicle,
@@ -283,7 +283,7 @@ export const StopMarker = React.memo(
         radius={markerRadius}
       >
         {includeStopCard ? (
-          <StopCard stop={stop} direction={direction} />
+          <SafeAreaContextStopCard stop={stop} direction={direction} />
         ) : (
           <MobileFriendlyTooltip
             className={"m-vehicle-map__stop-tooltip"}

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -553,8 +553,8 @@ const MapDisplay = ({
     >
       <MapSafeArea.Provider
         value={{
-          paddingTopLeft: [445, 50],
-          paddingBottomRight: [20, 50],
+          paddingTopLeft: [445, 54],
+          paddingBottomRight: [50, 50],
         }}
       >
         <SelectionDataLayers

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -115,7 +115,7 @@ const onFollowerUpdate: UpdateMapFromPointsFn = (map, points) => {
   } else {
     const pointsBounds = Leaflet.latLngBounds(points)
     map.fitBounds(pointsBounds, {
-      paddingBottomRight: [20, 50],
+      paddingBottomRight: [50, 20],
       paddingTopLeft: topLeft,
     })
   }
@@ -554,7 +554,7 @@ const MapDisplay = ({
       <MapSafeArea.Provider
         value={{
           paddingTopLeft: [445, 54],
-          paddingBottomRight: [50, 50],
+          paddingBottomRight: [50, 20],
         }}
       >
         <SelectionDataLayers

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -38,7 +38,7 @@ import {
   useInteractiveFollowerState,
 } from "../map"
 import { RouteShape, RouteStopMarkers, VehicleMarker } from "../mapMarkers"
-import { MapSafeArea } from "../stopCard"
+import { MapSafeAreaContext } from "../../contexts/mapSafeAreaContext"
 import ZoomLevelWrapper from "../ZoomLevelWrapper"
 import RoutePropertiesCard from "./routePropertiesCard"
 import VehiclePropertiesCard from "./vehiclePropertiesCard"
@@ -551,7 +551,7 @@ const MapDisplay = ({
       shapes={[]}
       stateClasses={stateClasses}
     >
-      <MapSafeArea.Provider
+      <MapSafeAreaContext.Provider
         value={{
           paddingTopLeft: [445, 54],
           paddingBottomRight: [50, 20],
@@ -564,7 +564,7 @@ const MapDisplay = ({
           setSelection={setSelection}
           setStateClasses={setStateClasses}
         />
-      </MapSafeArea.Provider>
+      </MapSafeAreaContext.Provider>
     </BaseMap>
   )
 }

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -92,14 +92,15 @@ const onFollowerUpdate: UpdateMapFromPointsFn = (map, points) => {
   // with the distance from the right side of the VPC to the left side of the
   // map container
   const topLeft = new Point(445, 0)
-  const innerBounds = new Bounds(topLeft, mapContainerBounds.getBottomRight())
-  // The "new center" is the offset between the two bounding boxes centers
-  const offset = innerBounds
-    .getCenter()
-    .subtract(mapContainerBounds.getCenter())
 
   if (points.length === 1) {
     const targetZoom = 16
+    const innerBounds = new Bounds(topLeft, mapContainerBounds.getBottomRight())
+    // The "new center" is the offset between the two bounding boxes centers
+    const offset = innerBounds
+      .getCenter()
+      .subtract(mapContainerBounds.getCenter())
+
     const targetPoint = map
         // Project the target point into screenspace for the target zoom
         .project(points[0], targetZoom)

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -38,6 +38,7 @@ import {
   useInteractiveFollowerState,
 } from "../map"
 import { RouteShape, RouteStopMarkers, VehicleMarker } from "../mapMarkers"
+import { MapSafeArea } from "../stopCard"
 import ZoomLevelWrapper from "../ZoomLevelWrapper"
 import RoutePropertiesCard from "./routePropertiesCard"
 import VehiclePropertiesCard from "./vehiclePropertiesCard"
@@ -549,13 +550,20 @@ const MapDisplay = ({
       shapes={[]}
       stateClasses={stateClasses}
     >
-      <SelectionDataLayers
-        selectedEntity={selectedEntity}
-        showSelectionCard={showSelectionCard}
-        deleteSelection={deleteSelection}
-        setSelection={setSelection}
-        setStateClasses={setStateClasses}
-      />
+      <MapSafeArea.Provider
+        value={{
+          paddingTopLeft: [445, 50],
+          paddingBottomRight: [20, 50],
+        }}
+      >
+        <SelectionDataLayers
+          selectedEntity={selectedEntity}
+          showSelectionCard={showSelectionCard}
+          deleteSelection={deleteSelection}
+          setSelection={setSelection}
+          setStateClasses={setStateClasses}
+        />
+      </MapSafeArea.Provider>
     </BaseMap>
   )
 }

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -1,7 +1,8 @@
 import { PointExpression } from "leaflet"
-import React, { createContext, useContext, useId } from "react"
+import React, { useContext, useId } from "react"
 import { Popup } from "react-leaflet"
 import { DirectionId, Stop } from "../schedule"
+import { MapSafeAreaContext } from "../contexts/mapSafeAreaContext"
 import { RoutePill } from "./routePill"
 import StreetViewButton from "./streetViewButton"
 
@@ -108,14 +109,12 @@ const StopCard = ({
   )
 }
 
-export const MapSafeArea = createContext<LeafletPaddingOptions>({})
-
 /**
  * A <{@link StopCard}/> which provides it's `autoPanPadding` parameter via the
- * nearest {@link MapSafeArea} Context
+ * nearest {@link MapSafeAreaContext} Context
  */
 export const SafeAreaContextStopCard = (props: StopCardProps) => {
-  const safeArea = useContext(MapSafeArea)
+  const safeArea = useContext(MapSafeAreaContext)
 
   return <StopCard {...props} autoPanPadding={safeArea} />
 }

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -1,16 +1,30 @@
-import React, { useId } from "react"
+import { PointExpression } from "leaflet"
+import React, { createContext, useContext, useId } from "react"
 import { Popup } from "react-leaflet"
 import { DirectionId, Stop } from "../schedule"
 import { RoutePill } from "./routePill"
 import StreetViewButton from "./streetViewButton"
 
+export type LeafletPaddingOptions = {
+  padding?: PointExpression | undefined
+  paddingTopLeft?: PointExpression | undefined
+  paddingBottomRight?: PointExpression | undefined
+}
+
+type StopCardProps = {
+  stop: Stop
+  direction?: DirectionId
+}
+
+type AutoPanProps = {
+  autoPanPadding?: LeafletPaddingOptions
+}
+
 const StopCard = ({
   stop,
   direction,
-}: {
-  stop: Stop
-  direction?: DirectionId
-}): JSX.Element => {
+  autoPanPadding,
+}: StopCardProps & AutoPanProps): JSX.Element => {
   const connectionsLabelId = "stop-card-connections-label-" + useId()
 
   const connections = stop.connections
@@ -54,6 +68,9 @@ const StopCard = ({
       className="m-stop-card"
       closeButton={false}
       offset={[-125, 7]}
+      autoPanPadding={autoPanPadding?.padding || [20, 20]}
+      autoPanPaddingTopLeft={autoPanPadding?.paddingTopLeft}
+      autoPanPaddingBottomRight={autoPanPadding?.paddingBottomRight}
     >
       <div className="m-stop-card__stop-info">
         <div className="m-stop-card__stop-name">{stop.name}</div>
@@ -88,6 +105,22 @@ const StopCard = ({
         longitude={stop.lon}
       ></StreetViewButton>
     </Popup>
+  )
+}
+
+export const MapSafeArea = createContext<LeafletPaddingOptions>({})
+
+/**
+ * A <{@link StopCard}/> which provides it's `autoPanPadding` parameter via the
+ * nearest {@link MapSafeArea} Context
+ */
+export const SafeAreaContextStopCard = (props: StopCardProps) => {
+  const safeArea = useContext(MapSafeArea)
+
+  return (
+    <>
+      <StopCard {...props} autoPanPadding={safeArea} />
+    </>
   )
 }
 

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -113,10 +113,13 @@ const StopCard = ({
  * A <{@link StopCard}/> which provides it's `autoPanPadding` parameter via the
  * nearest {@link MapSafeAreaContext} Context
  */
-export const SafeAreaContextStopCard = (props: StopCardProps) => {
+const StopCardWithSafeArea = (props: StopCardProps) => {
   const safeArea = useContext(MapSafeAreaContext)
 
   return <StopCard {...props} autoPanPadding={safeArea} />
 }
+
+/** @borrows StopCardWithSafeArea as StopCard#WithSafeArea  */
+StopCard.WithSafeArea = StopCardWithSafeArea
 
 export default StopCard

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -117,11 +117,7 @@ export const MapSafeArea = createContext<LeafletPaddingOptions>({})
 export const SafeAreaContextStopCard = (props: StopCardProps) => {
   const safeArea = useContext(MapSafeArea)
 
-  return (
-    <>
-      <StopCard {...props} autoPanPadding={safeArea} />
-    </>
-  )
+  return <StopCard {...props} autoPanPadding={safeArea} />
 }
 
 export default StopCard

--- a/assets/src/contexts/mapSafeAreaContext.tsx
+++ b/assets/src/contexts/mapSafeAreaContext.tsx
@@ -1,0 +1,4 @@
+import { createContext } from "react"
+import { LeafletPaddingOptions } from "../components/stopCard"
+
+export const MapSafeAreaContext = createContext<LeafletPaddingOptions>({})


### PR DESCRIPTION
# Summary

This PR implements a simple way of getting the "safe zone" passed down into the component tree to use leaflet's `autoPanPadding` features[^1]. We could probably also use the new context provider to provide the safe zone bounds for the follower logic too.

The two largest problems were
 - Should this be done via Context or Prop Drilling? (or something else?)
 - What should these new components/contexts/types be named. (All the names are composite names, which has been difficult to find something which feels "right")

I'm still considering the names used and would appreciate any input's y'all may have.

## Todo
 - Design and product approved this solution as ok for MVP fidelity
	 - [x] Design 🆗
	 - [x] Product 🆗

---

Asana Ticket: https://app.asana.com/0/inbox/1203014709797732/1203674636294159/1203947212316076

[^1]: https://leafletjs.com/reference.html#popup-autopanpaddingtopleft