### PR TITLE
fix(css-prefixes): kf/chunk/1

### DIFF
--- a/assets/css/_ladder.scss
+++ b/assets/css/_ladder.scss
@@ -29,29 +29,29 @@
   cursor: pointer;
 
   &:hover {
-    .m-vehicle-icon__triangle {
+    .c-vehicle-icon__triangle {
       stroke: $color-secondary-light;
     }
 
-    .m-vehicle-icon__ghost-highlight {
+    .c-vehicle-icon__ghost-highlight {
       stroke: $color-secondary-light;
     }
 
-    .m-vehicle-icon__label-background {
+    .c-vehicle-icon__label-background {
       fill: $color-secondary-light;
     }
   }
 
   &.selected {
-    .m-vehicle-icon__triangle {
+    .c-vehicle-icon__triangle {
       stroke: $color-secondary-medium;
     }
 
-    .m-vehicle-icon__ghost-highlight {
+    .c-vehicle-icon__ghost-highlight {
       stroke: $color-secondary-medium;
     }
 
-    .m-vehicle-icon__label-background {
+    .c-vehicle-icon__label-background {
       fill: $color-secondary-medium;
     }
   }

--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -6,7 +6,7 @@ $max-leaflet-z-index: 1000;
   height: 100%;
 }
 
-.m-vehicle-map-state--street-view-enabled + .leaflet-container {
+.c-vehicle-map-state--street-view-enabled + .leaflet-container {
   cursor: url("data:image/svg+xml,%3Csvg height='114' width='114' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='57' cy='57' r='57' fill='%230000FF' opacity='0.25'/%3E%3Ccircle cx='57' cy='57' r='5' fill='%235182FF' stroke='%230016DB' stroke-width='2' /%3E%3C/svg%3E%0A")
       57 57,
     pointer;

--- a/assets/css/_schedule_adherence.scss
+++ b/assets/css/_schedule_adherence.scss
@@ -1,9 +1,9 @@
-.m-schedule-adherence > * {
+.c-schedule-adherence > * {
   display: inline-block;
   line-height: 1;
 }
 
-.m-schedule-adherence__status-icon {
+.c-schedule-adherence__status-icon {
   margin-right: 4px;
 
   width: 8px;

--- a/assets/css/_search_results.scss
+++ b/assets/css/_search_results.scss
@@ -62,7 +62,7 @@
     svg {
       width: 2.5rem !important;
 
-      .m-vehicle-icon__label-background {
+      .c-vehicle-icon__label-background {
         fill: none;
       }
     }

--- a/assets/css/_shuttle_map.scss
+++ b/assets/css/_shuttle_map.scss
@@ -13,7 +13,7 @@
   position: absolute;
   width: 100%;
 
-  .m-vehicle-map__label.selected .m-vehicle-icon__label-background {
+  .c-vehicle-map__label.selected .m-vehicle-icon__label-background {
     fill: $color-secondary-medium;
   }
 }

--- a/assets/css/_shuttle_map.scss
+++ b/assets/css/_shuttle_map.scss
@@ -13,7 +13,7 @@
   position: absolute;
   width: 100%;
 
-  .c-vehicle-map__label.selected .m-vehicle-icon__label-background {
+  .c-vehicle-map__label.selected .c-vehicle-icon__label-background {
     fill: $color-secondary-medium;
   }
 }

--- a/assets/css/_street_view_button.scss
+++ b/assets/css/_street_view_button.scss
@@ -1,7 +1,7 @@
 $street-view-button-background-color: $color-eggplant-700;
 $street-view-button-text-color: $color-eggplant-50;
 
-.m-street-view-button {
+.c-street-view-button {
   /* Layout */
   /** push button to newline */
   display: block;
@@ -20,7 +20,7 @@ $street-view-button-text-color: $color-eggplant-50;
   line-height: 1;
 }
 
-.m-street-view-button__icon {
+.c-street-view-button__icon {
   display: inline-block;
   margin-right: 4px;
 
@@ -34,6 +34,6 @@ $street-view-button-text-color: $color-eggplant-50;
 }
 
 /* Override `.leaflet-container a` */
-.leaflet-container .m-street-view-button {
+.leaflet-container .c-street-view-button {
   color: $street-view-button-text-color;
 }

--- a/assets/css/_vehicle_icon.scss
+++ b/assets/css/_vehicle_icon.scss
@@ -1,4 +1,4 @@
-.m-vehicle-icon__triangle {
+.c-vehicle-icon__triangle {
   fill: $color-vehicle-normal;
   stroke: $color-bg-base;
   stroke-width: 2;
@@ -23,35 +23,35 @@
   }
 }
 
-.m-vehicle-icon__ghost-highlight {
+.c-vehicle-icon__ghost-highlight {
   fill: none;
   stroke: none;
   stroke-width: 9;
 }
 
-.m-vehicle-icon__ghost-body {
+.c-vehicle-icon__ghost-body {
   fill: $color-vehicle-ghost;
   stroke: $color-vehicle-ghost-border;
   stroke-width: 3;
 }
 
-.m-vehicle-icon__ghost-eye {
+.c-vehicle-icon__ghost-eye {
   fill: $color-vehicle-ghost-border;
 }
 
-.m-vehicle-icon__label-background {
+.c-vehicle-icon__label-background {
   fill: $color-bg-base;
 
-  .m-vehicle-icon--highlighted & {
+  .c-vehicle-icon--highlighted & {
     fill: $color-component-highlight;
   }
 }
 
-.m-vehicle-icon__label {
+.c-vehicle-icon__label {
   fill: currentColor;
 }
 
-.m-vehicle-icon__variant {
+.c-vehicle-icon__variant {
   fill: $color-font-light;
 
   .ghost & {
@@ -59,28 +59,28 @@
   }
 }
 
-.m-vehicle-icon--small {
-  .m-vehicle-icon__label {
+.c-vehicle-icon--small {
+  .c-vehicle-icon__label {
     @include font-tiny;
   }
 
-  .m-vehicle-icon__variant {
+  .c-vehicle-icon__variant {
     @include font-tiny;
   }
 }
 
-.m-vehicle-icon--medium {
-  .m-vehicle-icon__label {
+.c-vehicle-icon--medium {
+  .c-vehicle-icon__label {
     @include font-tiny;
   }
 
-  .m-vehicle-icon__variant {
+  .c-vehicle-icon__variant {
     @include font-small;
   }
 }
 
-.m-vehicle-icon--large {
-  .m-vehicle-icon__label {
+.c-vehicle-icon--large {
+  .c-vehicle-icon__label {
     @include font-header-big;
 
     &--extended {
@@ -88,7 +88,7 @@
     }
   }
 
-  .m-vehicle-icon__variant {
+  .c-vehicle-icon__variant {
     @include font-big;
   }
 }

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -11,7 +11,7 @@
     @include font-tiny;
   }
 
-  &.selected .m-vehicle-icon__label-background {
+  &.selected .c-vehicle-icon__label-background {
     fill: $color-eggplant-300;
   }
 }

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -184,7 +184,7 @@
     stroke-width: 2;
   }
 
-  .m-vehicle-map-state--auto-centering + .m-vehicle-map & a {
+  .c-vehicle-map-state--auto-centering + .m-vehicle-map & a {
     background-color: $color-button-disabled;
     color: $color-font-grey;
     cursor: default;

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -1,4 +1,4 @@
-.m-vehicle-map__label {
+.c-vehicle-map__label {
   svg {
     overflow: visible;
   }
@@ -16,7 +16,7 @@
   }
 }
 
-.m-vehicle-map__icon {
+.c-vehicle-map__icon {
   path {
     fill: $color-primary;
     stroke: $color-bg-base;
@@ -56,11 +56,11 @@
   }
 }
 
-.c-vehicle-properties-panel__location .m-vehicle-map .leaflet-right {
+.c-vehicle-properties-panel__location .c-vehicle-map .leaflet-right {
   padding-right: calc(env(safe-area-inset-right) - #{$vpp-location-padding});
 }
 
-.m-vehicle-map__train-icon {
+.c-vehicle-map__train-icon {
   fill: $white;
   stroke: $color-component-dark;
   stroke-width: 4;
@@ -72,13 +72,13 @@
   }
 }
 
-.m-vehicle-map__route-shape {
+.c-vehicle-map__route-shape {
   stroke: $color-kiwi-500;
   stroke-opacity: 0.5;
   stroke-width: 5;
 }
 
-.m-vehicle-map__route-shape:focus {
+.c-vehicle-map__route-shape:focus {
   outline: none;
 }
 
@@ -87,28 +87,28 @@
   stroke-width: 4;
 }
 
-.m-vehicle-map__route-shape.route-shape--blue {
+.c-vehicle-map__route-shape.route-shape--blue {
   stroke: $color-mbta-blue;
 }
 
-.m-vehicle-map__route-shape.route-shape--green {
+.c-vehicle-map__route-shape.route-shape--green {
   stroke: $color-mbta-green;
 }
 
-.m-vehicle-map__route-shape.route-shape--orange {
+.c-vehicle-map__route-shape.route-shape--orange {
   stroke: $color-mbta-orange;
 }
 
-.m-vehicle-map__route-shape.route-shape--red {
+.c-vehicle-map__route-shape.route-shape--red {
   stroke: $color-mbta-red;
 }
 
-.m-vehicle-map__route-shape:not(.m-vehicle-map__route-shape--no-hover):hover,
-.m-vehicle-map__route-shape--selected {
+.c-vehicle-map__route-shape:not(.c-vehicle-map__route-shape--no-hover):hover,
+.c-vehicle-map__route-shape--selected {
   stroke-width: 7;
 }
 
-.m-vehicle-map__stop {
+.c-vehicle-map__stop {
   fill: $color-stop-fill;
   fill-opacity: 1;
 
@@ -133,7 +133,7 @@
   }
 }
 
-.leaflet-tooltip.m-vehicle-map__mobile-friendly-tooltip,
+.leaflet-tooltip.c-vehicle-map__mobile-friendly-tooltip,
 .leaflet-tooltip.route-shape__tooltip {
   background-color: $color-tooltip-background;
   color: $white;
@@ -141,14 +141,14 @@
   opacity: 1 !important;
 }
 
-.leaflet-popup.m-vehicle-map__mobile-friendly-tooltip .leaflet-popup-content {
+.leaflet-popup.c-vehicle-map__mobile-friendly-tooltip .leaflet-popup-content {
   margin: 0px;
   background-color: $color-tooltip-background;
   opacity: 1 !important;
   text-align: center;
 }
 
-.leaflet-popup.m-vehicle-map__mobile-friendly-tooltip
+.leaflet-popup.c-vehicle-map__mobile-friendly-tooltip
   .leaflet-popup-content-wrapper {
   background-color: $color-tooltip-background;
   color: $white;
@@ -156,35 +156,35 @@
   box-shadow: none;
 }
 
-.leaflet-popup.m-vehicle-map__mobile-friendly-tooltip .leaflet-popup-content {
+.leaflet-popup.c-vehicle-map__mobile-friendly-tooltip .leaflet-popup-content {
   font-size: 0.75rem;
   line-height: 1.5;
 }
 
-.leaflet-popup.m-vehicle-map__mobile-friendly-tooltip {
+.leaflet-popup.c-vehicle-map__mobile-friendly-tooltip {
   margin-bottom: 6px !important;
 }
 
 // Hide popup pointer triangle - replaced by tooltip triangle
-.leaflet-popup.m-vehicle-map__mobile-friendly-tooltip
+.leaflet-popup.c-vehicle-map__mobile-friendly-tooltip
   .leaflet-popup-tip-container {
   display: none;
 }
 
 // The tooltip triangle
-.leaflet-tooltip-top.m-vehicle-map__mobile-friendly-tooltip::before,
+.leaflet-tooltip-top.c-vehicle-map__mobile-friendly-tooltip::before,
 .leaflet-tooltip-top.route-shape__tooltip::before {
   border-top-color: $color-tooltip-background;
 }
 
-.m-vehicle-map__recenter-button {
+.c-vehicle-map__recenter-button {
   path {
     fill: none;
     stroke: $color-button-secondary;
     stroke-width: 2;
   }
 
-  .c-vehicle-map-state--auto-centering + .m-vehicle-map & a {
+  .c-vehicle-map-state--auto-centering + .c-vehicle-map & a {
     background-color: $color-button-disabled;
     color: $color-font-grey;
     cursor: default;

--- a/assets/css/_vehicle_map.scss
+++ b/assets/css/_vehicle_map.scss
@@ -56,7 +56,7 @@
   }
 }
 
-.m-vehicle-properties-panel__location .m-vehicle-map .leaflet-right {
+.c-vehicle-properties-panel__location .m-vehicle-map .leaflet-right {
   padding-right: calc(env(safe-area-inset-right) - #{$vpp-location-padding});
 }
 

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -20,7 +20,7 @@
     grid-area: separator;
   }
 
-  .m-schedule-adherence {
+  .c-schedule-adherence {
     grid-area: adherence;
   }
 
@@ -35,7 +35,7 @@
 
   // #region Bespoke alignment within cells
   // adherence should stick to the right side of the card
-  .m-schedule-adherence {
+  .c-schedule-adherence {
     justify-self: end;
   }
 
@@ -46,14 +46,14 @@
   }
 
   // Adherence and direction should hug the top of the container
-  .m-schedule-adherence,
+  .c-schedule-adherence,
   .m-vehicle-route-direction {
     line-height: 1;
   }
   // #endregion
 
   // #region component layout
-  .m-schedule-adherence {
+  .c-schedule-adherence {
     & > * {
       display: inline-block;
     }

--- a/assets/css/_vehicle_route_summary.scss
+++ b/assets/css/_vehicle_route_summary.scss
@@ -28,7 +28,7 @@
     grid-area: direction;
   }
 
-  .m-route-variant-name {
+  .c-route-variant-name {
     grid-area: route-name;
   }
   // #endregion
@@ -60,7 +60,7 @@
   }
 
   // route variant name should not move when text gets longer
-  .m-route-variant-name {
+  .c-route-variant-name {
     // Fill grid container
     height: 100%;
     width: 100%;

--- a/assets/css/_view_header.scss
+++ b/assets/css/_view_header.scss
@@ -1,4 +1,4 @@
-.m-view-header {
+.c-view-header {
   position: sticky;
   top: 0;
   z-index: 1;
@@ -29,13 +29,13 @@
   }
 }
 
-.m-view-header__title {
+.c-view-header__title {
   font-size: 0.875rem;
   font-weight: 500;
   color: $color-gray-800;
 }
 
-.m-view-header__backlink {
+.c-view-header__backlink {
   @include button-icon(0.875rem);
   position: absolute;
   top: 0;

--- a/assets/css/properties_panel/_header.scss
+++ b/assets/css/properties_panel/_header.scss
@@ -1,7 +1,7 @@
 .m-properties-panel__header {
   display: flex;
 
-  .m-route-variant-name {
+  .c-route-variant-name {
     @include font-header;
   }
 }

--- a/assets/css/properties_panel/_stale_data_properties_panel.scss
+++ b/assets/css/properties_panel/_stale_data_properties_panel.scss
@@ -4,7 +4,7 @@
     margin: 1.25rem 1rem 0 1rem;
   }
 
-  .m-vehicle-icon__triangle {
+  .c-vehicle-icon__triangle {
     fill: $color-gray-400;
   }
 }

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -1,20 +1,20 @@
-.m-vehicle-properties-panel {
+.c-vehicle-properties-panel {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
 }
 
-.m-vehicle-properties-panel__notes {
+.c-vehicle-properties-panel__notes {
   margin: 0.5rem;
 }
 
-.m-vehicle-properties-panel__invalid-banner h3 {
+.c-vehicle-properties-panel__invalid-banner h3 {
   margin: 0;
   font-size: var(--font-size-m);
   font-weight: var(--font-weight-semi);
 }
 
-.m-vehicle-properties-panel__location {
+.c-vehicle-properties-panel__location {
   border-top: 1px solid $color-rule;
   display: flex;
   flex: 1 1 auto;
@@ -22,35 +22,35 @@
   padding: $vpp-location-padding;
 }
 
-.m-vehicle-properties-panel__latlng {
+.c-vehicle-properties-panel__latlng {
   flex: 0 1 4.25rem;
 }
 
-.m-vehicle-properties-panel__next-stop {
+.c-vehicle-properties-panel__next-stop {
   flex: 0 0 auto;
 }
 
-.m-vehicle-properties-panel__label {
+.c-vehicle-properties-panel__label {
   @include font-label;
   margin-bottom: 0.25rem;
   margin-top: 0.5rem;
 }
 
-.m-vehicle-properties-panel__value {
+.c-vehicle-properties-panel__value {
   @include font-body;
   margin-bottom: 0.25rem;
 }
 
-.m-vehicle-properties-panel__link {
+.c-vehicle-properties-panel__link {
   @include font-link;
   margin-bottom: 0.25rem;
 }
 
-.m-vehicle-properties-panel__not-available {
+.c-vehicle-properties-panel__not-available {
   color: $color-font-warning;
 }
 
-.m-vehicle-properties-panel__map {
+.c-vehicle-properties-panel__map {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
@@ -68,7 +68,7 @@
   }
 }
 
-.m-vehicle-properties-panel__map-open-link {
+.c-vehicle-properties-panel__map-open-link {
   position: absolute;
   z-index: #{$max-leaflet-z-index + 1};
   top: 10px;
@@ -86,11 +86,11 @@
   }
 }
 
-.m-vehicle-properties-panel__data-discrepancies {
+.c-vehicle-properties-panel__data-discrepancies {
   padding: 1rem;
 }
 
-.m-vehicle-properties-panel__data-discrepancy-source-id {
+.c-vehicle-properties-panel__data-discrepancy-source-id {
   font-style: italic;
 
   &::after {

--- a/assets/css/properties_panel/_vehicle_properties_panel.scss
+++ b/assets/css/properties_panel/_vehicle_properties_panel.scss
@@ -57,13 +57,13 @@
   margin-top: 1rem;
   min-height: 320px;
 
-  .m-vehicle-map {
+  .c-vehicle-map {
     flex: 1 0 auto;
     z-index: map-get($z-properties-panel-context, "map");
   }
   // Fullscreen on mobile safari not naitively supported - uses 'pseudo-fullscreen' css
   // Ensure fullscreen VPP map appears above VPP header
-  .m-vehicle-map.leaflet-pseudo-fullscreen {
+  .c-vehicle-map.leaflet-pseudo-fullscreen {
     z-index: map-get($z-properties-panel-context, "fullscreen-map");
   }
 }

--- a/assets/src/components/crowdingIcon.tsx
+++ b/assets/src/components/crowdingIcon.tsx
@@ -72,8 +72,8 @@ export const CrowdingIconSvgNode = React.memo(
     isLayingOver,
   }: Props): ReactElement<SVGElement> => {
     const classes: string[] = [
-      "m-vehicle-icon",
-      `m-vehicle-icon${sizeClassSuffix(size)}`,
+      "c-vehicle-icon",
+      `c-vehicle-icon${sizeClassSuffix(size)}`,
     ]
     return (
       <g className={className(classes)}>

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -311,8 +311,8 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const { allowFullscreen = true } = props
 
   const stateClasses = className([
-    "m-vehicle-map-state",
-    streetViewEnabled ? "m-vehicle-map-state--street-view-enabled" : null,
+    "c-vehicle-map-state",
+    streetViewEnabled ? "c-vehicle-map-state--street-view-enabled" : null,
     props.stateClasses,
   ])
 
@@ -440,7 +440,7 @@ export const vehicleToLeafletLatLng = ({
 export const FollowerStatusClasses = (
   shouldFollow: boolean
 ): string | undefined => {
-  return shouldFollow ? "m-vehicle-map-state--auto-centering" : undefined
+  return shouldFollow ? "c-vehicle-map-state--auto-centering" : undefined
 }
 
 export const MapFollowingPrimaryVehicles = (props: Props) => {

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -89,7 +89,7 @@ class LeafletRecenterControl extends Control {
   onAdd() {
     const controlContainer = DomUtil.create(
       "div",
-      "leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+      "leaflet-control leaflet-bar c-vehicle-map__recenter-button"
     )
     controlContainer.onclick = (e) => {
       e.stopPropagation()
@@ -322,7 +322,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
     <>
       <div className={stateClasses} />
       <MapContainer
-        className="m-vehicle-map"
+        className="c-vehicle-map"
         id="id-vehicle-map"
         maxBounds={[
           [41.2, -72],

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -87,11 +87,11 @@ const makeLabelIcon = (
     ]),
     html: `<svg viewBox="0 0 ${labelBackgroundWidth} ${labelBackgroundHeight}" width="${labelBackgroundWidth}" height="${labelBackgroundHeight}">
             <rect
-                class="m-vehicle-icon__label-background"
+                class="c-vehicle-icon__label-background"
                 width="100%" height="100%"
                 rx="5.5px" ry="5.5px"
               />
-            <text class="m-vehicle-icon__label" x="50%" y="50%" text-anchor="middle" dominant-baseline="central">
+            <text class="c-vehicle-icon__label" x="50%" y="50%" text-anchor="middle" dominant-baseline="central">
               ${labelString}
             </text>
           </svg>`,

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -64,7 +64,7 @@ const makeVehicleIcon = (
         />
       </svg>`,
     iconAnchor: [0, 0],
-    className: "m-vehicle-map__icon",
+    className: "c-vehicle-map__icon",
   })
 }
 
@@ -81,7 +81,7 @@ const makeLabelIcon = (
   const selectedClass = isSelected ? "selected" : null
   return Leaflet.divIcon({
     className: className([
-      "m-vehicle-map__label",
+      "c-vehicle-map__label",
       isPrimary ? "primary" : "secondary",
       selectedClass,
     ]),
@@ -158,7 +158,7 @@ const makeTrainVehicleIcon = ({ bearing }: TrainVehicle): Leaflet.DivIcon => {
           <path fill="#fff" d="m42.88 45.83a2.1 2.1 0 0 1 -.87-.19l-15.92-7.17a5.23 5.23 0 0 0 -2.09-.47 5.14 5.14 0 0 0 -2.08.44l-15.92 7.2a2.1 2.1 0 0 1 -.87.19 2.14 2.14 0 0 1 -1.76-1 2 2 0 0 1 -.12-2l18.86-40.83a2.08 2.08 0 0 1 3.78 0l18.87 40.87a2 2 0 0 1 -.12 2 2.14 2.14 0 0 1 -1.76.96z"/>
         </g>
     </svg>`,
-    className: "m-vehicle-map__train-icon",
+    className: "c-vehicle-map__train-icon",
   })
 }
 
@@ -199,7 +199,7 @@ const MobileFriendlyTooltip = ({
 }) => {
   const supportsHover = useDeviceSupportsHover()
 
-  const fullClassName = `m-vehicle-map__mobile-friendly-tooltip ${className}`
+  const fullClassName = `c-vehicle-map__mobile-friendly-tooltip ${className}`
 
   return supportsHover ? (
     <Tooltip
@@ -254,7 +254,7 @@ export const StopIcon = ({
     <CircleMarker
       {...props}
       ref={setMarker}
-      className={className(["m-vehicle-map__stop"])}
+      className={className(["c-vehicle-map__stop"])}
       center={[stop.lat, stop.lon]}
       radius={radius}
     >
@@ -294,7 +294,7 @@ export const StopMarker = React.memo(
           <StopCard.WithSafeArea stop={stop} direction={direction} />
         ) : (
           <MobileFriendlyTooltip
-            className={"m-vehicle-map__stop-tooltip"}
+            className={"c-vehicle-map__stop-tooltip"}
             markerRadius={markerRadius}
           >
             {stop.name}
@@ -330,7 +330,7 @@ export const StationMarker = React.memo(
         }}
       >
         <MobileFriendlyTooltip
-          className={"m-vehicle-map__stop-tooltip"}
+          className={"c-vehicle-map__stop-tooltip"}
           markerRadius={iconSizeLength / 2}
         >
           {station.name}
@@ -398,9 +398,9 @@ export const RouteShape = React.memo(
     return (
       <Polyline
         className={
-          `m-vehicle-map__route-shape ${shape.className || ""}` +
-          `${isSelected ? " m-vehicle-map__route-shape--selected" : ""}` +
-          `${onClick ? "" : " m-vehicle-map__route-shape--no-hover"}`
+          `c-vehicle-map__route-shape ${shape.className || ""}` +
+          `${isSelected ? " c-vehicle-map__route-shape--selected" : ""}` +
+          `${onClick ? "" : " c-vehicle-map__route-shape--no-hover"}`
         }
         positions={positions}
         eventHandlers={onClick ? { click: onClick } : {}}

--- a/assets/src/components/propertiesPanel/miniMap.tsx
+++ b/assets/src/components/propertiesPanel/miniMap.tsx
@@ -22,7 +22,7 @@ const SearchMapLink = ({ vehicleId }: { vehicleId: VehicleId }) => {
   return (
     <Link
       ref={openMapLinkRef}
-      className="m-vehicle-properties-panel__map-open-link leaflet-bar"
+      className="c-vehicle-properties-panel__map-open-link leaflet-bar"
       to={mapModeForUser().path}
       onClick={() => {
         window.FS?.event("Map opened from VPP mini map")

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -69,7 +69,7 @@ const StaleDataHeader: React.FC<{
         </div>
         <div className="m-properties-panel__variant">
           <div className="m-properties-panel__inbound-outbound">N/A</div>
-          <div className="m-route-variant-name">Not Available</div>
+          <div className="c-route-variant-name">Not Available</div>
         </div>
       </div>
       {vehicle.isShuttle || (

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 const InvalidBanner = () => (
   <Card
-    additionalClass="m-vehicle-properties-panel__invalid-banner"
+    additionalClass="c-vehicle-properties-panel__invalid-banner"
     style="lemon"
     title={<h3>Invalid Bus</h3>}
     noFocusOrHover={true}
@@ -41,7 +41,7 @@ const InvalidBanner = () => (
 )
 
 const NotAvailable = () => (
-  <span className="m-vehicle-properties-panel__not-available">
+  <span className="c-vehicle-properties-panel__not-available">
     Not available
   </span>
 )
@@ -84,18 +84,18 @@ const Location = ({ vehicle }: { vehicle: Vehicle }) => {
     : null
 
   return (
-    <div className="m-vehicle-properties-panel__location">
-      <div className="m-vehicle-properties-panel__latlng">
-        <div className="m-vehicle-properties-panel__label">
+    <div className="c-vehicle-properties-panel__location">
+      <div className="c-vehicle-properties-panel__latlng">
+        <div className="c-vehicle-properties-panel__label">
           Current Location
         </div>
         {nearestIntersection ? (
-          <div className="m-vehicle-properties-panel__value">
+          <div className="c-vehicle-properties-panel__value">
             {nearestIntersection}
           </div>
         ) : null}
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href={directionsUrl(latitude, longitude)}
           target="_blank"
           rel="noreferrer"
@@ -103,9 +103,9 @@ const Location = ({ vehicle }: { vehicle: Vehicle }) => {
           Directions
         </a>
       </div>
-      <div className="m-vehicle-properties-panel__next-stop">
-        <div className="m-vehicle-properties-panel__label">Next Stop</div>
-        <div className="m-vehicle-properties-panel__value">
+      <div className="c-vehicle-properties-panel__next-stop">
+        <div className="c-vehicle-properties-panel__label">Next Stop</div>
+        <div className="c-vehicle-properties-panel__value">
           {isOffCourse || vehicle.isShuttle ? (
             <NotAvailable />
           ) : (
@@ -113,7 +113,7 @@ const Location = ({ vehicle }: { vehicle: Vehicle }) => {
           )}
         </div>
       </div>
-      <div className="m-vehicle-properties-panel__map">
+      <div className="c-vehicle-properties-panel__map">
         <MiniMap
           vehicle={vehicle}
           routeVehicles={routeVehicles}
@@ -129,16 +129,16 @@ const Discrepancy = ({
 }: {
   dataDiscrepancy: DataDiscrepancy
 }) => (
-  <dl className="m-vehicle-properties-panel__data-discrepancy">
+  <dl className="c-vehicle-properties-panel__data-discrepancy">
     <dt>{attribute}</dt>
     <dd>
       <ul>
         {sources.map(({ id, value }) => (
           <li key={`${attribute}-${id}`} data-testid="data-discrepancy">
-            <span className="m-vehicle-properties-panel__data-discrepancy-source-id">
+            <span className="c-vehicle-properties-panel__data-discrepancy-source-id">
               {id}
             </span>
-            <span className="m-vehicle-properties-panel__data-discrepancy-source-value">
+            <span className="c-vehicle-properties-panel__data-discrepancy-source-value">
               {value}
             </span>
           </li>
@@ -153,7 +153,7 @@ const DataDiscrepancies = ({
 }: {
   vehicle: Vehicle
 }) => (
-  <ul className="m-vehicle-properties-panel__data-discrepancies">
+  <ul className="c-vehicle-properties-panel__data-discrepancies">
     {dataDiscrepancies.map((dataDiscrepancy) => (
       <li key={dataDiscrepancy.attribute}>
         <Discrepancy dataDiscrepancy={dataDiscrepancy} />
@@ -170,7 +170,7 @@ const shouldShowDataDiscrepancies = ({ dataDiscrepancies }: Vehicle): boolean =>
 
 const StatusContent = ({ selectedVehicle }: { selectedVehicle: Vehicle }) => (
   <>
-    <div className="m-vehicle-properties-panel__notes">
+    <div className="c-vehicle-properties-panel__notes">
       {selectedVehicle.isOffCourse && <InvalidBanner />}
 
       {hasBlockWaiver(selectedVehicle) && (
@@ -194,7 +194,7 @@ const VehiclePropertiesPanel = ({ selectedVehicle }: Props) => {
   const [tabMode, setTabMode] = useState<TabMode>("status")
 
   return (
-    <div className="m-vehicle-properties-panel">
+    <div className="c-vehicle-properties-panel">
       <Header
         vehicle={selectedVehicle}
         tabMode={tabMode}

--- a/assets/src/components/routeVariantName.tsx
+++ b/assets/src/components/routeVariantName.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentPropsWithoutRef } from "react"
 import { useRoute } from "../contexts/routesContext"
+import { className as joinClassNames } from "../helpers/dom"
 import { isVehicle } from "../models/vehicle"
 import { VehicleOrGhost } from "../realtime"
 
@@ -17,7 +18,7 @@ export const RouteVariantName = ({
   return (
     <output
       aria-label="Route Variant Name"
-      className={"c-route-variant-name " + className}
+      className={joinClassNames(["c-route-variant-name", className])}
       {...props}
     >
       {isShuttle ? (

--- a/assets/src/components/routeVariantName.tsx
+++ b/assets/src/components/routeVariantName.tsx
@@ -17,7 +17,7 @@ export const RouteVariantName = ({
   return (
     <output
       aria-label="Route Variant Name"
-      className={"m-route-variant-name " + className}
+      className={"c-route-variant-name " + className}
       {...props}
     >
       {isShuttle ? (
@@ -26,14 +26,14 @@ export const RouteVariantName = ({
         <>
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             {`${route?.name || routeId}_${viaVariantFormatted}`}
           </output>
           &nbsp;
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             {headsign}
           </output>

--- a/assets/src/components/scheduleAdherence.tsx
+++ b/assets/src/components/scheduleAdherence.tsx
@@ -18,7 +18,7 @@ const ScheduleAdherenceStatusIcon = () => (
     viewBox="0 0 100 100"
     width={8}
     height={8}
-    className="m-schedule-adherence__status-icon"
+    className="c-schedule-adherence__status-icon"
   >
     <circle cx={50} cy={50} r={40} />
   </svg>
@@ -30,7 +30,7 @@ const ScheduleAdherenceDescription = ({
   ...props
 }: { vehicle: Vehicle } & ComponentPropsWithoutRef<"output">) => (
   <output
-    className={classNames(["m-schedule-adherence-status", className])}
+    className={classNames(["c-schedule-adherence-status", className])}
     {...props}
   >
     {humanReadableScheduleAdherence(vehicle)}
@@ -72,7 +72,7 @@ export const ScheduleAdherence = ({
   const [{ userSettings }] = useContext(StateDispatchContext)
 
   const classes = classNames([
-    "m-schedule-adherence",
+    "c-schedule-adherence",
     ...statusClasses(drawnStatus(vehicle), userSettings.vehicleAdherenceColors),
     className,
   ])

--- a/assets/src/components/streetViewButton.tsx
+++ b/assets/src/components/streetViewButton.tsx
@@ -30,7 +30,7 @@ const StreetViewButton = ({
   return (
     <a
       className={classNames([
-        "m-street-view-button",
+        "c-street-view-button",
         "button-dark-small",
         className,
       ])}
@@ -49,7 +49,7 @@ const StreetViewButton = ({
       {...(title && { title })}
     >
       <WalkingIcon
-        className="m-street-view-button__icon"
+        className="c-street-view-button__icon"
         role="img"
         aria-label=""
         aria-hidden={true}

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -264,10 +264,10 @@ export const VehicleIconSvgNode = React.memo(
       orientation = Orientation.Up
     }
     const classes: string[] = [
-      "m-vehicle-icon",
-      `m-vehicle-icon${sizeClassSuffix(size)}`,
+      "c-vehicle-icon",
+      `c-vehicle-icon${sizeClassSuffix(size)}`,
       alertIconStyle === AlertIconStyle.Highlighted
-        ? "m-vehicle-icon--highlighted"
+        ? "c-vehicle-icon--highlighted"
         : "",
     ].concat(statusClasses(status, userSettings.vehicleAdherenceColors))
     return (
@@ -308,7 +308,7 @@ const Triangle = React.memo(
     const rotation = rotationForOrientation(orientation)
     return (
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         data-testid="vehicle-triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         // Move the center to 0,0
@@ -330,26 +330,26 @@ const Ghost = React.memo(
       >
         <path
           // The outline that gets highlighted when it's selected
-          className="m-vehicle-icon__ghost-highlight"
+          className="c-vehicle-icon__ghost-highlight"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <path
-          className="m-vehicle-icon__ghost-body"
+          className="c-vehicle-icon__ghost-body"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         {variant === undefined ? (
           <>
             <ellipse
-              className="m-vehicle-icon__ghost-eye"
+              className="c-vehicle-icon__ghost-eye"
               cx="19.73"
               cy="22.8"
               rx="3.11"
               ry="3.03"
             />
             <ellipse
-              className="m-vehicle-icon__ghost-eye"
+              className="c-vehicle-icon__ghost-eye"
               cx="35.29"
               cy="22.8"
               rx="3.11"
@@ -393,14 +393,14 @@ export const Label = React.memo(
 
     const labelClassWithModifier =
       label.length > 4
-        ? "m-vehicle-icon__label--extended"
-        : "m-vehicle-icon__label--normal"
-    const labelClass = `m-vehicle-icon__label ${labelClassWithModifier}`
+        ? "c-vehicle-icon__label--extended"
+        : "c-vehicle-icon__label--normal"
+    const labelClass = `c-vehicle-icon__label ${labelClassWithModifier}`
 
     return (
       <>
         <rect
-          className="m-vehicle-icon__label-background"
+          className="c-vehicle-icon__label-background"
           x={-labelBgWidth / 2}
           y={labelBgTop}
           width={labelBgWidth}
@@ -487,7 +487,7 @@ const Variant = React.memo(
         break
     }
     return (
-      <text className="m-vehicle-icon__variant" {...variantPositionOpts}>
+      <text className="c-vehicle-icon__variant" {...variantPositionOpts}>
         {variant}
       </text>
     )

--- a/assets/src/components/viewHeader.tsx
+++ b/assets/src/components/viewHeader.tsx
@@ -32,12 +32,12 @@ const ViewHeader: ViewHeaderType = ({
   const deviceType = useScreenSize()
 
   return (
-    <div className="m-view-header">
+    <div className="c-view-header">
       {backlinkToView &&
       backlinkToView !== OpenView.None &&
       deviceType === "mobile" ? (
         <button
-          className="m-view-header__backlink"
+          className="c-view-header__backlink"
           onClick={followBacklink}
           title={backlinkTitle(backlinkToView)}
         >
@@ -45,7 +45,7 @@ const ViewHeader: ViewHeaderType = ({
           {backlinkTitle(backlinkToView)}
         </button>
       ) : null}
-      <h2 className="m-view-header__title">{title}</h2>
+      <h2 className="c-view-header__title">{title}</h2>
       <CloseButton closeButtonType="xl_light" onClick={closeView} />
     </div>
   )

--- a/assets/src/helpers/dom.ts
+++ b/assets/src/helpers/dom.ts
@@ -2,6 +2,5 @@ type RemovedTypes = null | undefined | false
 export const joinTruthy = (strings: (string | RemovedTypes)[], joiner = " ") =>
   strings.filter(Boolean).join(joiner)
 
-export const className = (
-  classes: (string | null | undefined | false)[]
-): string => joinTruthy(classes, " ")
+export const className = (classes: (string | RemovedTypes)[]): string =>
+  joinTruthy(classes, " ")

--- a/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/incomingBox.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`IncomingBox renders a crowding view missing crowding data 1`] = `
           viewBox="-8.36 -7.6 16.72 15.2"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small"
+            className="c-vehicle-icon c-vehicle-icon--small"
           >
             <g
               className="m-ladder__crowding m-ladder__crowding--no-data"
@@ -185,7 +185,7 @@ exports[`IncomingBox renders a crowding view of a vehicle 1`] = `
           viewBox="-8.36 -7.6 16.72 15.2"
         >
           <g
-            className="m-vehicle-icon m-vehicle-icon--small"
+            className="c-vehicle-icon c-vehicle-icon--small"
           >
             <g
               className="m-ladder__crowding m-ladder__crowding--empty"
@@ -307,24 +307,24 @@ exports[`IncomingBox renders a ghost 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--small ghost early-red"
+            className="c-vehicle-icon c-vehicle-icon--small ghost early-red"
           >
             <g
               transform="scale(0.26599999999999996) translate(-24,-23)"
             >
               <path
-                className="m-vehicle-icon__ghost-highlight"
+                className="c-vehicle-icon__ghost-highlight"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
               <path
-                className="m-vehicle-icon__ghost-body"
+                className="c-vehicle-icon__ghost-body"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
             </g>
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -447,16 +447,16 @@ exports[`IncomingBox renders a vehicle 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            className="c-vehicle-icon c-vehicle-icon--small on-time early-red"
           >
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -548,16 +548,16 @@ exports[`IncomingBox renders a vehicle with the opposite incoming direction ID 1
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            className="c-vehicle-icon c-vehicle-icon--small on-time early-red"
           >
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(180) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="hanging"
               textAnchor="middle"
               x={0}

--- a/assets/tests/components/__snapshots__/ladder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladder.test.tsx.snap
@@ -73,10 +73,10 @@ exports[`ladder highlights a selected vehicle 1`] = `
         transform="translate(-63,-68.75)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -85,7 +85,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -94,7 +94,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
             2
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -153,10 +153,10 @@ exports[`ladder highlights a selected vehicle 1`] = `
         transform="translate(63,-82.5)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -165,7 +165,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -174,7 +174,7 @@ exports[`ladder highlights a selected vehicle 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -357,10 +357,10 @@ exports[`ladder renders a ghost bus 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium c-vehicle-icon--highlighted ghost early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -369,7 +369,7 @@ exports[`ladder renders a ghost bus 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -381,18 +381,18 @@ exports[`ladder renders a ghost bus 1`] = `
             transform="scale(0.4375) translate(-24,-23)"
           >
             <path
-              className="m-vehicle-icon__ghost-highlight"
+              className="c-vehicle-icon__ghost-highlight"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
             <path
-              className="m-vehicle-icon__ghost-body"
+              className="c-vehicle-icon__ghost-body"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
           </g>
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -614,10 +614,10 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(63,-82.5)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -626,7 +626,7 @@ exports[`ladder renders a ladder 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -635,7 +635,7 @@ exports[`ladder renders a ladder 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -694,10 +694,10 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(-63,-68.75)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -706,7 +706,7 @@ exports[`ladder renders a ladder 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -715,7 +715,7 @@ exports[`ladder renders a ladder 1`] = `
             2
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -774,10 +774,10 @@ exports[`ladder renders a ladder 1`] = `
         transform="translate(-63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -786,7 +786,7 @@ exports[`ladder renders a ladder 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -795,7 +795,7 @@ exports[`ladder renders a ladder 1`] = `
             3
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -977,10 +977,10 @@ exports[`ladder renders a ladder with no timepoints 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -989,7 +989,7 @@ exports[`ladder renders a ladder with no timepoints 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -998,7 +998,7 @@ exports[`ladder renders a ladder with no timepoints 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -1090,10 +1090,10 @@ exports[`ladder renders a laying over vehicle 1`] = `
         transform="translate(0,-35)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--small on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -1102,7 +1102,7 @@ exports[`ladder renders a laying over vehicle 1`] = `
             y={7.359999999999999}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            className="c-vehicle-icon__label c-vehicle-icon__label--extended"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1111,7 +1111,7 @@ exports[`ladder renders a laying over vehicle 1`] = `
             ADDED
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.38) rotate(270) translate(-24,-22)"
@@ -1300,10 +1300,10 @@ exports[`ladder renders a laying over vehicle with a scheduled line 1`] = `
         transform="translate(0,-35)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--small on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -1312,7 +1312,7 @@ exports[`ladder renders a laying over vehicle with a scheduled line 1`] = `
             y={7.359999999999999}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1321,7 +1321,7 @@ exports[`ladder renders a laying over vehicle with a scheduled line 1`] = `
             over
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.38) rotate(270) translate(-24,-22)"
@@ -1510,10 +1510,10 @@ exports[`ladder renders a reversed ladder 1`] = `
         transform="translate(63,-82.5)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -1522,7 +1522,7 @@ exports[`ladder renders a reversed ladder 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1531,7 +1531,7 @@ exports[`ladder renders a reversed ladder 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -1714,10 +1714,10 @@ exports[`ladder renders an off-course vehicle 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium off-course early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium off-course early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -1726,7 +1726,7 @@ exports[`ladder renders an off-course vehicle 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1735,13 +1735,13 @@ exports[`ladder renders an off-course vehicle 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -1926,10 +1926,10 @@ exports[`ladder renders an overload vehicle 1`] = `
         transform="translate(63,-82.5)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -1938,7 +1938,7 @@ exports[`ladder renders an overload vehicle 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            className="c-vehicle-icon__label c-vehicle-icon__label--extended"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1947,7 +1947,7 @@ exports[`ladder renders an overload vehicle 1`] = `
             ADDED
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -2136,10 +2136,10 @@ exports[`ladder shows schedule line in the other direction 1`] = `
         transform="translate(-63,41.25)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -2148,7 +2148,7 @@ exports[`ladder shows schedule line in the other direction 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -2157,7 +2157,7 @@ exports[`ladder shows schedule line in the other direction 1`] = `
             2
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -2354,10 +2354,10 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
         transform="translate(63,0)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium ghost early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium ghost early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -2366,7 +2366,7 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             y={11.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -2378,18 +2378,18 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             transform="scale(0.4375) translate(-24,-23)"
           >
             <path
-              className="m-vehicle-icon__ghost-highlight"
+              className="c-vehicle-icon__ghost-highlight"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
             <path
-              className="m-vehicle-icon__ghost-body"
+              className="c-vehicle-icon__ghost-body"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
           </g>
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -2481,10 +2481,10 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
         transform="translate(-87,-68.75)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -2493,7 +2493,7 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -2502,7 +2502,7 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             run
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -2591,10 +2591,10 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
         transform="translate(-63,-68.75)"
       >
         <g
-          className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={11}
             rx={5.5}
             ry={5.5}
@@ -2603,7 +2603,7 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             y={-22.5}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -2612,7 +2612,7 @@ exports[`ladder shows vehicles with current block waivers 1`] = `
             run
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"

--- a/assets/tests/components/__snapshots__/lateView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/lateView.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`LateView renders missing logons and late buses 1`] = `
     className="m-late-view__content-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Late View
       </h2>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1246,7 +1246,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 
             
                 <rect
-                  class="m-vehicle-icon__label-background"
+                  class="c-vehicle-icon__label-background"
                   height="100%"
                   rx="5.5px"
                   ry="5.5px"
@@ -1255,7 +1255,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 
             
                 <text
-                  class="m-vehicle-icon__label"
+                  class="c-vehicle-icon__label"
                   dominant-baseline="central"
                   text-anchor="middle"
                   x="50%"
@@ -1514,10 +1514,10 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                       Vehicle Status Icon
                     </title>
                     <g
-                      class="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+                      class="c-vehicle-icon c-vehicle-icon--large on-time early-red"
                     >
                       <rect
-                        class="m-vehicle-icon__label-background"
+                        class="c-vehicle-icon__label-background"
                         height="24"
                         rx="12"
                         ry="12"
@@ -1526,7 +1526,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                         y="19"
                       />
                       <text
-                        class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                        class="c-vehicle-icon__label c-vehicle-icon__label--normal"
                         dominant-baseline="central"
                         text-anchor="middle"
                         x="0"
@@ -1535,13 +1535,13 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                         1
                       </text>
                       <path
-                        class="m-vehicle-icon__triangle"
+                        class="c-vehicle-icon__triangle"
                         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                         data-testid="vehicle-triangle"
                         transform="scale(1) rotate(0) translate(-24,-22)"
                       />
                       <text
-                        class="m-vehicle-icon__variant"
+                        class="c-vehicle-icon__variant"
                         dominant-baseline="alphabetic"
                         text-anchor="middle"
                         x="0"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -276,7 +276,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -531,7 +531,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -642,7 +642,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -897,7 +897,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -1210,7 +1210,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
               </div>
             </div>
             <div
-              class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+              class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
               role="button"
               style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 1000;"
               tabindex="0"
@@ -1233,7 +1233,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
               </svg>
             </div>
             <div
-              class="leaflet-marker-icon m-vehicle-map__label primary selected leaflet-zoom-hide leaflet-interactive"
+              class="leaflet-marker-icon c-vehicle-map__label primary selected leaflet-zoom-hide leaflet-interactive"
               role="button"
               style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 1000;"
               tabindex="0"
@@ -1330,7 +1330,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1473,12 +1473,12 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </output>
                 <output
                   aria-label="Vehicle Schedule Adherence"
-                  class="m-schedule-adherence on-time early-red m-vehicle-route-summary__adherence label font-xs-reg"
+                  class="c-schedule-adherence on-time early-red m-vehicle-route-summary__adherence label font-xs-reg"
                 >
                   <svg
                     aria-hidden="true"
                     aria-label=""
-                    class="m-schedule-adherence__status-icon"
+                    class="c-schedule-adherence__status-icon"
                     height="8"
                     role="img"
                     viewBox="0 0 100 100"
@@ -1491,7 +1491,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                     />
                   </svg>
                   <output
-                    class="m-schedule-adherence-status label font-xs-semi title-case"
+                    class="c-schedule-adherence-status label font-xs-semi title-case"
                   >
                     on time
                   </output>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1455,18 +1455,18 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 />
                 <output
                   aria-label="Route Variant Name"
-                  class="m-route-variant-name m-vehicle-route-summary__route-variant headsign font-m-semi"
+                  class="c-route-variant-name m-vehicle-route-summary__route-variant headsign font-m-semi"
                 >
                   <output
                     aria-label="Route & Variant"
-                    class="m-route-variant-name__route-id"
+                    class="c-route-variant-name__route-id"
                   >
                     39_X
                   </output>
                    
                   <output
                     aria-label="Headsign"
-                    class="m-route-variant-name__headsign"
+                    class="c-route-variant-name__headsign"
                   >
                     Forest Hills
                   </output>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
       class="m-map-page__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -528,7 +528,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
       class="m-map-page__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -894,7 +894,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
       class="m-map-page__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1640,7 +1640,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                   </output>
                 </div>
                 <a
-                  class="m-street-view-button button-dark-small"
+                  class="c-street-view-button button-dark-small"
                   href="https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=42.360718%2C-71.05891&heading=33&pitch=0&fov=80"
                   rel="noreferrer"
                   target="_blank"
@@ -1648,7 +1648,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                   <span
                     aria-hidden="true"
                     aria-label=""
-                    class="m-street-view-button__icon"
+                    class="c-street-view-button__icon"
                     role="img"
                   >
                     <svg />

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`NotificationDrawer renders empty state 1`] = `
   className="m-notification-drawer"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Notifications
     </h2>
@@ -47,10 +47,10 @@ exports[`NotificationDrawer renders notifications 1`] = `
   className="m-notification-drawer"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Notifications
     </h2>

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -324,7 +324,7 @@ Array [
     id="m-properties-panel"
   >
     <div
-      className="m-vehicle-properties-panel"
+      className="c-vehicle-properties-panel"
     >
       <div
         className="m-properties-panel__header-wrapper"
@@ -574,7 +574,7 @@ Array [
         className="m-tabs__tab-panel"
       >
         <div
-          className="m-vehicle-properties-panel__notes"
+          className="c-vehicle-properties-panel__notes"
         />
         <div
           className="m-properties-list"
@@ -643,18 +643,18 @@ Array [
           </table>
         </div>
         <div
-          className="m-vehicle-properties-panel__location"
+          className="c-vehicle-properties-panel__location"
         >
           <div
-            className="m-vehicle-properties-panel__latlng"
+            className="c-vehicle-properties-panel__latlng"
           >
             <div
-              className="m-vehicle-properties-panel__label"
+              className="c-vehicle-properties-panel__label"
             >
               Current Location
             </div>
             <a
-              className="m-vehicle-properties-panel__link"
+              className="c-vehicle-properties-panel__link"
               href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
               rel="noreferrer"
               target="_blank"
@@ -663,21 +663,21 @@ Array [
             </a>
           </div>
           <div
-            className="m-vehicle-properties-panel__next-stop"
+            className="c-vehicle-properties-panel__next-stop"
           >
             <div
-              className="m-vehicle-properties-panel__label"
+              className="c-vehicle-properties-panel__label"
             >
               Next Stop
             </div>
             <div
-              className="m-vehicle-properties-panel__value"
+              className="c-vehicle-properties-panel__value"
             >
               Stop Name
             </div>
           </div>
           <div
-            className="m-vehicle-properties-panel__map"
+            className="c-vehicle-properties-panel__map"
           >
             <div
               className="m-vehicle-map-state m-vehicle-map-state--auto-centering"

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -57,10 +57,10 @@ Array [
                 Vehicle Status Icon
               </title>
               <g
-                className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+                className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
               >
                 <rect
-                  className="m-vehicle-icon__label-background"
+                  className="c-vehicle-icon__label-background"
                   height={24}
                   rx={12}
                   ry={12}
@@ -69,7 +69,7 @@ Array [
                   y={19}
                 />
                 <text
-                  className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                  className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                   dominantBaseline="central"
                   textAnchor="middle"
                   x="0"
@@ -81,18 +81,18 @@ Array [
                   transform="scale(0.7) translate(-24,-23)"
                 >
                   <path
-                    className="m-vehicle-icon__ghost-highlight"
+                    className="c-vehicle-icon__ghost-highlight"
                     d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                     strokeLinejoin="round"
                   />
                   <path
-                    className="m-vehicle-icon__ghost-body"
+                    className="c-vehicle-icon__ghost-body"
                     d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                     strokeLinejoin="round"
                   />
                 </g>
                 <text
-                  className="m-vehicle-icon__variant"
+                  className="c-vehicle-icon__variant"
                   dominantBaseline="alphabetic"
                   textAnchor="middle"
                   x={0}
@@ -374,10 +374,10 @@ Array [
                 Vehicle Status Icon
               </title>
               <g
-                className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+                className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
               >
                 <rect
-                  className="m-vehicle-icon__label-background"
+                  className="c-vehicle-icon__label-background"
                   height={24}
                   rx={12}
                   ry={12}
@@ -386,7 +386,7 @@ Array [
                   y={19}
                 />
                 <text
-                  className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                  className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                   dominantBaseline="central"
                   textAnchor="middle"
                   x="0"
@@ -395,13 +395,13 @@ Array [
                   1
                 </text>
                 <path
-                  className="m-vehicle-icon__triangle"
+                  className="c-vehicle-icon__triangle"
                   d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                   data-testid="vehicle-triangle"
                   transform="scale(1) rotate(0) translate(-24,-22)"
                 />
                 <text
-                  className="m-vehicle-icon__variant"
+                  className="c-vehicle-icon__variant"
                   dominantBaseline="alphabetic"
                   textAnchor="middle"
                   x={0}

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -683,7 +683,7 @@ Array [
               className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
             />
             <div
-              className="m-vehicle-map"
+              className="c-vehicle-map"
               id="id-vehicle-map"
             />
           </div>

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -113,7 +113,7 @@ Array [
             </div>
             <output
               aria-label="Route Variant Name"
-              className="c-route-variant-name undefined"
+              className="c-route-variant-name"
             >
               <output
                 aria-label="Route & Variant"
@@ -422,7 +422,7 @@ Array [
             </div>
             <output
               aria-label="Route Variant Name"
-              className="c-route-variant-name undefined"
+              className="c-route-variant-name"
             >
               <output
                 aria-label="Route & Variant"

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -13,10 +13,10 @@ Array [
         className="m-properties-panel__header-wrapper"
       >
         <div
-          className="m-view-header"
+          className="c-view-header"
         >
           <h2
-            className="m-view-header__title"
+            className="c-view-header__title"
           >
             Vehicles
           </h2>
@@ -330,10 +330,10 @@ Array [
         className="m-properties-panel__header-wrapper"
       >
         <div
-          className="m-view-header"
+          className="c-view-header"
         >
           <h2
-            className="m-view-header__title"
+            className="c-view-header__title"
           >
             Vehicles
           </h2>

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -680,7 +680,7 @@ Array [
             className="c-vehicle-properties-panel__map"
           >
             <div
-              className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+              className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
             />
             <div
               className="m-vehicle-map"

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -113,18 +113,18 @@ Array [
             </div>
             <output
               aria-label="Route Variant Name"
-              className="m-route-variant-name undefined"
+              className="c-route-variant-name undefined"
             >
               <output
                 aria-label="Route & Variant"
-                className="m-route-variant-name__route-id"
+                className="c-route-variant-name__route-id"
               >
                 39_X
               </output>
                
               <output
                 aria-label="Headsign"
-                className="m-route-variant-name__headsign"
+                className="c-route-variant-name__headsign"
               >
                 headsign
               </output>
@@ -422,18 +422,18 @@ Array [
             </div>
             <output
               aria-label="Route Variant Name"
-              className="m-route-variant-name undefined"
+              className="c-route-variant-name undefined"
             >
               <output
                 aria-label="Route & Variant"
-                className="m-route-variant-name__route-id"
+                className="c-route-variant-name__route-id"
               >
                 39_X
               </output>
                
               <output
                 aria-label="Headsign"
-                className="m-route-variant-name__headsign"
+                className="c-route-variant-name__headsign"
               >
                 Forest Hills
               </output>

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -111,10 +111,10 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
         transform="translate(63,-27.5)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--small"
+          class="c-vehicle-icon c-vehicle-icon--small"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -123,7 +123,7 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
             y="6.6"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            class="c-vehicle-icon__label c-vehicle-icon__label--extended"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -262,7 +262,7 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
           viewBox="-8.36 -7.6 16.72 15.2"
         >
           <g
-            class="m-vehicle-icon m-vehicle-icon--small"
+            class="c-vehicle-icon c-vehicle-icon--small"
           >
             <g
               class="m-ladder__crowding m-ladder__crowding--no-data"
@@ -369,10 +369,10 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
         transform="translate(63,-27.5)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -381,7 +381,7 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
             y="11.5"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -390,13 +390,13 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
             1
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
           />
           <text
-            class="m-vehicle-icon__variant"
+            class="c-vehicle-icon__variant"
             dominant-baseline="alphabetic"
             text-anchor="middle"
             x="0"
@@ -503,10 +503,10 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
             Vehicle Status Icon
           </title>
           <g
-            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            class="c-vehicle-icon c-vehicle-icon--small on-time early-red"
           >
             <path
-              class="m-vehicle-icon__triangle"
+              class="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(180) translate(-24,-22)"
@@ -580,10 +580,10 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
         transform="translate(63,-27.5)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -592,7 +592,7 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
             y="11.5"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -601,13 +601,13 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
             1
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
           />
           <text
-            class="m-vehicle-icon__variant"
+            class="c-vehicle-icon__variant"
             dominant-baseline="alphabetic"
             text-anchor="middle"
             x="0"
@@ -904,10 +904,10 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
         transform="translate(63,-27.5)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--small"
+          class="c-vehicle-icon c-vehicle-icon--small"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -916,7 +916,7 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
             y="6.6"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            class="c-vehicle-icon__label c-vehicle-icon__label--extended"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -967,10 +967,10 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
         transform="translate(-63,-110)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--small"
+          class="c-vehicle-icon c-vehicle-icon--small"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -979,7 +979,7 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
             y="-17.6"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1166,10 +1166,10 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
         transform="translate(0,-35)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--small on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -1178,7 +1178,7 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
             y="7.359999999999999"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1187,7 +1187,7 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
             2
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.38) rotate(270) translate(-24,-22)"
@@ -1199,10 +1199,10 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
         transform="translate(0,-85)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--small on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -1211,7 +1211,7 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
             y="7.359999999999999"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1220,13 +1220,13 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
             1
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.38) rotate(90) translate(-24,-22)"
           />
           <text
-            class="m-vehicle-icon__variant"
+            class="c-vehicle-icon__variant"
             dominant-baseline="central"
             text-anchor="start"
             x="-5.6"
@@ -1384,10 +1384,10 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         transform="translate(63,-27.5)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -1396,7 +1396,7 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             y="11.5"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1405,13 +1405,13 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             1
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(0) translate(-24,-22)"
           />
           <text
-            class="m-vehicle-icon__variant"
+            class="c-vehicle-icon__variant"
             dominant-baseline="alphabetic"
             text-anchor="middle"
             x="0"
@@ -1426,10 +1426,10 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         transform="translate(63,-110)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
+          class="c-vehicle-icon c-vehicle-icon--medium c-vehicle-icon--highlighted ghost early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -1438,7 +1438,7 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             y="11.5"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1450,24 +1450,24 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             transform="scale(0.4375) translate(-24,-23)"
           >
             <path
-              class="m-vehicle-icon__ghost-highlight"
+              class="c-vehicle-icon__ghost-highlight"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               stroke-linejoin="round"
             />
             <path
-              class="m-vehicle-icon__ghost-body"
+              class="c-vehicle-icon__ghost-body"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               stroke-linejoin="round"
             />
             <ellipse
-              class="m-vehicle-icon__ghost-eye"
+              class="c-vehicle-icon__ghost-eye"
               cx="19.73"
               cy="22.8"
               rx="3.11"
               ry="3.03"
             />
             <ellipse
-              class="m-vehicle-icon__ghost-eye"
+              class="c-vehicle-icon__ghost-eye"
               cx="35.29"
               cy="22.8"
               rx="3.11"
@@ -1511,10 +1511,10 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
         transform="translate(-63,-110)"
       >
         <g
-          class="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+          class="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
         >
           <rect
-            class="m-vehicle-icon__label-background"
+            class="c-vehicle-icon__label-background"
             height="11"
             rx="5.5"
             ry="5.5"
@@ -1523,7 +1523,7 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             y="-22.5"
           />
           <text
-            class="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            class="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominant-baseline="central"
             text-anchor="middle"
             x="0"
@@ -1532,7 +1532,7 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
             2
           </text>
           <path
-            class="m-vehicle-icon__triangle"
+            class="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -1772,16 +1772,16 @@ exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`
             Vehicle Status Icon
           </title>
           <g
-            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            class="c-vehicle-icon c-vehicle-icon--small on-time early-red"
           >
             <path
-              class="m-vehicle-icon__triangle"
+              class="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(0) translate(-24,-22)"
             />
             <text
-              class="m-vehicle-icon__variant"
+              class="c-vehicle-icon__variant"
               dominant-baseline="alphabetic"
               text-anchor="middle"
               x="0"
@@ -1813,10 +1813,10 @@ exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`
             Vehicle Status Icon
           </title>
           <g
-            class="m-vehicle-icon m-vehicle-icon--small on-time early-red"
+            class="c-vehicle-icon c-vehicle-icon--small on-time early-red"
           >
             <path
-              class="m-vehicle-icon__triangle"
+              class="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(0.38) rotate(180) translate(-24,-22)"

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`SearchPage renders the empty state 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -266,7 +266,7 @@ exports[`SearchPage renders the empty state 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -478,7 +478,7 @@ exports[`SearchPage renders vehicle data 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -521,7 +521,7 @@ exports[`SearchPage renders vehicle data 1`] = `
               style="z-index: 499;"
             >
               <div
-                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -544,7 +544,7 @@ exports[`SearchPage renders vehicle data 1`] = `
                 </svg>
               </div>
               <div
-                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -912,7 +912,7 @@ exports[`SearchPage renders vehicle data 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -557,7 +557,7 @@ exports[`SearchPage renders vehicle data 1`] = `
                   
             
                   <rect
-                    class="m-vehicle-icon__label-background"
+                    class="c-vehicle-icon__label-background"
                     height="100%"
                     rx="5.5px"
                     ry="5.5px"
@@ -566,7 +566,7 @@ exports[`SearchPage renders vehicle data 1`] = `
                   
             
                   <text
-                    class="m-vehicle-icon__label"
+                    class="c-vehicle-icon__label"
                     dominant-baseline="central"
                     text-anchor="middle"
                     x="50%"

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`SearchPage renders the empty state 1`] = `
       class="m-search-page__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -475,7 +475,7 @@ exports[`SearchPage renders vehicle data 1`] = `
       class="m-search-page__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -94,18 +94,18 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="m-route-variant-name undefined"
+                  className="c-route-variant-name undefined"
                 >
                   <output
                     aria-label="Route & Variant"
-                    className="m-route-variant-name__route-id"
+                    className="c-route-variant-name__route-id"
                   >
                     39_X
                   </output>
                    
                   <output
                     aria-label="Headsign"
-                    className="m-route-variant-name__headsign"
+                    className="c-route-variant-name__headsign"
                   >
                     headsign
                   </output>
@@ -223,18 +223,18 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="m-route-variant-name undefined"
+                  className="c-route-variant-name undefined"
                 >
                   <output
                     aria-label="Route & Variant"
-                    className="m-route-variant-name__route-id"
+                    className="c-route-variant-name__route-id"
                   >
                     39_X
                   </output>
                    
                   <output
                     aria-label="Headsign"
-                    className="m-route-variant-name__headsign"
+                    className="c-route-variant-name__headsign"
                   >
                     Forest Hills
                   </output>
@@ -418,18 +418,18 @@ exports[`SearchResults renders a selected result card 1`] = `
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="m-route-variant-name undefined"
+                  className="c-route-variant-name undefined"
                 >
                   <output
                     aria-label="Route & Variant"
-                    className="m-route-variant-name__route-id"
+                    className="c-route-variant-name__route-id"
                   >
                     1_
                   </output>
                    
                   <output
                     aria-label="Headsign"
-                    className="m-route-variant-name__headsign"
+                    className="c-route-variant-name__headsign"
                   >
                     headsign
                   </output>
@@ -547,18 +547,18 @@ exports[`SearchResults renders a selected result card 1`] = `
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="m-route-variant-name undefined"
+                  className="c-route-variant-name undefined"
                 >
                   <output
                     aria-label="Route & Variant"
-                    className="m-route-variant-name__route-id"
+                    className="c-route-variant-name__route-id"
                   >
                     39_X
                   </output>
                    
                   <output
                     aria-label="Headsign"
-                    className="m-route-variant-name__headsign"
+                    className="c-route-variant-name__headsign"
                   >
                     Forest Hills
                   </output>

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="c-route-variant-name undefined"
+                  className="c-route-variant-name"
                 >
                   <output
                     aria-label="Route & Variant"
@@ -223,7 +223,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="c-route-variant-name undefined"
+                  className="c-route-variant-name"
                 >
                   <output
                     aria-label="Route & Variant"
@@ -418,7 +418,7 @@ exports[`SearchResults renders a selected result card 1`] = `
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="c-route-variant-name undefined"
+                  className="c-route-variant-name"
                 >
                   <output
                     aria-label="Route & Variant"
@@ -547,7 +547,7 @@ exports[`SearchResults renders a selected result card 1`] = `
               >
                 <output
                   aria-label="Route Variant Name"
-                  className="c-route-variant-name undefined"
+                  className="c-route-variant-name"
                 >
                   <output
                     aria-label="Route & Variant"

--- a/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchResults.test.tsx.snap
@@ -35,10 +35,10 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                   Vehicle Status Icon
                 </title>
                 <g
-                  className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+                  className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
                 >
                   <rect
-                    className="m-vehicle-icon__label-background"
+                    className="c-vehicle-icon__label-background"
                     height={24}
                     rx={12}
                     ry={12}
@@ -47,7 +47,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                     y={19}
                   />
                   <text
-                    className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                    className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                     dominantBaseline="central"
                     textAnchor="middle"
                     x="0"
@@ -59,18 +59,18 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                     transform="scale(0.7) translate(-24,-23)"
                   >
                     <path
-                      className="m-vehicle-icon__ghost-highlight"
+                      className="c-vehicle-icon__ghost-highlight"
                       d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                       strokeLinejoin="round"
                     />
                     <path
-                      className="m-vehicle-icon__ghost-body"
+                      className="c-vehicle-icon__ghost-body"
                       d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                       strokeLinejoin="round"
                     />
                   </g>
                   <text
-                    className="m-vehicle-icon__variant"
+                    className="c-vehicle-icon__variant"
                     dominantBaseline="alphabetic"
                     textAnchor="middle"
                     x={0}
@@ -172,10 +172,10 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                   Vehicle Status Icon
                 </title>
                 <g
-                  className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+                  className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
                 >
                   <rect
-                    className="m-vehicle-icon__label-background"
+                    className="c-vehicle-icon__label-background"
                     height={24}
                     rx={12}
                     ry={12}
@@ -184,7 +184,7 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                     y={19}
                   />
                   <text
-                    className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                    className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                     dominantBaseline="central"
                     textAnchor="middle"
                     x="0"
@@ -193,13 +193,13 @@ exports[`SearchResults renders a list of results including vehicles and ghosts 1
                     1
                   </text>
                   <path
-                    className="m-vehicle-icon__triangle"
+                    className="c-vehicle-icon__triangle"
                     d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                     data-testid="vehicle-triangle"
                     transform="scale(1) rotate(0) translate(-24,-22)"
                   />
                   <text
-                    className="m-vehicle-icon__variant"
+                    className="c-vehicle-icon__variant"
                     dominantBaseline="alphabetic"
                     textAnchor="middle"
                     x={0}
@@ -354,10 +354,10 @@ exports[`SearchResults renders a selected result card 1`] = `
                   Vehicle Status Icon
                 </title>
                 <g
-                  className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+                  className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
                 >
                   <rect
-                    className="m-vehicle-icon__label-background"
+                    className="c-vehicle-icon__label-background"
                     height={24}
                     rx={12}
                     ry={12}
@@ -366,7 +366,7 @@ exports[`SearchResults renders a selected result card 1`] = `
                     y={19}
                   />
                   <text
-                    className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                    className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                     dominantBaseline="central"
                     textAnchor="middle"
                     x="0"
@@ -378,24 +378,24 @@ exports[`SearchResults renders a selected result card 1`] = `
                     transform="scale(0.7) translate(-24,-23)"
                   >
                     <path
-                      className="m-vehicle-icon__ghost-highlight"
+                      className="c-vehicle-icon__ghost-highlight"
                       d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                       strokeLinejoin="round"
                     />
                     <path
-                      className="m-vehicle-icon__ghost-body"
+                      className="c-vehicle-icon__ghost-body"
                       d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                       strokeLinejoin="round"
                     />
                     <ellipse
-                      className="m-vehicle-icon__ghost-eye"
+                      className="c-vehicle-icon__ghost-eye"
                       cx="19.73"
                       cy="22.8"
                       rx="3.11"
                       ry="3.03"
                     />
                     <ellipse
-                      className="m-vehicle-icon__ghost-eye"
+                      className="c-vehicle-icon__ghost-eye"
                       cx="35.29"
                       cy="22.8"
                       rx="3.11"
@@ -496,10 +496,10 @@ exports[`SearchResults renders a selected result card 1`] = `
                   Vehicle Status Icon
                 </title>
                 <g
-                  className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+                  className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
                 >
                   <rect
-                    className="m-vehicle-icon__label-background"
+                    className="c-vehicle-icon__label-background"
                     height={24}
                     rx={12}
                     ry={12}
@@ -508,7 +508,7 @@ exports[`SearchResults renders a selected result card 1`] = `
                     y={19}
                   />
                   <text
-                    className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+                    className="c-vehicle-icon__label c-vehicle-icon__label--normal"
                     dominantBaseline="central"
                     textAnchor="middle"
                     x="0"
@@ -517,13 +517,13 @@ exports[`SearchResults renders a selected result card 1`] = `
                     1
                   </text>
                   <path
-                    className="m-vehicle-icon__triangle"
+                    className="c-vehicle-icon__triangle"
                     d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
                     data-testid="vehicle-triangle"
                     transform="scale(1) rotate(0) translate(-24,-22)"
                   />
                   <text
-                    className="m-vehicle-icon__variant"
+                    className="c-vehicle-icon__variant"
                     dominantBaseline="alphabetic"
                     textAnchor="middle"
                     x={0}

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`Shuttle Map Page renders 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -212,7 +212,7 @@ exports[`Shuttle Map Page renders 1`] = `
               style="z-index: 499;"
             >
               <div
-                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -235,7 +235,7 @@ exports[`Shuttle Map Page renders 1`] = `
                 </svg>
               </div>
               <div
-                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -603,7 +603,7 @@ exports[`Shuttle Map Page renders 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -829,7 +829,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -872,7 +872,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
               style="z-index: 499;"
             >
               <div
-                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -895,7 +895,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 </svg>
               </div>
               <div
-                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -1263,7 +1263,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -1489,7 +1489,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -1532,7 +1532,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
               style="z-index: 499;"
             >
               <div
-                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -1555,7 +1555,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 </svg>
               </div>
               <div
-                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -1923,7 +1923,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -2014,7 +2014,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -2055,7 +2055,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
             >
               <g>
                 <path
-                  class="m-vehicle-map__route-shape m-vehicle-map__route-shape--no-hover leaflet-interactive"
+                  class="c-vehicle-map__route-shape c-vehicle-map__route-shape--no-hover leaflet-interactive"
                   d="M0 0"
                   fill="none"
                   stroke="#3388ff"
@@ -2146,7 +2146,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		
@@ -2372,7 +2372,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
         class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
+        class="c-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
         id="id-vehicle-map"
         style="position: relative;"
         tabindex="0"
@@ -2415,7 +2415,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
               style="z-index: 499;"
             >
               <div
-                class="leaflet-marker-icon m-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -2438,7 +2438,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 </svg>
               </div>
               <div
-                class="leaflet-marker-icon m-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
+                class="leaflet-marker-icon c-vehicle-map__label primary leaflet-zoom-hide leaflet-interactive"
                 role="button"
                 style="margin-left: -20px; margin-top: 16px; width: 12px; height: 12px; left: 0px; top: 0px; z-index: 0;"
                 tabindex="0"
@@ -2480,7 +2480,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
               style="z-index: 400;"
             />
             <div
-              class="leaflet-marker-icon m-vehicle-map__train-icon leaflet-zoom-hide leaflet-interactive"
+              class="leaflet-marker-icon c-vehicle-map__train-icon leaflet-zoom-hide leaflet-interactive"
               role="button"
               style="margin-left: -6px; margin-top: -6px; width: 12px; height: 12px; left: 2573px; top: 7219px; z-index: 7219;"
               tabindex="0"
@@ -2835,7 +2835,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
               />
             </div>
             <div
-              class="leaflet-control leaflet-bar m-vehicle-map__recenter-button"
+              class="leaflet-control leaflet-bar c-vehicle-map__recenter-button"
             >
               
 		

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`Shuttle Map Page renders 1`] = `
                   
             
                   <rect
-                    class="m-vehicle-icon__label-background"
+                    class="c-vehicle-icon__label-background"
                     height="100%"
                     rx="5.5px"
                     ry="5.5px"
@@ -257,7 +257,7 @@ exports[`Shuttle Map Page renders 1`] = `
                   
             
                   <text
-                    class="m-vehicle-icon__label"
+                    class="c-vehicle-icon__label"
                     dominant-baseline="central"
                     text-anchor="middle"
                     x="50%"
@@ -908,7 +908,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                   
             
                   <rect
-                    class="m-vehicle-icon__label-background"
+                    class="c-vehicle-icon__label-background"
                     height="100%"
                     rx="5.5px"
                     ry="5.5px"
@@ -917,7 +917,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                   
             
                   <text
-                    class="m-vehicle-icon__label"
+                    class="c-vehicle-icon__label"
                     dominant-baseline="central"
                     text-anchor="middle"
                     x="50%"
@@ -1568,7 +1568,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                   
             
                   <rect
-                    class="m-vehicle-icon__label-background"
+                    class="c-vehicle-icon__label-background"
                     height="100%"
                     rx="5.5px"
                     ry="5.5px"
@@ -1577,7 +1577,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                   
             
                   <text
-                    class="m-vehicle-icon__label"
+                    class="c-vehicle-icon__label"
                     dominant-baseline="central"
                     text-anchor="middle"
                     x="50%"
@@ -2451,7 +2451,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                   
             
                   <rect
-                    class="m-vehicle-icon__label-background"
+                    class="c-vehicle-icon__label-background"
                     height="100%"
                     rx="5.5px"
                     ry="5.5px"
@@ -2460,7 +2460,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                   
             
                   <text
-                    class="m-vehicle-icon__label"
+                    class="c-vehicle-icon__label"
                     dominant-baseline="central"
                     text-anchor="middle"
                     x="50%"

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`Shuttle Map Page renders 1`] = `
       class="m-shuttle-map__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -826,7 +826,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
       class="m-shuttle-map__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -1486,7 +1486,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
       class="m-shuttle-map__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -2011,7 +2011,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
       class="m-shuttle-map__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"
@@ -2369,7 +2369,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
       class="m-shuttle-map__map"
     >
       <div
-        class="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        class="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         class="m-vehicle-map leaflet-container leaflet-touch leaflet-grab leaflet-touch-drag leaflet-touch-zoom"

--- a/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/swingsView.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`SwingsView ignores vehicles without run ID (for linking to VPP) 1`] = `
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>
@@ -175,10 +175,10 @@ exports[`SwingsView includes swings less than 15 minutes in the past 1`] = `
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>
@@ -342,10 +342,10 @@ exports[`SwingsView links to both swing-on and swing-off if both are active 1`] 
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>
@@ -535,10 +535,10 @@ exports[`SwingsView omits swings more than 15 minutes in the past 1`] = `
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>
@@ -655,10 +655,10 @@ exports[`SwingsView renders future swings, active and inactive 1`] = `
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>
@@ -942,10 +942,10 @@ exports[`SwingsView renders loading message 1`] = `
   id="m-swings-view"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Swings
     </h2>

--- a/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/vehicleIcon.test.tsx.snap
@@ -15,10 +15,10 @@ exports[`ghost going down puts label above it 1`] = `
     Vehicle Status Icon
   </title>
   <g
-    className="m-vehicle-icon m-vehicle-icon--medium ghost early-red"
+    className="c-vehicle-icon c-vehicle-icon--medium ghost early-red"
   >
     <rect
-      className="m-vehicle-icon__label-background"
+      className="c-vehicle-icon__label-background"
       height={11}
       rx={5.5}
       ry={5.5}
@@ -27,7 +27,7 @@ exports[`ghost going down puts label above it 1`] = `
       y={-22.5}
     />
     <text
-      className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+      className="c-vehicle-icon__label c-vehicle-icon__label--extended"
       dominantBaseline="central"
       textAnchor="middle"
       x="0"
@@ -39,24 +39,24 @@ exports[`ghost going down puts label above it 1`] = `
       transform="scale(0.4375) translate(-24,-23)"
     >
       <path
-        className="m-vehicle-icon__ghost-highlight"
+        className="c-vehicle-icon__ghost-highlight"
         d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
         strokeLinejoin="round"
       />
       <path
-        className="m-vehicle-icon__ghost-body"
+        className="c-vehicle-icon__ghost-body"
         d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
         strokeLinejoin="round"
       />
       <ellipse
-        className="m-vehicle-icon__ghost-eye"
+        className="c-vehicle-icon__ghost-eye"
         cx="19.73"
         cy="22.8"
         rx="3.11"
         ry="3.03"
       />
       <ellipse
-        className="m-vehicle-icon__ghost-eye"
+        className="c-vehicle-icon__ghost-eye"
         cx="35.29"
         cy="22.8"
         rx="3.11"
@@ -82,24 +82,24 @@ exports[`ghost with variant doesn't have eyes 1`] = `
     Vehicle Status Icon
   </title>
   <g
-    className="m-vehicle-icon m-vehicle-icon--medium ghost early-red"
+    className="c-vehicle-icon c-vehicle-icon--medium ghost early-red"
   >
     <g
       transform="scale(0.4375) translate(-24,-23)"
     >
       <path
-        className="m-vehicle-icon__ghost-highlight"
+        className="c-vehicle-icon__ghost-highlight"
         d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
         strokeLinejoin="round"
       />
       <path
-        className="m-vehicle-icon__ghost-body"
+        className="c-vehicle-icon__ghost-body"
         d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
         strokeLinejoin="round"
       />
     </g>
     <text
-      className="m-vehicle-icon__variant"
+      className="c-vehicle-icon__variant"
       dominantBaseline="alphabetic"
       textAnchor="middle"
       x={0}
@@ -114,10 +114,10 @@ exports[`ghost with variant doesn't have eyes 1`] = `
 exports[`renders an unwrapped svg node 1`] = `
 <svg>
   <g
-    className="m-vehicle-icon m-vehicle-icon--medium"
+    className="c-vehicle-icon c-vehicle-icon--medium"
   >
     <rect
-      className="m-vehicle-icon__label-background"
+      className="c-vehicle-icon__label-background"
       height={11}
       rx={5.5}
       ry={5.5}
@@ -126,7 +126,7 @@ exports[`renders an unwrapped svg node 1`] = `
       y={-22.5}
     />
     <text
-      className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+      className="c-vehicle-icon__label c-vehicle-icon__label--extended"
       dominantBaseline="central"
       textAnchor="middle"
       x="0"
@@ -135,7 +135,7 @@ exports[`renders an unwrapped svg node 1`] = `
       label
     </text>
     <path
-      className="m-vehicle-icon__triangle"
+      className="c-vehicle-icon__triangle"
       d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
       data-testid="vehicle-triangle"
       transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -160,10 +160,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -172,7 +172,7 @@ Array [
         y={19}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+        className="c-vehicle-icon__label c-vehicle-icon__label--extended"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -181,7 +181,7 @@ Array [
         SW-OFF
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(0) translate(-24,-22)"
@@ -202,10 +202,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -214,7 +214,7 @@ Array [
         y={19}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+        className="c-vehicle-icon__label c-vehicle-icon__label--extended"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -223,7 +223,7 @@ Array [
         PULL-B
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(0) translate(-24,-22)"
@@ -249,30 +249,30 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small ghost early-red"
+      className="c-vehicle-icon c-vehicle-icon--small ghost early-red"
     >
       <g
         transform="scale(0.26599999999999996) translate(-24,-23)"
       >
         <path
-          className="m-vehicle-icon__ghost-highlight"
+          className="c-vehicle-icon__ghost-highlight"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <path
-          className="m-vehicle-icon__ghost-body"
+          className="c-vehicle-icon__ghost-body"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="19.73"
           cy="22.8"
           rx="3.11"
           ry="3.03"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="35.29"
           cy="22.8"
           rx="3.11"
@@ -325,30 +325,30 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium m-vehicle-icon--highlighted ghost early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium c-vehicle-icon--highlighted ghost early-red"
     >
       <g
         transform="scale(0.4375) translate(-24,-23)"
       >
         <path
-          className="m-vehicle-icon__ghost-highlight"
+          className="c-vehicle-icon__ghost-highlight"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <path
-          className="m-vehicle-icon__ghost-body"
+          className="c-vehicle-icon__ghost-body"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="19.73"
           cy="22.8"
           rx="3.11"
           ry="3.03"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="35.29"
           cy="22.8"
           rx="3.11"
@@ -406,10 +406,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(0) translate(-24,-22)"
@@ -430,10 +430,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(90) translate(-24,-22)"
@@ -454,10 +454,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(180) translate(-24,-22)"
@@ -478,10 +478,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(270) translate(-24,-22)"
@@ -502,10 +502,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -526,10 +526,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(90) translate(-24,-22)"
@@ -550,10 +550,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(180) translate(-24,-22)"
@@ -574,10 +574,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(270) translate(-24,-22)"
@@ -598,10 +598,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(0) translate(-24,-22)"
@@ -622,10 +622,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(90) translate(-24,-22)"
@@ -646,10 +646,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(180) translate(-24,-22)"
@@ -670,10 +670,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(270) translate(-24,-22)"
@@ -699,10 +699,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium on-time early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium on-time early-red"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -723,10 +723,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium early early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium early early-red"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -747,10 +747,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium late early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium late early-red"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -771,10 +771,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium off-course early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium off-course early-red"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -795,30 +795,30 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium ghost early-red"
+      className="c-vehicle-icon c-vehicle-icon--medium ghost early-red"
     >
       <g
         transform="scale(0.4375) translate(-24,-23)"
       >
         <path
-          className="m-vehicle-icon__ghost-highlight"
+          className="c-vehicle-icon__ghost-highlight"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <path
-          className="m-vehicle-icon__ghost-body"
+          className="c-vehicle-icon__ghost-body"
           d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
           strokeLinejoin="round"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="19.73"
           cy="22.8"
           rx="3.11"
           ry="3.03"
         />
         <ellipse
-          className="m-vehicle-icon__ghost-eye"
+          className="c-vehicle-icon__ghost-eye"
           cx="35.29"
           cy="22.8"
           rx="3.11"
@@ -841,10 +841,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -865,10 +865,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
@@ -894,10 +894,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -906,7 +906,7 @@ Array [
         y={6.6}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -915,13 +915,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(0) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="alphabetic"
         textAnchor="middle"
         x={0}
@@ -975,10 +975,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -987,7 +987,7 @@ Array [
         y={7.359999999999999}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -996,13 +996,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(90) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="start"
         x={-5.6}
@@ -1056,10 +1056,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1068,7 +1068,7 @@ Array [
         y={-17.6}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1077,13 +1077,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(180) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="hanging"
         textAnchor="middle"
         x={0}
@@ -1137,10 +1137,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--small"
+      className="c-vehicle-icon c-vehicle-icon--small"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1149,7 +1149,7 @@ Array [
         y={7.359999999999999}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1158,13 +1158,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.38) rotate(270) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="end"
         x={5.6}
@@ -1218,10 +1218,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1230,7 +1230,7 @@ Array [
         y={11.5}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1239,13 +1239,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(0) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="alphabetic"
         textAnchor="middle"
         x={0}
@@ -1299,10 +1299,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1311,7 +1311,7 @@ Array [
         y={12.75}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1320,13 +1320,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(90) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="start"
         x={-8.5}
@@ -1380,10 +1380,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1392,7 +1392,7 @@ Array [
         y={-22.5}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1401,13 +1401,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(180) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="hanging"
         textAnchor="middle"
         x={0}
@@ -1461,10 +1461,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--medium"
+      className="c-vehicle-icon c-vehicle-icon--medium"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={11}
         rx={5.5}
         ry={5.5}
@@ -1473,7 +1473,7 @@ Array [
         y={12.75}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1482,13 +1482,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(0.625) rotate(270) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="end"
         x={8.5}
@@ -1542,10 +1542,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -1554,7 +1554,7 @@ Array [
         y={19}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1563,13 +1563,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(0) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="alphabetic"
         textAnchor="middle"
         x={0}
@@ -1623,10 +1623,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -1635,7 +1635,7 @@ Array [
         y={21}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1644,13 +1644,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(90) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="start"
         x={-14}
@@ -1704,10 +1704,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -1716,7 +1716,7 @@ Array [
         y={-43}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1725,13 +1725,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(180) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="hanging"
         textAnchor="middle"
         x={0}
@@ -1785,10 +1785,10 @@ Array [
       Vehicle Status Icon
     </title>
     <g
-      className="m-vehicle-icon m-vehicle-icon--large"
+      className="c-vehicle-icon c-vehicle-icon--large"
     >
       <rect
-        className="m-vehicle-icon__label-background"
+        className="c-vehicle-icon__label-background"
         height={24}
         rx={12}
         ry={12}
@@ -1797,7 +1797,7 @@ Array [
         y={21}
       />
       <text
-        className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+        className="c-vehicle-icon__label c-vehicle-icon__label--normal"
         dominantBaseline="central"
         textAnchor="middle"
         x="0"
@@ -1806,13 +1806,13 @@ Array [
         0617
       </text>
       <path
-        className="m-vehicle-icon__triangle"
+        className="c-vehicle-icon__triangle"
         d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
         data-testid="vehicle-triangle"
         transform="scale(1) rotate(270) translate(-24,-22)"
       />
       <text
-        className="m-vehicle-icon__variant"
+        className="c-vehicle-icon__variant"
         dominantBaseline="central"
         textAnchor="end"
         x={14}

--- a/assets/tests/components/ladder.test.tsx
+++ b/assets/tests/components/ladder.test.tsx
@@ -603,7 +603,7 @@ describe("ladder", () => {
     )
 
     await userEvent.click(
-      result.getByText("N/A", { selector: ".m-vehicle-icon__label" })
+      result.getByText("N/A", { selector: ".c-vehicle-icon__label" })
     )
 
     expect(mockDispatch).toHaveBeenCalledWith(selectVehicle(incomingGhost))

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -549,7 +549,7 @@ describe("auto centering", () => {
     )
     await animationFramePromise()
     expect(container.firstChild).toHaveClass(
-      "m-vehicle-map-state--auto-centering"
+      "c-vehicle-map-state--auto-centering"
     )
     const manualLatLng = { lat: 41.9, lng: -70.9 }
 
@@ -574,7 +574,7 @@ describe("auto centering", () => {
     await animationFramePromise()
     expect(getCenter(mapRef)).toEqual(manualLatLng)
     expect(container.firstChild).not.toHaveClass(
-      "m-vehicle-map-state--auto-centering"
+      "c-vehicle-map-state--auto-centering"
     )
   })
 
@@ -641,7 +641,7 @@ describe("auto centering", () => {
     })
     await animationFramePromise()
     expect(result.container.firstChild).not.toHaveClass(
-      "m-vehicle-map-state--auto-centering"
+      "c-vehicle-map-state--auto-centering"
     )
     expect(getCenter(mapRef)).toEqual(manualLatLng)
 
@@ -649,7 +649,7 @@ describe("auto centering", () => {
     await userEvent.click(result.getByTitle("Recenter Map"))
     await animationFramePromise()
     expect(result.container.firstChild).toHaveClass(
-      "m-vehicle-map-state--auto-centering"
+      "c-vehicle-map-state--auto-centering"
     )
     expect(getCenter(mapRef)).toEqual(defaultCenter)
     expect(window.FS!.event).toHaveBeenCalledWith("Recenter control clicked")
@@ -685,7 +685,7 @@ describe("auto centering", () => {
       )
       await animationFramePromise()
       expect(result.container.firstChild).toHaveClass(
-        "m-vehicle-map-state--auto-centering"
+        "c-vehicle-map-state--auto-centering"
       )
       expect(getCenter(mapRef)).toEqual(defaultCenter)
     })

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -64,8 +64,8 @@ describe("<MapFollowingPrimaryVehicles />", () => {
   test("draws vehicles", () => {
     const vehicle = vehicleFactory.build({})
     const result = render(<MapFollowingPrimaryVehicles vehicles={[vehicle]} />)
-    expect(result.container.innerHTML).toContain("m-vehicle-map__icon")
-    expect(result.container.innerHTML).toContain("m-vehicle-map__label")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__icon")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__label")
   })
 
   test("draws secondary vehicles", () => {
@@ -76,8 +76,8 @@ describe("<MapFollowingPrimaryVehicles />", () => {
         secondaryVehicles={[vehicle]}
       />
     )
-    expect(result.container.innerHTML).toContain("m-vehicle-map__icon")
-    expect(result.container.innerHTML).toContain("m-vehicle-map__label")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__icon")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__label")
   })
 
   test("draws train vehicles", () => {
@@ -93,15 +93,15 @@ describe("<MapFollowingPrimaryVehicles />", () => {
         trainVehicles={[trainVehicle]}
       />
     )
-    expect(result.container.innerHTML).toContain("m-vehicle-map__train-icon")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__train-icon")
   })
 
   test("draws shapes", () => {
     const result = render(
       <MapFollowingPrimaryVehicles vehicles={[]} shapes={[shape]} />
     )
-    expect(result.container.innerHTML).toContain("m-vehicle-map__route-shape")
-    expect(result.container.innerHTML).toContain("m-vehicle-map__stop")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__route-shape")
+    expect(result.container.innerHTML).toContain("c-vehicle-map__stop")
   })
 
   test("doesn't draw garage icons at zoom levels < 15", async () => {
@@ -282,7 +282,7 @@ describe("<MapFollowingPrimaryVehicles />", () => {
       />
     )
 
-    await userEvent.click(container.querySelector(".m-vehicle-map__stop")!)
+    await userEvent.click(container.querySelector(".c-vehicle-map__stop")!)
 
     expect(
       screen.getByRole("link", { name: /street view/i })
@@ -435,10 +435,10 @@ describe("<MapFollowingPrimaryVehicles />", () => {
     )
 
     expect(
-      container.querySelector(".m-vehicle-map__icon .selected")
+      container.querySelector(".c-vehicle-map__icon .selected")
     ).toBeInTheDocument()
     expect(
-      container.querySelector(".m-vehicle-map__label.selected")
+      container.querySelector(".c-vehicle-map__label.selected")
     ).toBeInTheDocument()
   })
 })

--- a/assets/tests/components/mapMarkers.test.tsx
+++ b/assets/tests/components/mapMarkers.test.tsx
@@ -39,7 +39,7 @@ describe("VehicleMarker", () => {
         isPrimary={true}
       />
     )
-    expect(container.querySelector(".m-vehicle-map__icon")).toBeInTheDocument()
+    expect(container.querySelector(".c-vehicle-map__icon")).toBeInTheDocument()
     expect(screen.getByText("101")).toBeInTheDocument()
   })
 })
@@ -50,7 +50,7 @@ describe("TrainVehicleMarker", () => {
       <TrainVehicleMarker trainVehicle={vehicleFactory.build()} />
     )
     expect(
-      container.querySelector(".m-vehicle-map__train-icon")
+      container.querySelector(".c-vehicle-map__train-icon")
     ).toBeInTheDocument()
   })
 })
@@ -60,7 +60,7 @@ describe("StopMarker", () => {
     const { container } = renderInMap(
       <StopMarker stop={stop} includeStopCard={false} />
     )
-    await userEvent.hover(container.querySelector(".m-vehicle-map__stop")!)
+    await userEvent.hover(container.querySelector(".c-vehicle-map__stop")!)
     expect(screen.getByText(stop.name)).toBeVisible()
   })
 
@@ -70,7 +70,7 @@ describe("StopMarker", () => {
     const { container } = renderInMap(
       <StopMarker stop={stop} includeStopCard={false} />
     )
-    await userEvent.click(container.querySelector(".m-vehicle-map__stop")!)
+    await userEvent.click(container.querySelector(".c-vehicle-map__stop")!)
     expect(screen.getByText(stop.name)).toBeVisible()
   })
 
@@ -80,7 +80,7 @@ describe("StopMarker", () => {
     const { container } = renderInMap(
       <StopMarker stop={stop} direction={0} includeStopCard={true} />
     )
-    await userEvent.click(container.querySelector(".m-vehicle-map__stop")!)
+    await userEvent.click(container.querySelector(".c-vehicle-map__stop")!)
     expect(screen.getByText("Outbound")).toBeInTheDocument()
     expect(window.FS!.event).toHaveBeenCalledWith("Bus stop card opened")
   })
@@ -124,7 +124,7 @@ describe("RouteStopMarkers", () => {
     )
 
     expect(container.querySelectorAll(".m-station-icon")).toHaveLength(1)
-    expect(container.querySelectorAll(".m-vehicle-map__stop")).toHaveLength(1)
+    expect(container.querySelectorAll(".c-vehicle-map__stop")).toHaveLength(1)
   })
 
   test("Deduplicates list by stop id", () => {
@@ -132,7 +132,7 @@ describe("RouteStopMarkers", () => {
       <RouteStopMarkers stops={[stop, stop]} zoomLevel={13} />
     )
 
-    expect(container.querySelectorAll(".m-vehicle-map__stop")).toHaveLength(1)
+    expect(container.querySelectorAll(".c-vehicle-map__stop")).toHaveLength(1)
   })
 })
 
@@ -142,7 +142,7 @@ describe("RouteShape", () => {
       <RouteShape shape={{ id: "shape1", points: [{ lat: 0, lon: 0 }] }} />
     )
     expect(
-      container.querySelector(".m-vehicle-map__route-shape")
+      container.querySelector(".c-vehicle-map__route-shape")
     ).toBeInTheDocument()
   })
 
@@ -153,8 +153,8 @@ describe("RouteShape", () => {
         isSelected={true}
       />
     )
-    expect(container.querySelector(".m-vehicle-map__route-shape")).toHaveClass(
-      "m-vehicle-map__route-shape--selected"
+    expect(container.querySelector(".c-vehicle-map__route-shape")).toHaveClass(
+      "c-vehicle-map__route-shape--selected"
     )
   })
 
@@ -168,7 +168,7 @@ describe("RouteShape", () => {
         }}
       />
     )
-    expect(container.querySelector(".m-vehicle-map__route-shape")).toHaveClass(
+    expect(container.querySelector(".c-vehicle-map__route-shape")).toHaveClass(
       "route-shape--red"
     )
   })
@@ -182,7 +182,7 @@ describe("RouteShape", () => {
       />
     )
     await userEvent.click(
-      container.querySelector(".m-vehicle-map__route-shape")!
+      container.querySelector(".c-vehicle-map__route-shape")!
     )
     expect(mockOnClick).toHaveBeenCalled()
   })

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -288,7 +288,7 @@ describe("<MapPage />", () => {
 
     await userEvent.click(screen.getByRole("button", { name: runId! }))
     expect(
-      container.querySelector(".m-vehicle-map__route-shape")
+      container.querySelector(".c-vehicle-map__route-shape")
     ).toBeInTheDocument()
 
     expect(container.querySelector(".selected")).toBeVisible()
@@ -318,7 +318,7 @@ describe("<MapPage />", () => {
     await userEvent.click(screen.getByRole("cell", { name: "Run" }))
 
     expect(vehiclePropertiesCard.get()).toBeVisible()
-    expect(container.querySelector(".m-vehicle-map__route-shape")).toBeVisible()
+    expect(container.querySelector(".c-vehicle-map__route-shape")).toBeVisible()
   })
 
   test("submitting a new search clears the previously selected route shape", async () => {
@@ -349,7 +349,7 @@ describe("<MapPage />", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /submit/i }))
     expect(
-      container.querySelector(".m-vehicle-map__route-shape")
+      container.querySelector(".c-vehicle-map__route-shape")
     ).not.toBeInTheDocument()
   })
 
@@ -389,7 +389,7 @@ describe("<MapPage />", () => {
       })
     )
 
-    const routeShape = container.querySelector(".m-vehicle-map__route-shape")
+    const routeShape = container.querySelector(".c-vehicle-map__route-shape")
     const vpc = vehiclePropertiesCard.get()
 
     expect(mapSearchPanel).toHaveClass("hidden")
@@ -631,7 +631,7 @@ describe("<MapPage />", () => {
       )
       expect(vehiclePropertiesCard.get()).toBeVisible()
 
-      fireEvent.click(container.querySelector(".m-vehicle-map__route-shape")!)
+      fireEvent.click(container.querySelector(".c-vehicle-map__route-shape")!)
       await waitFor(() => expect(routePropertiesCard.get()).toBeVisible())
       expect(vehiclePropertiesCard.query()).not.toBeInTheDocument()
     })
@@ -781,7 +781,7 @@ describe("<MapPage />", () => {
           mapContainer.querySelector(".m-vehicle-icon__label")
         ).not.toBeInTheDocument()
         expect(
-          mapContainer.querySelector(".m-vehicle-map__route-shape")
+          mapContainer.querySelector(".c-vehicle-map__route-shape")
         ).not.toBeInTheDocument()
 
         await userEvent.click(
@@ -794,7 +794,7 @@ describe("<MapPage />", () => {
           mapContainer.querySelector(".m-vehicle-icon__label")
         ).toBeInTheDocument()
         expect(
-          mapContainer.querySelector(".m-vehicle-map__route-shape")
+          mapContainer.querySelector(".c-vehicle-map__route-shape")
         ).toBeInTheDocument()
         expect(
           screen.getAllByRole("button", { name: runIdToLabel(vehicle.runId!) })
@@ -802,7 +802,7 @@ describe("<MapPage />", () => {
 
         expect(vehiclePropertiesCard.get()).toBeVisible()
         expect(
-          mapContainer.querySelector(".m-vehicle-map__route-shape")
+          mapContainer.querySelector(".c-vehicle-map__route-shape")
         ).toBeVisible()
       })
     })
@@ -889,10 +889,10 @@ describe("<MapPage />", () => {
             ).toHaveLength(selectedRouteVehicles.length)
 
             expect(
-              container.querySelectorAll(".m-vehicle-map__stop")
+              container.querySelectorAll(".c-vehicle-map__stop")
             ).toHaveLength(stopCount)
             expect(
-              container.querySelector(".m-vehicle-map__route-shape")
+              container.querySelector(".c-vehicle-map__route-shape")
             ).toBeInTheDocument()
           })
         })
@@ -924,10 +924,10 @@ describe("<MapPage />", () => {
           expect(selectedVehicleLabel).toHaveClass("selected")
 
           expect(
-            container.querySelectorAll(".m-vehicle-map__stop")
+            container.querySelectorAll(".c-vehicle-map__stop")
           ).toHaveLength(0)
           expect(
-            container.querySelector(".m-vehicle-map__route-shape")
+            container.querySelector(".c-vehicle-map__route-shape")
           ).not.toBeInTheDocument()
           expect(
             within(vehiclePropertiesCard.get()).getByRole("status", {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -430,13 +430,13 @@ describe("<MapPage />", () => {
       </RealDispatchWrapper>
     )
 
-    expect(container.querySelector(".m-vehicle-icon__label")).toBeVisible()
+    expect(container.querySelector(".c-vehicle-icon__label")).toBeVisible()
     expect(
       screen.getByRole("generic", { name: /map search panel/i })
     ).toBeVisible()
 
     await userEvent.click(screen.getByRole("button", { name: /clear search/i }))
-    expect(container.querySelector(".m-vehicle-icon__label")).toBeVisible()
+    expect(container.querySelector(".c-vehicle-icon__label")).toBeVisible()
   })
 
   test("When a vehicle is selected, the search panel should be collapsed", async () => {
@@ -778,7 +778,7 @@ describe("<MapPage />", () => {
 
         const mapContainer = container.querySelector(".m-map-page__map")!
         expect(
-          mapContainer.querySelector(".m-vehicle-icon__label")
+          mapContainer.querySelector(".c-vehicle-icon__label")
         ).not.toBeInTheDocument()
         expect(
           mapContainer.querySelector(".c-vehicle-map__route-shape")
@@ -791,7 +791,7 @@ describe("<MapPage />", () => {
         )
 
         expect(
-          mapContainer.querySelector(".m-vehicle-icon__label")
+          mapContainer.querySelector(".c-vehicle-icon__label")
         ).toBeInTheDocument()
         expect(
           mapContainer.querySelector(".c-vehicle-map__route-shape")

--- a/assets/tests/components/mapPage/mapDisplay.test.tsx
+++ b/assets/tests/components/mapPage/mapDisplay.test.tsx
@@ -185,7 +185,7 @@ describe("<MapDisplay />", () => {
         />
       )
 
-      const routeShape = container.querySelector(".m-vehicle-map__route-shape")
+      const routeShape = container.querySelector(".c-vehicle-map__route-shape")
       expect(routeShape).toBeVisible()
       expect(vehiclePropertiesCard.query()).not.toBeInTheDocument()
     })
@@ -213,7 +213,7 @@ describe("<MapDisplay />", () => {
         />
       )
 
-      const routeShape = container.querySelector(".m-vehicle-map__route-shape")
+      const routeShape = container.querySelector(".c-vehicle-map__route-shape")
 
       expect(routeShape).toBeVisible()
       expect(vehiclePropertiesCard.get()).toBeVisible()
@@ -287,10 +287,10 @@ describe("<MapDisplay />", () => {
             ).toHaveLength(selectedRouteVehicles.length)
 
             expect(
-              container.querySelectorAll(".m-vehicle-map__stop")
+              container.querySelectorAll(".c-vehicle-map__stop")
             ).toHaveLength(stopCount)
             expect(
-              container.querySelector(".m-vehicle-map__route-shape")
+              container.querySelector(".c-vehicle-map__route-shape")
             ).toBeInTheDocument()
           })
 
@@ -328,7 +328,7 @@ describe("<MapDisplay />", () => {
             )
 
             await userEvent.hover(
-              container.querySelector(".m-vehicle-map__route-shape")!
+              container.querySelector(".c-vehicle-map__route-shape")!
             )
             expect(
               screen.getByText("Click to select route 66_3.")
@@ -369,7 +369,7 @@ describe("<MapDisplay />", () => {
             )
 
             await userEvent.hover(
-              container.querySelector(".m-vehicle-map__route-shape")!
+              container.querySelector(".c-vehicle-map__route-shape")!
             )
 
             expect(screen.getByText("Click to select route 66.")).toBeVisible()
@@ -409,7 +409,7 @@ describe("<MapDisplay />", () => {
             )
 
             await userEvent.hover(
-              container.querySelector(".m-vehicle-map__route-shape")!
+              container.querySelector(".c-vehicle-map__route-shape")!
             )
 
             expect(screen.getByText("Click to select route 66.")).toBeVisible()
@@ -450,7 +450,7 @@ describe("<MapDisplay />", () => {
             )
 
             fireEvent.click(
-              container.querySelector(".m-vehicle-map__route-shape")!
+              container.querySelector(".c-vehicle-map__route-shape")!
             )
             await waitFor(() =>
               expect(setSelectedEntityMock).toHaveBeenCalledWith({
@@ -489,10 +489,10 @@ describe("<MapDisplay />", () => {
           expect(selectedVehicleLabel).toHaveClass("selected")
 
           expect(
-            container.querySelectorAll(".m-vehicle-map__stop")
+            container.querySelectorAll(".c-vehicle-map__stop")
           ).toHaveLength(0)
           expect(
-            container.querySelector(".m-vehicle-map__route-shape")
+            container.querySelector(".c-vehicle-map__route-shape")
           ).not.toBeInTheDocument()
           expect(
             within(vehiclePropertiesCard.get()).getByRole("status", {

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -108,18 +108,18 @@ exports[`GhostPropertiesPanel renders 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             headsign
           </output>
@@ -411,18 +411,18 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             headsign
           </output>
@@ -764,18 +764,18 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             headsign
           </output>

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -52,10 +52,10 @@ exports[`GhostPropertiesPanel renders 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+            className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -64,7 +64,7 @@ exports[`GhostPropertiesPanel renders 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -76,18 +76,18 @@ exports[`GhostPropertiesPanel renders 1`] = `
               transform="scale(0.7) translate(-24,-23)"
             >
               <path
-                className="m-vehicle-icon__ghost-highlight"
+                className="c-vehicle-icon__ghost-highlight"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
               <path
-                className="m-vehicle-icon__ghost-body"
+                className="c-vehicle-icon__ghost-body"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
             </g>
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -357,10 +357,10 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+            className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -369,7 +369,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -381,18 +381,18 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
               transform="scale(0.7) translate(-24,-23)"
             >
               <path
-                className="m-vehicle-icon__ghost-highlight"
+                className="c-vehicle-icon__ghost-highlight"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
               <path
-                className="m-vehicle-icon__ghost-body"
+                className="c-vehicle-icon__ghost-body"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
             </g>
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -708,10 +708,10 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+            className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -720,7 +720,7 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -732,18 +732,18 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
               transform="scale(0.7) translate(-24,-23)"
             >
               <path
-                className="m-vehicle-icon__ghost-highlight"
+                className="c-vehicle-icon__ghost-highlight"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
               <path
-                className="m-vehicle-icon__ghost-body"
+                className="c-vehicle-icon__ghost-body"
                 d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
                 strokeLinejoin="round"
               />
             </g>
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`GhostPropertiesPanel renders 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -313,10 +313,10 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -664,10 +664,10 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`GhostPropertiesPanel renders 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -411,7 +411,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -764,7 +764,7 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`Header renders a header 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -250,10 +250,10 @@ exports[`Header renders for a ghost 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -469,10 +469,10 @@ exports[`Header renders for a late vehicle 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -714,10 +714,10 @@ exports[`Header renders for a shuttle 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -827,10 +827,10 @@ exports[`Header renders for an early vehicle 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -1072,10 +1072,10 @@ exports[`Header renders for an off-course vehicle 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>
@@ -1315,10 +1315,10 @@ exports[`Header renders with route data 1`] = `
   className="m-properties-panel__header-wrapper"
 >
   <div
-    className="m-view-header"
+    className="c-view-header"
   >
     <h2
-      className="m-view-header__title"
+      className="c-view-header__title"
     >
       Vehicles
     </h2>

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`Header renders a header 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"
@@ -348,7 +348,7 @@ exports[`Header renders for a ghost 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"
@@ -559,7 +559,7 @@ exports[`Header renders for a late vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"
@@ -804,7 +804,7 @@ exports[`Header renders for a shuttle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         Shuttle
       </output>
@@ -917,7 +917,7 @@ exports[`Header renders for an early vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"
@@ -1162,7 +1162,7 @@ exports[`Header renders for an off-course vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"
@@ -1407,7 +1407,7 @@ exports[`Header renders with route data 1`] = `
       </div>
       <output
         aria-label="Route Variant Name"
-        className="c-route-variant-name undefined"
+        className="c-route-variant-name"
       >
         <output
           aria-label="Route & Variant"

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -49,10 +49,10 @@ exports[`Header renders a header 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -61,7 +61,7 @@ exports[`Header renders a header 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -70,13 +70,13 @@ exports[`Header renders a header 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -294,10 +294,10 @@ exports[`Header renders for a ghost 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large ghost early-red"
+          className="c-vehicle-icon c-vehicle-icon--large ghost early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -306,7 +306,7 @@ exports[`Header renders for a ghost 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -318,18 +318,18 @@ exports[`Header renders for a ghost 1`] = `
             transform="scale(0.7) translate(-24,-23)"
           >
             <path
-              className="m-vehicle-icon__ghost-highlight"
+              className="c-vehicle-icon__ghost-highlight"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
             <path
-              className="m-vehicle-icon__ghost-body"
+              className="c-vehicle-icon__ghost-body"
               d="m43.79 19c0-9.68-8.79-17.49-19.59-17.49s-19.6 7.81-19.6 17.49v12.88 11a2 2 0 0 0 2.55 1.87l6.78-4.09 10.27 5.92 10.26-5.88 6.78 4.09a2 2 0 0 0 2.55-1.87z"
               strokeLinejoin="round"
             />
           </g>
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -513,10 +513,10 @@ exports[`Header renders for a late vehicle 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large late early-red"
+          className="c-vehicle-icon c-vehicle-icon--large late early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -525,7 +525,7 @@ exports[`Header renders for a late vehicle 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -534,13 +534,13 @@ exports[`Header renders for a late vehicle 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -758,10 +758,10 @@ exports[`Header renders for a shuttle 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large"
+          className="c-vehicle-icon c-vehicle-icon--large"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -770,7 +770,7 @@ exports[`Header renders for a shuttle 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+            className="c-vehicle-icon__label c-vehicle-icon__label--extended"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -779,13 +779,13 @@ exports[`Header renders for a shuttle 1`] = `
             v1-label
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -871,10 +871,10 @@ exports[`Header renders for an early vehicle 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large early early-red"
+          className="c-vehicle-icon c-vehicle-icon--large early early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -883,7 +883,7 @@ exports[`Header renders for an early vehicle 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -892,13 +892,13 @@ exports[`Header renders for an early vehicle 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -1116,10 +1116,10 @@ exports[`Header renders for an off-course vehicle 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large off-course early-red"
+          className="c-vehicle-icon c-vehicle-icon--large off-course early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -1128,7 +1128,7 @@ exports[`Header renders for an off-course vehicle 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1137,13 +1137,13 @@ exports[`Header renders for an off-course vehicle 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}
@@ -1359,10 +1359,10 @@ exports[`Header renders with route data 1`] = `
           Vehicle Status Icon
         </title>
         <g
-          className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+          className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
         >
           <rect
-            className="m-vehicle-icon__label-background"
+            className="c-vehicle-icon__label-background"
             height={24}
             rx={12}
             ry={12}
@@ -1371,7 +1371,7 @@ exports[`Header renders with route data 1`] = `
             y={19}
           />
           <text
-            className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+            className="c-vehicle-icon__label c-vehicle-icon__label--normal"
             dominantBaseline="central"
             textAnchor="middle"
             x="0"
@@ -1380,13 +1380,13 @@ exports[`Header renders with route data 1`] = `
             1
           </text>
           <path
-            className="m-vehicle-icon__triangle"
+            className="c-vehicle-icon__triangle"
             d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
             data-testid="vehicle-triangle"
             transform="scale(1) rotate(0) translate(-24,-22)"
           />
           <text
-            className="m-vehicle-icon__variant"
+            className="c-vehicle-icon__variant"
             dominantBaseline="alphabetic"
             textAnchor="middle"
             x={0}

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -95,18 +95,18 @@ exports[`Header renders a header 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           Forest Hills
         </output>
@@ -348,18 +348,18 @@ exports[`Header renders for a ghost 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           headsign
         </output>
@@ -559,18 +559,18 @@ exports[`Header renders for a late vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           Forest Hills
         </output>
@@ -804,7 +804,7 @@ exports[`Header renders for a shuttle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         Shuttle
       </output>
@@ -917,18 +917,18 @@ exports[`Header renders for an early vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           Forest Hills
         </output>
@@ -1162,18 +1162,18 @@ exports[`Header renders for an off-course vehicle 1`] = `
       />
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           Forest Hills
         </output>
@@ -1407,18 +1407,18 @@ exports[`Header renders with route data 1`] = `
       </div>
       <output
         aria-label="Route Variant Name"
-        className="m-route-variant-name undefined"
+        className="c-route-variant-name undefined"
       >
         <output
           aria-label="Route & Variant"
-          className="m-route-variant-name__route-id"
+          className="c-route-variant-name__route-id"
         >
           39_X
         </output>
          
         <output
           aria-label="Headsign"
-          className="m-route-variant-name__headsign"
+          className="c-route-variant-name__headsign"
         >
           Forest Hills
         </output>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -250,7 +250,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     />
     <div
       className="m-properties-list"
@@ -319,18 +319,18 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -339,21 +339,21 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           Stop Name
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -370,7 +370,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
 
 exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -618,7 +618,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     />
     <div
       className="m-properties-list"
@@ -687,18 +687,18 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -707,21 +707,21 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           Stop Name
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -738,7 +738,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
 
 exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -851,7 +851,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
     </div>
   </div>
   <div
-    className="m-vehicle-properties-panel__notes"
+    className="c-vehicle-properties-panel__notes"
   />
   <div
     className="m-properties-list"
@@ -920,18 +920,18 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
     </table>
   </div>
   <div
-    className="m-vehicle-properties-panel__location"
+    className="c-vehicle-properties-panel__location"
   >
     <div
-      className="m-vehicle-properties-panel__latlng"
+      className="c-vehicle-properties-panel__latlng"
     >
       <div
-        className="m-vehicle-properties-panel__label"
+        className="c-vehicle-properties-panel__label"
       >
         Current Location
       </div>
       <a
-        className="m-vehicle-properties-panel__link"
+        className="c-vehicle-properties-panel__link"
         href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
         rel="noreferrer"
         target="_blank"
@@ -940,25 +940,25 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       </a>
     </div>
     <div
-      className="m-vehicle-properties-panel__next-stop"
+      className="c-vehicle-properties-panel__next-stop"
     >
       <div
-        className="m-vehicle-properties-panel__label"
+        className="c-vehicle-properties-panel__label"
       >
         Next Stop
       </div>
       <div
-        className="m-vehicle-properties-panel__value"
+        className="c-vehicle-properties-panel__value"
       >
         <span
-          className="m-vehicle-properties-panel__not-available"
+          className="c-vehicle-properties-panel__not-available"
         >
           Not available
         </span>
       </div>
     </div>
     <div
-      className="m-vehicle-properties-panel__map"
+      className="c-vehicle-properties-panel__map"
     >
       <div
         className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -974,7 +974,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
 
 exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -1222,7 +1222,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     >
       <div
         className="m-block-waiver-list"
@@ -1388,18 +1388,18 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -1408,21 +1408,21 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           Stop Name
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -1439,7 +1439,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
 
 exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -1687,7 +1687,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     />
     <div
       className="m-properties-list"
@@ -1756,18 +1756,18 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -1776,21 +1776,21 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           Stop Name
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -1807,7 +1807,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
 
 exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -2053,11 +2053,11 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     >
       <div
         aria-labelledby="card-label-:r4:"
-        className="c-card c-card--lemon m-vehicle-properties-panel__invalid-banner c-card--no-focus-or-hover c-card--inactive"
+        className="c-card c-card--lemon c-vehicle-properties-panel__invalid-banner c-card--no-focus-or-hover c-card--inactive"
       >
         <div
           className="c-card__left"
@@ -2157,18 +2157,18 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -2177,25 +2177,25 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           <span
-            className="m-vehicle-properties-panel__not-available"
+            className="c-vehicle-properties-panel__not-available"
           >
             Not available
           </span>
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
@@ -2212,7 +2212,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
 
 exports[`VehiclePropertiesPanel renders with route data 1`] = `
 <div
-  className="m-vehicle-properties-panel"
+  className="c-vehicle-properties-panel"
 >
   <div
     className="m-properties-panel__header-wrapper"
@@ -2462,7 +2462,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
     className="m-tabs__tab-panel"
   >
     <div
-      className="m-vehicle-properties-panel__notes"
+      className="c-vehicle-properties-panel__notes"
     />
     <div
       className="m-properties-list"
@@ -2531,18 +2531,18 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
       </table>
     </div>
     <div
-      className="m-vehicle-properties-panel__location"
+      className="c-vehicle-properties-panel__location"
     >
       <div
-        className="m-vehicle-properties-panel__latlng"
+        className="c-vehicle-properties-panel__latlng"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Current Location
         </div>
         <a
-          className="m-vehicle-properties-panel__link"
+          className="c-vehicle-properties-panel__link"
           href="https://www.google.com/maps/dir/?api=1&destination=0,0&travelmode=driving"
           rel="noreferrer"
           target="_blank"
@@ -2551,21 +2551,21 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         </a>
       </div>
       <div
-        className="m-vehicle-properties-panel__next-stop"
+        className="c-vehicle-properties-panel__next-stop"
       >
         <div
-          className="m-vehicle-properties-panel__label"
+          className="c-vehicle-properties-panel__label"
         >
           Next Stop
         </div>
         <div
-          className="m-vehicle-properties-panel__value"
+          className="c-vehicle-properties-panel__value"
         >
           Stop Name
         </div>
       </div>
       <div
-        className="m-vehicle-properties-panel__map"
+        className="c-vehicle-properties-panel__map"
       >
         <div
           className="m-vehicle-map-state m-vehicle-map-state--auto-centering"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -359,7 +359,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>
@@ -727,7 +727,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>
@@ -964,7 +964,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
         className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
-        className="m-vehicle-map"
+        className="c-vehicle-map"
         id="id-vehicle-map"
       />
     </div>
@@ -1428,7 +1428,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>
@@ -1796,7 +1796,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>
@@ -2201,7 +2201,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>
@@ -2571,7 +2571,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
           className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
-          className="m-vehicle-map"
+          className="c-vehicle-map"
           id="id-vehicle-map"
         />
       </div>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -98,18 +98,18 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>
@@ -466,18 +466,18 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>
@@ -834,7 +834,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           Shuttle
         </output>
@@ -1070,18 +1070,18 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>
@@ -1535,18 +1535,18 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>
@@ -1903,18 +1903,18 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>
@@ -2310,18 +2310,18 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="m-route-variant-name undefined"
+          className="c-route-variant-name undefined"
         >
           <output
             aria-label="Route & Variant"
-            className="m-route-variant-name__route-id"
+            className="c-route-variant-name__route-id"
           >
             39_X
           </output>
            
           <output
             aria-label="Headsign"
-            className="m-route-variant-name__headsign"
+            className="c-route-variant-name__headsign"
           >
             Forest Hills
           </output>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -52,10 +52,10 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+            className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -64,7 +64,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -73,13 +73,13 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -420,10 +420,10 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large late early-red"
+            className="c-vehicle-icon c-vehicle-icon--large late early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -432,7 +432,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -441,13 +441,13 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -788,10 +788,10 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large"
+            className="c-vehicle-icon c-vehicle-icon--large"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -800,7 +800,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--extended"
+              className="c-vehicle-icon__label c-vehicle-icon__label--extended"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -809,13 +809,13 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
               v1-label
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -1024,10 +1024,10 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+            className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -1036,7 +1036,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -1045,13 +1045,13 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -1489,10 +1489,10 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large early early-red"
+            className="c-vehicle-icon c-vehicle-icon--large early early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -1501,7 +1501,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -1510,13 +1510,13 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -1857,10 +1857,10 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large off-course early-red"
+            className="c-vehicle-icon c-vehicle-icon--large off-course early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -1869,7 +1869,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -1878,13 +1878,13 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}
@@ -2262,10 +2262,10 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
             Vehicle Status Icon
           </title>
           <g
-            className="m-vehicle-icon m-vehicle-icon--large on-time early-red"
+            className="c-vehicle-icon c-vehicle-icon--large on-time early-red"
           >
             <rect
-              className="m-vehicle-icon__label-background"
+              className="c-vehicle-icon__label-background"
               height={24}
               rx={12}
               ry={12}
@@ -2274,7 +2274,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
               y={19}
             />
             <text
-              className="m-vehicle-icon__label m-vehicle-icon__label--normal"
+              className="c-vehicle-icon__label c-vehicle-icon__label--normal"
               dominantBaseline="central"
               textAnchor="middle"
               x="0"
@@ -2283,13 +2283,13 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
               1
             </text>
             <path
-              className="m-vehicle-icon__triangle"
+              className="c-vehicle-icon__triangle"
               d="m27.34 9.46 16.84 24.54a4.06 4.06 0 0 1 -1 5.64 4.11 4.11 0 0 1 -2.3.71h-33.72a4.06 4.06 0 0 1 -4.06-4.11 4 4 0 0 1 .72-2.24l16.84-24.54a4.05 4.05 0 0 1 5.64-1.05 4 4 0 0 1 1.04 1.05z"
               data-testid="vehicle-triangle"
               transform="scale(1) rotate(0) translate(-24,-22)"
             />
             <text
-              className="m-vehicle-icon__variant"
+              className="c-vehicle-icon__variant"
               dominantBaseline="alphabetic"
               textAnchor="middle"
               x={0}

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -356,7 +356,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"
@@ -724,7 +724,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"
@@ -961,7 +961,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       className="c-vehicle-properties-panel__map"
     >
       <div
-        className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+        className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
       />
       <div
         className="m-vehicle-map"
@@ -1425,7 +1425,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"
@@ -1793,7 +1793,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"
@@ -2198,7 +2198,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"
@@ -2568,7 +2568,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         className="c-vehicle-properties-panel__map"
       >
         <div
-          className="m-vehicle-map-state m-vehicle-map-state--auto-centering"
+          className="c-vehicle-map-state c-vehicle-map-state--auto-centering"
         />
         <div
           className="m-vehicle-map"

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -376,10 +376,10 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -744,10 +744,10 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -980,10 +980,10 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -1445,10 +1445,10 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -1813,10 +1813,10 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>
@@ -2218,10 +2218,10 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
     className="m-properties-panel__header-wrapper"
   >
     <div
-      className="m-view-header"
+      className="c-view-header"
     >
       <h2
-        className="m-view-header__title"
+        className="c-view-header__title"
       >
         Vehicles
       </h2>

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -466,7 +466,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -834,7 +834,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           Shuttle
         </output>
@@ -1070,7 +1070,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -1535,7 +1535,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -1903,7 +1903,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
         />
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"
@@ -2310,7 +2310,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
         </div>
         <output
           aria-label="Route Variant Name"
-          className="c-route-variant-name undefined"
+          className="c-route-variant-name"
         >
           <output
             aria-label="Route & Variant"

--- a/assets/tests/components/shuttleMapPage.test.tsx
+++ b/assets/tests/components/shuttleMapPage.test.tsx
@@ -170,7 +170,7 @@ describe("Shuttle Map Page", () => {
 
     expect(
       result.container.getElementsByClassName(
-        "m-vehicle-map-state--auto-centering"
+        "c-vehicle-map-state--auto-centering"
       ).length
     ).toBe(1)
   })


### PR DESCRIPTION
I liked the way @KaylaBrady was chunking CSS so I decided to try it, Thanks Kayla!

Each commit should be individually reviewable and a atomic update to the css classes.

Everything in this was changed over to component prefixes, I didn't see opportunities for other prefixes but I also wasn't looking super closely on the larger changesets.

---

<details>
<summary>
My change process
</summary>

I've been using `ripgrep` and `sd` (and `fish` shell) to update files using the form similar to the following snippet

```
❯ sd m-vehicle-icon c-vehicle-icon (rg m-vehicle-icon -l)
```

</details>

---

Asana Ticket: https://app.asana.com/0/1200180014510248/1203760641228313