### PR TITLE
feat: New vehicle search channel that accepts a limit

### DIFF
--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -96,6 +96,14 @@ defmodule Realtime.Server do
     )
   end
 
+  @spec update_search_subscription(search_params(), GenServer.server()) :: [VehicleOrGhost.t()]
+  def update_search_subscription(search_params, server \\ default_name()) do
+    update_subscription(
+      server,
+      {:search, search_params}
+    )
+  end
+
   @spec subscribe_to_vehicle(String.t(), GenServer.server()) :: [VehicleOrGhost.t()]
   def subscribe_to_vehicle(vehicle_id, server \\ default_name()) do
     subscribe(
@@ -157,6 +165,14 @@ defmodule Realtime.Server do
   @spec subscribe(GenServer.server(), {:alerts, Route.id()}) :: [String.t()]
   defp subscribe(server, subscription_key) do
     {registry_key, ets} = GenServer.call(server, :subscription_info)
+    Registry.register(Realtime.Registry, registry_key, subscription_key)
+    lookup({ets, subscription_key})
+  end
+
+  defp update_subscription(server, {:search, _search_params} = subscription_key) do
+    {registry_key, ets} = GenServer.call(server, :subscription_info)
+    # Replace the old search subscription with the new one
+    Registry.unregister_match(Realtime.Registry, registry_key, {:search, %{}})
     Registry.register(Realtime.Registry, registry_key, subscription_key)
     lookup({ets, subscription_key})
   end

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -91,18 +91,12 @@ defmodule Realtime.Server do
 
   @spec subscribe_to_search(search_params(), GenServer.server()) :: [VehicleOrGhost.t()]
   def subscribe_to_search(search_params, server \\ default_name()) do
-    subscribe(
-      server,
-      {:search, search_params}
-    )
+    subscribe(server, {:search, search_params})
   end
 
   @spec update_search_subscription(search_params(), GenServer.server()) :: [VehicleOrGhost.t()]
   def update_search_subscription(search_params, server \\ default_name()) do
-    update_subscription(
-      server,
-      {:search, search_params}
-    )
+    update_subscription(server, {:search, search_params})
   end
 
   @spec subscribe_to_vehicle(String.t(), GenServer.server()) :: [VehicleOrGhost.t()]
@@ -175,6 +169,7 @@ defmodule Realtime.Server do
     # Replace the old search subscription with the new one
     Registry.unregister_match(Realtime.Registry, registry_key, {:search, %{}})
     Registry.register(Realtime.Registry, registry_key, subscription_key)
+
     lookup({ets, subscription_key})
   end
 

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -44,7 +44,8 @@ defmodule Realtime.Server do
   @type search_params :: %{
           :text => String.t(),
           :property => search_property(),
-          optional(:include_logged_out_vehicles) => boolean()
+          optional(:include_logged_out_vehicles) => boolean(),
+          optional(:limit) => pos_integer()
         }
 
   @type search_property :: :all | :run | :vehicle | :operator

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -35,6 +35,7 @@ defmodule Realtime.Server do
           | :all_shuttles
           | :logged_in_vehicles
           | {:search, search_params()}
+          | {:limited_search, limited_search_params()}
           | {:vehicle, String.t()}
           | {:vehicle_with_logged_out, String.t()}
           | {:run_ids, [Run.id()]}
@@ -48,11 +49,23 @@ defmodule Realtime.Server do
           optional(:limit) => pos_integer()
         }
 
+  @type limited_search_params :: %{
+          :text => String.t(),
+          :property => search_property(),
+          optional(:include_logged_out_vehicles) => boolean(),
+          optional(:limit) => pos_integer()
+        }
+
   @type search_property :: :all | :run | :vehicle | :operator
 
   @type lookup_key :: {:ets.tid(), subscription_key}
 
   @type broadcast_message :: {:new_realtime_data, lookup_key}
