### PR TITLE
[⚙️🐞] fix(ts/components/routeLadder): route ladder detour icon popup

### DIFF
--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -59,7 +59,10 @@ const Header = ({
           trigger="click"
           onShow={() => tagManagerEvent("alert_tooltip_clicked")}
         >
-          <AlertIcon className="m-route-ladder__alert-icon" />
+          <AlertIcon
+            className="m-route-ladder__alert-icon"
+            aria-label="Route Alert"
+          />
         </Tippy>
       )}
       <div className="m-route-ladder__close-button-container">

--- a/assets/src/helpers/svgIcon.tsx
+++ b/assets/src/helpers/svgIcon.tsx
@@ -1,15 +1,18 @@
-import React, { ComponentPropsWithoutRef } from "react"
+import React, { ComponentPropsWithoutRef, forwardRef } from "react"
 
 // https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring
 interface SvgIconProps extends ComponentPropsWithoutRef<"span"> {
   svgText: string
 }
 
-export const SvgIcon = ({ svgText, ...props }: SvgIconProps) => (
-  // eslint-disable-next-line react/no-danger
-  <span {...props} dangerouslySetInnerHTML={{ __html: svgText }} />
+export const SvgIcon = forwardRef<HTMLSpanElement, SvgIconProps>(
+  ({ svgText, ...props }, ref) => (
+    // eslint-disable-next-line react/no-danger
+    <span ref={ref} {...props} dangerouslySetInnerHTML={{ __html: svgText }} />
+  )
 )
 
-export const svgIcon =
-  (svgText: string) => (props: ComponentPropsWithoutRef<"span">) =>
-    <SvgIcon svgText={svgText} {...props} />
+export const svgIcon = (svgText: string) =>
+  forwardRef<HTMLSpanElement, ComponentPropsWithoutRef<"span">>(
+    (props, ref) => <SvgIcon {...props} ref={ref} svgText={svgText} />
+  )

--- a/assets/src/helpers/svgIcon.tsx
+++ b/assets/src/helpers/svgIcon.tsx
@@ -5,6 +5,13 @@ interface SvgIconProps extends ComponentPropsWithoutRef<"span"> {
   svgText: string
 }
 
+/**
+ * Takes a SVG string and renders that as the `innerHTML` of the `container`
+ * element.
+ *
+ * Also exposes valid props of the `container` element, and passes the `ref`
+ * attribute to the `container` element.
+ */
 export const SvgIcon = forwardRef<HTMLSpanElement, SvgIconProps>(
   ({ svgText, ...props }, ref) => (
     // eslint-disable-next-line react/no-danger
@@ -12,6 +19,12 @@ export const SvgIcon = forwardRef<HTMLSpanElement, SvgIconProps>(
   )
 )
 
+/**
+ * Factory to construct a {@link SvgIcon} Component Definition from SVG.
+ *
+ * @param svgText HTML representation of the Icon
+ * @returns React Component Constructor
+ */
 export const svgIcon = (svgText: string) =>
   forwardRef<HTMLSpanElement, ComponentPropsWithoutRef<"span">>(
     (props, ref) => <SvgIcon {...props} ref={ref} svgText={svgText} />

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -5,11 +5,13 @@ import SearchPage from "../components/searchPage"
 import { SearchIcon, SearchMapIcon } from "../helpers/icon"
 import inTestGroup, { MAP_BETA_GROUP_NAME } from "../userInTestGroup"
 
+type HTMLElementProps = React.PropsWithoutRef<React.HTMLAttributes<HTMLElement>>
+
 export interface NavMode {
   path: string
   title: string
   element: ReactElement
-  navIcon: React.JSXElementConstructor<any>
+  navIcon: React.JSXElementConstructor<HTMLElementProps>
   supportsRightPanel: boolean
   navEventText?: string
 }

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -9,7 +9,7 @@ export interface NavMode {
   path: string
   title: string
   element: ReactElement
-  navIcon: (props: any) => ReactElement
+  navIcon: React.JSXElementConstructor<any>
   supportsRightPanel: boolean
   navEventText?: string
 }

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -106,80 +106,167 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
       viewBox="-92 -55 184 0"
       width="184"
     >
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-27.5)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-27.5)"
+          class="m-vehicle-icon m-vehicle-icon--small"
+        >
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="40"
+            x="-20"
+            y="6.6"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="12.1"
+          >
+            14/18
+          </text>
+          <g
+            class="m-ladder__crowding m-ladder__crowding--some-crowding"
+            transform="scale(0.38) translate(-24,-30)"
+          >
+            <rect
+              fill="transparent"
+              height="52"
+              width="52"
+              x="-2"
+              y="-2"
+            />
+            <path
+              d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
+            />
+            <circle
+              cx="6.74"
+              cy="8.54"
+              r="4.93"
+            />
+            <path
+              d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
+            />
+            <circle
+              cx="23.88"
+              cy="8.48"
+              r="4.93"
+            />
+            <path
+              d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
+            />
+            <circle
+              cx="41.03"
+              cy="8.48"
+              r="4.93"
+            />
+          </g>
+        </g>
+      </g>
+      <line
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
+        y1="0"
+        y2="-110"
+      />
+      <line
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
+        y1="0"
+        y2="-110"
+      />
+      <circle
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
+        r="3"
+      />
+      <circle
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
+        r="3"
+      />
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
+      >
+        MATPN
+      </text>
+      <circle
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
+        r="3"
+      />
+      <circle
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
+        r="3"
+      />
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
+      >
+        WELLH
+      </text>
+      <circle
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
+        r="3"
+      />
+      <circle
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
+        r="3"
+      />
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
+      >
+        MORTN
+      </text>
+    </svg>
+  </div>
+  <div
+    class="m-incoming-box"
+  >
+    <button
+      class="m-incoming-box__vehicle "
+    >
+      <div
+        class="m-incoming-box__vehicle-icon"
+      >
+        <svg
+          style="width: 16.72px; height: 15.2px;"
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
           <g
             class="m-vehicle-icon m-vehicle-icon--small"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="40"
-              x="-20"
-              y="6.6"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--extended"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="12.1"
-            >
-              14/18
-            </text>
             <g
-              class="m-ladder__crowding m-ladder__crowding--some-crowding"
-              transform="scale(0.38) translate(-24,-30)"
+              class="m-ladder__crowding m-ladder__crowding--no-data"
+              transform="scale(0.38) translate(-24,-14)"
             >
               <rect
                 fill="transparent"
@@ -214,217 +301,14 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
               />
             </g>
           </g>
-        </g>
+        </svg>
       </div>
-      <line
-        class="m-ladder__line"
-        x1="-40"
-        x2="-40"
-        y1="0"
-        y2="-110"
-      />
-      <line
-        class="m-ladder__line"
-        x1="40"
-        x2="40"
-        y1="0"
-        y2="-110"
-      />
-      <circle
-        class="m-ladder__stop-circle"
-        cx="-40"
-        cy="0"
-        r="3"
-      />
-      <circle
-        class="m-ladder__stop-circle"
-        cx="40"
-        cy="0"
-        r="3"
-      />
       <div
-        class="mock-tippy"
+        class="m-incoming-box__vehicle-label"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
+        ?/?
       </div>
-      <circle
-        class="m-ladder__stop-circle"
-        cx="-40"
-        cy="-55"
-        r="3"
-      />
-      <circle
-        class="m-ladder__stop-circle"
-        cx="40"
-        cy="-55"
-        r="3"
-      />
-      <div
-        class="mock-tippy"
-      >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
-      <circle
-        class="m-ladder__stop-circle"
-        cx="-40"
-        cy="-110"
-        r="3"
-      />
-      <circle
-        class="m-ladder__stop-circle"
-        cx="40"
-        cy="-110"
-        r="3"
-      />
-      <div
-        class="mock-tippy"
-      >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
-    </svg>
-  </div>
-  <div
-    class="m-incoming-box"
-  >
-    <div
-      class="mock-tippy"
-    >
-      <div
-        class="mock-tippy-content"
-      >
-        <b>
-          Block:
-        </b>
-         block-1
-        <br />
-        <b>
-          Run:
-        </b>
-         2
-        <br />
-        <b>
-          Vehicle:
-        </b>
-         0479
-        <br />
-        <b>
-          Variant:
-        </b>
-         
-        <br />
-        <b>
-          Adherence:
-        </b>
-         0 min early
-        <br />
-        <b>
-          Operator:
-        </b>
-         
-        <span
-          class="fs-mask"
-        >
-          NORA JONES #op2
-        </span>
-      </div>
-      <button
-        class="m-incoming-box__vehicle "
-      >
-        <div
-          class="m-incoming-box__vehicle-icon"
-        >
-          <svg
-            style="width: 16.72px; height: 15.2px;"
-            viewBox="-8.36 -7.6 16.72 15.2"
-          >
-            <g
-              class="m-vehicle-icon m-vehicle-icon--small"
-            >
-              <g
-                class="m-ladder__crowding m-ladder__crowding--no-data"
-                transform="scale(0.38) translate(-24,-14)"
-              >
-                <rect
-                  fill="transparent"
-                  height="52"
-                  width="52"
-                  x="-2"
-                  y="-2"
-                />
-                <path
-                  d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
-                />
-                <circle
-                  cx="6.74"
-                  cy="8.54"
-                  r="4.93"
-                />
-                <path
-                  d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
-                />
-                <circle
-                  cx="23.88"
-                  cy="8.48"
-                  r="4.93"
-                />
-                <path
-                  d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
-                />
-                <circle
-                  cx="41.03"
-                  cy="8.48"
-                  r="4.93"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="m-incoming-box__vehicle-label"
-        >
-          ?/?
-        </div>
-      </button>
-    </div>
+    </button>
   </div>
 </DocumentFragment>
 `;
@@ -480,95 +364,48 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
       viewBox="-92 -55 184 0"
       width="184"
     >
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-27.5)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-27.5)"
+          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="11.5"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="17"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="11.5"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="17"
-            >
-              1
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.625) rotate(0) translate(-24,-22)"
-            />
-            <text
-              class="m-vehicle-icon__variant"
-              dominant-baseline="alphabetic"
-              text-anchor="middle"
-              x="0"
-              y="8.5"
-            >
-              4
-            </text>
-          </g>
+            1
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+          <text
+            class="m-vehicle-icon__variant"
+            dominant-baseline="alphabetic"
+            text-anchor="middle"
+            x="0"
+            y="8.5"
+          >
+            4
+          </text>
         </g>
-      </div>
+      </g>
       <line
         class="m-ladder__line"
         x1="-40"
@@ -595,24 +432,15 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -625,24 +453,15 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -655,103 +474,52 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
     class="m-incoming-box"
   >
-    <div
-      class="mock-tippy"
+    <button
+      class="m-incoming-box__vehicle "
     >
       <div
-        class="mock-tippy-content"
+        class="m-incoming-box__vehicle-icon"
       >
-        <b>
-          Block:
-        </b>
-         block-1
-        <br />
-        <b>
-          Run:
-        </b>
-         2
-        <br />
-        <b>
-          Vehicle:
-        </b>
-         0479
-        <br />
-        <b>
-          Variant:
-        </b>
-         
-        <br />
-        <b>
-          Adherence:
-        </b>
-         0 min early
-        <br />
-        <b>
-          Operator:
-        </b>
-         
-        <span
-          class="fs-mask"
+        <svg
+          role="img"
+          style="width: 16.72px; height: 15.2px;"
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
-          NORA JONES #op2
-        </span>
-      </div>
-      <button
-        class="m-incoming-box__vehicle "
-      >
-        <div
-          class="m-incoming-box__vehicle-icon"
-        >
-          <svg
-            role="img"
-            style="width: 16.72px; height: 15.2px;"
-            viewBox="-8.36 -7.6 16.72 15.2"
+          <title>
+            Vehicle Status Icon
+          </title>
+          <g
+            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
           >
-            <title>
-              Vehicle Status Icon
-            </title>
-            <g
-              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
-            >
-              <path
-                class="m-vehicle-icon__triangle"
-                d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-                data-testid="vehicle-triangle"
-                transform="scale(0.38) rotate(180) translate(-24,-22)"
-              />
-            </g>
-          </svg>
-        </div>
-        <div
-          class="m-incoming-box__vehicle-label"
-        >
-          2
-        </div>
-      </button>
-    </div>
+            <path
+              class="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              data-testid="vehicle-triangle"
+              transform="scale(0.38) rotate(180) translate(-24,-22)"
+            />
+          </g>
+        </svg>
+      </div>
+      <div
+        class="m-incoming-box__vehicle-label"
+      >
+        2
+      </div>
+    </button>
   </div>
 </DocumentFragment>
 `;
@@ -807,95 +575,48 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
       viewBox="-92 -55 184 0"
       width="184"
     >
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-27.5)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-27.5)"
+          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="11.5"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="17"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="11.5"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="17"
-            >
-              1
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.625) rotate(0) translate(-24,-22)"
-            />
-            <text
-              class="m-vehicle-icon__variant"
-              dominant-baseline="alphabetic"
-              text-anchor="middle"
-              x="0"
-              y="8.5"
-            >
-              4
-            </text>
-          </g>
+            1
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+          <text
+            class="m-vehicle-icon__variant"
+            dominant-baseline="alphabetic"
+            text-anchor="middle"
+            x="0"
+            y="8.5"
+          >
+            4
+          </text>
         </g>
