### PR TITLE
fix(ts/components/mapPage): put stop markers on top of station markers

### DIFF
--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -7,7 +7,7 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { Tooltip } from "react-leaflet"
+import { Pane, Tooltip } from "react-leaflet"
 import { SocketContext } from "../../contexts/socketContext"
 import useMostRecentVehicleById from "../../hooks/useMosRecentVehicleById"
 import usePatternsByIdForRoute from "../../hooks/usePatternsByIdForRoute"
@@ -280,12 +280,18 @@ const RoutePatternLayers = ({
                     )) ||
                       undefined}
                   </RouteShape>
-                  <RouteStopMarkers
-                    stops={routePattern.shape.stops || []}
-                    includeStopCard={true}
-                    direction={routePattern.directionId}
-                    zoomLevel={zoomLevel}
-                  />
+                  <Pane
+                    name="routeStopMarkers2"
+                    pane="markerPane"
+                    style={{ zIndex: 450 }} // should be above other non-interactive elements
+                  >
+                    <RouteStopMarkers
+                      stops={routePattern.shape.stops || []}
+                      includeStopCard={true}
+                      direction={routePattern.directionId}
+                      zoomLevel={zoomLevel}
+                    />
+                  </Pane>
                 </>
               )}
             </>

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -281,7 +281,7 @@ const RoutePatternLayers = ({
                       undefined}
                   </RouteShape>
                   <Pane
-                    name="routeStopMarkers2"
+                    name="selectedRoutePatternStops"
                     pane="markerPane"
                     style={{ zIndex: 450 }} // should be above other non-interactive elements
                   >


### PR DESCRIPTION
The stop markers were under the station markers because the stop markers used the default `z-index` of the markers pane (`400`) but the station markers were moved into their own pane of `z-index` `410`.

This makes another pane similar to the `routeStopMarkers` pane at `zIndex` `450` as this was the easiest way to address this bug.

I tried to reuse the existing `routeStopMarkers` pane by setting `pane="routeStopMarkers"` on the `<StopMarker>` component, but this breaks both encapsulation and tests. While I think that would be one of the nicer solutions, it required a larger refactor than would be useful to make it work.

Similarly, I've been considering pulling out some self contained components of the `<BaseMap>`, such as converting the `stations` prop into a `includeStations` prop similar to the leaflet `attributionControl={false}` props. I made a [stub of a ticket](https://app.asana.com/0/1152340551558956/1204081206701126/f) for getting to this in the future.
If we pulled out the stations we could sort them under the stop markers via HTML order instead of `z-index`. If devs prefer that solution I can pursue that for this ticket instead.

## Todo
- [ ] [Rename the Pane](https://github.com/mbta/skate/pull/1952#discussion_r1123595928)

---

Asana Ticket: https://app.asana.com/0/1148853526253437/1203941643219723/f