### PR TITLE
feat: don't parse Swiftly operator data

### DIFF
--- a/lib/concentrate/parser/swiftly_realtime_vehicles.ex
+++ b/lib/concentrate/parser/swiftly_realtime_vehicles.ex
@@ -26,7 +26,6 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehicles do
   @spec decode_vehicle(map()) :: VehiclePosition.t()
   def decode_vehicle(vehicle_data) do
     loc = Map.get(vehicle_data, "loc", %{})
-    {operator_last_name, operator_id} = vehicle_data |> Map.get("driver") |> operator_details()
 
     last_updated = Map.get(loc, "time")
 
@@ -42,8 +41,6 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehicles do
       bearing: Map.get(loc, "heading"),
       block_id: Map.get(vehicle_data, "blockId"),
       run_id: Map.get(vehicle_data, "runId"),
-      operator_id: operator_id,
-      operator_last_name: operator_last_name,
       stop_name: Map.get(vehicle_data, "nextStopName"),
       direction_id: vehicle_data |> Map.get("directionId") |> direction_id_from_string(),
       headsign: Map.get(vehicle_data, "headsign"),
@@ -59,16 +56,6 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehicles do
       sources: MapSet.new(["swiftly"]),
       data_discrepancies: []
     )
-  end
-
-  @spec operator_details(String.t() | nil) :: {String.t() | nil, String.t() | nil}
-  defp operator_details(nil), do: {nil, nil}
-
-  defp operator_details(operator_string) do
-    case String.split(operator_string, " - ") do
-      [operator_last_name, operator_id] -> {operator_last_name, operator_id}
-      _ -> {nil, nil}
-    end
   end
 
   defp direction_id_from_string(nil), do: nil

--- a/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
+++ b/test/concentrate/parser/swiftly_realtime_vehicles_test.exs
@@ -72,8 +72,6 @@ defmodule Concentrate.Parser.SwiftlyRealtimeVehiclesTest do
           trip_id: "39998535",
           block_id: "B36-173",
           run_id: "122-1065",
-          operator_id: operator_id,
-          operator_last_name: operator_last_name,
           last_updated: 1_559_672_827,
           last_updated_by_source: %{"swiftly" => 1_559_672_827},
           stop_name: "Back Bay",


### PR DESCRIPTION
Asana ticket: [⚙️ Ignore operator data from Swiftly](https://app.asana.com/0/1200180014510248/1204818709617516/f)

I figured that since we want to ignore this data entirely it made more sense to simply remove the logic for parsing it, rather than writing some complicated merge logic to discard it, but I'm open to changing my mind on that.