### PR TITLE
Revert "build(deps-dev): bump @testing-library/react in /assets (#1932)"

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2207,62 +2207,24 @@
       }
     },
     "@testing-library/react": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
-      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
+        "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.21.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-          "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+          "version": "7.19.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+          "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
           "dev": true,
           "requires": {
-            "regenerator-runtime": "^0.13.11"
+            "regenerator-runtime": "^0.13.4"
           }
-        },
-        "@testing-library/dom": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.0.tgz",
-          "integrity": "sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^5.0.1",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "@types/aria-query": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-          "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.11",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-          "dev": true
         }
       }
     },

--- a/assets/package.json
+++ b/assets/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-env": "^7.19.3",
     "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.2.1",
     "@types/jest": "^27.4.1",
     "@types/leaflet": "^1.9.1",


### PR DESCRIPTION
This reverts commit 27f6943a7a5902ecd82fd88e83e986c23954e43d.

We got a bunch of new warnings about updates not being wrapped in `act` - we'll eventually need to revisit this and identify the root cause but for now I'm going to revert.