### PR TITLE
fix(Realtime.Vehicles): don't list interlining vehicles as incoming on their old route)

### DIFF
--- a/lib/realtime/vehicles.ex
+++ b/lib/realtime/vehicles.ex
@@ -9,16 +9,16 @@ defmodule Realtime.Vehicles do
 
   Also fills in ghost buses and checks for buses incoming from another route
 
-  Vehicles are incoming from another route if they're scheduled to run within 15 minutes but are currently on another route.
+  Vehicles are incoming from another route if they're scheduled to start a trip on a route within 15 minutes that is different from the route they are currently on.
   """
-  @spec group_by_route([Vehicle.t()], Timepoint.timepoint_names_by_id()) ::
+  @spec group_by_route([Vehicle.t()], Timepoint.timepoint_names_by_id(), Util.Time.timestamp()) ::
           Route.by_id([VehicleOrGhost.t()])
-  def group_by_route(ungrouped_vehicles, timepoint_names_by_id) do
-    now = Util.Time.now()
+  def group_by_route(ungrouped_vehicles, timepoint_names_by_id, now \\ Util.Time.now()) do
     in_fifteen_minutes = now + 15 * 60
 
     # We show vehicles incoming from another route if they'll start the new route within 15 minutes
     incoming_trips = Schedule.active_trips(now, in_fifteen_minutes)
+
     # Includes runs that are scheduled to be pulling out
     active_runs_by_date = Schedule.active_runs(now, now)
 

--- a/lib/realtime/vehicles.ex
+++ b/lib/realtime/vehicles.ex
@@ -17,7 +17,7 @@ defmodule Realtime.Vehicles do
     in_fifteen_minutes = now + 15 * 60
 
     # We show vehicles incoming from another route if they'll start the new route within 15 minutes
-    incoming_trips = Schedule.active_trips(now, in_fifteen_minutes)
+    incoming_trips = Schedule.trips_starting_in_range(now, in_fifteen_minutes)
 
     # Includes runs that are scheduled to be pulling out
     active_runs_by_date = Schedule.active_runs(now, now)

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -221,13 +221,19 @@ defmodule Schedule do
   """
   @spec call_with_data(persistent_term_key(), any(), atom(), any()) :: any()
   def call_with_data(persistent_term_key, args, function_name, default_result) do
-    case :persistent_term.get(persistent_term_key, :not_loaded) do
+    data_get_fn = Application.get_env(:skate, :schedule_data_get_fn, &persistent_term_lookup/2)
+
+    case data_get_fn.(persistent_term_key, :not_loaded) do
       {:loaded, data} ->
         apply(Data, function_name, [data | args])
 
       :not_loaded ->
         default_result
     end
+  end
+
+  defp persistent_term_lookup(key, default_value) do
+    :persistent_term.get(key, default_value)
   end
 
   @spec update_state(state(), term()) :: :ok

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -100,11 +100,15 @@ defmodule Schedule do
   @doc """
   All trips that are scheduled to be active at the given time, on all routes.
   """
-  @spec active_trips(Util.Time.timestamp(), Util.Time.timestamp()) :: [Trip.t()]
-  @spec active_trips(Util.Time.timestamp(), Util.Time.timestamp(), persistent_term_key()) ::
+  @spec trips_starting_in_range(Util.Time.timestamp(), Util.Time.timestamp()) :: [Trip.t()]
+  @spec trips_starting_in_range(
+          Util.Time.timestamp(),
+          Util.Time.timestamp(),
+          persistent_term_key()
+        ) ::
           [Trip.t()]
