### PR TITLE
cleanup(ex/skate/database): remove users without email

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -32,6 +32,7 @@ defmodule Skate.Application do
     link = Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
 
     Migrate.up()
+    Skate.RemoveUsersWithoutEmail.run()
 
     link
   end

--- a/lib/skate/remove_users_without_email.ex
+++ b/lib/skate/remove_users_without_email.ex
@@ -8,11 +8,16 @@ defmodule Skate.RemoveUsersWithoutEmail do
   alias Skate.Settings.Db.User
 
   def run() do
-    Repo.delete_all(
-      from(user in User,
-        where: is_nil(user.email) or user.email == "",
-        select: user.id
+    user_ids_to_delete =
+      Repo.all(
+        from(user in User,
+          where: is_nil(user.email) or user.email == "",
+          select: user.id
+        )
       )
-    )
+
+    Enum.each(user_ids_to_delete, fn user_id ->
+      Repo.delete_all(from(user in User, where: user.id == ^user_id))
+    end)
   end
 end

--- a/lib/skate/remove_users_without_email.ex
+++ b/lib/skate/remove_users_without_email.ex
@@ -1,0 +1,18 @@
+defmodule Skate.RemoveUsersWithoutEmail do
+  @moduledoc """
+  Removes users from the database who don't have an email associated
+  """
+
+  import Ecto.Query
+  alias Skate.Repo
+  alias Skate.Settings.Db.User
+
+  def run() do
+    Repo.delete_all(
+      from(user in User,
+        where: is_nil(user.email) or user.email == "",
+        select: user.id
+      )
+    )
+  end
+end

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -37,7 +37,7 @@ defmodule Skate.Settings.User do
   @doc """
   Update the user with the given email if one exists, otherwise insert a new one.
   """
-  def upsert(username, email) when is_binary(email) do
+  def upsert(username, email) when is_binary(email) and email != "" do
     email = String.downcase(email)
 
     user =

--- a/test/skate/remove_users_without_email_test.exs
+++ b/test/skate/remove_users_without_email_test.exs
@@ -1,0 +1,20 @@
+defmodule Skate.RemoveUsersWithoutEmailTest do
+  use Skate.DataCase
+  import Skate.Factory
+  alias Skate.Settings.Db.User
+
+  describe "run/0" do
+    test "deletes only the users with missing email addresses" do
+      %{id: user_nil_id} = Skate.Repo.insert!(build(:user, %{email: nil}))
+
+      %{id: user_blank_id} = Skate.Repo.insert!(build(:user, %{email: ""}))
+
+      %{id: user_good_id} = Skate.Repo.insert!(build(:user))
+      Skate.RemoveUsersWithoutEmail.run()
+
+      assert nil === Skate.Repo.get(User, user_nil_id)
+      assert nil === Skate.Repo.get(User, user_blank_id)
+      assert %{id: ^user_good_id} = Skate.Repo.get(User, user_good_id)
+    end
+  end
+end

--- a/test/skate/settings/user_test.exs
+++ b/test/skate/settings/user_test.exs
@@ -120,5 +120,9 @@ defmodule Skate.Settings.UserTest do
     test "raises error if email is nil" do
       assert_raise FunctionClauseError, fn -> User.upsert(@username, nil) end
     end
+
+    test "raises error if email is empty string" do
+      assert_raise FunctionClauseError, fn -> User.upsert(@username, "") end
+    end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -186,4 +186,12 @@ defmodule Skate.Factory do
       save_changes_to_tab_uuid: nil
     }
   end
+
+  def user_factory do
+    %Skate.Settings.Db.User{
+      uuid: Ecto.UUID.generate(),
+      email: sequence("test@mbta.com"),
+      username: sequence("test_user")
+    }
+  end
 end


### PR DESCRIPTION
This restores the previous function for deleting users from the DB. It includes an additional change to delete users one by one rather than all at onceDeleting users doesn't need to be done as a single transaction, so opting to split it up just in case. There are ~300 records to delete, so I do not expect the volume of queries to cause an issue.