### PR TITLE
 fix(css/_map_page): make visual separator visible on results view 

### DIFF
--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -57,6 +57,7 @@ $z-map-page-context: (
   }
 
   .c-map-page__horizontal-separator {
+    flex: 0 0 1px;
     height: 1px;
     background-color: $color-gray-100;
     border: none;


### PR DESCRIPTION
When the parent flexbox is laying out elements, it shrinks this one as there is no `min-height`. This tells flex to not do that.

- set flex to
  - minimum size `1px`
  - do not shrink
  - do not grow

--- 

Merge after #2088 