+
+  @type limited_search_result :: %{
+          matching_vehicles: [VehicleOrGhost.t()],
+          has_more_matches: boolean()
+        }
 
   @typep t :: %__MODULE__{
            ets: :ets.tid(),
@@ -94,9 +107,16 @@ defmodule Realtime.Server do
     subscribe(server, {:search, search_params})
   end
 
-  @spec update_search_subscription(search_params(), GenServer.server()) :: [VehicleOrGhost.t()]
-  def update_search_subscription(search_params, server \\ default_name()) do
-    update_subscription(server, {:search, search_params})
+  @spec subscribe_to_limited_search(search_params(), GenServer.server()) ::
+          limited_search_result()
+  def subscribe_to_limited_search(search_params, server \\ default_name()) do
+    subscribe(server, {:limited_search, search_params})
+  end
+
+  @spec update_limited_search_subscription(search_params(), GenServer.server()) ::
+          limited_search_result()
+  def update_limited_search_subscription(search_params, server \\ default_name()) do
+    update_subscription(server, {:limited_search, search_params})
   end
 
   @spec subscribe_to_vehicle(String.t(), GenServer.server()) :: [VehicleOrGhost.t()]
@@ -151,6 +171,8 @@ defmodule Realtime.Server do
   @spec subscribe(GenServer.server(), :all_shuttles) :: [Vehicle.t()]
   @spec subscribe(GenServer.server(), :logged_in_vehicles) :: [Vehicle.t()]
   @spec subscribe(GenServer.server(), {:search, search_params()}) :: [VehicleOrGhost.t()]
+  @spec subscribe(GenServer.server(), {:limited_search, search_params()}) ::
+          limited_search_result()
   @spec subscribe(GenServer.server(), {:vehicle, String.t()}) :: [VehicleOrGhost.t()]
   @spec subscribe(GenServer.server(), {:vehicle_with_logged_out, String.t()}) :: [
           VehicleOrGhost.t()
@@ -164,10 +186,10 @@ defmodule Realtime.Server do
     lookup({ets, subscription_key})
   end
 
-  defp update_subscription(server, {:search, _search_params} = subscription_key) do
+  defp update_subscription(server, {:limited_search, _search_params} = subscription_key) do
     {registry_key, ets} = GenServer.call(server, :subscription_info)
     # Replace the old search subscription with the new one
-    Registry.unregister_match(Realtime.Registry, registry_key, {:search, %{}})
+    Registry.unregister_match(Realtime.Registry, registry_key, {:limited_search, %{}})
     Registry.register(Realtime.Registry, registry_key, subscription_key)
 
     lookup({ets, subscription_key})
@@ -198,6 +220,7 @@ defmodule Realtime.Server do
   @spec lookup({:ets.tid(), :logged_out_vehicles}) :: [VehicleOrGhost.t()]
   @spec lookup({:ets.tid(), :all_shuttles}) :: [Vehicle.t()]
   @spec lookup({:ets.tid(), {:search, search_params()}}) :: [VehicleOrGhost.t()]
+  @spec lookup({:ets.tid(), {:limited_search, search_params()}}) :: limited_search_result()
   @spec lookup({:ets.tid(), {:vehicle, String.t()}}) :: [VehicleOrGhost.t()]
   @spec lookup({:ets.tid(), {:vehicle_with_logged_out, String.t()}}) :: [VehicleOrGhost.t()]
   @spec lookup({:ets.tid(), {:run_ids, [Run.id()]}}) :: [VehicleOrGhost.t()]
@@ -214,6 +237,19 @@ defmodule Realtime.Server do
       end
 
     VehicleOrGhost.find_by(vehicles_to_search, search_params)
+  end
+
+  def lookup({table, {:limited_search, search_params}}) do
+    logged_in_vehicles = lookup({table, :logged_in_vehicles})
+
+    vehicles_to_search =
+      if Map.get(search_params, :include_logged_out_vehicles, false) do
+        logged_in_vehicles ++ lookup({table, :logged_out_vehicles})
+      else
+        logged_in_vehicles
+      end
+
+    VehicleOrGhost.take_limited_matches(vehicles_to_search, search_params)
   end
 
   def lookup({table, {:run_ids, run_ids}}) do

--- a/lib/realtime/vehicle_or_ghost.ex
+++ b/lib/realtime/vehicle_or_ghost.ex
@@ -4,59 +4,87 @@ defmodule Realtime.VehicleOrGhost do
   @type t :: Vehicle.t() | Ghost.t()
 
   @spec find_by([t()], Server.search_params()) :: [t()]
-  def find_by(vehicles, %{
-        text: text,
-        property: :all
-      }),
-      do:
-        filter_by_prop_matching(
-          vehicles,
-          [:run_id, :label, :operator_id, :operator_first_name, :operator_last_name],
-          text
-        )
+  def find_by(vehicles, %{text: text, property: search_property, limit: limit}) do
+    search_terms = text |> clean_for_matching |> Enum.reject(&(String.length(&1) < 2))
 
-  def find_by(vehicles, %{
-        text: text,
-        property: :run
-      }),
-      do: filter_by_prop_matching(vehicles, :run_id, text)
+    if search_terms == [] do
+      []
+    else
+      take_by_props_matching(
+        vehicles,
+        prop_names_for_search_prop(search_property),
+        search_terms,
+        limit,
+        []
+      )
+    end
+  end
 
-  def find_by(vehicles, %{
-        text: text,
-        property: :vehicle
-      }),
-      do: filter_by_prop_matching(vehicles, :label, text)
+  def find_by(vehicles, %{text: text, property: search_property}) do
+    filter_by_prop_matching(
+      vehicles,
+      prop_names_for_search_prop(search_property),
+      text
+    )
+  end
 
-  def find_by(vehicles, %{
-        text: text,
-        property: :operator
-      }),
-      do:
-        filter_by_prop_matching(
-          vehicles,
-          [:operator_id, :operator_first_name, :operator_last_name],
-          text
-        )
+  @spec prop_names_for_search_prop(Server.search_property()) :: [atom()]
+  defp prop_names_for_search_prop(:operator),
+    do: [:operator_id, :operator_first_name, :operator_last_name]
 
-  @spec filter_by_prop_matching([t()], atom() | [atom()], String.t()) :: [t()]
+  defp prop_names_for_search_prop(:vehicle), do: [:label]
+  defp prop_names_for_search_prop(:run), do: [:run_id]
+
+  defp prop_names_for_search_prop(:all),
+    do: [:operator_id, :operator_first_name, :operator_last_name, :label, :run_id]
+
+  @spec take_by_props_matching([t()], [atom()], [String.t()], pos_integer(), [t()]) :: [t()]
+  defp take_by_props_matching(vehicles, _prop_names, _search_terms, limit, acc_matching_vehicles)
+       when limit <= 0 or vehicles == [] do
+    Enum.reverse(acc_matching_vehicles)
+  end
+
+  defp take_by_props_matching(
+         [first_vehicle | remaining_vehicles],
+         prop_names,
+         search_terms,
+         limit,
+         acc_matching_vehicles
+       ) do
+    vehicle_matches = vehicle_matches_all_search_terms(first_vehicle, prop_names, search_terms)
+
+    if vehicle_matches do
+      take_by_props_matching(remaining_vehicles, prop_names, search_terms, limit - 1, [
+        first_vehicle | acc_matching_vehicles
+      ])
+    else
+      take_by_props_matching(
+        remaining_vehicles,
+        prop_names,
+        search_terms,
+        limit,
+        acc_matching_vehicles
+      )
+    end
+  end
+
+  @spec filter_by_prop_matching([t()], [atom()], String.t()) :: [t()]
   defp filter_by_prop_matching(vehicles, prop_names, text) when is_list(prop_names) do
     search_terms = text |> clean_for_matching |> Enum.reject(&(String.length(&1) < 2))
 
     if search_terms == [] do
       []
     else
-      Enum.filter(vehicles, fn vehicle ->
-        Enum.all?(search_terms, fn search_term ->
-          Enum.any?(prop_names, fn prop_name ->
-            vehicle_matches?(vehicle, prop_name, search_term)
-          end)
-        end)
-      end)
+      Enum.filter(vehicles, &vehicle_matches_all_search_terms(&1, prop_names, search_terms))
     end
   end
 
-  defp filter_by_prop_matching(vehicles, prop_name, text) do
-    filter_by_prop_matching(vehicles, [prop_name], text)
+  defp vehicle_matches_all_search_terms(vehicle, prop_names, search_terms) do
+    Enum.all?(search_terms, fn search_term ->
+      Enum.any?(prop_names, fn prop_name ->
+        vehicle_matches?(vehicle, prop_name, search_term)
+      end)
+    end)
   end
 
   @spec vehicle_matches?(t(), atom(), String.t()) :: boolean()

--- a/lib/skate_web/channels/user_socket.ex
+++ b/lib/skate_web/channels/user_socket.ex
@@ -5,6 +5,7 @@ defmodule SkateWeb.UserSocket do
   channel("data_status", SkateWeb.DataStatusChannel)
   channel("vehicle:*", SkateWeb.VehicleChannel)
   channel("vehicles:*", SkateWeb.VehiclesChannel)
+  channel("vehicles_search:*", SkateWeb.VehiclesSearchChannel)
   channel("train_vehicles:*", SkateWeb.TrainVehiclesChannel)
   channel("notifications", SkateWeb.NotificationsChannel)
   channel("alerts:*", SkateWeb.AlertsChannel)

--- a/lib/skate_web/channels/vehicles_search_channel.ex
+++ b/lib/skate_web/channels/vehicles_search_channel.ex
@@ -1,0 +1,76 @@
+defmodule SkateWeb.VehiclesSearchChannel do
+  use SkateWeb, :channel
+  use SkateWeb.AuthenticatedChannel
+  require Logger
+
+  alias Realtime.Server
+  alias Util.Duration
+
+  @impl SkateWeb.AuthenticatedChannel
+  def join_authenticated(
+        "vehicles_search:",
+        %{"limit" => limit, "text" => text, "property" => property},
+        socket
+      ) do
+    username_from_socket! =
+      Application.get_env(
+        :skate,
+        :username_from_socket!,
+        &SkateWeb.AuthManager.username_from_socket!/1
+      )
+
+    username = username_from_socket!.(socket)
+    %{id: user_id} = Guardian.Phoenix.Socket.current_resource(socket)
+
+    subscribe_args = %{
+      property: String.to_existing_atom(property),
+      limit: limit,
+      text: text
+    }
+
+    subscribe_args =
+      Map.put(
+        subscribe_args,
+        :include_logged_out_vehicles,
+        Skate.Settings.User.is_in_test_group(user_id, "search-logged-out-vehicles")
+      )
+
+    Logger.info(fn ->
+      "User=#{username} searched for property=#{subscribe_args.property}, text=#{subscribe_args.text} limit=#{subscribe_args.limit}"
+    end)
+
+    vehicles = Duration.log_duration(Server, :subscribe_to_search, [subscribe_args])
+
+    {:ok, %{data: vehicles}, socket}
+  end
+
+  @impl Phoenix.Channel
+  def handle_in(
+        "update_search_query",
+        %{"text" => text, "limit" => limit, "property" => property},
+        socket
+      ) do
+    vehicles =
+      Duration.log_duration(Server, :update_search_subscription, [
+        %{text: text, limit: limit, property: String.to_existing_atom(property)}
+      ])
+
+    {:reply, {:ok, %{data: vehicles}}, socket}
+  end
+
+  @impl Phoenix.Channel
+  def handle_info({:new_realtime_data, lookup_args}, socket) do
+    if SkateWeb.ChannelAuth.valid_token?(socket) do
+      event_name = event_name(lookup_args)
+      data = Server.lookup(lookup_args)
+      :ok = push(socket, event_name, %{data: data})
+      {:noreply, socket}
+    else
+      :ok = push(socket, "auth_expired", %{})
+      {:stop, :normal, socket}
+    end
+  end
+
+  @spec event_name(Server.lookup_key()) :: String.t()
+  defp event_name({_ets, {:search, _}}), do: "search"
+end

--- a/lib/skate_web/channels/vehicles_search_channel.ex
+++ b/lib/skate_web/channels/vehicles_search_channel.ex
@@ -8,7 +8,7 @@ defmodule SkateWeb.VehiclesSearchChannel do
 
   @impl SkateWeb.AuthenticatedChannel
   def join_authenticated(
-        "vehicles_search:",
+        "vehicles_search:" <> _unique_id,
         %{"limit" => limit, "text" => text, "property" => property},
         socket
       ) do

--- a/lib/skate_web/channels/vehicles_search_channel.ex
+++ b/lib/skate_web/channels/vehicles_search_channel.ex
@@ -39,9 +39,9 @@ defmodule SkateWeb.VehiclesSearchChannel do
       "User=#{username} searched for property=#{subscribe_args.property}, text=#{subscribe_args.text} limit=#{subscribe_args.limit}"
     end)
 
-    vehicles = Duration.log_duration(Server, :subscribe_to_search, [subscribe_args])
+    result = Duration.log_duration(Server, :subscribe_to_limited_search, [subscribe_args])
 
-    {:ok, %{data: vehicles}, socket}
+    {:ok, %{data: result}, socket}
   end
 
   @impl Phoenix.Channel
@@ -50,12 +50,12 @@ defmodule SkateWeb.VehiclesSearchChannel do
         %{"text" => text, "limit" => limit, "property" => property},
         socket
       ) do
