### PR TITLE
fix: Safari flash issues

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -148,6 +148,7 @@ main,
 #app,
 .l-app {
   height: 100%;
+  width: 100%;
 }
 
 body {
@@ -160,7 +161,6 @@ body {
 .l-app {
   display: flex;
   flex-direction: column;
-  width: 100vw;
 }
 
 .l-app__banner {

--- a/assets/src/hooks/useScreenSize.ts
+++ b/assets/src/hooks/useScreenSize.ts
@@ -1,4 +1,4 @@
-import { useMediaQueries } from "@react-hook/media-query"
+import { useEffect, useState } from "react"
 import { DeviceType } from "../skate"
 
 const maxMobileWidth = 480
@@ -7,18 +7,30 @@ const maxMobileLandscapeTabletPortraitWidth = 800
 const minTabletWidth = maxMobileLandscapeTabletPortraitWidth + 1
 const maxTabletWidth = 1340
 
-const useScreenSize = (): DeviceType => {
-  const { matches } = useMediaQueries({
-    mobile: `(max-width: ${maxMobileWidth}px)`,
-    mobile_landscape_tablet_portrait: `(min-width: ${minMobileLandscapeTabletPortraitWidth}px) and (max-width: ${maxMobileLandscapeTabletPortraitWidth}px)`,
-    tablet: `(min-width: ${minTabletWidth}px) and (max-width: ${maxTabletWidth}px)`,
-  })
+function getWidth() {
+  // Return size of viewport, including any scrollbars
+  return window.innerWidth
+}
 
-  if (matches.mobile) {
+const useScreenSize = (): DeviceType => {
+  // Initialize to current size
+  const [screenWidth, setScreenWidth] = useState<number>(getWidth())
+
+  useEffect(() => {
+    const resizeHandler = () => setScreenWidth(getWidth())
+
+    window.addEventListener("resize", resizeHandler)
+    return () => window.removeEventListener("resize", resizeHandler)
+  }, [])
+
+  if (screenWidth <= maxMobileWidth) {
     return "mobile"
-  } else if (matches.mobile_landscape_tablet_portrait) {
+  } else if (
+    minMobileLandscapeTabletPortraitWidth <= screenWidth &&
+    screenWidth <= maxMobileLandscapeTabletPortraitWidth
+  ) {
     return "mobile_landscape_tablet_portrait"
-  } else if (matches.tablet) {
+  } else if (minTabletWidth <= screenWidth && screenWidth <= maxTabletWidth) {
     return "tablet"
   } else {
     return "desktop"


### PR DESCRIPTION
Safari excludes it's scrollbar[^scrollbar-state] from it's media queries by default[^1], so when `useScreenSize` changes the layout of the page, the change in layout can change the width that the media query recieves, which in the `15px` between our tablet breakpoint `1340` and `1355`, will flip flop back and forth between the two breakpoints as the media query changes values.

To fix this, I've changed `useScreenSize` to query the viewport size in javascript, rather than the size that the media queries are getting. This is more in-line with `@media` standards, as the `width` media query is supposed to test against the viewport, not the document width or the viewport without the scrollbar.[^3]

[W3C media query specification for width](https://www.w3.org/TR/css3-mediaqueries/#width):
> The ‘width’ media feature describes the width of the targeted display area of the output device. For continuous media, this is the width of the viewport (as described by CSS2, section 9.1.1 [CSS21]) including the size of a rendered scroll bar (if any). 

Commits are reviewable individually, and the [app container commit](https://github.com/mbta/skate/commit/addb93ad467bd16aa3542f5dd6ae4225ce7da32b) contains more information on _why_ in the commit message.

[^1]: WebKit does let you [style scrollbars via custom webkit pseudo selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar), but the amount of work doesn't seem like it's worth it for a non-standard feature.

[^scrollbar-state]: this is also non-standard, and is expected to be fixed _eventually_.

[^3]: Some background on this in the following links
    - https://stackoverflow.com/questions/8146874/issue-with-css-media-queriesscrollbar 
    - https://www.sitepoint.com/rwd-scrollbars-is-chrome-better/
---

Asana Ticket: [🐛 Fix Safari flash issues in Search Maps](https://app.asana.com/0/1148853526253437/1204826855654099/f)
