### PR TITLE
fix(SearchPage): Resolve mobile z-index issues

### DIFF
--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -1,5 +1,10 @@
 $map-page-search-panel-width: 24rem;
 
+$z-map-page-context: (
+  "map": 100,
+  "search-drawer": 200,
+);
+
 .c-map-page {
   display: flex;
   flex: 1 1 auto;
@@ -13,6 +18,7 @@ $map-page-search-panel-width: 24rem;
   display: flex;
   flex: 1 1 auto;
   position: relative;
+  z-index: map-get($z-map-page-context, "map");
 }
 
 .c-map-page__input {
@@ -29,7 +35,7 @@ $map-page-search-panel-width: 24rem;
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  z-index: #{$max-leaflet-z-index + 100};
+  z-index: map-get($z-map-page-context, "search-drawer");
 
   padding: 1.25rem 0 0 0;
 
@@ -66,7 +72,6 @@ $map-page-search-panel-width: 24rem;
 .c-map-page__input-and-results .c-drawer-tab {
   @include button-primary;
   left: 100%;
-  z-index: #{$max-leaflet-z-index + 100};
   box-shadow: 1px 0px 4px rgba(0, 0, 0, 0.25);
 }
 

--- a/assets/css/_search_page.scss
+++ b/assets/css/_search_page.scss
@@ -1,5 +1,10 @@
 $search-page-search-panel-width: 22.0625rem;
 
+$z-search-page-context: (
+  "map": 100,
+  "search-drawer": 200,
+);
+
 .c-search-page {
   display: flex;
   flex: 1 1 auto;
@@ -13,6 +18,7 @@ $search-page-search-panel-width: 22.0625rem;
   display: flex;
   flex: 1 1 auto;
   position: relative;
+  z-index: map-get($z-search-page-context, "map");
 }
 
 .c-search-page__input {
@@ -29,7 +35,7 @@ $search-page-search-panel-width: 22.0625rem;
   height: 100%;
   box-sizing: border-box;
   position: absolute;
-  z-index: #{$max-leaflet-z-index + 100};
+  z-index: map-get($z-search-page-context, "search-drawer");
 
   padding: 1.25rem 0 0 0;
 


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1204649005443955/f

This PR sets the z-index of the map and search drawer within the search page. This creates a new stacking context for each, so that they can be z-indexed relative to each other as a whole unit. In trying to better understand stacking contexts for this ticket, I found the folder and file analogy in[ this article ](https://www.lullabot.com/articles/understanding-debugging-stacking-contexts)very helpful! 

This PR makes the same change to the new map page too, which didn't have the same bug but was prone to the same issue of search drawer & map elements being within a single stacking context.