-      </div>
+      </g>
       <line
         class="m-ladder__line"
         x1="-40"
@@ -922,24 +643,15 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -952,24 +664,15 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -982,24 +685,15 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
@@ -1085,24 +779,15 @@ exports[`routeLadder renders a route ladder 1`] = `
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1115,24 +800,15 @@ exports[`routeLadder renders a route ladder 1`] = `
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1145,24 +821,15 @@ exports[`routeLadder renders a route ladder 1`] = `
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
@@ -1232,226 +899,132 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
       viewBox="-92 -55 184 0"
       width="184"
     >
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-27.5)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-27.5)"
+          class="m-vehicle-icon m-vehicle-icon--small"
         >
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="40"
+            x="-20"
+            y="6.6"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="12.1"
+          >
+            14/18
+          </text>
           <g
-            class="m-vehicle-icon m-vehicle-icon--small"
+            class="m-ladder__crowding m-ladder__crowding--some-crowding"
+            transform="scale(0.38) translate(-24,-30)"
           >
             <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="40"
-              x="-20"
-              y="6.6"
+              fill="transparent"
+              height="52"
+              width="52"
+              x="-2"
+              y="-2"
             />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--extended"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="12.1"
-            >
-              14/18
-            </text>
-            <g
-              class="m-ladder__crowding m-ladder__crowding--some-crowding"
-              transform="scale(0.38) translate(-24,-30)"
-            >
-              <rect
-                fill="transparent"
-                height="52"
-                width="52"
-                x="-2"
-                y="-2"
-              />
-              <path
-                d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
-              />
-              <circle
-                cx="6.74"
-                cy="8.54"
-                r="4.93"
-              />
-              <path
-                d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
-              />
-              <circle
-                cx="23.88"
-                cy="8.48"
-                r="4.93"
-              />
-              <path
-                d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
-              />
-              <circle
-                cx="41.03"
-                cy="8.48"
-                r="4.93"
-              />
-            </g>
+            <path
+              d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
+            />
+            <circle
+              cx="6.74"
+              cy="8.54"
+              r="4.93"
+            />
+            <path
+              d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
+            />
+            <circle
+              cx="23.88"
+              cy="8.48"
+              r="4.93"
+            />
+            <path
+              d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
+            />
+            <circle
+              cx="41.03"
+              cy="8.48"
+              r="4.93"
+            />
           </g>
         </g>
-      </div>
-      <div
-        class="mock-tippy"
+      </g>
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(-63,-110)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             2
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               0479
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      NORA JONES #op2
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(-63,-110)"
+          class="m-vehicle-icon m-vehicle-icon--small"
         >
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="-17.6"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="-12.100000000000001"
+          >
+            ?/?
+          </text>
           <g
-            class="m-vehicle-icon m-vehicle-icon--small"
+            class="m-ladder__crowding m-ladder__crowding--no-data"
+            transform="scale(0.38) translate(-24,-14)"
           >
             <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="-17.6"
+              fill="transparent"
+              height="52"
+              width="52"
+              x="-2"
+              y="-2"
             />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="-12.100000000000001"
-            >
-              ?/?
-            </text>
-            <g
-              class="m-ladder__crowding m-ladder__crowding--no-data"
-              transform="scale(0.38) translate(-24,-14)"
-            >
-              <rect
-                fill="transparent"
-                height="52"
-                width="52"
-                x="-2"
-                y="-2"
-              />
-              <path
-                d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
-              />
-              <circle
-                cx="6.74"
-                cy="8.54"
-                r="4.93"
-              />
-              <path
-                d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
-              />
-              <circle
-                cx="23.88"
-                cy="8.48"
-                r="4.93"
-              />
-              <path
-                d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
-              />
-              <circle
-                cx="41.03"
-                cy="8.48"
-                r="4.93"
-              />
-            </g>
+            <path
+              d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z"
+            />
+            <circle
+              cx="6.74"
+              cy="8.54"
+              r="4.93"
+            />
+            <path
+              d="M23.88,16.17A6.86,6.86,0,0,0,17,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23a6.86,6.86,0,0,0-6.86-6.86Z"
+            />
+            <circle
+              cx="23.88"
+              cy="8.48"
+              r="4.93"
+            />
+            <path
+              d="M41,16.17A6.87,6.87,0,0,0,34.17,23V40.8a3.42,3.42,0,0,0,3.42,3.42h6.86a3.43,3.43,0,0,0,3.43-3.42V23A6.86,6.86,0,0,0,41,16.17Z"
+            />
+            <circle
+              cx="41.03"
+              cy="8.48"
+              r="4.93"
+            />
           </g>
         </g>
-      </div>
+      </g>
       <line
         class="m-ladder__line"
         x1="-40"
@@ -1478,24 +1051,15 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1508,24 +1072,15 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1538,24 +1093,15 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
@@ -1615,175 +1161,81 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
       viewBox="-92 -55 184 0"
       width="184"
     >
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(0,-35)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             2
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               0479
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      NORA JONES #op2
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(0,-35)"
+          class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="7.359999999999999"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="12.86"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="7.359999999999999"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="12.86"
-            >
-              2
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.38) rotate(270) translate(-24,-22)"
-            />
-          </g>
+            2
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.38) rotate(270) translate(-24,-22)"
+          />
         </g>
-      </div>
-      <div
-        class="mock-tippy"
+      </g>
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(0,-85)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(0,-85)"
+          class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="7.359999999999999"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="12.86"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="7.359999999999999"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="12.86"
-            >
-              1
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.38) rotate(90) translate(-24,-22)"
-            />
-            <text
-              class="m-vehicle-icon__variant"
-              dominant-baseline="central"
-              text-anchor="start"
-              x="-5.6"
-              y="0"
-            >
-              4
-            </text>
-          </g>
+            1
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.38) rotate(90) translate(-24,-22)"
+          />
+          <text
+            class="m-vehicle-icon__variant"
+            dominant-baseline="central"
+            text-anchor="start"
+            x="-5.6"
+            y="0"
+          >
+            4
+          </text>
         </g>
-      </div>
+      </g>
       <line
         class="m-ladder__line"
         x1="-40"
@@ -1810,24 +1262,15 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1840,24 +1283,15 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -1870,24 +1304,15 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
@@ -1954,307 +1379,166 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         y1="-110"
         y2="-110"
       />
-      <div
-        class="mock-tippy"
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-27.5)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             1
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               1818
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 4
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      PATTI SMITH #op1
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-27.5)"
+          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="11.5"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="17"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="11.5"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="17"
-            >
-              1
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.625) rotate(0) translate(-24,-22)"
-            />
-            <text
-              class="m-vehicle-icon__variant"
-              dominant-baseline="alphabetic"
-              text-anchor="middle"
-              x="0"
-              y="8.5"
-            >
-              4
-            </text>
-          </g>
+            1
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.625) rotate(0) translate(-24,-22)"
+          />
+          <text
+            class="m-vehicle-icon__variant"
+            dominant-baseline="alphabetic"
+            text-anchor="middle"
+            x="0"
+            y="8.5"
+          >
+            4
+          </text>
         </g>
-      </div>
-      <div
-        class="mock-tippy"
+      </g>
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(63,-110)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           ghost block
-          <br>
-            <b>
-              Run:
-            </b>
-             0123
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               N/A
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   N/A
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      N/A
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(63,-110)"
+          class="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="11.5"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="17"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="11.5"
+            0123
+          </text>
+          <g
+            transform="scale(0.4375) translate(-24,-23)"
+          >
+            <path
+              class="m-vehicle-icon__ghost-highlight"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-linejoin="round"
             />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="17"
-            >
-              0123
-            </text>
+            <path
+              class="m-vehicle-icon__ghost-body"
+              d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
+              stroke-linejoin="round"
+            />
+            <ellipse
+              class="m-vehicle-icon__ghost-eye"
+              cx="19.73"
+              cy="22.8"
+              rx="3.11"
+              ry="3.03"
+            />
+            <ellipse
+              class="m-vehicle-icon__ghost-eye"
+              cx="35.29"
+              cy="22.8"
+              rx="3.11"
+              ry="3.03"
+            />
+          </g>
+          <g
+            transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
+          >
             <g
-              transform="scale(0.4375) translate(-24,-23)"
+              class="c-icon-alert-circle--highlighted"
             >
-              <path
-                class="m-vehicle-icon__ghost-highlight"
-                d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-                stroke-linejoin="round"
+              <circle
+                class="c-icon-alert-circle__outline"
+                cx="24"
+                cy="24"
+                r="27"
               />
-              <path
-                class="m-vehicle-icon__ghost-body"
-                d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-                stroke-linejoin="round"
+              <circle
+                class="c-icon-alert-circle__fill"
+                cx="24"
+                cy="24"
+                r="22.59"
               />
-              <ellipse
-                class="m-vehicle-icon__ghost-eye"
-                cx="19.73"
-                cy="22.8"
-                rx="3.11"
-                ry="3.03"
-              />
-              <ellipse
-                class="m-vehicle-icon__ghost-eye"
-                cx="35.29"
-                cy="22.8"
-                rx="3.11"
-                ry="3.03"
-              />
-            </g>
-            <g
-              transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
-            >
               <g
-                class="c-icon-alert-circle--highlighted"
+                class="c-icon-alert-circle__exclamation-point"
               >
-                <circle
-                  class="c-icon-alert-circle__outline"
-                  cx="24"
-                  cy="24"
-                  r="27"
+                <path
+                  d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
                 />
-                <circle
-                  class="c-icon-alert-circle__fill"
-                  cx="24"
-                  cy="24"
-                  r="22.59"
+                <path
+                  d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
                 />
-                <g
-                  class="c-icon-alert-circle__exclamation-point"
-                >
-                  <path
-                    d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
-                  />
-                  <path
-                    d="m21.57 34.54h4.87a1.88 1.88 0 0 1 1.82 1.93v5.17a1.89 1.89 0 0 1 -1.82 1.94h-4.87a1.89 1.89 0 0 1 -1.83-1.94v-5.17a1.88 1.88 0 0 1 1.83-1.93"
-                  />
-                </g>
               </g>
             </g>
           </g>
         </g>
-      </div>
-      <div
-        class="mock-tippy"
+      </g>
+      <g
+        class="m-ladder__vehicle  "
+        transform="translate(-63,-110)"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          <b>
-            Block:
-          </b>
-           block-1
-          <br>
-            <b>
-              Run:
-            </b>
-             2
-            <br>
-              <b>
-                Vehicle:
-              </b>
-               0479
-              <br>
-                <b>
-                  Variant:
-                </b>
-                 
-                <br>
-                  <b>
-                    Adherence:
-                  </b>
-                   0 min early
-                  <br>
-                    <b>
-                      Operator:
-                    </b>
-                     
-                    <span
-                      class="fs-mask"
-                    >
-                      NORA JONES #op2
-                    </span>
-                  </br>
-                </br>
-              </br>
-            </br>
-          </br>
-        </div>
         <g
-          class="m-ladder__vehicle  "
-          transform="translate(-63,-110)"
+          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
         >
-          <g
-            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          <rect
+            class="m-vehicle-icon__label-background"
+            height="11"
+            rx="5.5"
+            ry="5.5"
+            width="26"
+            x="-13"
+            y="-22.5"
+          />
+          <text
+            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            dominant-baseline="central"
+            text-anchor="middle"
+            x="0"
+            y="-17"
           >
-            <rect
-              class="m-vehicle-icon__label-background"
-              height="11"
-              rx="5.5"
-              ry="5.5"
-              width="26"
-              x="-13"
-              y="-22.5"
-            />
-            <text
-              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominant-baseline="central"
-              text-anchor="middle"
-              x="0"
-              y="-17"
-            >
-              2
-            </text>
-            <path
-              class="m-vehicle-icon__triangle"
-              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-              data-testid="vehicle-triangle"
-              transform="scale(0.625) rotate(180) translate(-24,-22)"
-            />
-          </g>
+            2
+          </text>
+          <path
+            class="m-vehicle-icon__triangle"
+            d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+            data-testid="vehicle-triangle"
+            transform="scale(0.625) rotate(180) translate(-24,-22)"
+          />
         </g>
-      </div>
+      </g>
       <line
         class="m-ladder__line"
         x1="-40"
@@ -2281,24 +1565,15 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -2311,24 +1586,15 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -2341,24 +1607,15 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
@@ -2444,24 +1701,15 @@ exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`
         cy="0"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="0"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MATPN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="0"
