### PR TITLE
feat(NotificationsDrawer): New loading state

### DIFF
--- a/assets/src/components/notificationBellIcon.tsx
+++ b/assets/src/components/notificationBellIcon.tsx
@@ -12,7 +12,7 @@ const NotificationBellIcon = ({
 }) => {
   const [{ openView }] = useContext(StateDispatchContext)
   const { notifications } = useContext(NotificationsContext)
-  const unreadNotifications = notifications.filter(
+  const unreadNotifications = (notifications || []).filter(
     (notification) => notification.state === "unread"
   )
   const unreadBadge: boolean = unreadNotifications.length > 0

--- a/assets/src/components/notificationDrawer.tsx
+++ b/assets/src/components/notificationDrawer.tsx
@@ -12,6 +12,7 @@ import {
 import { openVPPForNotification } from "./notifications"
 import { NotificationCard } from "./notificationCard"
 import ViewHeader from "./viewHeader"
+import Loading from "./loading"
 
 const NotificationDrawer = () => {
   const elementRef = useRef<HTMLDivElement | null>(null)
@@ -59,8 +60,8 @@ const NotificationDrawer = () => {
 }
 
 const Content = () => {
-  const { notifications } = useContext(NotificationsContext)
-  const notificationsDispatch = useContext(NotificationsContext).dispatch
+  const { notifications, dispatch: notificationsDispatch } =
+    useContext(NotificationsContext)
 
   const currentTime = useCurrentTime()
 
@@ -68,6 +69,10 @@ const Content = () => {
 
   const openVPPForCurrentVehicle = (notification: Notification) => {
     openVPPForNotification(notification, stateDispatch, notificationsDispatch)
+  }
+
+  if (notifications === null) {
+    return <Loading />
   }
 
   if (notifications.length === 0) {

--- a/assets/src/components/notifications.tsx
+++ b/assets/src/components/notifications.tsx
@@ -19,7 +19,9 @@ export const Notifications = () => {
   const [, stateDispatch] = useContext(StateDispatchContext)
 
   const notificationToShow =
-    showLatestNotification && notifications.length > 0 ? notifications[0] : null
+    showLatestNotification && notifications && notifications.length > 0
+      ? notifications[0]
+      : null
 
   const openVPPForCurrentVehicle = (notification: Notification) => {
     openVPPForNotification(notification, stateDispatch, dispatch)

--- a/assets/src/hooks/useNotificationsReducer.ts
+++ b/assets/src/hooks/useNotificationsReducer.ts
@@ -19,12 +19,12 @@ import {
 } from "./useNotifications"
 
 export interface State {
-  notifications: Notification[]
+  notifications: Notification[] | null
   showLatestNotification: boolean
 }
 
 export const initialState: State = {
-  notifications: [],
+  notifications: null,
   showLatestNotification: false,
 }
 
@@ -107,41 +107,47 @@ export type Dispatch = ReactDispatch<Action>
 type Reducer = (state: State, action: Action) => State
 
 export const notificationsReducer = (
-  notifications: Notification[],
+  notifications: Notification[] | null,
   action: Action
-): Notification[] => {
+): Notification[] | null => {
   switch (action.type) {
     case "ADD_NOTIFICATION": {
       const newNotification = (action as AddNotificationAction).payload
         .notification
-      return [newNotification, ...notifications]
+      return [newNotification, ...(notifications || [])]
     }
     case "EXPIRE_NOTIFICATIONS":
-      return notifications.filter((notification) => {
-        const maxAgeInMs = 8 * 60 * 60 * 1000
-        const now = (action as ExpireNotificationsAction).payload.now
-        const ageInMs = now.valueOf() - notification.createdAt.valueOf()
-        return ageInMs < maxAgeInMs
-      })
+      return notifications
+        ? notifications.filter((notification) => {
+            const maxAgeInMs = 8 * 60 * 60 * 1000
+            const now = (action as ExpireNotificationsAction).payload.now
+            const ageInMs = now.valueOf() - notification.createdAt.valueOf()
+            return ageInMs < maxAgeInMs
+          })
+        : null
     case "MARK_ALL_AS_READ":
-      return notifications.map((notification) => ({
-        ...notification,
-        state: "read",
-      }))
+      return notifications
+        ? notifications.map((notification) => ({
+            ...notification,
+            state: "read",
+          }))
+        : null
     case "SET_NOTIFICATIONS": {
       return (action as SetNotificationsAction).payload.notifications
     }
     case "TOGGLE_READ_STATE": {
       const notificationToToggle = (action as ToggleReadStateAction).payload
         .notification
-      return notifications.map((notification) =>
-        notification.id === notificationToToggle.id
-          ? {
-              ...notification,
-              state: otherNotificationReadState(notification.state),
-            }
-          : notification
-      )
+      return notifications
+        ? notifications.map((notification) =>
+            notification.id === notificationToToggle.id
+              ? {
+                  ...notification,
+                  state: otherNotificationReadState(notification.state),
+                }
+              : notification
+          )
+        : null
     }
 
     default:
@@ -232,7 +238,7 @@ export const useNotificationsReducer = (
   const dispatchWithSideEffects: Dispatch = (action: Action): void => {
     switch (action.type) {
       case "MARK_ALL_AS_READ":
-        persistMarkAllAsRead(state.notifications)
+        persistMarkAllAsRead(state.notifications || [])
         break
       case "TOGGLE_READ_STATE": {
         const notificationToToggle = (action as ToggleReadStateAction).payload

--- a/assets/src/hooks/useNotificationsReducer.ts
+++ b/assets/src/hooks/useNotificationsReducer.ts
@@ -117,37 +117,40 @@ export const notificationsReducer = (
       return [newNotification, ...(notifications || [])]
     }
     case "EXPIRE_NOTIFICATIONS":
-      return notifications
-        ? notifications.filter((notification) => {
-            const maxAgeInMs = 8 * 60 * 60 * 1000
-            const now = (action as ExpireNotificationsAction).payload.now
-            const ageInMs = now.valueOf() - notification.createdAt.valueOf()
-            return ageInMs < maxAgeInMs
-          })
-        : null
+      return (
+        notifications &&
+        notifications.filter((notification) => {
+          const maxAgeInMs = 8 * 60 * 60 * 1000
+          const now = (action as ExpireNotificationsAction).payload.now
+          const ageInMs = now.valueOf() - notification.createdAt.valueOf()
+          return ageInMs < maxAgeInMs
+        })
+      )
     case "MARK_ALL_AS_READ":
-      return notifications
-        ? notifications.map((notification) => ({
-            ...notification,
-            state: "read",
-          }))
-        : null
+      return (
+        notifications &&
+        notifications.map((notification) => ({
+          ...notification,
+          state: "read",
+        }))
+      )
     case "SET_NOTIFICATIONS": {
       return (action as SetNotificationsAction).payload.notifications
     }
     case "TOGGLE_READ_STATE": {
       const notificationToToggle = (action as ToggleReadStateAction).payload
         .notification
-      return notifications
-        ? notifications.map((notification) =>
-            notification.id === notificationToToggle.id
-              ? {
-                  ...notification,
-                  state: otherNotificationReadState(notification.state),
-                }
-              : notification
-          )
-        : null
+      return (
+        notifications &&
+        notifications.map((notification) =>
+          notification.id === notificationToToggle.id
+            ? {
+                ...notification,
+                state: otherNotificationReadState(notification.state),
+              }
+            : notification
+        )
+      )
     }
 
     default:

--- a/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationDrawer.test.tsx.snap
@@ -1,172 +1,161 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationDrawer renders empty state 1`] = `
-<div
-  className="c-notification-drawer"
->
+<DocumentFragment>
   <div
-    className="c-view-header"
+    class="c-notification-drawer"
   >
-    <h2
-      className="c-view-header__title"
+    <div
+      class="c-view-header"
     >
-      Notifications
-    </h2>
-    <button
-      aria-label="Close"
-      className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      <h2
+        class="c-view-header__title"
+      >
+        Notifications
+      </h2>
+      <button
+        aria-label="Close"
+        class="c-close-button c-close-button--x-large c-close-button--light"
+      >
+        <span
+          aria-hidden="true"
+          aria-label=""
+          role="img"
+        >
+          <svg />
+        </span>
+      </button>
+    </div>
+    <div
+      class="c-notification-drawer__content"
     >
-      <span
-        aria-hidden={true}
-        aria-label=""
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-        role="img"
-      />
-    </button>
+      <p>
+        You have no notifications currently.
+      </p>
+      <p>
+        Here you'll be notified about events like accidents and ghost vehicles on any bus routes you have selected on the Route Ladders page.
+      </p>
+    </div>
   </div>
-  <div
-    className="c-notification-drawer__content"
-  >
-    <p>
-      You have no notifications currently.
-    </p>
-    <p>
-      Here you'll be notified about events like accidents and ghost vehicles on any bus routes you have selected on the Route Ladders page.
-    </p>
-  </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`NotificationDrawer renders notifications 1`] = `
-<div
-  className="c-notification-drawer"
->
+<DocumentFragment>
   <div
-    className="c-view-header"
-  >
-    <h2
-      className="c-view-header__title"
-    >
-      Notifications
-    </h2>
-    <button
-      aria-label="Close"
-      className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={true}
-        aria-label=""
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<svg/>",
-          }
-        }
-        role="img"
-      />
-    </button>
-  </div>
-  <div
-    className="c-notification-drawer__content"
+    class="c-notification-drawer"
   >
     <div
-      className="c-notification-drawer__cards"
+      class="c-view-header"
     >
-      <div
-        className="c-notification-drawer__header"
+      <h2
+        class="c-view-header__title"
+      >
+        Notifications
+      </h2>
+      <button
+        aria-label="Close"
+        class="c-close-button c-close-button--x-large c-close-button--light"
       >
         <span
-          className="c-notification-drawer__n-unread"
+          aria-hidden="true"
+          aria-label=""
+          role="img"
         >
-          1
-           new
+          <svg />
         </span>
-        <button
-          className="c-notification-drawer__mark-all-read-button"
-          onClick={[Function]}
+      </button>
+    </div>
+    <div
+      class="c-notification-drawer__content"
+    >
+      <div
+        class="c-notification-drawer__cards"
+      >
+        <div
+          class="c-notification-drawer__header"
         >
-          Mark all as read
-        </button>
-      </div>
-      <ul>
-        <li>
-          <div
-            aria-labelledby="card-label-:r0:"
-            className="c-card c-card--kiwi"
+          <span
+            class="c-notification-drawer__n-unread"
           >
-            <button
-              className="c-card__left"
-              onClick={[Function]}
+            1 new
+          </span>
+          <button
+            class="c-notification-drawer__mark-all-read-button"
+          >
+            Mark all as read
+          </button>
+        </div>
+        <ul>
+          <li>
+            <div
+              aria-labelledby="card-label-:r0:"
+              class="c-card c-card--kiwi"
             >
-              <div
-                className="c-card__left-content"
+              <button
+                class="c-card__left"
               >
                 <div
-                  className="c-card__top-row"
+                  class="c-card__left-content"
                 >
                   <div
-                    className="c-card__title"
-                    id="card-label-:r0:"
+                    class="c-card__top-row"
                   >
-                    <span
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<svg/>",
-                        }
-                      }
-                    />
-                    No Operator
-                  </div>
-                  <div
-                    className="c-card__time"
-                  >
-                    0 min
-                  </div>
-                </div>
-                <div
-                  className="c-card__contents"
-                >
-                  <div
-                    className="c-card__body"
-                  >
-                    OCC reported that an operator is not available on the r1, r2.
-                  </div>
-                  <div
-                    className="c-properties-list"
-                  >
-                    <table
-                      className="c-properties-list__table"
+                    <div
+                      class="c-card__title"
+                      id="card-label-:r0:"
                     >
-                      <tbody>
-                        <tr
-                          className="c-properties-list__property "
-                        >
-                          <td
-                            className="c-properties-list__property-label"
+                      <span>
+                        <svg />
+                      </span>
+                      No Operator
+                    </div>
+                    <div
+                      class="c-card__time"
+                    >
+                      0 min
+                    </div>
+                  </div>
+                  <div
+                    class="c-card__contents"
+                  >
+                    <div
+                      class="c-card__body"
+                    >
+                      OCC reported that an operator is not available on the r1, r2.
+                    </div>
+                    <div
+                      class="c-properties-list"
+                    >
+                      <table
+                        class="c-properties-list__table"
+                      >
+                        <tbody>
+                          <tr
+                            class="c-properties-list__property "
                           >
-                            Run
-                          </td>
-                          <td
-                            className="c-properties-list__property-value"
-                          >
-                            run1, run2
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
+                            <td
+                              class="c-properties-list__property-label"
+                            >
+                              Run
+                            </td>
+                            <td
+                              class="c-properties-list__property-value"
+                            >
+                              run1, run2
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </button>
-          </div>
-        </li>
-      </ul>
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/assets/tests/components/notificationDrawer.test.tsx
+++ b/assets/tests/components/notificationDrawer.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { render } from "@testing-library/react"
-import renderer from "react-test-renderer"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
 import routeFactory from "../factories/route"
 import NotificationDrawer from "../../src/components/notificationDrawer"
 import { NotificationsContext } from "../../src/contexts/notificationsContext"
@@ -54,9 +54,37 @@ const routes: Route[] = [
 ]
 
 describe("NotificationDrawer", () => {
+  test("renders loading state", () => {
+    render(
+      <NotificationsContext.Provider
+        value={{
+          notifications: null,
+          showLatestNotification: false,
+          dispatch: jest.fn(),
+          notificationWithOpenSubmenuId: null,
+          setNotificationWithOpenSubmenuId: jest.fn(),
+        }}
+      >
+        <NotificationDrawer />
+      </NotificationsContext.Provider>
+    )
+    expect(screen.getByText(/loading/)).toBeInTheDocument()
+  })
   test("renders empty state", () => {
-    const tree = renderer.create(<NotificationDrawer />).toJSON()
-    expect(tree).toMatchSnapshot()
+    const result = render(
+      <NotificationsContext.Provider
+        value={{
+          notifications: [],
+          showLatestNotification: true,
+          dispatch: jest.fn(),
+          notificationWithOpenSubmenuId: null,
+          setNotificationWithOpenSubmenuId: jest.fn(),
+        }}
+      >
+        <NotificationDrawer />
+      </NotificationsContext.Provider>
+    )
+    expect(result.asFragment()).toMatchSnapshot()
   })
 
   test("close button closes the drawer", async () => {
@@ -76,24 +104,23 @@ describe("NotificationDrawer", () => {
   })
 
   test("renders notifications", () => {
-    const tree = renderer
-      .create(
-        <RoutesProvider routes={routes}>
-          <NotificationsContext.Provider
-            value={{
-              notifications: [notification],
-              showLatestNotification: true,
-              dispatch: jest.fn(),
-              notificationWithOpenSubmenuId: null,
-              setNotificationWithOpenSubmenuId: jest.fn(),
-            }}
-          >
-            <NotificationDrawer />
-          </NotificationsContext.Provider>
-        </RoutesProvider>
-      )
-      .toJSON()
-    expect(tree).toMatchSnapshot()
+    const result = render(
+      <RoutesProvider routes={routes}>
+        <NotificationsContext.Provider
+          value={{
+            notifications: [notification],
+            showLatestNotification: true,
+            dispatch: jest.fn(),
+            notificationWithOpenSubmenuId: null,
+            setNotificationWithOpenSubmenuId: jest.fn(),
+          }}
+        >
+          <NotificationDrawer />
+        </NotificationsContext.Provider>
+      </RoutesProvider>
+    )
+
+    expect(result.asFragment()).toMatchSnapshot()
   })
 
   test("clicking a notification tries to open the VPP for it", async () => {

--- a/assets/tests/contexts/notificationsContext.test.tsx
+++ b/assets/tests/contexts/notificationsContext.test.tsx
@@ -61,7 +61,7 @@ describe("NotificationsProvider", () => {
     const { result } = renderHook(() => useContext(NotificationsContext), {
       wrapper: NotificationsProvider,
     })
-    expect(result.current.notifications).toEqual([])
+    expect(result.current.notifications).toBeNull()
   })
 
   test("receives incoming notifications and logs a tag manager event", () => {

--- a/assets/tests/hooks/useNotificationsReducer.test.tsx
+++ b/assets/tests/hooks/useNotificationsReducer.test.tsx
@@ -84,7 +84,7 @@ describe("notificationsReducer", () => {
     }
     const resultState = reducer(initialState, markAllAsRead())
     expect(
-      resultState.notifications.map((notification) => notification.state)
+      resultState.notifications!.map((notification) => notification.state)
     ).toEqual(["read", "read"])
     expect(resultState.showLatestNotification).toEqual(true)
   })


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1202584021125991/f
This adds `null` to the type of notifications.
A couple of other approaches I considered
* using `FetchResult` 
* incorporating the existing `isInitialLoad` variable which isn't currently part of the state returned by `useNotificationsReducer`

Ultimately I opted for this simpler change of only adding `null` to the type, but open to other suggestions!
