### PR TITLE
feat(Application): test for connections before running migrator

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -108,7 +108,8 @@ config :skate, Skate.Repo,
 
 config :skate, Skate.WarmUp,
   minimum_percent_queries_to_succeed: 0.6,
-  max_attempts: 3
+  max_attempts: 3,
+  seconds_between_attempts: 3
 
 config :laboratory,
   features: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -106,6 +106,10 @@ config :skate, Skate.Repo,
   port: System.get_env("POSTGRES_PORT", "5432") |> String.to_integer(),
   show_sensitive_data_on_connection_error: true
 
+config :skate, Skate.WarmUp,
+  minimum_percent_queries_to_succeed: 0.6,
+  max_attempts: 3
+
 config :laboratory,
   features: [
     {:late_view, "Late View", "Grants access to experimental Late View"}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,3 +12,11 @@ config :ueberauth, Ueberauth.Strategy.Cognito,
   client_secret: System.get_env("COGNITO_CLIENT_SECRET")
 
 config :skate, SkateWeb.AuthManager, secret_key: System.get_env("GUARDIAN_SECRET_KEY")
+
+pool_size =
+  case Integer.parse(System.get_env("POOL_SIZE", "10")) do
+    {size, _extra_binary} -> size
+    :error -> 10
+  end
+
+config :skate, Skate.Repo, pool_size: pool_size

--- a/lib/skate/warm_up.ex
+++ b/lib/skate/warm_up.ex
@@ -1,0 +1,92 @@
+defmodule Skate.WarmUp do
+  use GenServer
+  require Logger
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  @impl true
+  def init(state) do
+    pool_size = Application.get_env(:skate, Skate.Repo)[:pool_size]
+
+    minimum_percent_queries_to_succeed =
+      Application.get_env(:skate, Skate.WarmUp)[:minimum_percent_queries_to_succeed] || 1
+
+    max_attempts = Application.get_env(:skate, Skate.WarmUp)[:max_attempts]
+
+    warm_up_check_fn =
+      Application.get_env(:skate, :warm_up_test_fn, fn _index, _attemptgit ->
+        Skate.Repo.query("SELECT 1", [])
+      end)
+
+    case check_connections_warmed_up(%{
+           pool_size: pool_size,
+           required_success_count: pool_size * minimum_percent_queries_to_succeed,
+           max_attempts: max_attempts,
+           attempt: 1,
+           check_fn: warm_up_check_fn
+         }) do
+      %{status: :success} = result ->
+        Logger.info(format_result_message(result))
+        {:ok, state}
+
+      %{status: :failure} = result ->
+        message = format_result_message(result)
+        Logger.error(message)
+        {:stop, message}
+    end
+  end
+
+  defp check_connections_warmed_up(
+         %{
+           pool_size: pool_size,
+           required_success_count: required_success_count,
+           max_attempts: max_attempts,
+           attempt: attempt,
+           check_fn: check_fn
+         } = config
+       ) do
+    count_success =
+      Enum.map(0..(pool_size - 1), fn index ->
+        Task.async(fn ->
+          try do
+            check_fn.(index, attempt)
+          catch
+            e -> {:error, e}
+          end
+        end)
+      end)
+      |> Task.await_many()
+      |> Enum.count(&(elem(&1, 0) == :ok))
+
+    status = if count_success >= required_success_count, do: :success, else: :failure
+
+    result = %{
+      status: status,
+      count_success: count_success,
+      total_count: pool_size,
+      attempt: attempt
+    }
+
+    if result.status == :success do
+      result
+    else
+      if max_attempts == attempt do
+        result
+      else
+        Logger.warn(format_result_message(result))
+        check_connections_warmed_up(%{config | attempt: attempt + 1})
+      end
+    end
+  end
+
+  defp format_result_message(%{
+         status: status,
+         count_success: count_success,
+         total_count: total_count,
+         attempt: attempt
+       }) do
+    "#{__MODULE__} Repo warm-up attempt complete. status=#{status} count_query_success=#{count_success} total_query_count=#{total_count} attempt=#{attempt}"
+  end
+end

--- a/lib/skate/warm_up.ex
+++ b/lib/skate/warm_up.ex
@@ -7,7 +7,7 @@ defmodule Skate.WarmUp do
   end
 
   @impl true
-  def init(state) do
+  def init(_arg) do
     pool_size = Application.get_env(:skate, Skate.Repo)[:pool_size]
 
     minimum_percent_queries_to_succeed =
@@ -29,7 +29,7 @@ defmodule Skate.WarmUp do
          }) do
       %{status: :success} = result ->
         Logger.info(format_result_message(result))
-        {:ok, state}
+        :ignore
 
       %{status: :failure} = result ->
         message = format_result_message(result)