-        >
-          MATPN
-        </text>
-      </div>
+        MATPN
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -2474,24 +1722,15 @@ exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`
         cy="-55"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-55"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          WELLH Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-55"
-        >
-          WELLH
-        </text>
-      </div>
+        WELLH
+      </text>
       <circle
         class="m-ladder__stop-circle"
         cx="-40"
@@ -2504,186 +1743,93 @@ exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`
         cy="-110"
         r="3"
       />
-      <div
-        class="mock-tippy"
+      <text
+        class="m-ladder__timepoint-name"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        x="0"
+        y="-110"
       >
-        <div
-          class="mock-tippy-content"
-        >
-          MORTN Name
-        </div>
-        <text
-          class="m-ladder__timepoint-name"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          x="0"
-          y="-110"
-        >
-          MORTN
-        </text>
-      </div>
+        MORTN
+      </text>
     </svg>
   </div>
   <div
     class="m-incoming-box"
   >
-    <div
-      class="mock-tippy"
+    <button
+      class="m-incoming-box__vehicle "
     >
       <div
-        class="mock-tippy-content"
+        class="m-incoming-box__vehicle-icon"
       >
-        <b>
-          Block:
-        </b>
-         block-1
-        <br />
-        <b>
-          Run:
-        </b>
-         1
-        <br />
-        <b>
-          Vehicle:
-        </b>
-         1818
-        <br />
-        <b>
-          Variant:
-        </b>
-         4
-        <br />
-        <b>
-          Adherence:
-        </b>
-         0 min early
-        <br />
-        <b>
-          Operator:
-        </b>
-         
-        <span
-          class="fs-mask"
+        <svg
+          role="img"
+          style="width: 16.72px; height: 15.2px;"
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
-          PATTI SMITH #op1
-        </span>
-      </div>
-      <button
-        class="m-incoming-box__vehicle "
-      >
-        <div
-          class="m-incoming-box__vehicle-icon"
-        >
-          <svg
-            role="img"
-            style="width: 16.72px; height: 15.2px;"
-            viewBox="-8.36 -7.6 16.72 15.2"
+          <title>
+            Vehicle Status Icon
+          </title>
+          <g
+            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
           >
