### PR TITLE
fix(ui/overscroll): disable overscroll behavior

### DIFF
--- a/assets/css/_u_no_overscroll.scss
+++ b/assets/css/_u_no_overscroll.scss
@@ -1,0 +1,6 @@
+.u-no-overscroll-y,
+html {
+  // Disable scrolling past the bottom of the page on iOS
+  // Disable pull to refresh
+  overscroll-behavior-y: none;
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -119,6 +119,8 @@ $component-active-bg: $color-eggplant-700;
 @import "vehicle_route_summary";
 @import "view_header";
 
+@import "u_no_overscroll";
+
 // #region Effects
 @import "demo_mode";
 // #endregion


### PR DESCRIPTION
While this does clean up overscroll on iOS, this also disables pull to refresh on both iOS and Android Chrome.

I tried querying fullstory for users who use the pull to refresh feature, but there was no definitive way to find when a scroll triggered a refresh, especially as pull to refresh doesn't actually show up in fullstory.

For this reason, this should not be merged without design and product review.
- [ ] Product Approved
- [x] Design Approved

I have tested and confirmed that this works on a real iPhone, but the behavior is unchanged in the simulator because it turns out that it does not respect these css properties.

---

EDIT: So I've learned that [`overscroll-behavior` was implemented on iOS as of Sep 2022](https://caniuse.com/css-overscroll-behavior), which is a bit to recent to rely upon. Fortunately, css simply ignores this property if it's unavailable. We could do more to try and "polyfill" this for older devices, but given that this is an incremental change that has no effect on devices that don't implement it, I think this is a good progressive update to the application.

The scope has been narrowed to just the main app segment. There are a few more views (Notifications, Swings View, "Properties Panel") Which are not affected by this PR but still do overscroll due to being a "fullscreen" `position: fixed`.

Polyfill could look something like this
```
@supports not (overscroll-behavior: none) {
  html {
    overflow: hidden;
  }
  body {
    overflow: auto;
  }
}
```