### PR TITLE
feat(ts/components/map): make street view switch fit on smaller screen sizes

### DIFF
--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -177,38 +177,6 @@
   border-top-color: $color-tooltip-background;
 }
 
-// Adding .leaflet-control-container increases specificity to make sure we override
-// base Leaflet control positioning
-.leaflet-control-container .m-vehicle-map__street-view-control {
-  position: absolute;
-  // Leaflet uses px for positioning of their controls so we use px here to match
-  top: 10px;
-  right: 55px;
-
-  padding: 0.5rem 0.5rem 0.5rem 1rem;
-
-  background-color: $white;
-
-  border: 1px solid $color-gray-400;
-  border-radius: 7px;
-
-  color: $color-eggplant-700;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  user-select: none;
-  display: flex;
-
-  label {
-    span svg {
-      height: 1rem;
-      padding-right: 0.5rem;
-      fill: currentColor;
-    }
-
-    padding-right: 0.5rem;
-  }
-}
-
 .m-vehicle-map__recenter-button {
   path {
     fill: none;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -69,6 +69,7 @@ $component-active-bg: $color-eggplant-700;
 @import "loading_modal";
 @import "loading_spinner";
 @import "map_page";
+@import "map/controls/street_view_switch";
 @import "minischedule";
 @import "modal";
 @import "nav";

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -22,6 +22,27 @@ $z-properties-panel-context: (
 
 @import "ui_kit";
 
+// #region External Libraries
+// Import External Libraries first so that css selectors specified after these
+// imports are more specific and do not require extra work to override styles
+// imported externally
+
+// #region Bootstrap
+// See https://getbootstrap.com/docs/5.2/customize/sass/#importing - import only
+// the parts of Bootstrap that we need
+@import "../node_modules/bootstrap/scss/functions";
+
+// Bootstrap variable customization
+$component-active-bg: $color-eggplant-700;
+
+@import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/maps";
+@import "../node_modules/bootstrap/scss/mixins";
+@import "../node_modules/bootstrap/scss/root";
+@import "../node_modules/bootstrap/scss/forms";
+// #endregion
+// #endregion
+
 @import "base";
 @import "inter";
 @import "leaflet";
@@ -92,19 +113,6 @@ $z-properties-panel-context: (
 @import "vehicle_properties_card";
 @import "vehicle_route_summary";
 @import "view_header";
-
-// See https://getbootstrap.com/docs/5.2/customize/sass/#importing - import only
-// the parts of Bootstrap that we need
-@import "../node_modules/bootstrap/scss/functions";
-
-// Bootstrap variable customization
-$component-active-bg: $color-eggplant-700;
-
-@import "../node_modules/bootstrap/scss/variables";
-@import "../node_modules/bootstrap/scss/maps";
-@import "../node_modules/bootstrap/scss/mixins";
-@import "../node_modules/bootstrap/scss/root";
-@import "../node_modules/bootstrap/scss/forms";
 
 [hidden] {
   display: none !important;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -41,6 +41,10 @@ $component-active-bg: $color-eggplant-700;
 @import "../node_modules/bootstrap/scss/root";
 @import "../node_modules/bootstrap/scss/forms";
 // #endregion
+
+// #region Leaflet
+@import "../node_modules/leaflet/dist/leaflet.css";
+// #endregion
 // #endregion
 
 @import "base";

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -1,0 +1,31 @@
+// Adding .leaflet-control-container increases specificity to make sure we override
+// base Leaflet control positioning
+.leaflet-control-container .m-vehicle-map__street-view-control {
+  position: absolute;
+  // Leaflet uses px for positioning of their controls so we use px here to match
+  top: 10px;
+  right: 55px;
+
+  padding: 0.5rem 0.5rem 0.5rem 1rem;
+
+  background-color: $white;
+
+  border: 1px solid $color-gray-400;
+  border-radius: 7px;
+
+  color: $color-eggplant-700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  user-select: none;
+  display: flex;
+
+  label {
+    span svg {
+      height: 1rem;
+      padding-right: 0.5rem;
+      fill: currentColor;
+    }
+
+    padding-right: 0.5rem;
+  }
+}

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -1,6 +1,3 @@
-// Adding .leaflet-control-container increases specificity to make sure we override
-// base Leaflet control positioning
-.m-vehicle-map__street-view-control,
 .lc-street-view-switch {
   position: absolute;
   // Leaflet uses px for positioning of their controls so we use px here to match

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -1,58 +1,65 @@
 // BEM-PREFIX: LC = Leaflet Control
 .lc-street-view-switch {
+  // #region Position
   position: absolute;
   // Leaflet uses px for positioning of their controls so we use px here to match
   top: 10px;
   right: 55px;
+  // #endregion
 
-  padding: 0.5rem 0.5rem 0.5rem 1rem;
+  // #region Look
+  user-select: none;
 
+  color: $color-eggplant-700;
   background-color: $white;
+  // #endregion
+
+  // #region Layout
+  display: flex;
+
+  font-size: 1rem;
+  line-height: 1.5rem;
+
+  padding: 8px;
 
   border: 1px solid $color-gray-400;
   border-radius: 7px;
+  // #endregion
 
-  color: $color-eggplant-700;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  user-select: none;
-  display: flex;
-
-  label {
-    span svg {
-      height: 1rem;
-      padding-right: 0.5rem;
-      fill: currentColor;
-    }
-
+  // #region Sub-Components
+  &__label {
     padding-right: 0.5rem;
   }
-}
 
-@media screen and (max-width: $non-mobile-min-width) {
-  .lc-street-view-switch {
-    padding-block: 4px;
-    padding-inline: 8px;
+  &__label-icon svg {
+    fill: currentColor;
+
+    height: 1em;
+    min-width: 16px;
+  }
+
+  &__input {
+
+    // Remove layout offsets
+    padding-left: 0;
+    margin-bottom: 0;
+
+    // Remove Negative Margins so shrinkwrap works
+    .form-check-input {
+      margin-left: 0;
+    }
+  }
+  // #endregion
+
+  // #region Media Queries
+  @media screen and (max-width: 800px) {
+    & {
+      padding: 4px;
+    }
 
     &__label-text {
       @include visually-hidden;
     }
-
-    &__input {
-      // padding: 4px;
-      margin: 0;
-      padding-left: 0;
-
-      // display: flex;
-      align-items: center;
-    }
-
-    // &__input-box {}
-
-    &__input .form-check-input {
-      // margin: auto;
-      margin-left: 0;
-      // padding-inline: 0;
-    }
   }
+  // #endregion
 }

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -49,7 +49,7 @@
 
     // Remove Negative Margins so shrinkwrap works
     .form-check-input {
-      margin-left: 0;
+      margin-inline: 4px;
     }
   }
   // #endregion

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -16,6 +16,7 @@
 
   // #region Layout
   display: flex;
+  align-items: center;
 
   font-size: 1rem;
   line-height: 1.5rem;
@@ -35,10 +36,15 @@
     fill: currentColor;
 
     height: 1em;
+    height: calc(1em - 2px);
     min-width: 16px;
   }
 
   &__input {
+    // Shrinkwrap the wrapper component to the input component so that flexbox
+    // can align this element properly
+    min-height: unset;
+    height: min-content;
 
     // Remove layout offsets
     padding-left: 0;

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -65,6 +65,11 @@
     &__label-text {
       @include visually-hidden;
     }
+
+    &__input .form-check-input {
+      // Move street view icon closer to switch
+      margin-inline-start: 0;
+    }
   }
   // #endregion
 }

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -1,6 +1,7 @@
 // Adding .leaflet-control-container increases specificity to make sure we override
 // base Leaflet control positioning
-.leaflet-control-container .m-vehicle-map__street-view-control {
+.m-vehicle-map__street-view-control,
+.lc-street-view-switch {
   position: absolute;
   // Leaflet uses px for positioning of their controls so we use px here to match
   top: 10px;
@@ -27,5 +28,33 @@
     }
 
     padding-right: 0.5rem;
+  }
+}
+
+@media screen and (max-width: $non-mobile-min-width) {
+  .lc-street-view-switch {
+    padding-block: 4px;
+    padding-inline: 8px;
+
+    &__label-text {
+      @include visually-hidden;
+    }
+
+    &__input {
+      // padding: 4px;
+      margin: 0;
+      padding-left: 0;
+
+      // display: flex;
+      align-items: center;
+    }
+
+    // &__input-box {}
+
+    &__input .form-check-input {
+      // margin: auto;
+      margin-left: 0;
+      // padding-inline: 0;
+    }
   }
 }

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -57,6 +57,7 @@
   // #region Media Queries
   @media screen and (max-width: 800px) {
     & {
+      font-size: var(--font-size-s);
       padding: 4px;
     }
 

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -17,6 +17,7 @@
   // #region Layout
   display: flex;
   align-items: center;
+  gap: 4px;
 
   font-size: 1rem;
   line-height: 1.5rem;
@@ -28,10 +29,6 @@
   // #endregion
 
   // #region Sub-Components
-  &__label {
-    padding-right: 0.5rem;
-  }
-
   &__label-icon svg {
     fill: currentColor;
 

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -20,7 +20,7 @@
   gap: 4px;
 
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1;
 
   padding: 8px;
 

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -1,3 +1,4 @@
+// BEM-PREFIX: LC = Leaflet Control
 .lc-street-view-switch {
   position: absolute;
   // Leaflet uses px for positioning of their controls so we use px here to match

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -57,6 +57,7 @@
   // #region Media Queries
   @media screen and (max-width: 800px) {
     & {
+      // Change size of icon and switch when on a smaller screen
       font-size: var(--font-size-s);
       padding: 4px;
     }

--- a/assets/css/map/controls/_street_view_switch.scss
+++ b/assets/css/map/controls/_street_view_switch.scss
@@ -20,7 +20,7 @@
   gap: 4px;
 
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.5;
 
   padding: 8px;
 

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -12,7 +12,6 @@ require("../css/app.scss")
 //
 import "core-js/stable"
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
-import "leaflet/dist/leaflet.css"
 import "phoenix_html"
 import * as React from "react"
 import { createRoot } from "react-dom/client"

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -18,11 +18,9 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useId,
   useRef,
   useState,
 } from "react"
-import ReactDOM from "react-dom"
 import {
   AttributionControl,
   MapContainer,
@@ -50,8 +48,8 @@ import {
   TrainVehicleMarker,
   VehicleMarker,
 } from "./mapMarkers"
-import { WalkingIcon } from "../helpers/icon"
 import ZoomLevelWrapper from "./ZoomLevelWrapper"
+import { StreetViewControl } from "./map/controls/StreetViewSwitch"
 
 export interface Props {
   reactLeafletRef?: MutableRefObject<LeafletMap | null>
@@ -80,66 +78,6 @@ export const defaultCenter: LatLngLiteral = {
 
 interface RecenterControlProps extends ControlOptions {
   recenter: () => void
-}
-
-interface StreetViewControlProps extends ControlOptions {
-  streetViewEnabled: boolean
-  setStreetViewEnabled: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-const StreetViewControl = ({
-  streetViewEnabled: streetViewEnabled,
-  setStreetViewEnabled: setStreetViewEnabled,
-}: StreetViewControlProps): JSX.Element | null => {
-  const map = useMap()
-  const portalParent = map
-    .getContainer()
-    .querySelector(".leaflet-control-container")
-  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
-  const id = "street-view-toggle-" + useId()
-
-  useEffect(() => {
-    if (!portalParent || !portalElement) {
-      setPortalElement(document.createElement("div"))
-    }
-
-    if (portalParent && portalElement) {
-      portalElement.className =
-        "leaflet-control leaflet-bar m-vehicle-map__street-view-control"
-      portalParent.append(portalElement)
-      Leaflet.DomEvent.disableClickPropagation(portalElement)
-    }
-
-    return () => portalElement?.remove()
-  }, [portalElement, portalParent, setStreetViewEnabled])
-
-  const control = (
-    <>
-      <label htmlFor={id}>
-        <WalkingIcon />
-        Street View
-      </label>
-      <div className="form-check form-switch">
-        <input
-          id={id}
-          className="form-check-input"
-          type="checkbox"
-          role="switch"
-          checked={streetViewEnabled}
-          onChange={() => {
-            // since the value is being toggled, the new value will be the opposite of the current value
-            window.FS?.event("Dedicated street view toggled", {
-              streetViewEnabled_bool: !streetViewEnabled,
-            })
-
-            setStreetViewEnabled((enabled) => !enabled)
-          }}
-        />
-      </div>
-    </>
-  )
-
-  return portalElement ? ReactDOM.createPortal(control, portalElement) : null
 }
 
 class LeafletRecenterControl extends Control {

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -1,0 +1,63 @@
+import { ControlOptions } from "leaflet"
+import React, { useEffect, useId, useState } from "react"
+import { useMap } from "react-leaflet"
+
+interface StreetViewControlProps extends ControlOptions {
+  streetViewEnabled: boolean
+  setStreetViewEnabled: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export const StreetViewControl = ({
+  streetViewEnabled: streetViewEnabled,
+  setStreetViewEnabled: setStreetViewEnabled,
+}: StreetViewControlProps): JSX.Element | null => {
+  const map = useMap()
+  const portalParent = map
+    .getContainer()
+    .querySelector(".leaflet-control-container")
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
+  const id = "street-view-toggle-" + useId()
+
+  useEffect(() => {
+    if (!portalParent || !portalElement) {
+      setPortalElement(document.createElement("div"))
+    }
+
+    if (portalParent && portalElement) {
+      portalElement.className =
+        "leaflet-control leaflet-bar m-vehicle-map__street-view-control"
+      portalParent.append(portalElement)
+      Leaflet.DomEvent.disableClickPropagation(portalElement)
+    }
+
+    return () => portalElement?.remove()
+  }, [portalElement, portalParent, setStreetViewEnabled])
+
+  const control = (
+    <>
+      <label htmlFor={id}>
+        <WalkingIcon />
+        Street View
+      </label>
+      <div className="form-check form-switch">
+        <input
+          id={id}
+          className="form-check-input"
+          type="checkbox"
+          role="switch"
+          checked={streetViewEnabled}
+          onChange={() => {
+            // since the value is being toggled, the new value will be the opposite of the current value
+            window.FS?.event("Dedicated street view toggled", {
+              streetViewEnabled_bool: !streetViewEnabled,
+            })
+
+            setStreetViewEnabled((enabled) => !enabled)
+          }}
+        />
+      </div>
+    </>
+  )
+
+  return portalElement ? ReactDOM.createPortal(control, portalElement) : null
+}

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -1,15 +1,18 @@
-import { ControlOptions } from "leaflet"
+import Leaflet, { ControlOptions } from "leaflet"
 import React, { useEffect, useId, useState } from "react"
+import ReactDOM from "react-dom"
 import { useMap } from "react-leaflet"
+import { className } from "../../../helpers/dom"
+import { WalkingIcon } from "../../../helpers/icon"
 
-interface StreetViewControlProps extends ControlOptions {
+export interface StreetViewControlProps extends ControlOptions {
   streetViewEnabled: boolean
   setStreetViewEnabled: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export const StreetViewControl = ({
-  streetViewEnabled: streetViewEnabled,
-  setStreetViewEnabled: setStreetViewEnabled,
+  streetViewEnabled,
+  setStreetViewEnabled,
 }: StreetViewControlProps): JSX.Element | null => {
   const map = useMap()
   const portalParent = map
@@ -24,8 +27,12 @@ export const StreetViewControl = ({
     }
 
     if (portalParent && portalElement) {
-      portalElement.className =
-        "leaflet-control leaflet-bar m-vehicle-map__street-view-control"
+      portalElement.className = className([
+        "leaflet-control",
+        "leaflet-bar",
+        "m-vehicle-map__street-view-control",
+        "lc-street-view-switch",
+      ])
       portalParent.append(portalElement)
       Leaflet.DomEvent.disableClickPropagation(portalElement)
     }
@@ -35,11 +42,11 @@ export const StreetViewControl = ({
 
   const control = (
     <>
-      <label htmlFor={id}>
-        <WalkingIcon />
-        Street View
+      <label htmlFor={id} className="lc-street-view-switch__label">
+        <WalkingIcon className="lc-street-view-switch__label-icon" />
+        <span className="lc-street-view-switch__label-text">Street View</span>
       </label>
-      <div className="form-check form-switch">
+      <div className="form-check form-switch lc-street-view-switch__input">
         <input
           id={id}
           className="form-check-input"

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -41,7 +41,13 @@ export const StreetViewControl = ({
 
   const control = (
     <>
-      <label htmlFor={id} className="lc-street-view-switch__label">
+      <label
+        htmlFor={id}
+        className="lc-street-view-switch__label"
+        aria-label=""
+        aria-hidden={true}
+        role="presentation"
+      >
         <WalkingIcon className="lc-street-view-switch__label-icon" />
       </label>
       <label

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -44,7 +44,12 @@ export const StreetViewControl = ({
     <>
       <label htmlFor={id} className="lc-street-view-switch__label">
         <WalkingIcon className="lc-street-view-switch__label-icon" />
-        <span className="lc-street-view-switch__label-text">Street View</span>
+      </label>
+      <label
+        htmlFor={id}
+        className="lc-street-view-switch__label lc-street-view-switch__label-text"
+      >
+        Street View
       </label>
       <div className="form-check form-switch lc-street-view-switch__input">
         <input

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -30,7 +30,6 @@ export const StreetViewControl = ({
       portalElement.className = className([
         "leaflet-control",
         "leaflet-bar",
-        "m-vehicle-map__street-view-control",
         "lc-street-view-switch",
       ])
       portalParent.append(portalElement)

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
+            class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
               class="lc-street-view-switch__label"
@@ -690,7 +690,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
+            class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
               class="lc-street-view-switch__label"
@@ -1375,7 +1375,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
+            class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
               class="lc-street-view-switch__label"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -330,8 +330,11 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
+              aria-hidden="true"
+              aria-label=""
               class="lc-street-view-switch__label"
               for="street-view-toggle-:r1:"
+              role="presentation"
             >
               <span
                 class="lc-street-view-switch__label-icon"
@@ -693,8 +696,11 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
+              aria-hidden="true"
+              aria-label=""
               class="lc-street-view-switch__label"
               for="street-view-toggle-:r0:"
+              role="presentation"
             >
               <span
                 class="lc-street-view-switch__label-icon"
@@ -1378,8 +1384,11 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             class="leaflet-control leaflet-bar lc-street-view-switch"
           >
             <label
+              aria-hidden="true"
+              aria-label=""
               class="lc-street-view-switch__label"
               for="street-view-toggle-:r2:"
+              role="presentation"
             >
               <span
                 class="lc-street-view-switch__label-icon"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -327,18 +327,25 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
           >
             <label
+              class="lc-street-view__label"
               for="street-view-toggle-:r1:"
             >
-              <span>
+              <span
+                class="lc-street-view__label-icon"
+              >
                 <svg />
               </span>
-              Street View
+              <span
+                class="desktop-view mc-street-view__label-text"
+              >
+                Street View
+              </span>
             </label>
             <div
-              class="form-check form-switch"
+              class="form-check form-switch lc-street-view__input-box"
             >
               <input
                 class="form-check-input"
@@ -682,18 +689,25 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
           >
             <label
+              class="lc-street-view__label"
               for="street-view-toggle-:r0:"
             >
-              <span>
+              <span
+                class="lc-street-view__label-icon"
+              >
                 <svg />
               </span>
-              Street View
+              <span
+                class="desktop-view mc-street-view__label-text"
+              >
+                Street View
+              </span>
             </label>
             <div
-              class="form-check form-switch"
+              class="form-check form-switch lc-street-view__input-box"
             >
               <input
                 class="form-check-input"
@@ -1359,18 +1373,25 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
           >
             <label
+              class="lc-street-view__label"
               for="street-view-toggle-:r2:"
             >
-              <span>
+              <span
+                class="lc-street-view__label-icon"
+              >
                 <svg />
               </span>
-              Street View
+              <span
+                class="desktop-view mc-street-view__label-text"
+              >
+                Street View
+              </span>
             </label>
             <div
-              class="form-check form-switch"
+              class="form-check form-switch lc-street-view__input-box"
             >
               <input
                 class="form-check-input"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -327,25 +327,26 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
           >
             <label
-              class="lc-street-view__label"
+              class="lc-street-view-switch__label"
               for="street-view-toggle-:r1:"
             >
               <span
-                class="lc-street-view__label-icon"
+                class="lc-street-view-switch__label-icon"
               >
                 <svg />
               </span>
-              <span
-                class="desktop-view mc-street-view__label-text"
-              >
-                Street View
-              </span>
+            </label>
+            <label
+              class="lc-street-view-switch__label lc-street-view-switch__label-text"
+              for="street-view-toggle-:r1:"
+            >
+              Street View
             </label>
             <div
-              class="form-check form-switch lc-street-view__input-box"
+              class="form-check form-switch lc-street-view-switch__input"
             >
               <input
                 class="form-check-input"
@@ -689,25 +690,26 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
           >
             <label
-              class="lc-street-view__label"
+              class="lc-street-view-switch__label"
               for="street-view-toggle-:r0:"
             >
               <span
-                class="lc-street-view__label-icon"
+                class="lc-street-view-switch__label-icon"
               >
                 <svg />
               </span>
-              <span
-                class="desktop-view mc-street-view__label-text"
-              >
-                Street View
-              </span>
+            </label>
+            <label
+              class="lc-street-view-switch__label lc-street-view-switch__label-text"
+              for="street-view-toggle-:r0:"
+            >
+              Street View
             </label>
             <div
-              class="form-check form-switch lc-street-view__input-box"
+              class="form-check form-switch lc-street-view-switch__input"
             >
               <input
                 class="form-check-input"
@@ -1373,25 +1375,26 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             </div>
           </div>
           <div
-            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view"
+            class="leaflet-control leaflet-bar m-vehicle-map__street-view-control lc-street-view-switch"
           >
             <label
-              class="lc-street-view__label"
+              class="lc-street-view-switch__label"
               for="street-view-toggle-:r2:"
             >
               <span
-                class="lc-street-view__label-icon"
+                class="lc-street-view-switch__label-icon"
               >
                 <svg />
               </span>
-              <span
-                class="desktop-view mc-street-view__label-text"
-              >
-                Street View
-              </span>
+            </label>
+            <label
+              class="lc-street-view-switch__label lc-street-view-switch__label-text"
+              for="street-view-toggle-:r2:"
+            >
+              Street View
             </label>
             <div
-              class="form-check form-switch lc-street-view__input-box"
+              class="form-check form-switch lc-street-view-switch__input"
             >
               <input
                 class="form-check-input"


### PR DESCRIPTION
A few notes

I added a prefix to the BEM class name when I moved it into it's own file since this feels like it's own component rather than just a subcomponent of the map.

Also, I was able to stop fighting with leaflet and bootstrap css specificity by importing them first before any of our styles, I don't think I missed anything or caused any problems and I didn't see anything but that might be a good thing to mull over a bit.

Also bootstrap's component was making it somewhat difficult to get layout to look nice, so I ended up overriding padding and margins to shrinkwrap the div to the input, I don't like having had to override bootstrap and worry I may have misunderstood why the padding/negative margins were used in the first place.

---

Asana Ticket: https://app.asana.com/0/1203014709808707/1203888345713851