-            <title>
-              Vehicle Status Icon
-            </title>
-            <g
-              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            <path
+              class="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              data-testid="vehicle-triangle"
+              transform="scale(0.38) rotate(0) translate(-24,-22)"
+            />
+            <text
+              class="m-vehicle-icon__variant"
+              dominant-baseline="alphabetic"
+              text-anchor="middle"
+              x="0"
+              y="5.6"
             >
-              <path
-                class="m-vehicle-icon__triangle"
-                d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-                data-testid="vehicle-triangle"
-                transform="scale(0.38) rotate(0) translate(-24,-22)"
-              />
-              <text
-                class="m-vehicle-icon__variant"
-                dominant-baseline="alphabetic"
-                text-anchor="middle"
-                x="0"
-                y="5.6"
-              >
-                4
-              </text>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="m-incoming-box__vehicle-label"
-        >
-          1
-        </div>
-      </button>
-    </div>
-    <div
-      class="mock-tippy"
+              4
+            </text>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="m-incoming-box__vehicle-label"
+      >
+        1
+      </div>
+    </button>
+    <button
+      class="m-incoming-box__vehicle "
     >
       <div
-        class="mock-tippy-content"
+        class="m-incoming-box__vehicle-icon"
       >
-        <b>
-          Block:
-        </b>
-         block-1
-        <br />
-        <b>
-          Run:
-        </b>
-         2
-        <br />
-        <b>
-          Vehicle:
-        </b>
-         0479
-        <br />
-        <b>
-          Variant:
-        </b>
-         
-        <br />
-        <b>
-          Adherence:
-        </b>
-         0 min early
-        <br />
-        <b>
-          Operator:
-        </b>
-         
-        <span
-          class="fs-mask"
+        <svg
+          role="img"
+          style="width: 16.72px; height: 15.2px;"
+          viewBox="-8.36 -7.6 16.72 15.2"
         >
-          NORA JONES #op2
-        </span>
-      </div>
-      <button
-        class="m-incoming-box__vehicle "
-      >
-        <div
-          class="m-incoming-box__vehicle-icon"
-        >
-          <svg
-            role="img"
-            style="width: 16.72px; height: 15.2px;"
-            viewBox="-8.36 -7.6 16.72 15.2"
+          <title>
+            Vehicle Status Icon
+          </title>
+          <g
+            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
           >
-            <title>
-              Vehicle Status Icon
-            </title>
-            <g
-              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
-            >
-              <path
-                class="m-vehicle-icon__triangle"
-                d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
-                data-testid="vehicle-triangle"
-                transform="scale(0.38) rotate(180) translate(-24,-22)"
-              />
-            </g>
-          </svg>
-        </div>
-        <div
-          class="m-incoming-box__vehicle-label"
-        >
-          2
-        </div>
-      </button>
-    </div>
+            <path
+              class="m-vehicle-icon__triangle"
+              d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
+              data-testid="vehicle-triangle"
+              transform="scale(0.38) rotate(180) translate(-24,-22)"
+            />
+          </g>
+        </svg>
+      </div>
+      <div
+        class="m-incoming-box__vehicle-label"
+      >
+        2
+      </div>
+    </button>
   </div>
 </DocumentFragment>
 `;

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -1,209 +1,184 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`routeLadder displays loading if we are fetching the timepoints 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
-  "loading...",
-]
+  </div>
+  loading...
+</DocumentFragment>
 `;
 
 exports[`routeLadder displays no crowding data for a bus coming off a route with no crowding data onto a route with crowding data 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
     <button
-      className="m-route-ladder__crowding-toggle m-route-ladder__crowding-toggle--hide"
-      onClick={[Function]}
+      class="m-route-ladder__crowding-toggle m-route-ladder__crowding-toggle--hide"
     >
       <span
-        className="m-route-ladder__crowding-toggle-icon m-route-ladder__crowding-toggle-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__crowding-toggle-icon m-route-ladder__crowding-toggle-icon"
+      >
+        <svg />
+      </span>
       Hide riders
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-27.5)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small"
+            class="m-vehicle-icon m-vehicle-icon--small"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={40}
-              x={-20}
-              y={6.6}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="40"
+              x="-20"
+              y="6.6"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--extended"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={12.1}
+              y="12.1"
             >
               14/18
             </text>
             <g
-              className="m-ladder__crowding m-ladder__crowding--some-crowding"
+              class="m-ladder__crowding m-ladder__crowding--some-crowding"
               transform="scale(0.38) translate(-24,-30)"
             >
               <rect
