### PR TITLE
fix: don't position search page contents over views

### DIFF
--- a/assets/css/_late_view.scss
+++ b/assets/css/_late_view.scss
@@ -8,7 +8,7 @@ $late-view-background-color: $color-bg-light;
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 1001;
+  z-index: map-get($z-page-layout-context, "view");
 
   @media screen and (max-width: 700px) {
     width: 100%;

--- a/assets/css/_notification_drawer.scss
+++ b/assets/css/_notification_drawer.scss
@@ -8,7 +8,7 @@
   right: 0;
   top: 0;
   width: 23.5rem;
-  z-index: 1001;
+  z-index: map-get($z-page-layout-context, "view");
 
   @media screen and (max-width: $mobile-max-width) {
     width: 100%;

--- a/assets/css/_swings_view.scss
+++ b/assets/css/_swings_view.scss
@@ -8,7 +8,7 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 1001;
+  z-index: map-get($z-page-layout-context, "view");
 
   .m-old-close-button {
     padding: 1.5rem;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -11,7 +11,8 @@ $vpp-location-padding: 1rem;
 $z-page-layout-context: (
   "modal-overlay": 1000,
   "properties-panel": 1002,
-  "navbar": 1100,
+  "view": 1100,
+  "navbar": 1200,
 );
 
 $z-properties-panel-context: (


### PR DESCRIPTION
Non-ticketed hotfix.

We updated the `z-index` of the search panel to make sure it appears above all of the contents of the Leaflet map, however it turns out that on mobile the search panel is now staying on top of the view - see attached screenshot.

![IMG_2098](https://user-images.githubusercontent.com/2010157/219758338-30c8da59-6fe9-41f8-a56a-685f37507961.png)

This update keeps the navbar above the views, and also integrates views into the `$z-page-layout-context` map we have. It doesn't integrate those with the `$max-leaflet-z-index` constant unfortunately as I suspect that might be a larger lift (at least on the QA side) and I'd like to get this fix out.