### PR TITLE
fix(frontend-template): put meta `charset` tag in first `1024` bytes

### DIFF
--- a/lib/skate_web/templates/layout/app.html.eex
+++ b/lib/skate_web/templates/layout/app.html.eex
@@ -5,9 +5,7 @@
     static_href = fn conn, path -> apply(static_href_module, static_href_fn, [conn, path]) end
   %>
   <head>
-    <%= if @google_tag_manager_id do %>
-      <%= render "_google_tag_manager.html", assigns %>
-    <% end %>
+
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, viewport-fit=cover">
@@ -31,6 +29,9 @@
 
     <link rel="stylesheet" href="<%= static_href.(@conn, "/css/app.css") %>"/>
 
+    <%= if @google_tag_manager_id do %>
+      <%= render "_google_tag_manager.html", assigns %>
+    <% end %>
     <%= if record_fullstory?() do %>
       <%= render "_fullstory.html", assigns %>
     <% end %>

--- a/lib/skate_web/templates/layout/app.html.eex
+++ b/lib/skate_web/templates/layout/app.html.eex
@@ -20,6 +20,10 @@
       <meta name="user-uuid" content="<%= @user_uuid %>">
     <% end %>
 
+    <%= if @google_tag_manager_id do %>
+      <%= render "_google_tag_manager.html", assigns %>
+    <% end %>
+
     <title>Skate</title>
 
     <link rel="apple-touch-icon" href="<%= static_href.(@conn, "/images/mbta-logo-t-180.png") %>" type="image/png">
@@ -28,9 +32,7 @@
 
     <link rel="stylesheet" href="<%= static_href.(@conn, "/css/app.css") %>"/>
 
-    <%= if @google_tag_manager_id do %>
-      <%= render "_google_tag_manager.html", assigns %>
-    <% end %>
+
     <%= if record_fullstory?() do %>
       <%= render "_fullstory.html", assigns %>
     <% end %>

--- a/lib/skate_web/templates/layout/app.html.eex
+++ b/lib/skate_web/templates/layout/app.html.eex
@@ -5,7 +5,6 @@
     static_href = fn conn, path -> apply(static_href_module, static_href_fn, [conn, path]) end
   %>
   <head>
-
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, viewport-fit=cover">


### PR DESCRIPTION
I noticed that the `meta` `charset` tag wasn't the first entry in the `head` tag. We use UTF-8 which is the default `charset` so this shouldn't have any impact on browsers parsing this page.

[`<meta charset>` tag MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#charset)