@@ -242,137 +217,134 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
+    class="m-incoming-box"
   >
     <div
-      className="mock-tippy"
+      class="mock-tippy"
     >
       <div
-        className="mock-tippy-content"
+        class="mock-tippy-content"
       >
         <b>
           Block:
         </b>
-         
-        block-1
+         block-1
         <br />
         <b>
           Run:
         </b>
-         
-        2
+         2
         <br />
         <b>
           Vehicle:
         </b>
-         
-        0479
+         0479
         <br />
         <b>
           Variant:
@@ -382,40 +354,33 @@ Array [
         <b>
           Adherence:
         </b>
-         
-        0 min early
+         0 min early
         <br />
         <b>
           Operator:
         </b>
          
         <span
-          className="fs-mask"
+          class="fs-mask"
         >
           NORA JONES #op2
         </span>
       </div>
       <button
-        className="m-incoming-box__vehicle "
-        onClick={[Function]}
+        class="m-incoming-box__vehicle "
       >
         <div
-          className="m-incoming-box__vehicle-icon"
+          class="m-incoming-box__vehicle-icon"
         >
           <svg
-            style={
-              Object {
-                "height": 15.2,
-                "width": 16.72,
-              }
-            }
+            style="width: 16.72px; height: 15.2px;"
             viewBox="-8.36 -7.6 16.72 15.2"
           >
             <g
-              className="m-vehicle-icon m-vehicle-icon--small"
+              class="m-vehicle-icon m-vehicle-icon--small"
             >
               <g
-                className="m-ladder__crowding m-ladder__crowding--no-data"
+                class="m-ladder__crowding m-ladder__crowding--no-data"
                 transform="scale(0.38) translate(-24,-14)"
               >
                 <rect
@@ -454,163 +419,150 @@ Array [
           </svg>
         </div>
         <div
-          className="m-incoming-box__vehicle-label"
+          class="m-incoming-box__vehicle-label"
         >
           ?/?
         </div>
       </button>
     </div>
-  </div>,
-]
+  </div>
+</DocumentFragment>
 `;
 
 exports[`routeLadder doesn't display crowding data for a vehicle coming off a route with crowding data onto a route with none 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-27.5)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={11.5}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="11.5"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={17}
+              y="17"
             >
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.625) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
-              dominantBaseline="alphabetic"
-              textAnchor="middle"
-              x={0}
-              y={8.5}
+              class="m-vehicle-icon__variant"
+              dominant-baseline="alphabetic"
+              text-anchor="middle"
+              x="0"
+              y="8.5"
             >
               4
             </text>
@@ -618,137 +570,134 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
+    class="m-incoming-box"
   >
     <div
-      className="mock-tippy"
+      class="mock-tippy"
     >
       <div
-        className="mock-tippy-content"
+        class="mock-tippy-content"
       >
         <b>
           Block:
         </b>
-         
-        block-1
+         block-1
         <br />
         <b>
           Run:
         </b>
-         
-        2
+         2
         <br />
         <b>
           Vehicle:
         </b>
-         
-        0479
+         0479
         <br />
         <b>
           Variant:
@@ -758,44 +707,37 @@ Array [
         <b>
           Adherence:
         </b>
-         
-        0 min early
+         0 min early
         <br />
         <b>
           Operator:
         </b>
          
         <span
-          className="fs-mask"
+          class="fs-mask"
         >
           NORA JONES #op2
         </span>
       </div>
       <button
-        className="m-incoming-box__vehicle "
-        onClick={[Function]}
+        class="m-incoming-box__vehicle "
       >
         <div
-          className="m-incoming-box__vehicle-icon"
+          class="m-incoming-box__vehicle-icon"
         >
           <svg
             role="img"
-            style={
-              Object {
-                "height": 15.2,
-                "width": 16.72,
-              }
-            }
+            style="width: 16.72px; height: 15.2px;"
             viewBox="-8.36 -7.6 16.72 15.2"
           >
             <title>
               Vehicle Status Icon
             </title>
             <g
-              className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
             >
               <path
-                className="m-vehicle-icon__triangle"
+                class="m-vehicle-icon__triangle"
                 d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                 data-testid="vehicle-triangle"
                 transform="scale(0.38) rotate(180) translate(-24,-22)"
@@ -804,163 +746,150 @@ Array [
           </svg>
         </div>
         <div
-          className="m-incoming-box__vehicle-label"
+          class="m-incoming-box__vehicle-label"
         >
           2
         </div>
       </button>
     </div>
-  </div>,
-]
+  </div>
+</DocumentFragment>
 `;
 
 exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-27.5)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={11.5}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="11.5"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={17}
+              y="17"
             >
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.625) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
-              dominantBaseline="alphabetic"
-              textAnchor="middle"
-              x={0}
-              y={8.5}
+              class="m-vehicle-icon__variant"
+              dominant-baseline="alphabetic"
+              text-anchor="middle"
+              x="0"
+              y="8.5"
             >
               4
             </text>
@@ -968,443 +897,414 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
-  />,
-]
+    class="m-incoming-box"
+  />
+</DocumentFragment>
 `;
 
 exports[`routeLadder renders a route ladder 1`] = `
-Array [
+<div>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
-  />,
-]
+    class="m-incoming-box"
+  />
+</div>
 `;
 
 exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
     <button
-      className="m-route-ladder__crowding-toggle m-route-ladder__crowding-toggle--hide"
-      onClick={[Function]}
+      class="m-route-ladder__crowding-toggle m-route-ladder__crowding-toggle--hide"
     >
       <span
-        className="m-route-ladder__crowding-toggle-icon m-route-ladder__crowding-toggle-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__crowding-toggle-icon m-route-ladder__crowding-toggle-icon"
+      >
+        <svg />
+      </span>
       Hide riders
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-27.5)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small"
+            class="m-vehicle-icon m-vehicle-icon--small"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={40}
-              x={-20}
-              y={6.6}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="40"
+              x="-20"
+              y="6.6"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--extended"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={12.1}
+              y="12.1"
             >
               14/18
             </text>
             <g
-              className="m-ladder__crowding m-ladder__crowding--some-crowding"
+              class="m-ladder__crowding m-ladder__crowding--some-crowding"
               transform="scale(0.38) translate(-24,-30)"
             >
               <rect
