### PR TITLE
fix: make drawers not visible after collapse

### DIFF
--- a/assets/css/_drawer_hide.scss
+++ b/assets/css/_drawer_hide.scss
@@ -1,0 +1,11 @@
+.u-hide {
+  transition: visibility 0s 1.2s;
+
+  .visible & {
+    transition-delay: 0s;
+  }
+
+  .hidden & {
+    visibility: hidden;
+  }
+}

--- a/assets/css/_drawer_hide.scss
+++ b/assets/css/_drawer_hide.scss
@@ -1,11 +1,14 @@
 .u-hide {
-  transition: visibility 0s 1.2s;
+  // Delay visibility transition to end of slide transition
+  transition: visibility 0s $transition-slide-duration;
 
   .visible & {
+    // when revealing do not delay visibility change
     transition-delay: 0s;
   }
 
   .hidden & {
+    // when parent hides, hide this element from accessibility tree
     visibility: hidden;
   }
 }

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -370,7 +370,8 @@ select {
 
 // #region transitions
 
-$transition-slide: all 0.2s ease-in-out;
+$transition-slide-duration: 0.2s;
+$transition-slide: all $transition-slide-duration ease-in-out;
 
 // #endregion
 

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -58,6 +58,7 @@ $component-active-bg: $color-eggplant-700;
 @import "crowding";
 @import "data_status_banner";
 @import "disconnected_modal";
+@import "drawer_hide";
 @import "drawer_tab";
 @import "garage_filter";
 @import "icon_alert_circle";

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -189,7 +189,7 @@ const LadderPage = (): ReactElement<HTMLDivElement> => {
 
       <PickerContainer>
         <>
-          <div className="m-ladder-page__routes-presets-toggle">
+          <div className="m-ladder-page__routes-presets-toggle u-hide">
             <button
               id="m-ladder-page__routes_picker_button"
               className={

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -45,7 +45,7 @@ const SearchInputAndResults = ({
 
   return (
     <>
-      <div className="m-map-page__input">
+      <div className="m-map-page__input u-hide">
         <SearchForm
           formTitle="Search Map"
           inputTitle="Search Map Query"
@@ -55,7 +55,7 @@ const SearchInputAndResults = ({
 
       <hr />
 
-      <div className="m-search-display">
+      <div className="m-search-display u-hide">
         {searchVehicles !== null &&
         thereIsAnActiveSearch(searchVehicles, searchPageState) ? (
           <SearchResults

--- a/assets/src/components/presets.tsx
+++ b/assets/src/components/presets.tsx
@@ -19,7 +19,7 @@ const Presets = () => {
   const currentTab = currentRouteTab(routeTabs)
 
   return (
-    <div className="m-presets-panel">
+    <div className="m-presets-panel u-hide">
       <ul>
         {presets.map((preset) => (
           <li key={preset.uuid}>

--- a/assets/src/components/routePicker.tsx
+++ b/assets/src/components/routePicker.tsx
@@ -38,7 +38,7 @@ const RoutePicker = ({
   ).filter((route) => !selectedRouteIds.includes(route.id))
 
   return (
-    <div className="m-route-picker">
+    <div className="m-route-picker u-hide">
       <RouteFilter {...routeFilterData} />
 
       <GarageFilter {...garageFilterData} />

--- a/assets/src/components/shuttlePicker.tsx
+++ b/assets/src/components/shuttlePicker.tsx
@@ -73,7 +73,7 @@ const ShuttlePicker = ({ shuttles }: Props): ReactElement<HTMLDivElement> => {
 
   return (
     <ShuttlePickerContainer>
-      <div className="m-shuttle-picker">
+      <div className="m-shuttle-picker u-hide">
         {shuttles === null ? (
           <Loading />
         ) : (

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`App renders 1`] = `
                 </button>
               </div>
               <div
-                class="m-ladder-page__routes-presets-toggle"
+                class="m-ladder-page__routes-presets-toggle u-hide"
               >
                 <button
                   class="m-ladder-page__routes_picker_button_selected"
@@ -56,7 +56,7 @@ exports[`App renders 1`] = `
                 </button>
               </div>
               <div
-                class="m-route-picker"
+                class="m-route-picker u-hide"
               >
                 <div
                   class="m-route-filter"

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`renders 1`] = `
                 </button>
               </div>
               <div
-                class="m-ladder-page__routes-presets-toggle"
+                class="m-ladder-page__routes-presets-toggle u-hide"
               >
                 <button
                   class="m-ladder-page__routes_picker_button_selected"
@@ -56,7 +56,7 @@ exports[`renders 1`] = `
                 </button>
               </div>
               <div
-                class="m-route-picker"
+                class="m-route-picker u-hide"
               >
                 <div
                   class="m-route-filter"

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`LadderPage renders the empty state 1`] = `
         </button>
       </div>
       <div
-        class="m-ladder-page__routes-presets-toggle"
+        class="m-ladder-page__routes-presets-toggle u-hide"
       >
         <button
           class="m-ladder-page__routes_picker_button_selected"
@@ -41,7 +41,7 @@ exports[`LadderPage renders the empty state 1`] = `
         </button>
       </div>
       <div
-        class="m-route-picker"
+        class="m-route-picker u-hide"
       >
         <div
           class="m-route-filter"
@@ -145,7 +145,7 @@ exports[`LadderPage renders with route tabs 1`] = `
         </button>
       </div>
       <div
-        class="m-ladder-page__routes-presets-toggle"
+        class="m-ladder-page__routes-presets-toggle u-hide"
       >
         <button
           class="m-ladder-page__routes_picker_button_selected"
@@ -161,7 +161,7 @@ exports[`LadderPage renders with route tabs 1`] = `
         </button>
       </div>
       <div
-        class="m-route-picker"
+        class="m-route-picker u-hide"
       >
         <div
           class="m-route-filter"
@@ -385,7 +385,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         </button>
       </div>
       <div
-        class="m-ladder-page__routes-presets-toggle"
+        class="m-ladder-page__routes-presets-toggle u-hide"
       >
         <button
           class="m-ladder-page__routes_picker_button_selected"
@@ -401,7 +401,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         </button>
       </div>
       <div
-        class="m-route-picker"
+        class="m-route-picker u-hide"
       >
         <div
           class="m-route-filter"
@@ -645,7 +645,7 @@ exports[`LadderPage renders with timepoints 1`] = `
         </button>
       </div>
       <div
-        class="m-ladder-page__routes-presets-toggle"
+        class="m-ladder-page__routes-presets-toggle u-hide"
       >
         <button
           class="m-ladder-page__routes_picker_button_selected"
@@ -661,7 +661,7 @@ exports[`LadderPage renders with timepoints 1`] = `
         </button>
       </div>
       <div
-        class="m-route-picker"
+        class="m-route-picker u-hide"
       >
         <div
           class="m-route-filter"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
         </button>
       </div>
       <div
-        class="m-map-page__input"
+        class="m-map-page__input u-hide"
       >
         <form
           aria-label="Search Map"
@@ -144,7 +144,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
       </div>
       <hr />
       <div
-        class="m-search-display"
+        class="m-search-display u-hide"
       >
         <div
           class="m-recent-searches"
@@ -389,7 +389,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
         </button>
       </div>
       <div
-        class="m-map-page__input"
+        class="m-map-page__input u-hide"
       >
         <form
           aria-label="Search Map"
@@ -510,7 +510,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
       </div>
       <hr />
       <div
-        class="m-search-display"
+        class="m-search-display u-hide"
       >
         <div
           class="m-recent-searches"
@@ -755,7 +755,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
         </button>
       </div>
       <div
-        class="m-map-page__input"
+        class="m-map-page__input u-hide"
       >
         <form
           aria-label="Search Map"
@@ -876,7 +876,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
       </div>
       <hr />
       <div
-        class="m-search-display"
+        class="m-search-display u-hide"
       >
         <div
           class="m-recent-searches"

--- a/assets/tests/components/__snapshots__/presets.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/presets.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Presets renders current presets 1`] = `
 <div
-  className="m-presets-panel"
+  className="m-presets-panel u-hide"
 >
   <ul>
     <li>

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
 <div
-  className="m-route-picker"
+  className="m-route-picker u-hide"
 >
   <div
     className="m-route-filter"
@@ -127,7 +127,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
 
 exports[`RoutePicker renders a loading/empty state 1`] = `
 <div
-  className="m-route-picker"
+  className="m-route-picker u-hide"
 >
   <div
     className="m-route-filter"

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Shuttle Map Page renders 1`] = `
         </button>
       </div>
       <div
-        class="m-shuttle-picker"
+        class="m-shuttle-picker u-hide"
       >
         <div
           class="m-shuttle-picker__label"
@@ -682,7 +682,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
         </button>
       </div>
       <div
-        class="m-shuttle-picker"
+        class="m-shuttle-picker u-hide"
       >
         <div
           class="m-shuttle-picker__label"
@@ -1342,7 +1342,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
         </button>
       </div>
       <div
-        class="m-shuttle-picker"
+        class="m-shuttle-picker u-hide"
       >
         <div
           class="m-shuttle-picker__label"
@@ -2002,7 +2002,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
         </button>
       </div>
       <div
-        class="m-shuttle-picker"
+        class="m-shuttle-picker u-hide"
       >
         loading...
       </div>
@@ -2225,7 +2225,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
         </button>
       </div>
       <div
-        class="m-shuttle-picker"
+        class="m-shuttle-picker u-hide"
       >
         <div
           class="m-shuttle-picker__label"

--- a/assets/tests/components/__snapshots__/shuttlePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttlePicker.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ShuttlePicker renders 1`] = `
     </button>
   </div>
   <div
-    className="m-shuttle-picker"
+    className="m-shuttle-picker u-hide"
   >
     <div
       className="m-shuttle-picker__label"
@@ -323,7 +323,7 @@ exports[`ShuttlePicker renders loaded state with no shuttles 1`] = `
     </button>
   </div>
   <div
-    className="m-shuttle-picker"
+    className="m-shuttle-picker u-hide"
   >
     <div
       className="m-shuttle-picker__label"
@@ -581,7 +581,7 @@ exports[`ShuttlePicker renders loading state 1`] = `
     </button>
   </div>
   <div
-    className="m-shuttle-picker"
+    className="m-shuttle-picker u-hide"
   >
     loading...
   </div>


### PR DESCRIPTION
# Summary
This animates the `visibility` property after the animation finishes when collapsing, and before the animation starts when expanding.

I was unable to update tests for this because jsdom doesn't have access to our scss files when testing.

I also opted to add `u-hide` to all elements which needed to be hidden, but the `drawer_hide` selector could also be inverted to select all children but the button. I think changing the document structure would be better but it resulted in a much larger changeset.