### PR TITLE
[Step 1] temp(Concentrate.Supervisor): Don't start the StopTimeUpdates (Block Waiver) pipeline

### DIFF
--- a/lib/concentrate/supervisor.ex
+++ b/lib/concentrate/supervisor.ex
@@ -4,13 +4,12 @@ defmodule Concentrate.Supervisor do
   """
 
   alias Concentrate.Pipeline
-  alias Concentrate.Pipeline.{StopTimeUpdatesPipeline, VehiclePositionsPipeline}
+  alias Concentrate.Pipeline.VehiclePositionsPipeline
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     Supervisor.start_link(
       [
-        {Pipeline, Keyword.merge(opts, module: StopTimeUpdatesPipeline)},
         {Pipeline, Keyword.merge(opts, module: VehiclePositionsPipeline)}
       ],
       strategy: :one_for_one

--- a/test/concentrate/supervisor_test.exs
+++ b/test/concentrate/supervisor_test.exs
@@ -23,9 +23,7 @@ defmodule Concentrate.SupervisorTest do
                  _pid,
                  :supervisor,
                  [Concentrate.Pipeline]
-               },
-               {Concentrate.Pipeline.StopTimeUpdatesPipeline, _other_pid, :supervisor,
-                [Concentrate.Pipeline]}
+               }
              ] = Supervisor.which_children(pid)
     end
   end

--- a/test/concentrate/supervisor_test.exs
+++ b/test/concentrate/supervisor_test.exs
@@ -13,6 +13,21 @@ defmodule Concentrate.SupervisorTest do
     test "can start the application" do
       assert {:ok, _pid} = Concentrate.Supervisor.start_link(@opts)
     end
+
+    test "starts the data pipelines" do
+      {:ok, pid} = Concentrate.Supervisor.start_link(@opts)
+
+      assert [
+               {
+                 Concentrate.Pipeline.VehiclePositionsPipeline,
+                 _pid,
+                 :supervisor,
+                 [Concentrate.Pipeline]
+               },
+               {Concentrate.Pipeline.StopTimeUpdatesPipeline, _other_pid, :supervisor,
+                [Concentrate.Pipeline]}
+             ] = Supervisor.which_children(pid)
+    end
   end
 
   describe "child_spec/1" do


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204432817126661/f
This will be deployed before https://github.com/mbta/skate/pull/2029 and the second commit reverted after the index creation is complete

This PR is step 1 in the following plan:
1. This PR
2. https://github.com/mbta/skate/pull/2029
3. https://github.com/mbta/skate/pull/2042
4. https://github.com/mbta/skate/pull/2043
5. https://github.com/mbta/skate/pull/2026