@@ -1443,78 +1343,78 @@ Array [
         </g>
       </div>
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          2
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          0479
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            NORA JONES #op2
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             2
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               0479
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      NORA JONES #op2
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(-63,-110)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small"
+            class="m-vehicle-icon m-vehicle-icon--small"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={-17.6}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="-17.6"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={-12.100000000000001}
+              y="-12.100000000000001"
             >
               ?/?
             </text>
             <g
-              className="m-ladder__crowding m-ladder__crowding--no-data"
+              class="m-ladder__crowding m-ladder__crowding--no-data"
               transform="scale(0.38) translate(-24,-14)"
             >
               <rect
@@ -1553,253 +1453,241 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
-  />,
-]
+    class="m-incoming-box"
+  />
+</DocumentFragment>
 `;
 
 exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          2
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          0479
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            NORA JONES #op2
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             2
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               0479
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      NORA JONES #op2
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(0,-35)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={7.359999999999999}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="7.359999999999999"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={12.86}
+              y="12.86"
             >
               2
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(270) translate(-24,-22)"
@@ -1808,89 +1696,88 @@ Array [
         </g>
       </div>
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(0,-85)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={7.359999999999999}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="7.359999999999999"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={12.86}
+              y="12.86"
             >
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(90) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
-              dominantBaseline="central"
-              textAnchor="start"
-              x={-5.6}
-              y={0}
+              class="m-vehicle-icon__variant"
+              dominant-baseline="central"
+              text-anchor="start"
+              x="-5.6"
+              y="0"
             >
               4
             </text>
@@ -1898,271 +1785,258 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
-  />,
-]
+    class="m-incoming-box"
+  />
+</DocumentFragment>
 `;
 
 exports[`routeLadder renders a route ladder with vehicles 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <line
-        className="m-ladder__scheduled-line on-time early-red"
-        x1={-63}
-        x2={-40}
-        y1={-110}
-        y2={-110}
+        class="m-ladder__scheduled-line on-time early-red"
+        x1="-63"
+        x2="-40"
+        y1="-110"
+        y2="-110"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          1
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          1818
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          4
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            PATTI SMITH #op1
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             1
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               1818
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 4
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      PATTI SMITH #op1
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-27.5)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={11.5}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="11.5"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={17}
+              y="17"
             >
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.625) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
-              dominantBaseline="alphabetic"
-              textAnchor="middle"
-              x={0}
-              y={8.5}
+              class="m-vehicle-icon__variant"
+              dominant-baseline="alphabetic"
+              text-anchor="middle"
+              x="0"
+              y="8.5"
             >
               4
             </text>
@@ -2170,73 +2044,73 @@ Array [
         </g>
       </div>
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          ghost block
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          0123
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          N/A
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          N/A
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            N/A
-          </span>
+           ghost block
+          <br>
+            <b>
+              Run:
+            </b>
+             0123
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               N/A
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   N/A
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      N/A
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(63,-110)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
+            class="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={11.5}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="11.5"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={17}
+              y="17"
             >
               0123
             </text>
@@ -2244,24 +2118,24 @@ Array [
               transform="scale(0.4375) translate(-24,-23)"
             >
               <path
-                className="m-vehicle-icon__ghost-highlight"
+                class="m-vehicle-icon__ghost-highlight"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-                strokeLinejoin="round"
+                stroke-linejoin="round"
               />
               <path
-                className="m-vehicle-icon__ghost-body"
+                class="m-vehicle-icon__ghost-body"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
-                strokeLinejoin="round"
+                stroke-linejoin="round"
               />
               <ellipse
-                className="m-vehicle-icon__ghost-eye"
+                class="m-vehicle-icon__ghost-eye"
                 cx="19.73"
                 cy="22.8"
                 rx="3.11"
                 ry="3.03"
               />
               <ellipse
-                className="m-vehicle-icon__ghost-eye"
+                class="m-vehicle-icon__ghost-eye"
                 cx="35.29"
                 cy="22.8"
                 rx="3.11"
@@ -2272,22 +2146,22 @@ Array [
               transform="translate(9.375, -6.25) scale(0.2) translate(-24, -24)"
             >
               <g
-                className="c-icon-alert-circle--highlighted"
+                class="c-icon-alert-circle--highlighted"
               >
                 <circle
-                  className="c-icon-alert-circle__outline"
+                  class="c-icon-alert-circle__outline"
                   cx="24"
                   cy="24"
                   r="27"
                 />
                 <circle
-                  className="c-icon-alert-circle__fill"
+                  class="c-icon-alert-circle__fill"
                   cx="24"
                   cy="24"
                   r="22.59"
                 />
                 <g
-                  className="c-icon-alert-circle__exclamation-point"
+                  class="c-icon-alert-circle__exclamation-point"
                 >
                   <path
                     d="m20.39 4.42h7.22a1.81 1.81 0 0 1 1.49 2.11l-1.49 23.22a1.73 1.73 0 0 1 -1.49 1.78h-4.24a1.73 1.73 0 0 1 -1.49-1.78l-1.49-23.22c-.07-1.13.61-2.11 1.49-2.11"
@@ -2302,78 +2176,78 @@ Array [
         </g>
       </div>
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           <b>
             Block:
           </b>
-           
-          block-1
-          <br />
-          <b>
-            Run:
-          </b>
-           
-          2
-          <br />
-          <b>
-            Vehicle:
-          </b>
-           
-          0479
-          <br />
-          <b>
-            Variant:
-          </b>
-           
-          <br />
-          <b>
-            Adherence:
-          </b>
-           
-          0 min early
-          <br />
-          <b>
-            Operator:
-          </b>
-           
-          <span
-            className="fs-mask"
-          >
-            NORA JONES #op2
-          </span>
+           block-1
+          <br>
+            <b>
+              Run:
+            </b>
+             2
+            <br>
+              <b>
+                Vehicle:
+              </b>
+               0479
+              <br>
+                <b>
+                  Variant:
+                </b>
+                 
+                <br>
+                  <b>
+                    Adherence:
+                  </b>
+                   0 min early
+                  <br>
+                    <b>
+                      Operator:
+                    </b>
+                     
+                    <span
+                      class="fs-mask"
+                    >
+                      NORA JONES #op2
+                    </span>
+                  </br>
+                </br>
+              </br>
+            </br>
+          </br>
         </div>
         <g
-          className="m-ladder__vehicle  "
-          onClick={[Function]}
+          class="m-ladder__vehicle  "
           transform="translate(-63,-110)"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+            class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
-              height={11}
-              rx={5.5}
-              ry={5.5}
-              width={26}
-              x={-13}
-              y={-22.5}
+              class="m-vehicle-icon__label-background"
+              height="11"
+              rx="5.5"
+              ry="5.5"
+              width="26"
+              x="-13"
+              y="-22.5"
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
-              dominantBaseline="central"
-              textAnchor="middle"
+              class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              dominant-baseline="central"
+              text-anchor="middle"
               x="0"
-              y={-17}
+              y="-17"
             >
               2
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              class="m-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -2382,370 +2256,347 @@ Array [
         </g>
       </div>
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
-  />,
-]
+    class="m-incoming-box"
+  />
+</DocumentFragment>
 `;
 
 exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`] = `
-Array [
+<DocumentFragment>
   <div
-    className="m-route-ladder__header"
+    class="m-route-ladder__header"
   >
     <div
-      className="m-route-ladder__close-button-container"
+      class="m-route-ladder__close-button-container"
     >
       <button
         aria-label="Close"
-        className="m-close-button m-close-button--large m-close-button--darker"
-        onClick={[Function]}
+        class="m-close-button m-close-button--large m-close-button--darker"
       >
         <span
-          aria-hidden={true}
+          aria-hidden="true"
           aria-label=""
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<svg/>",
-            }
-          }
           role="img"
-        />
+        >
+          <svg />
+        </span>
       </button>
     </div>
     <div
-      className="m-route-ladder__route-name"
+      class="m-route-ladder__route-name"
     >
       28
     </div>
-  </div>,
+  </div>
   <div
-    className="m-route-ladder__controls"
+    class="m-route-ladder__controls"
   >
     <button
-      className="m-route-ladder__reverse"
-      onClick={[Function]}
+      class="m-route-ladder__reverse"
     >
       <span
-        className="m-route-ladder__reverse-icon"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-      />
+        class="m-route-ladder__reverse-icon"
+      >
+        <svg />
+      </span>
       Reverse
     </button>
-  </div>,
+  </div>
   <div
-    className="m-ladder"
-    style={
-      Object {
-        "width": 184,
-      }
-    }
+    class="m-ladder"
+    style="width: 184px;"
   >
     <svg
-      className="m-ladder__svg"
-      height={0}
+      class="m-ladder__svg"
+      height="0"
       viewBox="-92 -55 184 0"
-      width={184}
+      width="184"
     >
       <line
-        className="m-ladder__line"
-        x1={-40}
-        x2={-40}
+        class="m-ladder__line"
+        x1="-40"
+        x2="-40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <line
-        className="m-ladder__line"
-        x1={40}
-        x2={40}
+        class="m-ladder__line"
+        x1="40"
+        x2="40"
         y1="0"
-        y2={-110}
+        y2="-110"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="0"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-0}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="0"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MATPN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-0}
+          y="0"
         >
           MATPN
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-55"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-55}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-55"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           WELLH Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-55}
+          y="-55"
         >
           WELLH
         </text>
       </div>
       <circle
