### PR TITLE
Make shuttle map re-enable autocenter when selected shuttle changes

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -500,6 +500,3 @@ export const MapFollowingPrimaryVehicles = (props: Props) => {
     </BaseMap>
   )
 }
-
-const Map = MapFollowingPrimaryVehicles
-export default Map

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -69,8 +69,6 @@ export interface Props {
   stopCardDirection?: DirectionId
   includeStopCard?: boolean
   stations?: Stop[] | null
-  // if set, changes to this value will cause the autofollower to reset to following the new selection
-  followerResetKey?: string
 }
 
 export const defaultCenter: LatLngLiteral = {
@@ -331,7 +329,7 @@ export const usePickerContainerFollowerFn = () => {
 // #endregion
 // #endregion
 
-export const BaseMap = (props: Props): ReactElement<HTMLDivElement> => {
+const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const mapRef: MutableRefObject<LeafletMap | null> =
     // this prop is only for tests, and is consistent between renders, so the hook call is consistent
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -478,17 +476,12 @@ export const FollowerStatusClasses = (
 
 export const MapFollowingPrimaryVehicles = (props: Props) => {
   const state = useInteractiveFollowerState(),
-    { shouldFollow, setShouldFollow } = state
+    { shouldFollow } = state
 
   const positions: LatLng[] = props.vehicles.map(vehicleToLeafletLatLng)
 
-  useEffect(
-    () => setShouldFollow(true),
-    [props.followerResetKey, setShouldFollow]
-  )
-
   return (
-    <BaseMap {...props} stateClasses={FollowerStatusClasses(shouldFollow)}>
+    <Map {...props} stateClasses={FollowerStatusClasses(shouldFollow)}>
       <>
         <InterruptibleFollower
           positions={positions}
@@ -497,6 +490,32 @@ export const MapFollowingPrimaryVehicles = (props: Props) => {
         />
         {props.children}
       </>
-    </BaseMap>
+    </Map>
   )
 }
+
+export const MapFollowingSelectionKey = (
+  props: Props & { selectionKey?: string }
+) => {
+  const state = useInteractiveFollowerState(),
+    { shouldFollow, setShouldFollow } = state
+
+  const positions: LatLng[] = props.vehicles.map(vehicleToLeafletLatLng)
+
+  useEffect(() => setShouldFollow(true), [props.selectionKey, setShouldFollow])
+
+  return (
+    <Map {...props} stateClasses={FollowerStatusClasses(shouldFollow)}>
+      <>
+        <InterruptibleFollower
+          positions={positions}
+          {...state}
+          onUpdate={usePickerContainerFollowerFn()}
+        />
+        {props.children}
+      </>
+    </Map>
+  )
+}
+
+export default Map

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -69,6 +69,8 @@ export interface Props {
   stopCardDirection?: DirectionId
   includeStopCard?: boolean
   stations?: Stop[] | null
+  // if set, changes to this value will cause the autofollower to reset to following the new selection
+  followerResetKey?: string
 }
 
 export const defaultCenter: LatLngLiteral = {
@@ -476,9 +478,14 @@ export const FollowerStatusClasses = (
 
 export const MapFollowingPrimaryVehicles = (props: Props) => {
   const state = useInteractiveFollowerState(),
-    { shouldFollow } = state
+    { shouldFollow, setShouldFollow } = state
 
   const positions: LatLng[] = props.vehicles.map(vehicleToLeafletLatLng)
+
+  useEffect(
+    () => setShouldFollow(true),
+    [props.followerResetKey, setShouldFollow]
+  )
 
   return (
     <BaseMap {...props} stateClasses={FollowerStatusClasses(shouldFollow)}>

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -28,9 +28,8 @@ import {
   SelectedEntityType,
   SelectedRoutePattern,
 } from "../../state/searchPageState"
-import {
+import Map, {
   vehicleToLeafletLatLng,
-  BaseMap,
   FollowerStatusClasses,
   InterruptibleFollower,
   defaultCenter,
@@ -549,7 +548,7 @@ const MapDisplay = ({
   )
 
   return (
-    <BaseMap
+    <Map
       vehicles={[]}
       allowStreetView={true}
       includeStopCard={true}
@@ -571,7 +570,7 @@ const MapDisplay = ({
           setStateClasses={setStateClasses}
         />
       </MapSafeAreaContext.Provider>
-    </BaseMap>
+    </Map>
   )
 }
 

--- a/assets/src/components/propertiesPanel/miniMap.tsx
+++ b/assets/src/components/propertiesPanel/miniMap.tsx
@@ -8,7 +8,7 @@ import { Shape, Stop } from "../../schedule"
 import { setSelectedVehicle } from "../../state/searchPageState"
 import inTestGroup, { MAP_BETA_GROUP_NAME } from "../../userInTestGroup"
 import { mapModeForUser } from "../../util/mapMode"
-import Map from "../map"
+import { MapFollowingPrimaryVehicles } from "../map"
 
 const SearchMapLink = ({ vehicleId }: { vehicleId: VehicleId }) => {
   const [, dispatch] = useContext(StateDispatchContext)
@@ -47,7 +47,7 @@ const MiniMap = ({
   const stations: Stop[] | null = useStations()
 
   return inTestGroup(MAP_BETA_GROUP_NAME) ? (
-    <Map
+    <MapFollowingPrimaryVehicles
       selectedVehicleId={vehicle.id}
       vehicles={[vehicle]}
       shapes={shapes}
@@ -56,9 +56,9 @@ const MiniMap = ({
       allowFullscreen={false}
     >
       <SearchMapLink vehicleId={vehicle.id} />
-    </Map>
+    </MapFollowingPrimaryVehicles>
   ) : (
-    <Map
+    <MapFollowingPrimaryVehicles
       selectedVehicleId={vehicle.id}
       vehicles={[vehicle]}
       shapes={shapes}

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -26,7 +26,6 @@ interface Props {
   selectedVehicle: Vehicle
 }
 
-/* eslint-disable no-irregular-whitespace */
 const InvalidBanner = () => (
   <Card
     additionalClass="m-vehicle-properties-panel__invalid-banner"
@@ -40,7 +39,6 @@ const InvalidBanner = () => (
     </CardBody>
   </Card>
 )
-/* eslint-enable no-irregular-whitespace */
 
 const NotAvailable = () => (
   <span className="m-vehicle-properties-panel__not-available">

--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -9,7 +9,7 @@ import { Vehicle, VehicleOrGhost } from "../realtime"
 import { Stop } from "../schedule"
 import { selectVehicle } from "../state"
 import { SearchPageState } from "../state/searchPageState"
-import Map from "./map"
+import { MapFollowingPrimaryVehicles } from "./map"
 import RecentSearches from "./recentSearches"
 import SearchForm from "./searchForm"
 import SearchResults from "./searchResults"
@@ -104,7 +104,7 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
       </div>
 
       <div className="m-search-page__map">
-        <Map
+        <MapFollowingPrimaryVehicles
           selectedVehicleId={selectedVehicleOrGhost?.id}
           vehicles={onlyVehicles}
           onPrimaryVehicleSelect={(vehicle) => dispatch(selectVehicle(vehicle))}

--- a/assets/src/components/shuttleMapPage.tsx
+++ b/assets/src/components/shuttleMapPage.tsx
@@ -58,6 +58,9 @@ const ShuttleMapPage = (): ReactElement<HTMLDivElement> => {
 
   const mobileMenuClass = mobileMenuIsOpen ? "blurred-mobile" : ""
 
+  const followerResetKey =
+    selectedShuttleRunIds === "all" ? "all" : selectedShuttleRunIds.join(",")
+
   return (
     <div className={`m-shuttle-map ${mobileMenuClass}`}>
       <ShuttlePicker shuttles={shuttles} />
@@ -69,6 +72,7 @@ const ShuttleMapPage = (): ReactElement<HTMLDivElement> => {
           shapes={shapes}
           trainVehicles={trainVehicles}
           onPrimaryVehicleSelect={(vehicle) => dispatch(selectVehicle(vehicle))}
+          followerResetKey={followerResetKey}
         />
       </div>
     </div>

--- a/assets/src/components/shuttleMapPage.tsx
+++ b/assets/src/components/shuttleMapPage.tsx
@@ -10,7 +10,7 @@ import { isASubwayRoute } from "../models/subwayRoute"
 import { RunId, TrainVehicle, Vehicle } from "../realtime"
 import { ByRouteId, RouteId, Shape } from "../schedule"
 import { selectVehicle } from "../state"
-import { MapFollowingPrimaryVehicles } from "./map"
+import { MapFollowingSelectionKey } from "./map"
 import ShuttlePicker from "./shuttlePicker"
 
 const filterShuttles = (
@@ -66,13 +66,13 @@ const ShuttleMapPage = (): ReactElement<HTMLDivElement> => {
       <ShuttlePicker shuttles={shuttles} />
 
       <div className="m-shuttle-map__map">
-        <MapFollowingPrimaryVehicles
+        <MapFollowingSelectionKey
           selectedVehicleId={selectedVehicleOrGhost?.id}
           vehicles={selectedShuttles}
           shapes={shapes}
           trainVehicles={trainVehicles}
           onPrimaryVehicleSelect={(vehicle) => dispatch(selectVehicle(vehicle))}
-          followerResetKey={followerResetKey}
+          selectionKey={followerResetKey}
         />
       </div>
     </div>

--- a/assets/src/components/shuttleMapPage.tsx
+++ b/assets/src/components/shuttleMapPage.tsx
@@ -10,7 +10,7 @@ import { isASubwayRoute } from "../models/subwayRoute"
 import { RunId, TrainVehicle, Vehicle } from "../realtime"
 import { ByRouteId, RouteId, Shape } from "../schedule"
 import { selectVehicle } from "../state"
-import Map from "./map"
+import { MapFollowingPrimaryVehicles } from "./map"
 import ShuttlePicker from "./shuttlePicker"
 
 const filterShuttles = (
@@ -66,7 +66,7 @@ const ShuttleMapPage = (): ReactElement<HTMLDivElement> => {
       <ShuttlePicker shuttles={shuttles} />
 
       <div className="m-shuttle-map__map">
-        <Map
+        <MapFollowingPrimaryVehicles
           selectedVehicleId={selectedVehicleOrGhost?.id}
           vehicles={selectedShuttles}
           shapes={shapes}

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -540,4 +540,38 @@ describe("auto centering", () => {
     expect(getCenter(mapRef)).toEqual(defaultCenter)
     expect(window.FS!.event).toHaveBeenCalledWith("Recenter control clicked")
   })
+
+  test("changing followerResetKey turns on auto center", async () => {
+    const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
+    const vehicles: Vehicle[] = []
+    const result = render(
+      <Map
+        vehicles={vehicles}
+        reactLeafletRef={mapRef}
+        followerResetKey="key1"
+      />
+    )
+    await animationFramePromise()
+
+    // Manual move to turn off auto centering
+    const manualLatLng = { lat: 41.9, lng: -70.9 }
+    act(() => {
+      mapRef.current!.fire("dragstart")
+      mapRef.current!.panTo(manualLatLng)
+    })
+    await animationFramePromise()
+
+    result.rerender(
+      <Map
+        vehicles={vehicles}
+        reactLeafletRef={mapRef}
+        followerResetKey="key2"
+      />
+    )
+    await animationFramePromise()
+    expect(result.container.firstChild).toHaveClass(
+      "m-vehicle-map-state--auto-centering"
+    )
+    expect(getCenter(mapRef)).toEqual(defaultCenter)
+  })
 })

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -4,7 +4,11 @@ import { LatLng } from "leaflet"
 import React, { MutableRefObject } from "react"
 import { act } from "@testing-library/react"
 import { Map as LeafletMap } from "leaflet"
-import Map, { autoCenter, defaultCenter } from "../../src/components/map"
+import {
+  autoCenter,
+  defaultCenter,
+  MapFollowingPrimaryVehicles,
+} from "../../src/components/map"
 import { TrainVehicle, Vehicle } from "../../src/realtime"
 import vehicleFactory from "../factories/vehicle"
 import stopFactory from "../factories/stop"
@@ -56,14 +60,19 @@ afterAll(() => {
 describe("<Map />", () => {
   test("draws vehicles", () => {
     const vehicle = vehicleFactory.build({})
-    const result = render(<Map vehicles={[vehicle]} />)
+    const result = render(<MapFollowingPrimaryVehicles vehicles={[vehicle]} />)
     expect(result.container.innerHTML).toContain("m-vehicle-map__icon")
     expect(result.container.innerHTML).toContain("m-vehicle-map__label")
   })
 
   test("draws secondary vehicles", () => {
     const vehicle = vehicleFactory.build({})
-    const result = render(<Map vehicles={[]} secondaryVehicles={[vehicle]} />)
+    const result = render(
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        secondaryVehicles={[vehicle]}
+      />
+    )
     expect(result.container.innerHTML).toContain("m-vehicle-map__icon")
     expect(result.container.innerHTML).toContain("m-vehicle-map__label")
   })
@@ -75,12 +84,19 @@ describe("<Map />", () => {
       longitude: -71.00369,
       bearing: 15,
     }
-    const result = render(<Map vehicles={[]} trainVehicles={[trainVehicle]} />)
+    const result = render(
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        trainVehicles={[trainVehicle]}
+      />
+    )
     expect(result.container.innerHTML).toContain("m-vehicle-map__train-icon")
   })
 
   test("draws shapes", () => {
-    const result = render(<Map vehicles={[]} shapes={[shape]} />)
+    const result = render(
+      <MapFollowingPrimaryVehicles vehicles={[]} shapes={[shape]} />
+    )
     expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
     expect(result.container.innerHTML).toContain("m-vehicle-map__stop")
   })
@@ -91,7 +107,10 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map vehicles={[vehicle]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        reactLeafletRef={mapRef}
+      />
     )
 
     // Manual zoom
@@ -108,7 +127,10 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map vehicles={[vehicle]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        reactLeafletRef={mapRef}
+      />
     )
 
     // Manual zoom
@@ -125,7 +147,10 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map vehicles={[vehicle]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        reactLeafletRef={mapRef}
+      />
     )
     // Manual zoom
     act(() => {
@@ -140,7 +165,7 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={[vehicleFactory.build()]}
         reactLeafletRef={mapRef}
         stations={[station]}
@@ -160,7 +185,7 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={[vehicleFactory.build()]}
         reactLeafletRef={mapRef}
         stations={[station]}
@@ -180,7 +205,7 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={[vehicleFactory.build()]}
         reactLeafletRef={mapRef}
         stations={[station]}
@@ -201,7 +226,7 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     const { container } = render(
-      <Map
+      <MapFollowingPrimaryVehicles
         shapes={[{ ...shape, stops: [station] }]}
         vehicles={[]}
         reactLeafletRef={mapRef}
@@ -219,7 +244,12 @@ describe("<Map />", () => {
   test("performs onPrimaryVehicleSelected function when primary vehicle selected", async () => {
     const vehicle = vehicleFactory.build({})
     const onClick = jest.fn()
-    render(<Map vehicles={[vehicle]} onPrimaryVehicleSelect={onClick} />)
+    render(
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        onPrimaryVehicleSelect={onClick}
+      />
+    )
     await userEvent.click(screen.getByText(runIdToLabel(vehicle.runId!)))
     expect(onClick).toHaveBeenCalledWith(expect.objectContaining(vehicle))
   })
@@ -228,7 +258,7 @@ describe("<Map />", () => {
     const vehicle = vehicleFactory.build({})
     const onClick = jest.fn()
     render(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={[]}
         secondaryVehicles={[vehicle]}
         onPrimaryVehicleSelect={onClick}
@@ -242,7 +272,11 @@ describe("<Map />", () => {
     ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
 
     const { container } = render(
-      <Map vehicles={[]} shapes={[shape]} includeStopCard={true} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        shapes={[shape]}
+        includeStopCard={true}
+      />
     )
 
     await userEvent.click(container.querySelector(".m-vehicle-map__stop")!)
@@ -255,7 +289,9 @@ describe("<Map />", () => {
   test("does not render street view link from stop if not in maps test group", async () => {
     ;(getTestGroups as jest.Mock).mockReturnValue([])
 
-    const { container } = render(<Map vehicles={[]} shapes={[shape]} />)
+    const { container } = render(
+      <MapFollowingPrimaryVehicles vehicles={[]} shapes={[shape]} />
+    )
 
     await userEvent.click(container.querySelector("e-map__stop")!)
 
@@ -270,7 +306,11 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     render(
-      <Map vehicles={[]} allowStreetView={true} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        allowStreetView={true}
+        reactLeafletRef={mapRef}
+      />
     )
 
     await userEvent.click(screen.getByRole("switch", { name: /Street View/ }))
@@ -294,7 +334,11 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     render(
-      <Map vehicles={[]} allowStreetView={true} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        allowStreetView={true}
+        reactLeafletRef={mapRef}
+      />
     )
 
     await userEvent.click(screen.getByRole("switch", { name: /Street View/ }))
@@ -317,7 +361,11 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     render(
-      <Map vehicles={[]} allowStreetView={true} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        allowStreetView={true}
+        reactLeafletRef={mapRef}
+      />
     )
 
     await userEvent.click(mapRef.current!.getPane("mapPane")!)
@@ -329,7 +377,11 @@ describe("<Map />", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
 
     render(
-      <Map vehicles={[]} allowStreetView={true} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[]}
+        allowStreetView={true}
+        reactLeafletRef={mapRef}
+      />
     )
 
     await userEvent.click(screen.getByRole("switch", { name: /Street View/ }))
@@ -342,7 +394,7 @@ describe("<Map />", () => {
   })
 
   test("does not show street view when prop is not specified", () => {
-    render(<Map vehicles={[]} />)
+    render(<MapFollowingPrimaryVehicles vehicles={[]} />)
 
     expect(
       screen.queryByRole("switch", { name: /Street View/ })
@@ -353,7 +405,10 @@ describe("<Map />", () => {
     const vehicle = vehicleFactory.build()
 
     const { container } = render(
-      <Map vehicles={[vehicle]} selectedVehicleId={vehicle.id} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        selectedVehicleId={vehicle.id}
+      />
     )
 
     expect(
@@ -417,7 +472,12 @@ describe("auto centering", () => {
       longitude: location.lng,
     })
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
-    render(<Map vehicles={[vehicle]} reactLeafletRef={mapRef} />)
+    render(
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        reactLeafletRef={mapRef}
+      />
+    )
 
     await animationFramePromise()
     expect(getCenter(mapRef)).toEqual(location)
@@ -433,7 +493,10 @@ describe("auto centering", () => {
       longitude: oldLatLng.lng,
     }
     const { rerender } = render(
-      <Map vehicles={[oldVehicle]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[oldVehicle]}
+        reactLeafletRef={mapRef}
+      />
     )
     await animationFramePromise()
     const newLatLng = { lat: 42.1, lng: -71.1 }
@@ -442,7 +505,12 @@ describe("auto centering", () => {
       latitude: newLatLng.lat,
       longitude: newLatLng.lng,
     }
-    rerender(<Map vehicles={[newVehicle]} reactLeafletRef={mapRef} />)
+    rerender(
+      <MapFollowingPrimaryVehicles
+        vehicles={[newVehicle]}
+        reactLeafletRef={mapRef}
+      />
+    )
     await animationFramePromise()
     expect(getCenter(mapRef)).toEqual(newLatLng)
   })
@@ -451,7 +519,10 @@ describe("auto centering", () => {
     const vehicle = vehicleFactory.build({})
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
     const { rerender, container } = render(
-      <Map vehicles={[vehicle]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle]}
+        reactLeafletRef={mapRef}
+      />
     )
     await animationFramePromise()
     expect(container.firstChild).toHaveClass(
@@ -471,7 +542,12 @@ describe("auto centering", () => {
       latitude: newLatLng.lat,
       longitude: newLatLng.lng,
     }
-    rerender(<Map vehicles={[newVehicle]} reactLeafletRef={mapRef} />)
+    rerender(
+      <MapFollowingPrimaryVehicles
+        vehicles={[newVehicle]}
+        reactLeafletRef={mapRef}
+      />
+    )
     await animationFramePromise()
     expect(getCenter(mapRef)).toEqual(manualLatLng)
     expect(container.firstChild).not.toHaveClass(
@@ -501,13 +577,26 @@ describe("auto centering", () => {
       longitude: latLng3.lng,
     }
     const { rerender } = render(
-      <Map vehicles={[vehicle1]} reactLeafletRef={mapRef} />
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle1]}
+        reactLeafletRef={mapRef}
+      />
     )
     await animationFramePromise()
-    rerender(<Map vehicles={[vehicle2]} reactLeafletRef={mapRef} />)
+    rerender(
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle2]}
+        reactLeafletRef={mapRef}
+      />
+    )
 
     await animationFramePromise()
-    rerender(<Map vehicles={[vehicle3]} reactLeafletRef={mapRef} />)
+    rerender(
+      <MapFollowingPrimaryVehicles
+        vehicles={[vehicle3]}
+        reactLeafletRef={mapRef}
+      />
+    )
 
     await animationFramePromise()
     expect(getCenter(mapRef)).toEqual(latLng3)
@@ -516,7 +605,9 @@ describe("auto centering", () => {
   test("recenter control turns on auto center", async () => {
     mockFullStoryEvent()
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
-    const result = render(<Map vehicles={[]} reactLeafletRef={mapRef} />)
+    const result = render(
+      <MapFollowingPrimaryVehicles vehicles={[]} reactLeafletRef={mapRef} />
+    )
     await animationFramePromise()
 
     // Manual move to turn off auto centering
@@ -545,7 +636,7 @@ describe("auto centering", () => {
     const mapRef: MutableRefObject<LeafletMap | null> = { current: null }
     const vehicles: Vehicle[] = []
     const result = render(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={vehicles}
         reactLeafletRef={mapRef}
         followerResetKey="key1"
@@ -562,7 +653,7 @@ describe("auto centering", () => {
     await animationFramePromise()
 
     result.rerender(
-      <Map
+      <MapFollowingPrimaryVehicles
         vehicles={vehicles}
         reactLeafletRef={mapRef}
         followerResetKey="key2"

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -21,7 +21,7 @@ jest
 
 jest.spyOn(Date, "now").mockImplementation(() => 234000)
 
-jest.spyOn(map, "default")
+jest.spyOn(map, "MapFollowingPrimaryVehicles")
 
 jest.mock("../../../src/hooks/useVehiclesForRoute", () => ({
   __esModule: true,
@@ -234,7 +234,7 @@ describe("VehiclePropertiesPanel", () => {
     const thisVehicle = vehicle
     const otherVehicle = { ...vehicle, id: "other" }
     const ghost = { id: "ghost" } as Ghost
-    jest.spyOn(map, "default")
+    jest.spyOn(map, "MapFollowingPrimaryVehicles")
     renderer.create(
       <VehiclesByRouteIdProvider
         vehiclesByRouteId={{ "39": [thisVehicle, otherVehicle, ghost] }}
@@ -242,8 +242,9 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel selectedVehicle={thisVehicle} />
       </VehiclesByRouteIdProvider>
     )
-    expect(map.default).toHaveBeenCalledTimes(1)
-    const mapArgs: map.Props = (map.default as jest.Mock).mock.calls[0][0]
+    expect(map.MapFollowingPrimaryVehicles).toHaveBeenCalledTimes(1)
+    const mapArgs: map.Props = (map.MapFollowingPrimaryVehicles as jest.Mock)
+      .mock.calls[0][0]
     expect(mapArgs.secondaryVehicles).toEqual([otherVehicle])
   })
 
@@ -251,7 +252,7 @@ describe("VehiclePropertiesPanel", () => {
     const thisVehicle = vehicle
     const otherVehicle = { ...vehicle, id: "other" }
     const ghost = { id: "ghost" } as Ghost
-    jest.spyOn(map, "default")
+    jest.spyOn(map, "MapFollowingPrimaryVehicles")
     ;(useVehiclesForRoute as jest.Mock).mockImplementationOnce(() => [
       thisVehicle,
       otherVehicle,
@@ -259,8 +260,9 @@ describe("VehiclePropertiesPanel", () => {
     ])
     renderer.create(<VehiclePropertiesPanel selectedVehicle={thisVehicle} />)
     expect(useVehiclesForRoute).toHaveBeenCalled()
-    expect(map.default).toHaveBeenCalledTimes(1)
-    const mapArgs: map.Props = (map.default as jest.Mock).mock.calls[0][0]
+    expect(map.MapFollowingPrimaryVehicles).toHaveBeenCalledTimes(1)
+    const mapArgs: map.Props = (map.MapFollowingPrimaryVehicles as jest.Mock)
+      .mock.calls[0][0]
     expect(mapArgs.secondaryVehicles).toEqual([otherVehicle])
   })
 

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -15,6 +15,10 @@ import * as dateTime from "../../src/util/dateTime"
 import { shuttleFactory } from "../factories/vehicle"
 import userEvent from "@testing-library/user-event"
 import shapeFactory from "../factories/shape"
+import {
+  zoomInButton,
+  zoomOutButton,
+} from "../testHelpers/selectors/components/map"
 
 jest
   .spyOn(dateTime, "now")
@@ -148,9 +152,9 @@ describe("Shuttle Map Page", () => {
     // We can't directly use the recenter button to disable recentering, but zooming works.
     // However, there is currently a bug causing us to not disable autocentering with a single
     // click on one of the zoom buttons, instead requiring two.
-    await userEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+    await userEvent.click(zoomInButton.get())
     await animationFramePromise()
-    await userEvent.click(screen.getByRole("button", { name: "Zoom out" }))
+    await userEvent.click(zoomOutButton.get())
     await animationFramePromise()
 
     result.rerender(

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -146,9 +146,8 @@ describe("Shuttle Map Page", () => {
     await animationFramePromise()
 
     // We can't directly use the recenter button to disable recentering, but zooming works.
-    // However, for some reason a single change in zoom doesn't suffice to turn it off.
-    // There's probably something else we could await for to get the recentering disabled
-    // by firing just a single click
+    // However, there is currently a bug causing us to not disable autocentering with a single
+    // click on one of the zoom buttons, instead requiring two.
     await userEvent.click(screen.getByRole("button", { name: "Zoom in" }))
     await animationFramePromise()
     await userEvent.click(screen.getByRole("button", { name: "Zoom out" }))

--- a/assets/tests/testHelpers/selectors/components/map.ts
+++ b/assets/tests/testHelpers/selectors/components/map.ts
@@ -1,3 +1,5 @@
 import { byRole } from "testing-library-selector"
 
 export const zoomInButton = byRole("button", { name: "Zoom in" })
+
+export const zoomOutButton = byRole("button", { name: "Zoom out" })

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :skate,
-  tileset_url: "https://mbta-map-tiles-dev.s3.amazonaws.com/osm_tiles",
+  tileset_url: "https://mbta-map-tiles-dev.s3.amazonaws.com/skate_osm_tiles",
   geonames_url_base: "http://api.geonames.org",
   log_duration_timing: false
 


### PR DESCRIPTION
Asana ticket: [⚙️🐛 Subsequent clicks on shuttle map entry don't start auto-centering](https://app.asana.com/0/1148853526253437/1203884615154359/f)