### PR TITLE
Stop selected vehicle from disappearing when no longer on its original route

### DIFF
--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -55,18 +55,19 @@ const RouteVehicles = ({
   const vehicles = useVehiclesForRoute(socket, selectedVehicleRoute)
   return (
     <>
-      {filterVehicles(vehicles).map((vehicle: Vehicle) => {
-        const isSelected = vehicle.id === selectedVehicleId
-        return (
-          <VehicleMarker
-            key={vehicle.id}
-            vehicle={vehicle}
-            isPrimary={isSelected === true}
-            isSelected={isSelected}
-            onSelect={onPrimaryVehicleSelect}
-          />
-        )
-      })}
+      {filterVehicles(vehicles)
+        .filter((vehicle) => vehicle.id !== selectedVehicleId)
+        .map((vehicle: Vehicle) => {
+          return (
+            <VehicleMarker
+              key={vehicle.id}
+              vehicle={vehicle}
+              isPrimary={false}
+              isSelected={false}
+              onSelect={onPrimaryVehicleSelect}
+            />
+          )
+        })}
     </>
   )
 }
@@ -361,21 +362,22 @@ const SelectedVehicleDataLayers = ({
               />
             </SelectionCardContainer>
           )}
-          {isVehicle(selectedVehicleOrGhost) &&
-            (selectedVehicleOrGhost?.isShuttle ? (
+          {isVehicle(selectedVehicleOrGhost) && (
+            <>
               <VehicleMarker
                 key={selectedVehicleOrGhost.id}
                 vehicle={selectedVehicleOrGhost}
                 isPrimary={true}
                 isSelected={true}
               />
-            ) : (
+
               <RouteVehicles
                 selectedVehicleRoute={selectedVehicleOrGhost.routeId}
                 selectedVehicleId={selectedVehicleOrGhost.id}
                 onPrimaryVehicleSelect={selectVehicle}
               />
-            ))}
+            </>
+          )}
           {showShapeAndStops && routePatternForVehicle && (
             <RoutePatternLayers
               routePattern={routePatternForVehicle}

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -371,11 +371,13 @@ const SelectedVehicleDataLayers = ({
                 isSelected={true}
               />
 
-              <SecondaryRouteVehicles
-                selectedVehicleRoute={selectedVehicleOrGhost.routeId}
-                selectedVehicleId={selectedVehicleOrGhost.id}
-                onVehicleSelect={selectVehicle}
-              />
+              {!selectedVehicleOrGhost.isShuttle && (
+                <SecondaryRouteVehicles
+                  selectedVehicleRoute={selectedVehicleOrGhost.routeId}
+                  selectedVehicleId={selectedVehicleOrGhost.id}
+                  onVehicleSelect={selectVehicle}
+                />
+              )}
             </>
           )}
           {showShapeAndStops && routePatternForVehicle && (

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -42,14 +42,14 @@ import ZoomLevelWrapper from "../ZoomLevelWrapper"
 import RoutePropertiesCard from "./routePropertiesCard"
 import VehiclePropertiesCard from "./vehiclePropertiesCard"
 
-const RouteVehicles = ({
+const SecondaryRouteVehicles = ({
   selectedVehicleRoute,
   selectedVehicleId,
-  onPrimaryVehicleSelect,
+  onVehicleSelect,
 }: {
   selectedVehicleId: VehicleId | null
   selectedVehicleRoute: RouteId | null
-  onPrimaryVehicleSelect: (vehicle: Vehicle) => void
+  onVehicleSelect: (vehicle: Vehicle) => void
 }) => {
   const { socket } = useSocket()
   const vehicles = useVehiclesForRoute(socket, selectedVehicleRoute)
@@ -64,7 +64,7 @@ const RouteVehicles = ({
               vehicle={vehicle}
               isPrimary={false}
               isSelected={false}
-              onSelect={onPrimaryVehicleSelect}
+              onSelect={onVehicleSelect}
             />
           )
         })}
@@ -371,10 +371,10 @@ const SelectedVehicleDataLayers = ({
                 isSelected={true}
               />
 
-              <RouteVehicles
+              <SecondaryRouteVehicles
                 selectedVehicleRoute={selectedVehicleOrGhost.routeId}
                 selectedVehicleId={selectedVehicleOrGhost.id}
-                onPrimaryVehicleSelect={selectVehicle}
+                onVehicleSelect={selectVehicle}
               />
             </>
           )}
@@ -447,10 +447,10 @@ const SelectedRouteDataLayers = ({
           onShapeClick={() => selectRoutePattern(selectedRoutePattern)}
         />
       )}
-      <RouteVehicles
+      <SecondaryRouteVehicles
         selectedVehicleRoute={routePatternIdentifier.routeId}
         selectedVehicleId={null}
-        onPrimaryVehicleSelect={selectVehicle}
+        onVehicleSelect={selectVehicle}
       />
       <InterruptibleFollower
         onUpdate={onFollowerUpdate}

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1269,6 +1269,66 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
           
               </svg>
             </div>
+            <div
+              class="leaflet-marker-icon c-vehicle-map__icon leaflet-zoom-hide leaflet-interactive"
+              role="button"
+              style="margin-left: 0px; margin-top: 0px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 0; z-index: 0; z-index: 0; z-index: 0; z-index: 0;"
+              tabindex="0"
+            >
+              <svg
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+        
+                <path
+                  class="on-time early-red"
+                  d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+                  transform="scale(0.8) rotate(33) translate(-12, -12)"
+                />
+                
+      
+              </svg>
+            </div>
+            <div
+              class="leaflet-marker-icon c-vehicle-map__label secondary leaflet-zoom-hide leaflet-interactive"
+              role="button"
+              style="margin-left: -15px; margin-top: 10px; width: 12px; height: 12px; left: 223px; top: 0px; z-index: 0; z-index: 0; z-index: 0; z-index: 0; z-index: 0;"
+              tabindex="0"
+            >
+              <svg
+                height="12"
+                viewBox="0 0 30 12"
+                width="30"
+              >
+                
+            
+                <rect
+                  class="c-vehicle-icon__label-background"
+                  height="100%"
+                  rx="5.5px"
+                  ry="5.5px"
+                  width="100%"
+                />
+                
+            
+                <text
+                  class="c-vehicle-icon__label"
+                  dominant-baseline="central"
+                  text-anchor="middle"
+                  x="50%"
+                  y="50%"
+                >
+                  
+              2
+            
+                </text>
+                
+          
+              </svg>
+            </div>
           </div>
           <div
             class="leaflet-pane leaflet-tooltip-pane"

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -898,6 +898,42 @@ describe("<MapPage />", () => {
               container.querySelector(".c-vehicle-map__route-shape")
             ).toBeInTheDocument()
           })
+
+          test("should display vehicle icon when selected vehicle is no longer on route", () => {
+            const changeApplicationState = jest.fn()
+
+            const route = routeFactory.build()
+
+            const selectedRouteVehicles = randomLocationVehicle.buildList(7, {
+              routeId: route.id,
+            })
+
+            const [selectedVehicle] = selectedRouteVehicles
+
+            setHtmlWidthHeightForLeafletMap()
+            mockUseVehicleForId([{ ...selectedVehicle, routeId: null }])
+            mockUseVehiclesForRouteMap({
+              [route.id]: selectedRouteVehicles.slice(1),
+            })
+            mockUsePatternsByIdForVehicles([selectedVehicle], {
+              stopCount: 8,
+            })
+
+            render(
+              <StateDispatchProvider
+                state={selectedStateFactory(selectedVehicle.id).build()}
+                dispatch={changeApplicationState}
+              >
+                <MapPage />
+              </StateDispatchProvider>
+            )
+
+            expect(
+              screen.getAllByRole("button", {
+                name: runIdToLabel(selectedVehicle.runId!),
+              })
+            ).toHaveLength(1)
+          })
         })
 
         test("and vehicle is a shuttle; should display: vehicle icon, but not route shape or stops", () => {

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -170,11 +170,14 @@ describe("<MapPage />", () => {
 
       jest.spyOn(Date, "now").mockImplementation(() => 234000)
 
-      const vehicle = vehicleFactory.build()
+      const vehicle1 = vehicleFactory.build()
+      const vehicle2 = vehicleFactory.build()
       const ghost = ghostFactory.build()
 
-      mockUseVehicleForId([vehicle])
-      mockUseVehiclesForRouteMap({ [vehicle.routeId!]: [vehicle, ghost] })
+      mockUseVehicleForId([vehicle1])
+      mockUseVehiclesForRouteMap({
+        [vehicle1.routeId!]: [vehicle1, vehicle2, ghost],
+      })
 
       const { asFragment } = render(
         <StateDispatchProvider
@@ -182,7 +185,7 @@ describe("<MapPage />", () => {
             searchPageState: {
               selectedEntity: {
                 type: SelectedEntityType.Vehicle,
-                vehicleId: vehicle.id,
+                vehicleId: vehicle1.id,
               },
             },
           })}


### PR DESCRIPTION
Asana ticket: [⚙️🐛 Selected vehicle can disappear from map in Search Map page](https://app.asana.com/0/1200180014510248/1204291981474926/f)

It turns out that we actually had the vehicle from `useVehicleForId`, but the actual display was happening via the `RouteVehicles` component which uses `useVehiclesForRoute`. This separates things out so that `SelectedVehicleDataLayers` always displays the selected vehicle directly, and `RouteVehicles` displays all of the vehicles on the route _except for_ the selected one.

Also extends one of the snapshot `MapPage` tests to display a non-primary vehicle on the route, to verify that both are rendered properly before and after this change.