### PR TITLE
feat(mix): add mix aliases for setup and reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 
 After updating merged changes or checking out a new branch (e.g. to test a new feature), you may need to do the following to update the dependencies:
 
+1. Update Elixir and Node.js dependencies at the same time by rerunning `mix setup`
+
+___OR___
+
+Update them independently with the following commands
 1. Update Elixir dependencies with `mix deps.get`
 1. Install Node.js dependencies with `cd assets && npm ci` 
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 ### Quick Setup
 
 1. Install language dependencies with `asdf install`
-1. Install Elixir dependencies with `mix deps.get`
-1. Install Node.js dependencies with `cd assets && npm ci` 
-1. To create the database, first ensure your Postgres server is running and you've updated your credentials in `.envrc` as described in "Configuration" above. Back in the Terminal, `` mix ecto.create && mix ecto.migrate ``
-1. To set up the testing database (not necessary to run the paplication, but must be done before you run tests): `` MIX_ENV=test mix ecto.create ``
-
+1. Setup project with `mix setup`
+	- This command will create the database, so you must first ensure your Postgres server is running and you've updated your credentials in `.envrc` as described in "Configuration" above.
+	- (not necessary to run the application) The `test` command will automatically setup the database when run. 
+		You can setup the the testing database manually by running `mix ecto.setup` in the `test` envrionment 
+		specified via `MIX_ENV`
+		```
+		$ MIX_ENV=test mix ecto.setup
+		```
 ### Updating
 
 After updating merged changes or checking out a new branch (e.g. to test a new feature), you may need to do the following to update the dependencies:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 1. Install language dependencies with `asdf install`
 1. Setup project with `mix setup`
 	- This command will create the database, so you must first ensure your Postgres server is running and you've updated your credentials in `.envrc` as described in "Configuration" above.
-	- (not necessary to run the application) The `test` command will automatically setup the database when run. 
-		You can setup the the testing database manually by running `mix ecto.setup` in the `test` envrionment 
+1. (not necessary to run the application) 
+	- The `test` command will automatically setup the database when run. 
+	- You can setup the the testing database manually by running `mix ecto.setup` in the `test` envrionment 
 		specified via `MIX_ENV`
 		```
 		$ MIX_ENV=test mix ecto.setup

--- a/mix.exs
+++ b/mix.exs
@@ -99,6 +99,7 @@ defmodule Skate.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "assets.setup": ["cmd npm --prefix=assets install"],
+      "assets.reset": ["cmd npm --prefix=assets ci"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Skate.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       test_coverage: [tool: LcovEx],
       elixirc_options: [warnings_as_errors: true],
@@ -83,6 +84,22 @@ defmodule Skate.MixProject do
       {:timex, "~> 3.7.5"},
       {:ueberauth_cognito, "~> 0.4.0"},
       {:ueberauth, "~> 0.9.0"}
+    ]
+  end
+
+  # Aliases are shortcuts or tasks specific to the current project.
+  # For example, to install project dependencies and perform other setup tasks, run:
+  #
+  #     $ mix setup
+  #
+  # See the documentation for `Mix` for more info on aliases.
+  defp aliases do
+    [
+      setup: ["deps.get", "ecto.setup", "assets.setup"],
+      "ecto.setup": ["ecto.create", "ecto.migrate"],
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      "assets.setup": ["cmd npm --prefix=assets install"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
     ]
   end
 end


### PR DESCRIPTION
I'd gotten used to the aliases that come in Phoenix 1.7 and I want them back! 😭

These are a few quality of life improvements that make setting up a new project folder or getting up to speed a bit faster and require less manual interaction.

I basically just copied the aliases from the my-charlie project that were generated by the phoenix application template and updated the readme a bit.