### PR TITLE
cleanup(ex/skate/database): remove users without email

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -32,6 +32,7 @@ defmodule Skate.Application do
     link = Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
 
     Migrate.up()
+    Skate.RemoveUsersWithoutEmail.run()
 
     link
   end

--- a/lib/skate/remove_users_without_email.ex
+++ b/lib/skate/remove_users_without_email.ex
@@ -1,0 +1,21 @@
+defmodule Skate.RemoveUsersWithoutEmail do
+  @shortdoc "Removes users from the database who don't have an email associated"
+
+  import Ecto.Query
+  alias Skate.Repo
+  alias Skate.Settings.Db.User
+
+  def run() do
+    # Get list of primary key `id` of affected users
+    from(user in User,
+      where: is_nil(user.email) or user.email == "",
+      select: user.id
+    )
+    #  Delete all records from `Skate.Settings.Db.TestGroupUser`
+    #  Delete all records from `Skate.Settings.Db.RouteTab`
+    #  Delete all records from `Notifications.Db.NotificationUser`
+    #  Delete all records from `Notifications.Db.Notification`
+
+  end
+
+end

--- a/lib/skate/remove_users_without_email.ex
+++ b/lib/skate/remove_users_without_email.ex
@@ -1,21 +1,18 @@
 defmodule Skate.RemoveUsersWithoutEmail do
-  @shortdoc "Removes users from the database who don't have an email associated"
+  @moduledoc """
+  Removes users from the database who don't have an email associated
+  """
 
   import Ecto.Query
   alias Skate.Repo
   alias Skate.Settings.Db.User
 
   def run() do
-    # Get list of primary key `id` of affected users
-    from(user in User,
-      where: is_nil(user.email) or user.email == "",
-      select: user.id
+    Repo.delete_all(
+      from(user in User,
+        where: is_nil(user.email) or user.email == "",
+        select: user.id
+      )
     )
-    #  Delete all records from `Skate.Settings.Db.TestGroupUser`
-    #  Delete all records from `Skate.Settings.Db.RouteTab`
-    #  Delete all records from `Notifications.Db.NotificationUser`
-    #  Delete all records from `Notifications.Db.Notification`
-
   end
-
 end

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -37,7 +37,7 @@ defmodule Skate.Settings.User do
   @doc """
   Update the user with the given email if one exists, otherwise insert a new one.
   """
-  def upsert(username, email) when is_binary(email) do
+  def upsert(username, email) when is_binary(email) and email != "" do
     email = String.downcase(email)
 
     user =

--- a/test/skate/remove_users_without_email_test.exs
+++ b/test/skate/remove_users_without_email_test.exs
@@ -1,0 +1,22 @@
+defmodule Skate.RemoveUsersWithoutEmailTest do
+  use Skate.DataCase
+  import Skate.Factory
+  alias Skate.Settings.Db.User
+
+  describe "run/0" do
+    test "deletes only the users with missing email addresses" do
+      %{id: user_nil_id} =
+        Skate.Repo.insert!(build(:user, %{email: nil, username: "nil_email_user"}))
+
+      %{id: user_blank_id} =
+        Skate.Repo.insert!(build(:user, %{email: "", username: "blank_email_user"}))
+
+      %{id: user_good_id} = Skate.Repo.insert!(build(:user))
+      Skate.RemoveUsersWithoutEmail.run()
+
+      assert nil === Skate.Repo.get(User, user_nil_id)
+      assert nil === Skate.Repo.get(User, user_blank_id)
+      assert %{id: ^user_good_id} = Skate.Repo.get(User, user_good_id)
+    end
+  end
+end

--- a/test/skate/remove_users_without_email_test.exs
+++ b/test/skate/remove_users_without_email_test.exs
@@ -5,11 +5,9 @@ defmodule Skate.RemoveUsersWithoutEmailTest do
 
   describe "run/0" do
     test "deletes only the users with missing email addresses" do
-      %{id: user_nil_id} =
-        Skate.Repo.insert!(build(:user, %{email: nil, username: "nil_email_user"}))
+      %{id: user_nil_id} = Skate.Repo.insert!(build(:user, %{email: nil}))
 
-      %{id: user_blank_id} =
-        Skate.Repo.insert!(build(:user, %{email: "", username: "blank_email_user"}))
+      %{id: user_blank_id} = Skate.Repo.insert!(build(:user, %{email: ""}))
 
       %{id: user_good_id} = Skate.Repo.insert!(build(:user))
       Skate.RemoveUsersWithoutEmail.run()

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -120,5 +120,9 @@ defmodule Skate.Settings.UserTest do
     test "raises error if email is nil" do
       assert_raise FunctionClauseError, fn -> User.upsert(@username, nil) end
     end
+
+    test "raises error if email is empty string" do
+      assert_raise FunctionClauseError, fn -> User.upsert(@username, "") end
+    end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -186,4 +186,12 @@ defmodule Skate.Factory do
       save_changes_to_tab_uuid: nil
     }
   end
+
+  def user_factory do
+    %Skate.Settings.Db.User{
+      uuid: Ecto.UUID.generate(),
+      email: "test@mbta.com",
+      username: "test_user"
+    }
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -190,8 +190,8 @@ defmodule Skate.Factory do
   def user_factory do
     %Skate.Settings.Db.User{
       uuid: Ecto.UUID.generate(),
-      email: "test@mbta.com",
-      username: "test_user"
+      email: sequence("test@mbta.com"),
+      username: sequence("test_user")
     }
   end
 end


### PR DESCRIPTION
We confirmed locally that when a user is deleted in the DB the deletion cascades to records linked via foreign key. We considered writing a test for this but due to unknown complexity opted for testing manually.

We've deployed this on dev green and successfully removed 1 user which did not have an email associated. We also need to run this on `dev blue`, `dev`, and `prod` to clean up the DB records for each environment, before we remove this code in #2026.

DB Cleanup applied to
- [x] Dev Green
- [x] Dev Blue
- [ ] Dev (will happen after merging this)
- [ ] Prod (will happen on production release)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204389997693497