### PR TITLE
[Step 3] Revert "temp(Concentrate.Supervisor): Don't start the StopTimeUpdates(Block Waiver) pipeline

### DIFF
--- a/lib/concentrate/supervisor.ex
+++ b/lib/concentrate/supervisor.ex
@@ -4,12 +4,13 @@ defmodule Concentrate.Supervisor do
   """
 
   alias Concentrate.Pipeline
-  alias Concentrate.Pipeline.VehiclePositionsPipeline
+  alias Concentrate.Pipeline.{StopTimeUpdatesPipeline, VehiclePositionsPipeline}
 
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     Supervisor.start_link(
       [
+        {Pipeline, Keyword.merge(opts, module: StopTimeUpdatesPipeline)},
         {Pipeline, Keyword.merge(opts, module: VehiclePositionsPipeline)}
       ],
       strategy: :one_for_one

--- a/test/concentrate/supervisor_test.exs
+++ b/test/concentrate/supervisor_test.exs
@@ -23,7 +23,9 @@ defmodule Concentrate.SupervisorTest do
                  _pid,
                  :supervisor,
                  [Concentrate.Pipeline]
-               }
+               },
+               {Concentrate.Pipeline.StopTimeUpdatesPipeline, _other_pid, :supervisor,
+                [Concentrate.Pipeline]}
              ] = Supervisor.which_children(pid)
     end
   end


### PR DESCRIPTION
This reverts commit 00904b66845b1553fc499e388f6933ddc2e42fbe.

This PR is step 3 in the following plan:
1. https://github.com/mbta/skate/pull/2041
2. https://github.com/mbta/skate/pull/2029
3. This PR
4. https://github.com/mbta/skate/pull/2043
5. https://github.com/mbta/skate/pull/2026