-    vehicles =
-      Duration.log_duration(Server, :update_search_subscription, [
+    result =
+      Duration.log_duration(Server, :update_limited_search_subscription, [
         %{text: text, limit: limit, property: String.to_existing_atom(property)}
       ])
 
-    {:reply, {:ok, %{data: vehicles}}, socket}
+    {:reply, {:ok, %{data: result}}, socket}
   end
 
   @impl Phoenix.Channel
@@ -72,5 +72,5 @@ defmodule SkateWeb.VehiclesSearchChannel do
   end
 
   @spec event_name(Server.lookup_key()) :: String.t()
-  defp event_name({_ets, {:search, _}}), do: "search"
+  defp event_name({_ets, {:limited_search, _}}), do: "limited_search"
 end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -397,7 +397,7 @@ defmodule Realtime.ServerTest do
     end
   end
 
-  describe "update_search_subscription/2" do
+  describe "subscribe_to_limited_search/2" do
     setup do
       {:ok, server_pid} = Server.start_link([])
 
@@ -406,20 +406,112 @@ defmodule Realtime.ServerTest do
       %{server_pid: server_pid}
     end
 
-    test "when update_search_subscription is called, then when vehicles update the subscribing process is pushed only a message with their latest search params",
+    test "clients get limited search results upon subscribing", %{server_pid: pid} do
+      assert %{matching_vehicles: [@vehicle], has_more_matches: true} ==
+               Server.subscribe_to_limited_search(%{property: :all, text: "90", limit: 1}, pid)
+    end
+
+    test "clients get updated limited search results pushed to them", %{server_pid: pid} do
+      Server.subscribe_to_limited_search(%{property: :all, text: "90", limit: 5}, pid)
+
+      Server.update_vehicles({%{}, [@shuttle], []}, pid)
+
+      assert_receive {:new_realtime_data, lookup_args}
+
+      assert %{matching_vehicles: [@shuttle], has_more_matches: false} ==
+               Server.lookup(lookup_args)
+    end
+
+    test "does not receive duplicate vehicles", %{server_pid: pid} do
+      Server.subscribe_to_limited_search(%{property: :all, text: "90", limit: 5}, pid)
+
+      Server.update_vehicles({%{}, [@shuttle, @shuttle], []}, pid)
+
+      assert_receive {:new_realtime_data, lookup_args}
+
+      assert %{matching_vehicles: [@shuttle], has_more_matches: false} =
+               Server.lookup(lookup_args)
+    end
+
+    test "vehicles on inactive blocks are included", %{server_pid: pid} do
+      Server.subscribe_to_limited_search(%{property: :vehicle, text: "v2-label", limit: 2}, pid)
+
+      Server.update_vehicles({%{"1" => [@vehicle_on_inactive_block]}, [], []}, pid)
+
+      assert_receive {:new_realtime_data, lookup_args}
+
+      assert %{matching_vehicles: [@vehicle_on_inactive_block], has_more_matches: false} =
+               Server.lookup(lookup_args)
+    end
+
+    test "logged out vehicles are returned when include_logged_out_vehicles is true",
          %{server_pid: pid} do
-      first_search_params = %{property: :all, text: "90"}
-      second_search_params = %{property: :all, text: "asdf"}
+      Server.subscribe_to_limited_search(
+        %{property: :vehicle, text: "123", include_logged_out_vehicles: true, limit: 4},
+        pid
+      )
 
-      Server.subscribe_to_search(first_search_params, pid)
+      logged_in_vehicle =
+        build(:vehicle, id: "y1235", label: "1235", route_id: "1", run_id: "run_id")
+
+      logged_out_vehicle = build(:vehicle, id: "y1234", label: "1234", route_id: nil, run_id: nil)
+
+      Server.update_vehicles(
+        {%{
+           "1" => [logged_in_vehicle]
+         }, [], [logged_out_vehicle]},
+        pid
+      )
+
+      assert_receive {:new_realtime_data, lookup_args}
+
+      assert %{
+               matching_vehicles: [logged_in_vehicle, logged_out_vehicle],
+               has_more_matches: false
+             } == Server.lookup(lookup_args)
+    end
+
+    test "logged out vehicles are not returned when include_logged_out_vehicles is not set",
+         %{server_pid: pid} do
+      Server.subscribe_to_limited_search(%{property: :vehicle, text: "123", limit: 5}, pid)
+
+      logged_in_vehicle =
+        build(:vehicle, id: "y1235", label: "1235", route_id: "1", run_id: "run_id")
+
+      logged_out_vehicle = build(:vehicle, id: "y1234", label: "1234", route_id: nil, run_id: nil)
+
+      Server.update_vehicles({%{"1" => [logged_in_vehicle]}, [], [logged_out_vehicle]}, pid)
+
+      assert_receive {:new_realtime_data, lookup_args}
+
+      assert %{matching_vehicles: [logged_in_vehicle], has_more_matches: false} ==
+               Server.lookup(lookup_args)
+    end
+  end
+
+  describe "update_limited_search_subscription/2" do
+    setup do
+      {:ok, server_pid} = Server.start_link([])
+
+      :ok = Server.update_vehicles({@vehicles_by_route_id, [@shuttle], []}, server_pid)
+
+      %{server_pid: server_pid}
+    end
+
+    test "when update_limited_search_subscription is called, then when vehicles update the subscribing process is pushed only a message with their latest search params",
+         %{server_pid: pid} do
+      first_search_params = %{property: :all, text: "90", limit: 5}
+      second_search_params = %{property: :all, text: "asdf", limit: 5}
+
+      Server.subscribe_to_limited_search(first_search_params, pid)
       Server.update_vehicles({%{}, [@shuttle], []}, pid)
 
-      assert_receive {:new_realtime_data, {_ets_tid, {:search, ^first_search_params}}}
+      assert_receive {:new_realtime_data, {_ets_tid, {:limited_search, ^first_search_params}}}
 
-      Server.update_search_subscription(second_search_params, pid)
+      Server.update_limited_search_subscription(second_search_params, pid)
       Server.update_vehicles({%{}, [@shuttle], []}, pid)
-      assert_receive {:new_realtime_data, {_ets_tid, {:search, ^second_search_params}}}
-      refute_receive {:new_realtime_data, {_ets_tid, {:search, ^first_search_params}}}
+      assert_receive {:new_realtime_data, {_ets_tid, {:limited_search, ^second_search_params}}}
+      refute_receive {:new_realtime_data, {_ets_tid, {:limited_search, ^first_search_params}}}
     end
   end
 

--- a/test/realtime/vehicle_or_ghost_test.exs
+++ b/test/realtime/vehicle_or_ghost_test.exs
@@ -176,5 +176,41 @@ defmodule Realtime.VehicleOrGhostTest do
 
       assert VehicleOrGhost.find_by([ghost_with_nil_run_id], %{text: "710", property: :all}) == []
     end
+
+    test "when given a limit, takes only the limited number of matches" do
+      match_1 = build(:vehicle, %{label: "0001"})
+      other_1 = build(:vehicle, %{label: "not_match_1"})
+      match_2 = build(:vehicle, %{label: "0002"})
+      other_2 = build(:vehicle, %{label: "not_match_2"})
+      match_3 = build(:vehicle, %{label: "0003"})
+
+      assert [match_1, match_2] ==
+               VehicleOrGhost.find_by(
+                 [match_1, other_1, match_2, other_2, match_3],
+                 %{
+                   text: "000",
+                   property: :vehicle,
+                   limit: 2
+                 }
+               )
+    end
+
+    test "when limit exceeds number of matches, returns all matches" do
+      match_1 = build(:vehicle, %{label: "0001"})
+      other_1 = build(:vehicle, %{label: "not_match_1"})
+      match_2 = build(:vehicle, %{label: "0002"})
+      other_2 = build(:vehicle, %{label: "not_match_2"})
+      match_3 = build(:vehicle, %{label: "0003"})
+
+      assert [match_1, match_2, match_3] ==
+               VehicleOrGhost.find_by(
+                 [match_1, other_1, match_2, other_2, match_3],
+                 %{
+                   text: "000",
+                   property: :vehicle,
+                   limit: 5
+                 }
+               )
+    end
   end
 end

--- a/test/realtime/vehicle_or_ghost_test.exs
+++ b/test/realtime/vehicle_or_ghost_test.exs
@@ -176,7 +176,9 @@ defmodule Realtime.VehicleOrGhostTest do
 
       assert VehicleOrGhost.find_by([ghost_with_nil_run_id], %{text: "710", property: :all}) == []
     end
+  end
 
+  describe "take_limited_matches/2" do
     test "when given a limit, takes only the limited number of matches" do
       match_1 = build(:vehicle, %{label: "0001"})
       other_1 = build(:vehicle, %{label: "not_match_1"})
@@ -184,8 +186,8 @@ defmodule Realtime.VehicleOrGhostTest do
       other_2 = build(:vehicle, %{label: "not_match_2"})
       match_3 = build(:vehicle, %{label: "0003"})
 
-      assert [match_1, match_2] ==
-               VehicleOrGhost.find_by(
+      assert %{matching_vehicles: [match_1, match_2], has_more_matches: true} ==
+               VehicleOrGhost.take_limited_matches(
                  [match_1, other_1, match_2, other_2, match_3],
                  %{
                    text: "000",
@@ -202,8 +204,8 @@ defmodule Realtime.VehicleOrGhostTest do
       other_2 = build(:vehicle, %{label: "not_match_2"})
       match_3 = build(:vehicle, %{label: "0003"})
 
-      assert [match_1, match_2, match_3] ==
-               VehicleOrGhost.find_by(
+      assert %{matching_vehicles: [match_1, match_2, match_3], has_more_matches: false} ==
+               VehicleOrGhost.take_limited_matches(
                  [match_1, other_1, match_2, other_2, match_3],
                  %{
                    text: "000",

--- a/test/skate_web/channels/vehicles_search_channel_test.exs
+++ b/test/skate_web/channels/vehicles_search_channel_test.exs
@@ -1,0 +1,133 @@
+defmodule SkateWeb.VehiclesSearchChannelTest do
+  use SkateWeb.ChannelCase
+
+  import Test.Support.Helpers
+  import Skate.Factory
+
+  alias Phoenix.Socket
+
+  alias SkateWeb.{UserSocket, VehiclesSearchChannel}
+
+  setup do
+    reassign_env(:skate, :valid_token_fn, fn _socket -> true end)
+    reassign_env(:skate, :username_from_socket!, fn _socket -> "test_uid" end)
+
+    user = Skate.Settings.User.upsert("test_uid", "test_email")
+
+    socket =
+      UserSocket
+      |> socket("", %{})
+      |> Guardian.Phoenix.Socket.put_current_resource(%{id: user.id})
+
+    start_supervised({Registry, keys: :duplicate, name: Realtime.Supervisor.registry_name()})
+    start_supervised({Realtime.Server, name: Realtime.Server.default_name()})
+
+    {:ok,
+     socket: socket,
+     user: user,
+     vehicles: [
+       build(:vehicle, %{id: "1", label: "0001", route_id: "1"}),
+       build(:vehicle, %{id: "2", label: "not_match_2", route_id: "1"}),
+       build(:vehicle, %{id: "3", label: "0002", route_id: "1"}),
+       build(:vehicle, %{id: "4", label: "not_match_3", route_id: "1"}),
+       build(:vehicle, %{id: "5", label: "0003", route_id: "1"})
+     ]}
+  end
+
+  describe "join/3" do
+    test "returns current data matching search", %{
+      socket: socket,
+      vehicles: vehicles
+    } do
+      [match_1, _other, match_2, _other_2, _match_3] = vehicles
+      assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
+      expected_payload = %{data: [match_1, match_2]}
+
+      assert {:ok, ^expected_payload, %Socket{} = _socket} =
+               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
+                 "property" => "vehicle",
+                 "text" => "000",
+                 "limit" => 2
+               })
+    end
+
+    test "subscribes to vehicle updates", %{
+      socket: socket,
+      vehicles: vehicles
+    } do
+      [match_1, _other, match_2, _other_2, _match_3] = vehicles
+      assert :ok = Realtime.Server.update_vehicles({%{"1" => []}, [], []})
+
+      assert {:ok, %{data: []}, %Socket{} = _socket} =
+               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
+                 "property" => "vehicle",
+                 "text" => "000",
+                 "limit" => 2
+               })
+
+      assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
+
+      assert_push("search", %{data: [^match_1, ^match_2]})
+    end
+  end
+
+  describe "handle_info/2" do
+    test "pushes new vehicle data onto the socket", %{
+      socket: socket,
+      vehicles: vehicles
+    } do
+      [match_1, _other, match_2, _other_2, _match_3] = vehicles
+      ets = GenServer.call(Realtime.Server.default_name(), :ets)
+      assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
+
+      {:ok, _data, socket} =
+        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
+          "property" => "vehicle",
+          "text" => "000",
+          "limit" => 2
+        })
+
+      assert {:noreply, _socket} =
+               VehiclesSearchChannel.handle_info(
+                 {:new_realtime_data,
+                  {ets, {:search, %{property: :vehicle, text: "000", limit: 2}}}},
+                 socket
+               )
+
+      assert_push("search", %{data: [^match_1, ^match_2]})
+    end
+  end
+
+  describe "handle_in/3" do
+    test "updates subscription and returns data for updated search query", %{
+      socket: socket,
+      vehicles: vehicles
+    } do
+      [match_1, _other, match_2, _other_2, match_3] = vehicles
+      new_match = build(:vehicle, %{id: "6", label: "0004", route_id: "1"})
+
+      assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
+
+      {:ok, %{data: [^match_1, ^match_2]}, socket} =
+        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
+          "property" => "vehicle",
+          "text" => "000",
+          "limit" => 2
+        })
+
+      ref =
+        Phoenix.ChannelTest.push(socket, "update_search_query", %{
+          "property" => "vehicle",
+          "text" => "000",
+          "limit" => 3
+        })
+
+      assert_reply ref, :ok, %{data: [^match_1, ^match_2, ^match_3]}
+
+      assert :ok =
+               Realtime.Server.update_vehicles({%{"1" => [new_match, match_1, match_2]}, [], []})
+
+      assert_push("search", %{data: [^new_match, ^match_1, ^match_2]})
+    end
+  end
+end

