### PR TITLE
feat: limit auth failure retry to 3 attempts

### DIFF
--- a/lib/skate_web/auth_manager/error_handler.ex
+++ b/lib/skate_web/auth_manager/error_handler.ex
@@ -1,10 +1,22 @@
 defmodule SkateWeb.AuthManager.ErrorHandler do
+  import Plug.Conn
+
   @behaviour Guardian.Plug.ErrorHandler
 
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_type, _reason}, _opts) do
-    Phoenix.Controller.redirect(conn,
-      to: SkateWeb.Router.Helpers.auth_path(conn, :request, "cognito")
-    )
+    auth_retries = get_session(conn, :auth_retries) || 3
+
+    if auth_retries > 0 do
+      conn
+      |> put_session(:auth_retries, auth_retries - 1)
+      |> Phoenix.Controller.redirect(
+        to: SkateWeb.Router.Helpers.auth_path(conn, :request, "cognito")
+      )
+    else
+      conn
+      |> delete_session(:auth_retries)
+      |> send_resp(:unauthorized, "unauthorized")
+    end
   end
 end

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -2,6 +2,7 @@ defmodule SkateWeb.AuthController do
   use SkateWeb, :controller
   plug(Ueberauth)
 
+  import Plug.Conn
   alias Skate.Settings.User
   alias SkateWeb.AuthManager
   alias SkateWeb.Router.Helpers
@@ -17,6 +18,7 @@ defmodule SkateWeb.AuthController do
     %{id: user_id} = User.upsert(username, email)
 
     conn
+    |> delete_session(:auth_retries)
     |> Guardian.Plug.sign_in(
       AuthManager,
       %{id: user_id},
@@ -28,10 +30,10 @@ defmodule SkateWeb.AuthController do
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
     # Users are sometimes seeing unexpected Ueberauth failures of unknown provenance.
-    # Instead of sending a 403 unauthenticated response, we are signing them out and
-    # sending them to the home page to start the auth path over again.
-    # We should be on the lookout for users getting trapped in a loop because of this.
-    # If we observe that happening we should rethink this remedy. -- MSS 2019-07-03
+    # Instead of sending a 403 unauthenticated response immediately, we are signing them out and
+    # sending them to the home page to start the auth path over again. -- MSS 2019-07-03
+    # We are maintaining the retry logic but limiting it to only a set number of retries using
+    # logic in SkateWeb.AuthManager.ErrorHandler. -- LEM 2023-04-27
     conn
     |> Guardian.Plug.sign_out(AuthManager, [])
     |> redirect(to: Helpers.page_path(conn, :index))

--- a/test/skate_web/auth_manager/error_handler_test.exs
+++ b/test/skate_web/auth_manager/error_handler_test.exs
@@ -2,13 +2,36 @@ defmodule SkateWeb.AuthManager.ErrorHandlerTest do
   use SkateWeb.ConnCase
 
   describe "auth_error/3" do
-    test "redirects to Cognito login", %{conn: conn} do
+    test "redirects to Cognito login with two remaining retries", %{conn: conn} do
       conn =
         conn
         |> init_test_session(%{username: "test_without_refresh_token@mbta.com"})
         |> SkateWeb.AuthManager.ErrorHandler.auth_error({:some_type, :reason}, [])
 
       assert html_response(conn, 302) =~ "\"/auth/cognito\""
+      assert get_session(conn, :auth_retries) == 2
+    end
+
+    test "redirects to Cognito login, decrementing retry count if present", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{username: "test_without_refresh_token@mbta.com"})
+        |> put_session(:auth_retries, 2)
+        |> SkateWeb.AuthManager.ErrorHandler.auth_error({:some_type, :reason}, [])
+
+      assert html_response(conn, 302) =~ "\"/auth/cognito\""
+      assert get_session(conn, :auth_retries) == 1
+    end
+
+    test "sends unauthorized response if out of retries", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{username: "test_without_refresh_token@mbta.com"})
+        |> put_session(:auth_retries, 0)
+        |> SkateWeb.AuthManager.ErrorHandler.auth_error({:some_type, :reason}, [])
+
+      assert response(conn, 401) =~ "unauthorized"
+      assert is_nil(get_session(conn, :auth_retries))
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [⚙️ Prevent infinite redirects on auth failure](https://app.asana.com/0/1152340551558956/1201523184137417/f)

I opted to use the Plug session to store a retry count in cookies and allow at most 3 tries. This will likely be enough to still prevent most of the user-facing errors while also not causing people to hit a redirect loop. We still reset the retry count on either a successful login or when the limit is hit, so the user can always hit refresh to try again manually.