### PR TITLE
fix(Concentrate.VehiclePosition.merge/2): Prioritize swiftly block_id when there isn't a block overload

### DIFF
--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -99,7 +99,13 @@ defmodule Concentrate.VehiclePosition do
           speed: first_value(second.speed, first.speed),
           odometer: first_value(second.odometer, first.odometer),
           stop_sequence: first_value(second.stop_sequence, first.stop_sequence),
-          block_id: overload_priority(second.block_id, first.block_id),
+          block_id:
+            overload_or_swiftly_priority(
+              second.sources,
+              second.block_id,
+              first.sources,
+              first.block_id
+            ),
           operator_id: first_value(second.operator_id, first.operator_id),
           operator_first_name: first_value(second.operator_first_name, first.operator_first_name),
           operator_last_name: first_value(second.operator_last_name, first.operator_last_name),
@@ -179,11 +185,11 @@ defmodule Concentrate.VehiclePosition do
       end
     end
 
-    defp overload_priority(block_id1, nil), do: block_id1
+    defp overload_or_swiftly_priority(_sources1, block_id1, _sources2, nil), do: block_id1
 
-    defp overload_priority(nil, block_id2), do: block_id2
+    defp overload_or_swiftly_priority(_sources1, nil, _sources2, block_id2), do: block_id2
 
-    defp overload_priority(block_id1, block_id2) do
+    defp overload_or_swiftly_priority(sources1, block_id1, sources2, block_id2) do
       cond do
         Block.overload?(block_id1) ->
           block_id1
@@ -192,7 +198,7 @@ defmodule Concentrate.VehiclePosition do
           block_id2
 
         true ->
-          block_id1
+          swiftly_priority(sources1, block_id1, sources2, block_id2)
       end
     end
 

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -153,8 +153,8 @@ defmodule Concentrate.VehiclePosition do
               first.sources,
               first.layover_departure_time
             ),
-          crowding: first_value(first.crowding, second.crowding),
-          revenue: first_value(first.revenue, second.revenue),
+          crowding: first_value(second.crowding, first.crowding),
+          revenue: first_value(second.revenue, first.revenue),
           last_updated_by_source: merge_last_updated_by_source(first, second)
       }
     end

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -374,6 +374,78 @@ defmodule Concentrate.VehiclePositionTest do
       assert Mergeable.merge(first, second) == expected
     end
 
+    test "merge/2 takes the latest non-nil value for crowding" do
+      crowding_1 = %{
+        load: 98,
+        capacity: 100,
+        occupancy_percentage: 0.98,
+        occupancy_status: "FULL"
+      }
+
+      first =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          crowding: crowding_1
+        )
+
+      crowding_2 = %{
+        load: 2,
+        capacity: 100,
+        occupancy_percentage: 0.02,
+        occupancy_status: "MANY_SEATS_AVAILABLE"
+      }
+
+      second =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          crowding: crowding_2
+        )
+
+      third_no_crowding =
+        new(
+          last_updated: 3,
+          latitude: 2,
+          longitude: 2,
+          crowding: nil
+        )
+
+      assert %{crowding: ^crowding_2} = Mergeable.merge(first, second)
+      assert %{crowding: ^crowding_2} = Mergeable.merge(second, third_no_crowding)
+    end
+
+    test "merge/2 takes the latest non-nil value for revenue" do
+      first =
+        new(
+          last_updated: 1,
+          latitude: 1,
+          longitude: 1,
+          revenue: true
+        )
+
+      second =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          revenue: false
+        )
+
+      third_nil_rev =
+        new(
+          last_updated: 3,
+          latitude: 2,
+          longitude: 2,
+          revenue: nil
+        )
+
+      assert %{revenue: false} = Mergeable.merge(first, second)
+      assert %{revenue: false} = Mergeable.merge(second, third_nil_rev)
+    end
+
     test "merge/2 retains all timestamps" do
       first =
         new(

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -414,7 +414,10 @@ defmodule Concentrate.VehiclePositionTest do
         )
 
       assert %{crowding: ^crowding_2} = Mergeable.merge(first, second)
+      assert %{crowding: ^crowding_2} = Mergeable.merge(second, first)
+
       assert %{crowding: ^crowding_2} = Mergeable.merge(second, third_no_crowding)
+      assert %{crowding: ^crowding_2} = Mergeable.merge(third_no_crowding, second)
     end
 
     test "merge/2 takes the latest non-nil value for revenue" do
@@ -443,7 +446,10 @@ defmodule Concentrate.VehiclePositionTest do
         )
 
       assert %{revenue: false} = Mergeable.merge(first, second)
+      assert %{revenue: false} = Mergeable.merge(second, first)
+
       assert %{revenue: false} = Mergeable.merge(second, third_nil_rev)
+      assert %{revenue: false} = Mergeable.merge(third_nil_rev, second)
     end
 
     test "merge/2 retains all timestamps" do

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -293,6 +293,51 @@ defmodule Concentrate.VehiclePositionTest do
                )
     end
 
+    test "merge/2 prioritizes the swiftly block_id when there isn't an overload" do
+      non_overloaded_swiftly =
+        new(
+          last_updated: 1,
+          block_id: "swiftly_block_id",
+          latitude: 1,
+          longitude: 1,
+          sources: MapSet.new(["swiftly"])
+        )
+
+      non_overloaded_other =
+        new(
+          last_updated: 2,
+          block_id: "other_block_id",
+          latitude: 1,
+          longitude: 1,
+          sources: MapSet.new(["other"])
+        )
+
+      overloaded =
+        new(
+          last_updated: 3,
+          block_id: "other_block_id-OL1",
+          latitude: 1,
+          longitude: 1,
+          sources: MapSet.new(["other"])
+        )
+
+      assert %{
+               block_id: "other_block_id-OL1"
+             } = Mergeable.merge(overloaded, non_overloaded_swiftly)
+
+      assert %{
+               block_id: "other_block_id-OL1"
+             } = Mergeable.merge(non_overloaded_swiftly, overloaded)
+
+      assert %{
+               block_id: "swiftly_block_id"
+             } = Mergeable.merge(non_overloaded_swiftly, non_overloaded_other)
+
+      assert %{
+               block_id: "swiftly_block_id"
+             } = Mergeable.merge(non_overloaded_other, non_overloaded_swiftly)
+    end
+
     test "merge/2 doesn't include any data discrepancies if they values are the same" do
       first =
         new(


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1204382924233721/f