--- a/test/skate_web/channels/vehicles_search_channel_test.exs
+++ b/test/skate_web/channels/vehicles_search_channel_test.exs
@@ -44,9 +44,7 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       expected_payload = %{data: %{matching_vehicles: [match_1, match_2], has_more_matches: true}}
 
       assert {:ok, ^expected_payload, %Socket{} = _socket} =
-               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
-                 "property" => "vehicle",
-                 "text" => "000",
+               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
                  "limit" => 2
                })
     end
@@ -60,9 +58,7 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
 
       assert {:ok, %{data: %{matching_vehicles: [], has_more_matches: false}},
               %Socket{} = _socket} =
-               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
-                 "property" => "vehicle",
-                 "text" => "000",
+               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
                  "limit" => 2
                })
 
@@ -84,9 +80,7 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
       {:ok, _data, socket} =
-        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
-          "property" => "vehicle",
-          "text" => "000",
+        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
           "limit" => 2
         })
 
@@ -114,16 +108,12 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
       {:ok, %{data: %{matching_vehicles: [^match_1, ^match_2], has_more_matches: true}}, socket} =
-        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:", %{
-          "property" => "vehicle",
-          "text" => "000",
+        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
           "limit" => 2
         })
 
       ref =
         Phoenix.ChannelTest.push(socket, "update_search_query", %{
-          "property" => "vehicle",
-          "text" => "000",
           "limit" => 3
         })
 