-        className="m-ladder__stop-circle"
-        cx={-40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="-40"
+        cy="-110"
         r="3"
       />
       <circle
-        className="m-ladder__stop-circle"
-        cx={40}
-        cy={-110}
+        class="m-ladder__stop-circle"
+        cx="40"
+        cy="-110"
         r="3"
       />
       <div
-        className="mock-tippy"
+        class="mock-tippy"
       >
         <div
-          className="mock-tippy-content"
+          class="mock-tippy-content"
         >
           MORTN Name
         </div>
         <text
-          className="m-ladder__timepoint-name"
-          dominantBaseline="middle"
-          textAnchor="middle"
+          class="m-ladder__timepoint-name"
+          dominant-baseline="middle"
+          text-anchor="middle"
           x="0"
-          y={-110}
+          y="-110"
         >
           MORTN
         </text>
       </div>
     </svg>
-  </div>,
+  </div>
   <div
-    className="m-incoming-box"
+    class="m-incoming-box"
   >
     <div
-      className="mock-tippy"
+      class="mock-tippy"
     >
       <div
-        className="mock-tippy-content"
+        class="mock-tippy-content"
       >
         <b>
           Block:
         </b>
-         
-        block-1
+         block-1
         <br />
         <b>
           Run:
         </b>
-         
-        1
+         1
         <br />
         <b>
           Vehicle:
         </b>
-         
-        1818
+         1818
         <br />
         <b>
           Variant:
         </b>
-         
-        4
+         4
         <br />
         <b>
           Adherence:
         </b>
-         
-        0 min early
+         0 min early
         <br />
         <b>
           Operator:
         </b>
          
         <span
-          className="fs-mask"
+          class="fs-mask"
         >
           PATTI SMITH #op1
         </span>
       </div>
       <button
-        className="m-incoming-box__vehicle "
-        onClick={[Function]}
+        class="m-incoming-box__vehicle "
       >
         <div
-          className="m-incoming-box__vehicle-icon"
+          class="m-incoming-box__vehicle-icon"
         >
           <svg
             role="img"
-            style={
-              Object {
-                "height": 15.2,
-                "width": 16.72,
-              }
-            }
+            style="width: 16.72px; height: 15.2px;"
             viewBox="-8.36 -7.6 16.72 15.2"
           >
             <title>
               Vehicle Status Icon
             </title>
             <g
-              className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
             >
               <path
-                className="m-vehicle-icon__triangle"
+                class="m-vehicle-icon__triangle"
                 d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                 data-testid="vehicle-triangle"
                 transform="scale(0.38) rotate(0) translate(-24,-22)"
               />
               <text
-                className="m-vehicle-icon__variant"
-                dominantBaseline="alphabetic"
-                textAnchor="middle"
-                x={0}
-                y={5.6}
+                class="m-vehicle-icon__variant"
+                dominant-baseline="alphabetic"
+                text-anchor="middle"
+                x="0"
+                y="5.6"
               >
                 4
               </text>
@@ -2753,35 +2604,32 @@ Array [
           </svg>
         </div>
         <div
-          className="m-incoming-box__vehicle-label"
+          class="m-incoming-box__vehicle-label"
         >
           1
         </div>
       </button>
     </div>
     <div
-      className="mock-tippy"
+      class="mock-tippy"
     >
       <div
-        className="mock-tippy-content"
+        class="mock-tippy-content"
       >
         <b>
           Block:
         </b>
-         
-        block-1
+         block-1
         <br />
         <b>
           Run:
         </b>
-         
-        2
+         2
         <br />
         <b>
           Vehicle:
         </b>
-         
-        0479
+         0479
         <br />
         <b>
           Variant:
@@ -2791,44 +2639,37 @@ Array [
         <b>
           Adherence:
         </b>
-         
-        0 min early
+         0 min early
         <br />
         <b>
           Operator:
         </b>
          
         <span
-          className="fs-mask"
+          class="fs-mask"
         >
           NORA JONES #op2
         </span>
       </div>
       <button
-        className="m-incoming-box__vehicle "
-        onClick={[Function]}
+        class="m-incoming-box__vehicle "
       >
         <div
-          className="m-incoming-box__vehicle-icon"
+          class="m-incoming-box__vehicle-icon"
         >
           <svg
             role="img"
-            style={
-              Object {
-                "height": 15.2,
-                "width": 16.72,
-              }
-            }
+            style="width: 16.72px; height: 15.2px;"
             viewBox="-8.36 -7.6 16.72 15.2"
           >
             <title>
               Vehicle Status Icon
             </title>
             <g
-              className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+              class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
             >
               <path
-                className="m-vehicle-icon__triangle"
+                class="m-vehicle-icon__triangle"
                 d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                 data-testid="vehicle-triangle"
                 transform="scale(0.38) rotate(180) translate(-24,-22)"
@@ -2837,12 +2678,12 @@ Array [
           </svg>
         </div>
         <div
-          className="m-incoming-box__vehicle-label"
+          class="m-incoming-box__vehicle-label"
         >
           2
         </div>
       </button>
     </div>
-  </div>,
-]
+  </div>
+</DocumentFragment>
 `;

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -118,6 +118,8 @@ const vehicles: Vehicle[] = [
   }),
 ]
 
+jest.unmock("@tippyjs/react")
+
 describe("routeLadder", () => {
   const originalGetBBox = SVGSVGElement.prototype.getBBox
   const originalGetElementsByClassName = document.getElementsByClassName

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import renderer from "react-test-renderer"
 import { render } from "@testing-library/react"
 import RouteLadder from "../../src/components/routeLadder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
@@ -153,22 +152,20 @@ describe("routeLadder", () => {
       { id: "MORTN", name: "MORTN Name" },
     ]
 
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={undefined}
-          selectedVehicleId={undefined}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={undefined}
+        selectedVehicleId={undefined}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).container
 
     expect(tree).toMatchSnapshot()
   })
@@ -203,22 +200,20 @@ describe("routeLadder", () => {
       blockWaivers: [],
     })
 
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={(vehicles as VehicleOrGhost[]).concat([ghost])}
-          selectedVehicleId={undefined}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={(vehicles as VehicleOrGhost[]).concat([ghost])}
+        selectedVehicleId={undefined}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -233,25 +228,23 @@ describe("routeLadder", () => {
       { id: "WELLH", name: "WELLH Name" },
       { id: "MORTN", name: "MORTN Name" },
     ]
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={vehicles.map((vehicle: Vehicle) => ({
-            ...vehicle,
-            routeStatus: "pulling_out" as RouteStatus,
-          }))}
-          selectedVehicleId={undefined}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={vehicles.map((vehicle: Vehicle) => ({
+          ...vehicle,
+          routeStatus: "pulling_out" as RouteStatus,
+        }))}
+        selectedVehicleId={undefined}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -269,25 +262,23 @@ describe("routeLadder", () => {
     ]
 
     const [v1, v2] = vehicles
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          selectedVehicleId={undefined}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            { ...v1, routeStatus: "laying_over" },
-            { ...v2, routeStatus: "laying_over" },
-          ]}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        selectedVehicleId={undefined}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          { ...v1, routeStatus: "laying_over" },
+          { ...v2, routeStatus: "laying_over" },
+        ]}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -306,36 +297,34 @@ describe("routeLadder", () => {
     ]
 
     const [v1, v2] = vehicles
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          selectedVehicleId={undefined}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            {
-              ...v1,
-              crowding: {
-                occupancyStatus: "FEW_SEATS_AVAILABLE",
-                occupancyPercentage: 0.78,
-                load: 14,
-                capacity: 18,
-              },
+    const tree = render(
+      <RouteLadder
+        route={route}
+        selectedVehicleId={undefined}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          {
+            ...v1,
+            crowding: {
+              occupancyStatus: "FEW_SEATS_AVAILABLE",
+              occupancyPercentage: 0.78,
+              load: 14,
+              capacity: 18,
             },
-            {
-              ...v2,
-              crowding: null,
-            },
-          ]}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={ladderCrowdingToggles}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+          },
+          {
+            ...v2,
+            crowding: null,
+          },
+        ]}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={ladderCrowdingToggles}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -353,31 +342,29 @@ describe("routeLadder", () => {
     ]
 
     const [v1, v2] = vehicles
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          selectedVehicleId={undefined}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            {
-              ...v1,
-            },
-            {
-              ...v2,
-              isOffCourse: true,
-              isRevenue: false,
-            },
-          ]}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        selectedVehicleId={undefined}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          {
+            ...v1,
+          },
+          {
+            ...v2,
+            isOffCourse: true,
+            isRevenue: false,
+          },
+        ]}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -396,37 +383,35 @@ describe("routeLadder", () => {
     ]
 
     const [v1, v2] = vehicles
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          selectedVehicleId={undefined}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            {
-              ...v1,
-              crowding: {
-                occupancyStatus: "FEW_SEATS_AVAILABLE",
-                occupancyPercentage: 0.78,
-                load: 14,
-                capacity: 18,
-              },
+    const tree = render(
+      <RouteLadder
+        route={route}
+        selectedVehicleId={undefined}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          {
+            ...v1,
+            crowding: {
+              occupancyStatus: "FEW_SEATS_AVAILABLE",
+              occupancyPercentage: 0.78,
+              load: 14,
+              capacity: 18,
             },
-            {
-              ...v2,
-              routeId: "741",
-              crowding: null,
-            },
-          ]}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={ladderCrowdingToggles}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+          },
+          {
+            ...v2,
+            routeId: "741",
+            crowding: null,
+          },
+        ]}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={ladderCrowdingToggles}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -445,37 +430,35 @@ describe("routeLadder", () => {
     ]
 
     const [v1, v2] = vehicles
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          selectedVehicleId={undefined}
-          timepoints={timepoints}
-          vehiclesAndGhosts={[
-            {
-              ...v1,
-              crowding: null,
+    const tree = render(
+      <RouteLadder
+        route={route}
+        selectedVehicleId={undefined}
+        timepoints={timepoints}
+        vehiclesAndGhosts={[
+          {
+            ...v1,
+            crowding: null,
+          },
+          {
+            ...v2,
+            routeId: "741",
+            crowding: {
+              occupancyStatus: "FEW_SEATS_AVAILABLE",
+              occupancyPercentage: 0.78,
+              load: 14,
+              capacity: 18,
             },
-            {
-              ...v2,
-              routeId: "741",
-              crowding: {
-                occupancyStatus: "FEW_SEATS_AVAILABLE",
-                occupancyPercentage: 0.78,
-                load: 14,
-                capacity: 18,
-              },
-            },
-          ]}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={ladderCrowdingToggles}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+          },
+        ]}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={ladderCrowdingToggles}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })
@@ -487,22 +470,20 @@ describe("routeLadder", () => {
     })
     const timepoints = null
 
-    const tree = renderer
-      .create(
-        <RouteLadder
-          route={route}
-          timepoints={timepoints}
-          vehiclesAndGhosts={undefined}
-          selectedVehicleId={undefined}
-          deselectRoute={() => {}}
-          reverseLadder={() => {}}
-          toggleCrowding={() => {}}
-          ladderDirections={{}}
-          ladderCrowdingToggles={{}}
-          hasAlert={false}
-        />
-      )
-      .toJSON()
+    const tree = render(
+      <RouteLadder
+        route={route}
+        timepoints={timepoints}
+        vehiclesAndGhosts={undefined}
+        selectedVehicleId={undefined}
+        deselectRoute={() => {}}
+        reverseLadder={() => {}}
+        toggleCrowding={() => {}}
+        ladderDirections={{}}
+        ladderCrowdingToggles={{}}
+        hasAlert={false}
+      />
+    ).asFragment()
 
     expect(tree).toMatchSnapshot()
   })

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -17,6 +17,7 @@ import routeFactory from "../factories/route"
 import userEvent from "@testing-library/user-event"
 import "@testing-library/jest-dom"
 import { tagManagerEvent } from "../../src/helpers/googleTagManager"
+import { routeAlert } from "../testHelpers/selectors/components/routeLadder"
 
 jest.mock("../../src/helpers/googleTagManager", () => ({
   __esModule: true,
@@ -501,7 +502,7 @@ describe("routeLadder", () => {
       { id: "MORTN", name: "MORTN Name" },
     ]
 
-    const result = render(
+    render(
       <RouteLadder
         route={route}
         timepoints={timepoints}
@@ -516,10 +517,10 @@ describe("routeLadder", () => {
       />
     )
 
-    expect(result.getByText("Active detour")).toBeInTheDocument()
+    expect(routeAlert.get()).toBeVisible()
   })
 
-  test("clicking alert icon to open tooltip triggers tag manager event", async () => {
+  test("clicking alert icon should show tooltip and observe event", async () => {
     const route: Route = routeFactory.build({
       id: "28",
       name: "28",
@@ -530,8 +531,7 @@ describe("routeLadder", () => {
       { id: "MORTN", name: "MORTN Name" },
     ]
 
-    const user = userEvent.setup()
-    const result = render(
+    render(
       <RouteLadder
         route={route}
         timepoints={timepoints}
@@ -546,8 +546,9 @@ describe("routeLadder", () => {
       />
     )
 
-    await user.click(result.getByText("Active detour"))
+    await userEvent.click(routeAlert.get())
 
+    expect(routeAlert.get()).toHaveAccessibleDescription(/Active Detour/i)
     expect(tagManagerEvent).toHaveBeenCalledWith("alert_tooltip_clicked")
   })
 

--- a/assets/tests/helpers/icon.test.tsx
+++ b/assets/tests/helpers/icon.test.tsx
@@ -72,11 +72,11 @@ describe.each([
   ["TriangleUpIcon", TriangleUpIcon],
   ["UpDownIcon", UpDownIcon],
   ["WalkingIcon", WalkingIcon],
-])(`%s`, (_, iconFn) => {
-  it("renders an icon with a class name", () => {
+])(`%s`, (_, IconFn) => {
+  it("should render icon with a class name", () => {
     const className = "test-class-name"
 
-    const result = render(iconFn({ className })).asFragment()
+    const result = render(<IconFn className={className}></IconFn>).asFragment()
 
     expect(result).toEqual(
       render(
@@ -87,8 +87,8 @@ describe.each([
     )
   })
 
-  it("renders without a class name", () => {
-    const result = render(iconFn({})).asFragment()
+  it("should render without a class name", () => {
+    const result = render(<IconFn />).asFragment()
 
     expect(result).toEqual(
       render(

--- a/assets/tests/helpers/svgIcon.test.tsx
+++ b/assets/tests/helpers/svgIcon.test.tsx
@@ -27,26 +27,6 @@ describe("<SvgIcon/>", () => {
 
 describe("svgIcon(text) -> (props)", () => {
   describe("first function returns react element which renders `svgText` and passed props", () => {
-    test("when called via function call", () => {
-      const className = "test-class-name"
-      const svgText = "<svg><title>hello test</title></svg>"
-
-      const TestSvgTextElement = svgIcon(svgText)
-      const { container } = render(
-        TestSvgTextElement({ className, role: "img" })
-      )
-
-      expect(container).toEqual(
-        render(
-          <span className={className} role="img">
-            <svg>
-              <title>hello test</title>
-            </svg>
-          </span>
-        ).container
-      )
-    })
-
     test("when used via JSX", () => {
       const className = "test-class-name"
       const spanTitle = "test span title"

--- a/assets/tests/testHelpers/selectors/components/routeLadder.ts
+++ b/assets/tests/testHelpers/selectors/components/routeLadder.ts
@@ -1,0 +1,3 @@
+import { byRole } from "testing-library-selector"
+
+export const routeAlert = byRole("generic", { name: "Route Alert" })


### PR DESCRIPTION
# Summary
So I found that [SVG refactor](https://github.com/mbta/skate/pull/1874) did cause the Tippy issues due to the `ref` prop not being available for `Tippy` to use to hook into events the DOM node will receive.
So while we could wrap every `<SvgIcon/>` that's a direct child of a `Tippy` with a element which Tippy could use the `ref` prop on, I felt that making `<SvgIcon/>` work "correctly" was the better choice.

This had downstream effects
- `SvgIcon`'s are now `ExoticComponent`s, which means they cannot be called directly, and instead need to be instantiated via JSX.
- Usages of `SvgIcon` which assumed what the shape(parameters + return type) of the function would be needed to be updated to use `JSXElementConstructor` instead (mapMode.tsx).

- [x] I'm still trying to come up with documentation for `SvgIcon`.

---

Asana Ticket: https://app.asana.com/0/1203014709808707/1203898422722677

---
## Reviewers
I do recommend ignoring the first commit when reviewing by filtering it out of your view after review of the specific commit.