--- a/test/skate/warm_up_test.exs
+++ b/test/skate/warm_up_test.exs
@@ -1,0 +1,73 @@
+defmodule Skate.WarmUpTest do
+  use ExUnit.Case
+  import Test.Support.Helpers
+  import ExUnit.CaptureLog
+
+  describe("init/1") do
+    test "returns :ok if test function succeeds at least the required number of times" do
+      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.5)
+      reassign_env(:skate, Skate.Repo, pool_size: 10)
+
+      reassign_env(:skate, :warm_up_test_fn, fn count, _attempt ->
+        if count <= 8, do: {:ok, :success}, else: {:error, :failure}
+      end)
+
+      set_log_level(:info)
+
+      {result, log} = with_log(fn -> Skate.WarmUp.init("initial_state") end)
+
+      assert {:ok, "initial_state"} = result
+
+      assert log =~
+               "Elixir.Skate.WarmUp Repo warm-up attempt complete. status=success count_query_success=9 total_query_count=10"
+    end
+
+    test "returns :ok if fails on first try and succeeds on second" do
+      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.8)
+      reassign_env(:skate, Skate.WarmUp, max_attempts: 2)
+
+      reassign_env(:skate, :warm_up_test_fn, fn _count, attempt ->
+        if attempt == 1 do
+          {:error, :failure}
+        else
+          {:ok, :success}
+        end
+      end)
+
+      set_log_level(:info)
+
+      {result, log} = with_log(fn -> Skate.WarmUp.init("initial_state") end)
+
+      assert {:ok, "initial_state"} = result
+
+      assert log =~
+               "[warning] Elixir.Skate.WarmUp Repo warm-up attempt complete. status=failure count_query_success=0 total_query_count=10 attempt=1"
+
+      assert log =~
+               "[info] Elixir.Skate.WarmUp Repo warm-up attempt complete. status=success count_query_success=10 total_query_count=10 attempt=2"
+    end
+
+    test "retries on failure the configured number of times before returning stop" do
+      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.8)
+      reassign_env(:skate, Skate.WarmUp, max_attempts: 2)
+
+      reassign_env(:skate, Skate.Repo, pool_size: 10)
+
+      reassign_env(:skate, :warm_up_test_fn, fn count, _attempt ->
+        if count <= 3, do: {:ok, :success}, else: {:error, :failure}
+      end)
+
+      {result, log} = with_log(fn -> Skate.WarmUp.init("initial_state") end)
+
+      assert {:stop,
+              "Elixir.Skate.WarmUp Repo warm-up attempt complete. status=failure count_query_success=4 total_query_count=10 attempt=2"} =
+               result
+
+      assert log =~
+               "[warning] Elixir.Skate.WarmUp Repo warm-up attempt complete. status=failure count_query_success=4 total_query_count=10 attempt=1"
+
+      assert log =~
+               "[error] Elixir.Skate.WarmUp Repo warm-up attempt complete. status=failure count_query_success=4 total_query_count=10 attempt=2"
+    end
+  end
+end

--- a/test/skate/warm_up_test.exs
+++ b/test/skate/warm_up_test.exs
@@ -1,11 +1,16 @@
 defmodule Skate.WarmUpTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import Test.Support.Helpers
   import ExUnit.CaptureLog
 
   describe("init/1") do
     test "returns :ok if test function succeeds at least the required number of times" do
-      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.5)
+      reassign_env(:skate, Skate.WarmUp,
+        minimum_percent_queries_to_succeed: 0.5,
+        seconds_between_attempts: 0,
+        max_attempts: 2
+      )
+
       reassign_env(:skate, Skate.Repo, pool_size: 10)
 
       reassign_env(:skate, :warm_up_test_fn, fn count, _attempt ->
@@ -23,8 +28,11 @@ defmodule Skate.WarmUpTest do
     end
 
     test "returns :ok if fails on first try and succeeds on second" do
-      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.8)
-      reassign_env(:skate, Skate.WarmUp, max_attempts: 2)
+      reassign_env(:skate, Skate.WarmUp,
+        minimum_percent_queries_to_succeed: 0.8,
+        max_attempts: 2,
+        seconds_between_attempts: 0
+      )
 
       reassign_env(:skate, :warm_up_test_fn, fn _count, attempt ->
         if attempt == 1 do
@@ -48,8 +56,11 @@ defmodule Skate.WarmUpTest do
     end
 
     test "retries on failure the configured number of times before returning stop" do
-      reassign_env(:skate, Skate.WarmUp, minimum_percent_queries_to_succeed: 0.8)
-      reassign_env(:skate, Skate.WarmUp, max_attempts: 2)
+      reassign_env(:skate, Skate.WarmUp,
+        minimum_percent_queries_to_succeed: 0.8,
+        max_attempts: 2,
+        seconds_between_attempts: 0
+      )
 
       reassign_env(:skate, Skate.Repo, pool_size: 10)
 

--- a/test/skate/warm_up_test.exs
+++ b/test/skate/warm_up_test.exs
@@ -16,7 +16,7 @@ defmodule Skate.WarmUpTest do
 
       {result, log} = with_log(fn -> Skate.WarmUp.init("initial_state") end)
 
-      assert {:ok, "initial_state"} = result
+      assert :ignore = result
 
       assert log =~
                "Elixir.Skate.WarmUp Repo warm-up attempt complete. status=success count_query_success=9 total_query_count=10"
@@ -38,7 +38,7 @@ defmodule Skate.WarmUpTest do
 
       {result, log} = with_log(fn -> Skate.WarmUp.init("initial_state") end)
 
-      assert {:ok, "initial_state"} = result
+      assert :ignore = result
 
       assert log =~
                "[warning] Elixir.Skate.WarmUp Repo warm-up attempt complete. status=failure count_query_success=0 total_query_count=10 attempt=1"


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204865954744424/f

This adds logic to attempt concurrent queries to the DB prior to running the migrator to ensure that the connections have started. This is based on the discussion and recommendation in this issue: https://github.com/elixir-ecto/ecto/issues/3428

> Postgrex is asynchronous when it connects to the database. So when the repo starts, you may not have a connection yet. If your database is loaded with extensions, this bootstrap time can be high.
>
>My suggestion is to have a single process immediately after Ecto.Repo in the supervision tree that is responsible for checking for the repository availability:


Two test deployments to dev-green succeeded without DBConnection.ConnectionErrors or task thrashing in ECS:
![image](https://github.com/mbta/skate/assets/31781298/a82b68f1-fe9c-43c8-9550-d95b8d873092)
