### PR TITLE
feat(Skate.WarmUp): Adjust config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -107,8 +107,8 @@ config :skate, Skate.Repo,
   show_sensitive_data_on_connection_error: true
 
 config :skate, Skate.WarmUp,
-  minimum_percent_queries_to_succeed: 0.6,
-  max_attempts: 3,
+  minimum_percent_queries_to_succeed: 0.8,
+  max_attempts: 5,
   seconds_between_attempts: 3
 
 config :laboratory,


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204925487890874

Looking in splunk, there are a few occurrences of instances failing on the 3rd warmup attempt. Bumping up `max_attempts` to 5, so up to 15 seconds spent on warmup before failing. 

Also increasing `minimum_percent_queries_to_succeed` to 80% - all warmup attempts were either 0 or 100% successful, so increasing this shouldn't have any adverse affects but may help prevent us from calling an attempt successful too early should this change in the future.