### PR TITLE
feat(tilesetUrls): Expose satellite tileset url

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -40,6 +40,12 @@ export ERL_FLAGS="+MIscs 2048"
 ## Location of map tile images
 # export TILESET_URL=
 
+## URL for map tile images, including {x} {y} coordinate and {z} zoom level placeholders
+# export BASE_TILESET_URL=
+
+## URL for satellite map tile images, including {x} {y} coordinate and {z} zoom level placeholders
+# export SATELLITE_TILESET_URL=
+
 ## Used by Erlang (only required in production)
 # export RELEASE_COOKIE=
 

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -131,6 +131,7 @@ export const FullscreenControl = createControlComponent(
   Leaflet.control.fullscreen
 )
 
+// TODO: use tilesetForType instead
 const tilesetUrl = (): string => appData()?.tilesetUrl || ""
 
 const EventAdder = (): ReactElement => {

--- a/assets/src/tilesetUrls.ts
+++ b/assets/src/tilesetUrls.ts
@@ -1,0 +1,12 @@
+import appData from "./appData"
+
+export const tilesetUrlForType = (
+  type: "base" | "satellite"
+): string | undefined => {
+  const data = appData()
+  if (data?.tilesetUrls === undefined) {
+    return undefined
+  }
+  const urls = JSON.parse(data.tilesetUrls)
+  return urls[type]
+}

--- a/assets/tests/tilesetUrls.test.ts
+++ b/assets/tests/tilesetUrls.test.ts
@@ -1,0 +1,26 @@
+import appData from "../src/appData"
+import { tilesetUrlForType } from "../src/tilesetUrls"
+
+jest.mock("appData")
+
+describe("tilesetUrlForType", () => {
+  test("returns the url of the requested type", () => {
+    const satelliteUrl = "satellite_url"
+    const baseUrl = "base_url"
+    ;(appData as jest.Mock).mockImplementation(() => ({
+      tilesetUrls: JSON.stringify({
+        base: baseUrl,
+        satellite: satelliteUrl,
+      }),
+    }))
+    expect(tilesetUrlForType("base")).toEqual(baseUrl)
+    expect(tilesetUrlForType("satellite")).toEqual(satelliteUrl)
+  })
+
+  test("returns undefined if config is missing", () => {
+    ;(appData as jest.Mock).mockImplementation(() => undefined)
+
+    expect(tilesetUrlForType("satellite")).toEqual(undefined)
+    expect(tilesetUrlForType("base")).toEqual(undefined)
+  })
+})

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,6 @@
 import Config
 
 config :skate,
-  tileset_url: "https://mbta-map-tiles-dev.s3.amazonaws.com/skate_osm_tiles",
   geonames_url_base: "http://api.geonames.org",
   log_duration_timing: false
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,9 @@ Application.ensure_all_started(:ex_aws)
 
 config :skate,
   secret_key_base: System.get_env("SECRET_KEY_BASE"),
-  restrict_environment_access?: System.get_env("RESTRICT_ENVIRONMENT_ACCESS") == "true"
+  restrict_environment_access?: System.get_env("RESTRICT_ENVIRONMENT_ACCESS") == "true",
+  base_tileset_url: System.get_env("BASE_TILESET_URL"),
+  satellite_tileset_url: System.get_env("SATELLITE_TILESET_URL")
 
 config :ueberauth, Ueberauth.Strategy.Cognito,
   client_secret: System.get_env("COGNITO_CLIENT_SECRET")

--- a/lib/skate_web/controllers/page_controller.ex
+++ b/lib/skate_web/controllers/page_controller.ex
@@ -29,6 +29,10 @@ defmodule SkateWeb.PageController do
     |> assign(:dispatcher_flag, dispatcher_flag)
     |> assign(:google_tag_manager_id, Application.get_env(:skate, :google_tag_manager_id))
     |> assign(:tileset_url, Application.get_env(:skate, :tileset_url))
+    |> assign(:tileset_urls, %{
+      base: Application.get_env(:skate, :base_tileset_url),
+      satellite: Application.get_env(:skate, :satellite_tileset_url)
+    })
     |> assign(:user_test_groups, user.test_groups |> Enum.map(& &1.name))
     |> render("index.html")
   end

--- a/lib/skate_web/templates/page/index.html.eex
+++ b/lib/skate_web/templates/page/index.html.eex
@@ -5,6 +5,7 @@
   data-route-tabs="<%= Jason.encode!(@route_tabs) %>"
   data-laboratory-features="<%= Jason.encode!(@laboratory_features) %>"
   data-tileset-url="<%= @tileset_url %>"
+  data-tileset-urls="<%= Jason.encode!(@tileset_urls) %>"
   data-dispatcher-flag="<%= Jason.encode!(@dispatcher_flag) %>"
   data-user-test-groups="<%= Jason.encode!(@user_test_groups) %>"
 ></div>

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -140,6 +140,19 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
+    test "correct tileset urls are set", %{conn: conn} do
+      reassign_env(:skate, :tileset_url, "tilesets.com/osm")
+      reassign_env(:skate, :base_tileset_url, "base_url")
+      reassign_env(:skate, :satellite_tileset_url, "satellite_url")
+
+      conn = get(conn, "/")
+      assert html_response(conn, 200) =~ "data-tileset-url=\"tilesets.com/osm\""
+
+      assert html_response(conn, 200) =~
+               "data-tileset-urls=\"{&quot;base&quot;:&quot;base_url&quot;,&quot;satellite&quot;:&quot;satellite_url&quot;}\""
+    end
+
+    @tag :authenticated
     test "correct tileset url set", %{conn: conn} do
       reassign_env(:skate, :tileset_url, "tilesets.com/osm")
 


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204573236791609/f
This ticket adds new tileset environment variables to distinguish between the base & satellite URLs. 
I'll add a corresponding terraform PR as well if these variable names look good. 


For the latency consideration of this ticket, testing with throttling for chrome's "fast 3G" setting, satellite tiles were taking ~2 seconds for the first load. Subsequent loads were faster due to browser caching. For the base tileset at the same network speed & location, tile requests took 1-1.5s. 

The ArcGIS tiles have permissive [terms of use](https://massgis.maps.arcgis.com/home/item.html?id=bd1ea555a71649508cb215edcc73feaa):

> No restrictions apply to these data

Order of operations:
* Merge terraform PR configuring these variables
* Merge this PR
* Start using `tilesetUrlForType`
* Remove references to the old tilesetUrl configuration