### PR TITLE
fix: add fs-mask class to operator name in Late View

### DIFF
--- a/assets/src/components/lateView.tsx
+++ b/assets/src/components/lateView.tsx
@@ -530,7 +530,7 @@ const LateBusRow = ({
           {runIdToLabel(vehicle.runId)}
         </button>
       </td>
-      <td className="m-late-view__operator-name">
+      <td className="m-late-view__operator-name fs-mask">
         {vehicle.operatorLastName} &ndash; {vehicle.operatorId}
       </td>
     </tr>

--- a/assets/tests/components/__snapshots__/lateView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/lateView.test.tsx.snap
@@ -286,7 +286,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
                 </button>
               </td>
               <td
-                className="m-late-view__operator-name"
+                className="m-late-view__operator-name fs-mask"
               >
                 SMITH
                  – 
@@ -340,7 +340,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
                 </button>
               </td>
               <td
-                className="m-late-view__operator-name"
+                className="m-late-view__operator-name fs-mask"
               >
                 SMITH
                  – 
@@ -394,7 +394,7 @@ exports[`LateView renders missing logons and late buses 1`] = `
                 </button>
               </td>
               <td
-                className="m-late-view__operator-name"
+                className="m-late-view__operator-name fs-mask"
               >
                 SMITH
                  – 


### PR DESCRIPTION
No Asana ticket, just something we noticed as a consequence of #1962 .