### PR TITLE
 refactor(ts/helpers/dom): rename function `className` to `joinClasses` 

### DIFF
--- a/assets/src/components/crowdingIcon.tsx
+++ b/assets/src/components/crowdingIcon.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { classModifierForStatus, OccupancyStatus } from "../models/crowding"
 import {
   Label,
@@ -49,7 +49,7 @@ const Crowd = React.memo(
     return (
       <g
         transform={`scale(${scale}) translate(-24,${yOffset - 22})`}
-        className={className(classNames)}
+        className={joinClasses(classNames)}
       >
         <rect x="-2" y="-2" width="52" height="52" fill="transparent" />
         <path d="M6.74,16.17A6.86,6.86,0,0,0-.12,23h0V40.8a3.43,3.43,0,0,0,3.43,3.42h6.86a3.42,3.42,0,0,0,3.42-3.42V23A6.87,6.87,0,0,0,6.74,16.17Z" />
@@ -76,7 +76,7 @@ export const CrowdingIconSvgNode = React.memo(
       `c-vehicle-icon${sizeClassSuffix(size)}`,
     ]
     return (
-      <g className={className(classes)}>
+      <g className={joinClasses(classes)}>
         {label ? (
           <Label size={size} orientation={orientation} label={label} />
         ) : null}

--- a/assets/src/components/ladder.tsx
+++ b/assets/src/components/ladder.tsx
@@ -4,7 +4,7 @@ import Tippy from "@tippyjs/react"
 import "tippy.js/dist/tippy.css"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { flatten, partition } from "../helpers/array"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import vehicleLabel from "../helpers/vehicleLabel"
 import { blockWaiverAlertStyle } from "../models/blockWaiver"
 import { crowdingLabel, OccupancyStatus } from "../models/crowding"
@@ -200,7 +200,7 @@ const VehicleSvg = ({
   return (
     <VehicleTooltip vehicleOrGhost={vehicle}>
       <g
-        className={className([
+        className={joinClasses([
           "m-ladder__vehicle",
           vehicle.id === selectedVehicleId && "m-ladder__vehicle--selected",
         ])}
@@ -351,7 +351,7 @@ const ScheduledLine = ({
 
   return (
     <line
-      className={className(
+      className={joinClasses(
         ["m-ladder__scheduled-line"].concat(
           statusClasses(status, userSettings.vehicleAdherenceColors)
         )

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -33,7 +33,7 @@ import {
 import { createControlComponent } from "@react-leaflet/core"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { TrainVehicle, Vehicle, VehicleId } from "../realtime.d"
 import { DirectionId, Shape, Stop } from "../schedule"
 import { equalByElements } from "../helpers/array"
@@ -310,7 +310,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const [streetViewEnabled, setStreetViewEnabled] = useState<boolean>(false)
   const { allowFullscreen = true } = props
 
-  const stateClasses = className([
+  const stateClasses = joinClasses([
     "c-vehicle-map-state",
     streetViewEnabled ? "c-vehicle-map-state--street-view-enabled" : null,
     props.stateClasses,

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -2,7 +2,7 @@ import Leaflet, { ControlOptions } from "leaflet"
 import React, { useEffect, useId, useState } from "react"
 import ReactDOM from "react-dom"
 import { useMap, useMapEvents } from "react-leaflet"
-import { className } from "../../../helpers/dom"
+import { joinClasses } from "../../../helpers/dom"
 import { WalkingIcon } from "../../../helpers/icon"
 import { streetViewUrl } from "../../../util/streetViewUrl"
 
@@ -28,7 +28,7 @@ export const StreetViewControl = ({
     }
 
     if (portalParent && portalElement) {
-      portalElement.className = className([
+      portalElement.className = joinClasses([
         "leaflet-control",
         "leaflet-bar",
         "c-street-view-switch",

--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-leaflet"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import vehicleLabelString from "../helpers/vehicleLabel"
 import { drawnStatus, statusClasses } from "../models/vehicleStatus"
 import { TrainVehicle, Vehicle } from "../realtime"
@@ -50,7 +50,7 @@ const makeVehicleIcon = (
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          class="${className([
+          class="${joinClasses([
             ...statusClasses(
               drawnStatus(vehicle),
               userSettings.vehicleAdherenceColors
@@ -80,7 +80,7 @@ const makeLabelIcon = (
     labelString.length <= 4 ? (isPrimary ? 40 : 30) : isPrimary ? 62 : 40
   const selectedClass = isSelected ? "selected" : null
   return Leaflet.divIcon({
-    className: className([
+    className: joinClasses([
       "c-vehicle-map__label",
       isPrimary ? "primary" : "secondary",
       selectedClass,
@@ -254,7 +254,7 @@ export const StopIcon = ({
     <CircleMarker
       {...props}
       ref={setMarker}
-      className={className(["c-vehicle-map__stop"])}
+      className={joinClasses(["c-vehicle-map__stop"])}
       center={[stop.lat, stop.lon]}
       radius={radius}
     >

--- a/assets/src/components/mapPage/vehiclePropertiesCard.tsx
+++ b/assets/src/components/mapPage/vehiclePropertiesCard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useId } from "react"
-import { joinTruthy, joinClasses as classNames } from "../../helpers/dom"
+import { joinTruthy, joinClasses } from "../../helpers/dom"
 import { useCurrentTimeSeconds } from "../../hooks/useCurrentTime"
 import { useNearestIntersection } from "../../hooks/useNearestIntersection"
 import { isGhost, isVehicle } from "../../models/vehicle"
@@ -79,7 +79,7 @@ const TrNameValue = ({
         {name}
       </th>
       <td
-        className={classNames([
+        className={joinClasses([
           "kv-value font-s-reg",
           shouldMaskInfo(sensitive !== HideSensitiveInfo.None),
         ])}

--- a/assets/src/components/mapPage/vehiclePropertiesCard.tsx
+++ b/assets/src/components/mapPage/vehiclePropertiesCard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useId } from "react"
-import { joinTruthy, className as classNames } from "../../helpers/dom"
+import { joinTruthy, joinClasses as classNames } from "../../helpers/dom"
 import { useCurrentTimeSeconds } from "../../hooks/useCurrentTime"
 import { useNearestIntersection } from "../../hooks/useNearestIntersection"
 import { isGhost, isVehicle } from "../../models/vehicle"

--- a/assets/src/components/notificationBellIcon.tsx
+++ b/assets/src/components/notificationBellIcon.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { NotificationsContext } from "../contexts/notificationsContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { NotificationBellIcon as NotificationBellIconSvg } from "../helpers/icon"
 import { OpenView } from "../state"
 
@@ -19,7 +19,7 @@ const NotificationBellIcon = ({
 
   return (
     <NotificationBellIconSvg
-      className={className([
+      className={joinClasses([
         "m-notification-bell-icon",
         openView === OpenView.NotificationDrawer
           ? "m-notification-bell-icon--open"

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction, useContext } from "react"
 import { useRoute } from "../../contexts/routesContext"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
-import { className } from "../../helpers/dom"
+import { joinClasses } from "../../helpers/dom"
 import vehicleLabel from "../../helpers/vehicleLabel"
 import { secondsAgoLabel, secondsToMinutes } from "../../util/dateTime"
 import { useCurrentTimeSeconds } from "../../hooks/useCurrentTime"
@@ -62,7 +62,7 @@ const ScheduleAdherence = ({ vehicle }: { vehicle: Vehicle }) => {
 
   return (
     <div
-      className={`m-properties-panel__schedule-adherence ${className(
+      className={`m-properties-panel__schedule-adherence ${joinClasses(
         statusClasses(drawnStatus(vehicle), userSettings.vehicleAdherenceColors)
       )}`}
     >

--- a/assets/src/components/propertiesPanel/minischedule.tsx
+++ b/assets/src/components/propertiesPanel/minischedule.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react"
 import { useRoute } from "../../contexts/routesContext"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
-import { className } from "../../helpers/dom"
+import { joinClasses } from "../../helpers/dom"
 import {
   BusFrontIcon,
   BusRearIcon,
@@ -106,7 +106,7 @@ export const Minischedule = ({
     )
     return (
       <div
-        className={className([
+        className={joinClasses([
           "m-minischedule",
           `m-minischedule--${showPast ? "show-past" : "hide-past"}`,
         ])}
@@ -733,7 +733,7 @@ const Row = ({
   const [{ userSettings }] = useContext(StateDispatchContext)
   return (
     <div
-      className={className([
+      className={joinClasses([
         "m-minischedule__row",
         timeBasedStyle && "m-minischedule__row--" + timeBasedStyle,
         ...(activeStatus

--- a/assets/src/components/routePill.tsx
+++ b/assets/src/components/routePill.tsx
@@ -1,12 +1,12 @@
 import React from "react"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 
 export const RoutePill = ({
   routeName,
 }: {
   routeName: string
 }): JSX.Element => {
-  const classes = className(["c-route-pill", modeClass(routeName)])
+  const classes = joinClasses(["c-route-pill", modeClass(routeName)])
 
   return <div className={classes}>{routeNameTransform(routeName)}</div>
 }

--- a/assets/src/components/routeVariantName.tsx
+++ b/assets/src/components/routeVariantName.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef } from "react"
 import { useRoute } from "../contexts/routesContext"
-import { joinClasses as joinClasses } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { isVehicle } from "../models/vehicle"
 import { VehicleOrGhost } from "../realtime"
 

--- a/assets/src/components/routeVariantName.tsx
+++ b/assets/src/components/routeVariantName.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef } from "react"
 import { useRoute } from "../contexts/routesContext"
-import { className as joinClassNames } from "../helpers/dom"
+import { joinClasses as joinClasses } from "../helpers/dom"
 import { isVehicle } from "../models/vehicle"
 import { VehicleOrGhost } from "../realtime"
 
@@ -18,7 +18,7 @@ export const RouteVariantName = ({
   return (
     <output
       aria-label="Route Variant Name"
-      className={joinClassNames(["c-route-variant-name", className])}
+      className={joinClasses(["c-route-variant-name", className])}
       {...props}
     >
       {isShuttle ? (

--- a/assets/src/components/scheduleAdherence.tsx
+++ b/assets/src/components/scheduleAdherence.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef, useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { className as classNames } from "../helpers/dom"
+import { joinClasses as classNames } from "../helpers/dom"
 import { isVehicle } from "../models/vehicle"
 import {
   drawnStatus,

--- a/assets/src/components/scheduleAdherence.tsx
+++ b/assets/src/components/scheduleAdherence.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef, useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { joinClasses as classNames } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { isVehicle } from "../models/vehicle"
 import {
   drawnStatus,
@@ -30,7 +30,7 @@ const ScheduleAdherenceDescription = ({
   ...props
 }: { vehicle: Vehicle } & ComponentPropsWithoutRef<"output">) => (
   <output
-    className={classNames(["c-schedule-adherence-status", className])}
+    className={joinClasses(["c-schedule-adherence-status", className])}
     {...props}
   >
     {humanReadableScheduleAdherence(vehicle)}
@@ -71,7 +71,7 @@ export const ScheduleAdherence = ({
 }: ScheduleAdherenceProps) => {
   const [{ userSettings }] = useContext(StateDispatchContext)
 
-  const classes = classNames([
+  const classes = joinClasses([
     "c-schedule-adherence",
     ...statusClasses(drawnStatus(vehicle), userSettings.vehicleAdherenceColors),
     className,

--- a/assets/src/components/streetViewButton.tsx
+++ b/assets/src/components/streetViewButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react"
-import { className as classNames } from "../helpers/dom"
+import { joinClasses as classNames } from "../helpers/dom"
 import { WalkingIcon } from "../helpers/icon"
 import { streetViewUrl as streetViewUrlFrom } from "../util/streetViewUrl"
 

--- a/assets/src/components/streetViewButton.tsx
+++ b/assets/src/components/streetViewButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react"
-import { joinClasses as classNames } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { WalkingIcon } from "../helpers/icon"
 import { streetViewUrl as streetViewUrlFrom } from "../util/streetViewUrl"
 
@@ -29,7 +29,7 @@ const StreetViewButton = ({
   const streetViewUrl = streetViewUrlFrom(worldPosition)
   return (
     <a
-      className={classNames([
+      className={joinClasses([
         "c-street-view-button",
         "button-dark-small",
         className,

--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react"
 import Tippy from "@tippyjs/react"
 import "tippy.js/dist/tippy.css"
-import { className } from "../helpers/dom"
+import { joinClasses } from "../helpers/dom"
 import { DrawnStatus, statusClasses } from "../models/vehicleStatus"
 import { AlertIconStyle, IconAlertCircleSvgNode } from "./iconAlertCircle"
 import { runIdToLabel } from "../helpers/vehicleLabel"
@@ -271,7 +271,7 @@ export const VehicleIconSvgNode = React.memo(
         : "",
     ].concat(statusClasses(status, userSettings.vehicleAdherenceColors))
     return (
-      <g className={className(classes)}>
+      <g className={joinClasses(classes)}>
         {label ? (
           <Label size={size} orientation={orientation} label={label} />
         ) : null}

--- a/assets/src/helpers/dom.ts
+++ b/assets/src/helpers/dom.ts
@@ -2,5 +2,5 @@ type RemovedTypes = null | undefined | false
 export const joinTruthy = (strings: (string | RemovedTypes)[], joiner = " ") =>
   strings.filter(Boolean).join(joiner)
 
-export const className = (classes: (string | RemovedTypes)[]): string =>
+export const joinClasses = (classes: (string | RemovedTypes)[]): string =>
   joinTruthy(classes, " ")

--- a/assets/tests/helpers/dom.test.ts
+++ b/assets/tests/helpers/dom.test.ts
@@ -1,6 +1,6 @@
 import { joinClasses } from "../../src/helpers/dom"
 
-describe("className", () => {
+describe("joinClasses", () => {
   test("combine a list of class names into a single string", () => {
     expect(joinClasses(["foo", "bar"])).toEqual("foo bar")
   })

--- a/assets/tests/helpers/dom.test.ts
+++ b/assets/tests/helpers/dom.test.ts
@@ -1,11 +1,11 @@
-import { className } from "../../src/helpers/dom"
+import { joinClasses } from "../../src/helpers/dom"
 
 describe("className", () => {
   test("combine a list of class names into a single string", () => {
-    expect(className(["foo", "bar"])).toEqual("foo bar")
+    expect(joinClasses(["foo", "bar"])).toEqual("foo bar")
   })
 
   test("filters out empty strings", () => {
-    expect(className(["foo", "bar", ""])).toEqual("foo bar")
+    expect(joinClasses(["foo", "bar", ""])).toEqual("foo bar")
   })
 })


### PR DESCRIPTION
the `className` function often collides with either local variables or sometimes even props/arguments. This rename is intended to make it clear what the function does as well as have less collisions.