### PR TITLE
fix: proper styling of hr regardless of search state

### DIFF
--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -56,7 +56,7 @@ $z-map-page-context: (
     flex-direction: column;
   }
 
-  & > hr {
+  hr {
     height: 1px;
     background-color: $color-gray-100;
     border: none;


### PR DESCRIPTION
Asana ticket: followup on [⚙️ Better Maps | RPC Usability Updates](https://app.asana.com/0/1200180014510248/1204680913839484/f)

Related to [this comment](https://github.com/mbta/skate/pull/2077#discussion_r1228180802), it turns out that the exact location of the `<hr/>` in the DOM varied depending on whether search results or a selection was being displayed, so fixing the CSS for one broke it for the other. Working around that by just going with the descent combinator rather than direct child.