### PR TITLE
refactor: require defaultResult for apiCall

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -60,20 +60,14 @@ export const apiCall = <T>({
 }: {
   url: string
   parser: (data: any) => T
-  defaultResult?: T
+  defaultResult: T
   fetchArgs?: RequestInit
 }): Promise<T> =>
   fetch(url, fetchArgs)
     .then(checkResponseStatus)
     .then((response) => parseJson(response) as any)
     .then(({ data: data }: { data: any }) => parser(data))
-    .catch((error) => {
-      if (defaultResult === undefined) {
-        throw error
-      } else {
-        return defaultResult
-      }
-    })
+    .catch(() => defaultResult)
 
 export const checkedApiCall = <T, U>({
   url,
@@ -122,6 +116,7 @@ export const fetchRoutes = (): Promise<Route[]> =>
   apiCall({
     url: "/api/routes",
     parser: parseRoutesData,
+    defaultResult: [],
   })
 
 export const fetchRoutePatterns = (routeId: RouteId): Promise<RoutePattern[]> =>

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -18,13 +18,14 @@ import {
   TripId,
 } from "./schedule.d"
 import { RouteTab } from "./models/routeTab"
-import { array, assert, Struct } from "superstruct"
+import { array, assert, Struct, StructError } from "superstruct"
 import { ShapeData, shapeFromData, shapesFromData } from "./models/shapeData"
 import { StopData, stopsFromData } from "./models/stopData"
 import {
   RoutePatternData,
   routePatternsFromData,
 } from "./models/routePatternData"
+import * as Sentry from "@sentry/react"
 
 export interface RouteData {
   id: string
@@ -89,7 +90,13 @@ export const checkedApiCall = <T, U>({
       assert(data, dataStruct)
       return parser(data)
     })
-    .catch(() => defaultResult)
+    .catch((error) => {
+      if (error instanceof StructError) {
+        Sentry.captureException(error)
+      }
+
+      return defaultResult
+    })
 
 export const parseRouteData = ({
   id,

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -79,7 +79,7 @@ export const checkedApiCall = <T, U>({
   url: string
   dataStruct: Struct<T, any>
   parser: (data: T) => U
-  defaultResult?: U
+  defaultResult: U
   fetchArgs?: RequestInit
 }): Promise<U> =>
   fetch(url, fetchArgs)
@@ -89,13 +89,7 @@ export const checkedApiCall = <T, U>({
       assert(data, dataStruct)
       return parser(data)
     })
-    .catch((error) => {
-      if (defaultResult !== undefined) {
-        return defaultResult
-      } else {
-        throw error
-      }
-    })
+    .catch(() => defaultResult)
 
 export const parseRouteData = ({
   id,
@@ -208,6 +202,7 @@ export const fetchSwings = (routeIds: RouteId[]): Promise<Swing[] | null> =>
     url: `/api/swings?route_ids=${routeIds.join(",")}`,
     dataStruct: array(SwingData),
     parser: nullableParser(swingsFromData),
+    defaultResult: [],
   })
 
 export const putNotificationReadState = (

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -19,7 +19,7 @@ import routeFactory from "./factories/route"
 import routeTabFactory from "./factories/routeTab"
 import stopFactory from "./factories/stop"
 import * as browser from "../src/models/browser"
-import { string, StructError, unknown } from "superstruct"
+import { string, unknown } from "superstruct"
 import { LocationType } from "../src/models/stopData"
 
 declare global {
@@ -128,28 +128,12 @@ describe("checkedApiCall", () => {
       url: "/",
       dataStruct: string(),
       parser: parse,
+      defaultResult: "default",
     }).then((parsed) => {
       expect(parse).toHaveBeenCalledWith("raw")
       expect(parsed).toEqual("parsed")
       done()
     })
-  })
-
-  test("raises error for malformed data when no default", async () => {
-    mockFetch(200, { data: 12 })
-
-    const parse = jest.fn(() => "parsed")
-
-    try {
-      await checkedApiCall({
-        url: "/",
-        dataStruct: string(),
-        parser: parse,
-      })
-      fail("did not raise an error")
-    } catch (error) {
-      expect(error).toBeInstanceOf(StructError)
-    }
   })
 
   test("returns default value when malformed data", async () => {
@@ -172,7 +156,8 @@ describe("checkedApiCall", () => {
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
-    }).catch(() => {
+      defaultResult: "default",
+    }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
       done()
     })
@@ -185,7 +170,8 @@ describe("checkedApiCall", () => {
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
-    }).catch(() => {
+      defaultResult: "default",
+    }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
       done()
     })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -58,6 +58,7 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: parse,
+      defaultResult: "default",
     }).then((parsed) => {
       expect(parse).toHaveBeenCalledWith("raw")
       expect(parsed).toEqual("parsed")
@@ -71,7 +72,8 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: () => null,
-    }).catch(() => {
+      defaultResult: "default",
+    }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
       done()
     })
@@ -83,7 +85,8 @@ describe("apiCall", () => {
     apiCall({
       url: "/",
       parser: () => null,
-    }).catch(() => {
+      defaultResult: "default",
+    }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
       done()
     })
@@ -100,22 +103,6 @@ describe("apiCall", () => {
       expect(result).toEqual("default")
       done()
     })
-  })
-
-  test("throws an error for any other response status if there's no default", (done) => {
-    mockFetch(500, { data: null })
-
-    apiCall({
-      url: "/",
-      parser: () => null,
-    })
-      .then(() => {
-        done("fetchRoutes did not throw an error")
-      })
-      .catch((error) => {
-        expect(error).toBeDefined()
-        done()
-      })
   })
 })
 
@@ -216,23 +203,6 @@ describe("checkedApiCall", () => {
       expect(result).toEqual("default")
       done()
     })
-  })
-
-  test("throws an error for any other response status if there's no default", (done) => {
-    mockFetch(500, { data: null })
-
-    checkedApiCall({
-      url: "/",
-      dataStruct: unknown(),
-      parser: () => null,
-    })
-      .then(() => {
-        done("fetchRoutes did not throw an error")
-      })
-      .catch((error) => {
-        expect(error).toBeDefined()
-        done()
-      })
   })
 })
 


### PR DESCRIPTION
Asana ticket: [⚙️ Add defaultResult for fetchRoutes API call](https://app.asana.com/0/1148853526253437/1201313313124099/f)

This ended up being fairly easy as changing the types to make `defaultResult` required revealed that `fetchRoutes` and `fetchSwings` are the only places that it needed to be added. If we're not yet adding a separate user-facing loading state, an empty array is a sensible return value (and is what is used for other similar API calls that return arrays, like the similar `fetchShuttleRoutes`).