### PR TITLE
Map page narrow screen behavior

### DIFF
--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -1,5 +1,5 @@
-// From here: https://github.com/Leaflet/Leaflet/blob/5c29d615563835d373a51b91fc3513a17907da96/dist/leaflet.css#L87
-$leaflet-pane-z-index: 400;
+// From here: https://github.com/Leaflet/Leaflet/blob/5c29d615563835d373a51b91fc3513a17907da96/dist/leaflet.css
+$max-leaflet-z-index: 1000;
 
 .leaflet-container {
   width: 100%;

--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -1,4 +1,4 @@
-// From here: https://github.com/Leaflet/Leaflet/blob/5c29d615563835d373a51b91fc3513a17907da96/dist/leaflet.css
+// From here: https://github.com/Leaflet/Leaflet/blob/5c29d615563835d373a51b91fc3513a17907da96/dist/leaflet.css#L110
 $max-leaflet-z-index: 1000;
 
 .leaflet-container {

--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -89,56 +89,6 @@ $map-page-search-panel-width: 24rem;
   padding: 0.625rem 1rem 0 1rem;
 }
 
-@media screen and (max-width: $mobile-max-width) {
-  .m-map-page {
-    flex-direction: column;
-  }
-
-  .m-map-page__input-and-results .c-drawer-tab {
-    display: none;
-  }
-
-  .m-map-page--show-list {
-    .m-map-page__input-and-results {
-      flex: 1 1 auto;
-      height: 100%;
-    }
-
-    .m-map-page__map {
-      // Needs to be hidden instead of not displayed so the map still gets drawn properly
-      position: fixed;
-      top: 100vh;
-    }
-  }
-
-  .m-map-page--show-map {
-    .m-map-page__input-and-results {
-      flex: 0 0 auto;
-      height: auto;
-    }
-
-    .m-search-display {
-      display: none;
-    }
-  }
-
-  .m-map-page__input-and-results {
-    box-sizing: border-box;
-    width: 100%;
-    position: relative;
-  }
-
-  .m-map-page__toggle-mobile-display-button {
-    display: block;
-  }
-
-  .m-map-page__map {
-    box-sizing: border-box;
-    height: 75%;
-    width: 100%;
-  }
-}
-
 $map-page-search-stub-size: 10px;
 
 .m-map-page__map .m-map-display__selected-entity-card-container {

--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -29,7 +29,7 @@ $map-page-search-panel-width: 24rem;
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  z-index: #{$leaflet-pane-z-index + 100};
+  z-index: #{$max-leaflet-z-index + 100};
 
   padding: 1.25rem 0 0 0;
 
@@ -68,7 +68,7 @@ $map-page-search-panel-width: 24rem;
   left: 100%;
   top: 0;
   background-color: $color-gray-300;
-  z-index: #{$leaflet-pane-z-index + 100};
+  z-index: #{$max-leaflet-z-index + 100};
 
   .c-drawer-tab__tab-button {
     &:focus,

--- a/assets/css/_search_page.scss
+++ b/assets/css/_search_page.scss
@@ -29,7 +29,7 @@ $search-page-search-panel-width: 22.0625rem;
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  z-index: #{$leaflet-pane-z-index + 100};
+  z-index: #{$max-leaflet-z-index + 100};
 
   padding: 1.25rem 0 0 0;
 

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -72,7 +72,7 @@
 
 .m-vehicle-properties-panel__map-open-link {
   position: absolute;
-  z-index: #{$leaflet-pane-z-index + 1};
+  z-index: #{$max-leaflet-z-index + 1};
   top: 10px;
   // Adjacent to controls - control width is 40px
   right: calc(env(safe-area-inset-right) + 40px + 0.5rem);

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -23,43 +23,17 @@ import RecentSearches from "./recentSearches"
 import SearchForm from "./searchForm"
 import SearchResults from "./searchResults"
 
-enum MobileDisplay {
-  List = 1,
-  Map,
-}
-
 const thereIsAnActiveSearch = (
   vehicles: VehicleOrGhost[] | null,
   searchPageState: SearchPageState
 ): boolean => vehicles !== null && searchPageState.isActive
 
-const ToggleMobileDisplayButton = ({
-  mobileDisplay,
-  onToggleMobileDisplay,
-}: {
-  mobileDisplay: MobileDisplay
-  onToggleMobileDisplay: () => void
-}) => {
-  const otherDisplayName = mobileDisplay === MobileDisplay.List ? "map" : "list"
-
-  return (
-    <button
-      className="m-map-page__toggle-mobile-display-button button-text"
-      onClick={onToggleMobileDisplay}
-    >
-      Show {otherDisplayName} instead
-    </button>
-  )
-}
-
 const SearchInputAndResults = ({
   searchPageState,
-  mobileDisplay,
   selectedEntity,
   selectVehicle,
 }: {
   searchPageState: SearchPageState
-  mobileDisplay?: ReactElement
   selectedEntity: SelectedEntity | null
   selectVehicle: (vehicle: VehicleOrGhost | null) => void
 }): React.ReactElement => {
@@ -77,7 +51,6 @@ const SearchInputAndResults = ({
           inputTitle="Search Map Query"
           submitEvent="Search submitted from map page"
         />
-        {mobileDisplay}
       </div>
 
       <hr />
@@ -103,7 +76,7 @@ const SearchInputAndResults = ({
 }
 
 const MapPage = (): ReactElement<HTMLDivElement> => {
-  const [{ searchPageState, mobileMenuIsOpen, openView }, dispatch] =
+  const [{ searchPageState, openView }, dispatch] =
       useContext(StateDispatchContext),
     { selectedEntity = null } = searchPageState
 
@@ -152,26 +125,9 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
     [setSelection]
   )
 
-  // #region mobile display
-  const [mobileDisplay, setMobileDisplay] = useState(MobileDisplay.List)
-  const toggleMobileDisplay = () => {
-    setMobileDisplay(
-      mobileDisplay === MobileDisplay.List
-        ? MobileDisplay.Map
-        : MobileDisplay.List
-    )
-  }
-  const mobileDisplayClass =
-    mobileDisplay === MobileDisplay.List
-      ? "m-map-page--show-list"
-      : "m-map-page--show-map"
-
-  const mobileMenuClass = mobileMenuIsOpen ? "blurred-mobile" : ""
-  // #endregion
-
   return (
     <div
-      className={`m-map-page ${mobileDisplayClass} ${mobileMenuClass} inherit-box border-box`}
+      className={`m-map-page inherit-box border-box`}
       aria-label="Search Map Page"
     >
       <div
@@ -190,12 +146,6 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
             selectedEntity,
             searchPageState,
           }}
-          mobileDisplay={
-            <ToggleMobileDisplayButton
-              mobileDisplay={mobileDisplay}
-              onToggleMobileDisplay={toggleMobileDisplay}
-            />
-          }
         />
       </div>
       <div className="m-map-page__map">

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -127,7 +127,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
 
   return (
     <div
-      className={`m-map-page inherit-box border-box`}
+      className="m-map-page inherit-box border-box"
       aria-label="Search Map Page"
     >
       <div

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
 <DocumentFragment>
   <div
     aria-label="Search Map Page"
-    class="m-map-page m-map-page--show-list  inherit-box border-box"
+    class="m-map-page inherit-box border-box"
   >
     <div
       aria-label="Map Search Panel"
@@ -141,11 +141,6 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </ul>
           </div>
         </form>
-        <button
-          class="m-map-page__toggle-mobile-display-button button-text"
-        >
-          Show map instead
-        </button>
       </div>
       <hr />
       <div
@@ -364,7 +359,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
 <DocumentFragment>
   <div
     aria-label="Search Map Page"
-    class="m-map-page m-map-page--show-list  inherit-box border-box"
+    class="m-map-page inherit-box border-box"
   >
     <div
       aria-label="Map Search Panel"
@@ -501,11 +496,6 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </ul>
           </div>
         </form>
-        <button
-          class="m-map-page__toggle-mobile-display-button button-text"
-        >
-          Show map instead
-        </button>
       </div>
       <hr />
       <div
@@ -724,7 +714,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
 <DocumentFragment>
   <div
     aria-label="Search Map Page"
-    class="m-map-page m-map-page--show-list  inherit-box border-box"
+    class="m-map-page inherit-box border-box"
   >
     <div
       aria-label="Map Search Panel"
@@ -861,11 +851,6 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             </ul>
           </div>
         </form>
-        <button
-          class="m-map-page__toggle-mobile-display-button button-text"
-        >
-          Show map instead
-        </button>
       </div>
       <hr />
       <div

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -247,12 +247,6 @@ describe("<MapPage />", () => {
     expect(getAllStationIcons(container)).toHaveLength(3)
   })
 
-  test("on mobile, shows the results list initially", () => {
-    const { container } = render(<MapPage />)
-
-    expect(container.firstChild).toHaveClass("m-map-page--show-list")
-  })
-
   test("clicking a vehicle on the map, should set vehicle as new selection", async () => {
     mockFullStoryEvent()
     jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
@@ -357,26 +351,6 @@ describe("<MapPage />", () => {
     expect(
       container.querySelector(".m-vehicle-map__route-shape")
     ).not.toBeInTheDocument()
-  })
-
-  test("on mobile, allows you to toggle to the map view and back again", async () => {
-    const { container } = render(
-      <BrowserRouter>
-        <MapPage />
-      </BrowserRouter>
-    )
-
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show map instead" })
-    )
-
-    expect(container.firstChild).toHaveClass("m-map-page--show-map")
-
-    await userEvent.click(
-      screen.getByRole("button", { name: "Show list instead" })
-    )
-
-    expect(container.firstChild).toHaveClass("m-map-page--show-list")
   })
 
   test("when vehicle properties card is closed, vehicle properties card should not be visible, search panel should be visible, elements should be removed from the map", async () => {


### PR DESCRIPTION
Asana ticket: [⚙️ Better Maps | Search Map behavior at <=800px](https://app.asana.com/0/1200180014510248/1203888345713854/f)

Simply removing the unneeded code seems to have worked as expected. I did also have to play around with the z-index of the search drawer a little bit because on narrow screens it becomes apparent that the Leaflet controls actually have a higher z-index than what we were using, so I replaced `$leaflet-pane-z-index` with a new variable that represents the maximum z-index out of the entire Leaflet CSS file.