-  def active_trips(start_time, end_time, persistent_term_key \\ __MODULE__) do
-    call_with_data(persistent_term_key, [start_time, end_time], :active_trips, [])
+  def trips_starting_in_range(start_time, end_time, persistent_term_key \\ __MODULE__) do
+    call_with_data(persistent_term_key, [start_time, end_time], :trips_starting_in_range, [])
   end
 
   @doc """

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -127,8 +127,10 @@ defmodule Schedule.Data do
     Enum.to_list(date_range)
   end
 
-  @spec active_trips(t(), Util.Time.timestamp(), Util.Time.timestamp()) :: [Schedule.Trip.t()]
-  def active_trips(%__MODULE__{calendar: calendar, trips: trips}, start_time, end_time) do
+  @spec trips_starting_in_range(t(), Util.Time.timestamp(), Util.Time.timestamp()) :: [
+          Schedule.Trip.t()
+        ]
+  def trips_starting_in_range(%__MODULE__{calendar: calendar, trips: trips}, start_time, end_time) do
     dates = potentially_active_service_dates(start_time, end_time)
     active_services = Map.take(calendar, dates)
 
@@ -146,12 +148,12 @@ defmodule Schedule.Data do
           Map.get(trips_by_service, service_id, [])
         end)
 
-      active_trips_on_date =
+      trips_starting_in_range_on_date =
         Enum.filter(trips_on_date, fn trip ->
-          Schedule.Trip.is_active(trip, start_time_of_day, end_time_of_day)
+          Schedule.Trip.starts_in_range(trip, start_time_of_day, end_time_of_day)
         end)
 
-      active_trips_on_date
+      trips_starting_in_range_on_date
     end)
   end
 

--- a/lib/schedule/trip.ex
+++ b/lib/schedule/trip.ex
@@ -134,6 +134,14 @@ defmodule Schedule.Trip do
       start_time_of_day < trip.end_time
   end
 
+  @doc """
+  Whether the trip starts within the given time_of_day range, exclusive
+  """
+  @spec starts_in_range(t(), Util.Time.time_of_day(), Util.Time.time_of_day()) :: boolean()
+  def starts_in_range(trip, start_time_of_day, end_time_of_day) do
+    start_time_of_day < trip.start_time and trip.start_time < end_time_of_day
+  end
+
   @spec id_sans_overload(id() | nil) :: id() | nil
   def id_sans_overload(nil), do: nil
 

--- a/test/realtime/vehicles_test.exs
+++ b/test/realtime/vehicles_test.exs
@@ -79,7 +79,6 @@ defmodule Realtime.VehiclesTest do
                @timepoint_names_by_id,
                now
              ) == %{
-               "first_route" => [],
                "second_route" => [vehicle]
              }
     end

--- a/test/schedule/trip_test.exs
+++ b/test/schedule/trip_test.exs
@@ -149,6 +149,32 @@ defmodule Schedule.TripTest do
     end
   end
 
+  describe "starts_in_range" do
+    test "when a trip that starts before the range and ends after, false" do
+      refute Trip.starts_in_range(@trip, 4, 5)
+    end
+
+    test "when a trip starts before the range and ends during, false" do
+      refute Trip.starts_in_range(@trip, 5, 7)
+    end
+
+    test "when a trip starts during the range and ends after, true" do
+      assert Trip.starts_in_range(@trip, 2, 4)
+    end
+
+    test "when a trip that's totally inside the time range, true" do
+      assert Trip.starts_in_range(@trip, 2, 7)
+    end
+
+    test "when a trip is trip totally before the range, false" do
+      refute Trip.starts_in_range(@trip, 10, 12)
+    end
+
+    test "when a trip is totally after the range, false" do
+      refute Trip.starts_in_range(@trip, 1, 2)
+    end
+  end
+
   describe "id_sans_overload/1" do
     test "removes the overload portion of the ID" do
       assert Trip.id_sans_overload("44169914-OL1") == "44169914"

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -507,8 +507,8 @@ defmodule ScheduleTest do
     end
   end
 
-  describe "active_trips" do
-    test "returns trips that are active right now" do
+  describe "trips_starting_in_range" do
+    test "returns only trips that start in the given range" do
       pid =
         Schedule.start_mocked(%{
           gtfs: %{
@@ -524,14 +524,17 @@ defmodule ScheduleTest do
             ],
             "trips.txt" => [
               "route_id,service_id,trip_id,trip_headsign,direction_id,block_id,route_pattern_id",
-              "route,today,now,headsign,0,now,",
-              "route,today,later,headsign,0,later,"
+              "route,today,started_earlier,headsign,0,started_earlier,",
+              "route,today,started_in_range,headsign,0,started_in_range,",
+              "route,today,started_later,headsign,0,started_later,"
             ],
             "stop_times.txt" => [
               "trip_id,arrival_time,departure_time,stop_id,stop_sequence,checkpoint_id",
-              "now,,00:00:01,stop1,1,",
-              "now,,00:00:03,stop2,2,",
-              "later,,00:00:04,stop1,1,"
+              "started_earlier,,00:00:01,stop1,1,",
+              "started_earlier,,00:00:05,stop2,2,",
+              "started_in_range,,00:00:03,stop1,1,",
+              "started_in_range,,00:00:10,stop2,2,",
+              "started_later,,00:00:20,stop1,1,"
             ]
           }
         })
@@ -539,7 +542,8 @@ defmodule ScheduleTest do
       # 2019-01-01 00:00:00 EST
       time0 = 1_546_318_800
 
-      assert [%Trip{id: "now"}] = Schedule.active_trips(time0 + 2, time0 + 2, pid)
+      assert [%Trip{id: "started_in_range"}] =
+               Schedule.trips_starting_in_range(time0 + 2, time0 + 10, pid)
     end
   end
 


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1204758166006987/f

Since the only use of `active_trips` was within `Realtime.Vehicles`, I opted to remove it in favor of `trips_starting_in_range`. If you think it should be preserved, I'll add it back in! 