--- a/test/skate_web/channels/vehicles_search_channel_test.exs
+++ b/test/skate_web/channels/vehicles_search_channel_test.exs
@@ -44,9 +44,14 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       expected_payload = %{data: %{matching_vehicles: [match_1, match_2], has_more_matches: true}}
 
       assert {:ok, ^expected_payload, %Socket{} = _socket} =
-               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
-                 "limit" => 2
-               })
+               subscribe_and_join(
+                 socket,
+                 VehiclesSearchChannel,
+                 "vehicles_search:limited:vehicle:000",
+                 %{
+                   "limit" => 2
+                 }
+               )
     end
 
     test "subscribes to vehicle updates", %{
@@ -58,9 +63,14 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
 
       assert {:ok, %{data: %{matching_vehicles: [], has_more_matches: false}},
               %Socket{} = _socket} =
-               subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
-                 "limit" => 2
-               })
+               subscribe_and_join(
+                 socket,
+                 VehiclesSearchChannel,
+                 "vehicles_search:limited:vehicle:000",
+                 %{
+                   "limit" => 2
+                 }
+               )
 
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
@@ -80,9 +90,14 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
       {:ok, _data, socket} =
-        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
-          "limit" => 2
-        })
+        subscribe_and_join(
+          socket,
+          VehiclesSearchChannel,
+          "vehicles_search:limited:vehicle:000",
+          %{
+            "limit" => 2
+          }
+        )
 
       assert {:noreply, _socket} =
                VehiclesSearchChannel.handle_info(
@@ -108,9 +123,14 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
       {:ok, %{data: %{matching_vehicles: [^match_1, ^match_2], has_more_matches: true}}, socket} =
-        subscribe_and_join(socket, VehiclesSearchChannel, "vehicles_search:vehicle:000", %{
-          "limit" => 2
-        })
+        subscribe_and_join(
+          socket,
+          VehiclesSearchChannel,
+          "vehicles_search:limited:vehicle:000",
+          %{
+            "limit" => 2
+          }
+        )
 
       ref =
         Phoenix.ChannelTest.push(socket, "update_search_query", %{


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204956501632025/f

This new channel accepts messages to change the value for limit as well as the other search parameters. Otherwise, if limit was part of the topic, then increasing the limit would result in leaving the old topic, resulting in search results being cleared. I'm not totally a fan of how this means the `vehicles_search` topic is generic... very open to alternative ideas! 

I played around a bit with hooking this up to the frontend in `kb-limited-search-results-hook` to make sure we can communicate with this new channel as expected.