### PR TITLE
feat: Implement new search components

### DIFF
--- a/assets/css/_circle_x_icon.scss
+++ b/assets/css/_circle_x_icon.scss
@@ -17,7 +17,7 @@
 
     vector-effect: non-scaling-stroke;
     stroke-width: 1px;
-    stroke: $color-eggplant-700;
+    stroke: $color-eggplant-500;
     fill: $color-eggplant-200;
 
     .c-circle-x-icon-container:is(:focus, :focus-visible, :focus-within) & {

--- a/assets/css/_circle_x_icon.scss
+++ b/assets/css/_circle_x_icon.scss
@@ -1,0 +1,32 @@
+.c-circle-x-icon {
+  overflow: visible;
+  width: 0.75rem;
+  height: 0.75rem;
+
+  color: $color-gray-600;
+
+  &__path {
+    fill: currentColor;
+    .c-circle-x-icon-container:hover & {
+      color: $color-eggplant-500;
+    }
+  }
+
+  &__focus-circle {
+    display: none;
+
+    stroke-width: 1px;
+    stroke: $color-eggplant-700;
+    fill: $color-eggplant-200;
+
+    .c-circle-x-icon-container:is(:focus, :focus-visible, :focus-within) & {
+      display: inline;
+    }
+  }
+
+  // Fill the `X` part of the `__path` with white
+  &__white-fill {
+    fill: white;
+    r: 50%;
+  }
+}

--- a/assets/css/_circle_x_icon.scss
+++ b/assets/css/_circle_x_icon.scss
@@ -15,6 +15,7 @@
   &__focus-circle {
     display: none;
 
+    vector-effect: non-scaling-stroke;
     stroke-width: 1px;
     stroke: $color-eggplant-700;
     fill: $color-eggplant-200;

--- a/assets/css/_filter_accordion.scss
+++ b/assets/css/_filter_accordion.scss
@@ -1,0 +1,66 @@
+.c-filter-accordion {
+  @extend .c-garage-filter;
+
+  &__body {
+    // Display visual separator between content and header when expanded
+    border-top: 1px solid #d8dde1;
+  }
+
+  &__toggle-button {
+    height: 2.25rem;
+    padding: 0 0.5rem 0 1rem;
+    width: 100%;
+    line-height: 1;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    user-select: none;
+
+    &:focus .c-garage-filter__show-hide-icon {
+      border-radius: 4px;
+      background-color: $color-gray-200;
+    }
+  }
+
+  &__separator {
+    width: 100%;
+    border-bottom: 1px solid $color-gray-300;
+  }
+
+  &__show-hide-icon {
+    @extend .c-garage-filter__show-hide-icon;
+  }
+
+  &__filter {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__filters {
+    margin: 1rem;
+    color: $color-gray-700;
+  }
+
+  &__filter-toggle {
+    width: 100%;
+    // Expand tap target'
+    padding-block: 0.25rem;
+
+    display: flex;
+    justify-content: space-between;
+
+    .c-filter-accordion__toggle-icon {
+      display: inline-block;
+      width: 1.6875rem;
+    }
+
+    &:hover .c-filter-accordion__toggle-icon {
+      outline: 1px solid $color-eggplant-400;
+    }
+
+    &:focus-within .c-filter-accordion__toggle-icon {
+      outline: 1px solid $color-eggplant-500;
+      box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
+    }
+  }
+}

--- a/assets/css/_filter_accordion.scss
+++ b/assets/css/_filter_accordion.scss
@@ -15,7 +15,8 @@
 
     user-select: none;
 
-    &:focus .c-garage-filter__show-hide-icon {
+    // Fill icon when button is focused
+    &:focus .c-filter-accordion__show-hide-icon {
       border-radius: 4px;
       background-color: $color-gray-200;
     }

--- a/assets/css/_filter_accordion.scss
+++ b/assets/css/_filter_accordion.scss
@@ -28,6 +28,10 @@
   &__body {
     // Display visual separator between content and header when body is visible
     border-top: 1px solid #d8dde1;
+
+    .c-filter-accordion[aria-expanded="false"] & {
+      display: none;
+    }
   }
 
   &__filters {

--- a/assets/css/_filter_accordion.scss
+++ b/assets/css/_filter_accordion.scss
@@ -1,19 +1,18 @@
 .c-filter-accordion {
   @extend .c-garage-filter;
 
-  &__body {
-    // Display visual separator between content and header when expanded
-    border-top: 1px solid #d8dde1;
-  }
-
+  // Visible when collapsed
   &__toggle-button {
-    height: 2.25rem;
-    padding: 0 0.5rem 0 1rem;
-    width: 100%;
-    line-height: 1;
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    height: 2.25rem;
+    width: 100%;
+    padding: 0 0.5rem 0 1rem;
+
+    line-height: 1;
+
     user-select: none;
 
     &:focus .c-garage-filter__show-hide-icon {
@@ -22,32 +21,28 @@
     }
   }
 
-  &__separator {
-    width: 100%;
-    border-bottom: 1px solid $color-gray-300;
-  }
-
   &__show-hide-icon {
     @extend .c-garage-filter__show-hide-icon;
   }
 
-  &__filter {
-    display: flex;
-    justify-content: space-between;
+  &__body {
+    // Display visual separator between content and header when body is visible
+    border-top: 1px solid #d8dde1;
   }
 
   &__filters {
     margin: 1rem;
+
     color: $color-gray-700;
   }
 
   &__filter-toggle {
-    width: 100%;
-    // Expand tap target'
-    padding-block: 0.25rem;
-
     display: flex;
     justify-content: space-between;
+
+    width: 100%;
+    // Expand tap target
+    padding-block: 0.25rem;
 
     .c-filter-accordion__toggle-icon {
       display: inline-block;
@@ -59,8 +54,8 @@
     }
 
     &:focus-within .c-filter-accordion__toggle-icon {
-      outline: 1px solid $color-eggplant-500;
       box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
+      outline: 1px solid $color-eggplant-500;
     }
   }
 }

--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -22,7 +22,7 @@ $z-map-page-context: (
 }
 
 .c-map-page__input {
-  padding: 0 1.5625rem;
+  padding: 0 1rem;
 }
 
 .c-map-page {

--- a/assets/css/_old_search_form.scss
+++ b/assets/css/_old_search_form.scss
@@ -1,0 +1,95 @@
+.c-old-search-form__row {
+  display: flex;
+
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+  }
+}
+
+.c-old-search-form__text {
+  position: relative;
+  flex: 1 1 auto;
+}
+
+.c-old-search-form__input {
+  width: 100%;
+  height: 2.375rem;
+  box-sizing: border-box;
+
+  border-radius: 4px 0 0 4px;
+  border: none;
+
+  padding: 7px 0 7px 13px;
+
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-reg);
+  color: var(--font-color-on-light-600);
+
+  &:focus {
+    border: 1px solid $color-eggplant-500;
+  }
+}
+
+.c-old-search-form__clear {
+  @include button-icon(0.875rem);
+  right: 0.75rem;
+  position: absolute;
+  top: 0.75rem;
+
+  color: $color-gray-600;
+
+  &:hover,
+  &:focus-within {
+    color: $color-eggplant-500;
+  }
+}
+
+.c-old-search-form__submit {
+  @include button-icon(1rem);
+
+  flex: 1 0 auto;
+  max-width: 2.625rem;
+  max-height: 2.375rem;
+
+  border-radius: 0 4px 4px 0;
+
+  display: flex;
+
+  justify-content: center;
+  align-items: center;
+}
+
+.c-old-search-form__property-buttons {
+  display: flex;
+  flex: 1 0 auto;
+  list-style-type: none;
+  margin: 0;
+}
+
+.c-old-search-form__property-button {
+  flex: 1 0 0;
+  margin-right: 0.75rem;
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+.c-old-search-form__property-input {
+  display: none;
+}
+
+.c-old-search-form__property-label {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  height: 1.5625rem;
+
+  text-transform: capitalize;
+
+  // Override base button-search-filter style by giving a more specific selector
+  &.button-search-filter {
+    font-size: var(--font-size-xs);
+  }
+}

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -50,8 +50,9 @@
 .c-search-form__input-controls {
   position: absolute;
   // Stick to right side of box, do not intercept mouse events to the text input
-  inset-block: 0;
-  right: 0;
+  inset: 0;
+  left: unset;
+
   width: 0;
 
   // Layout controls from the right side

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -72,7 +72,13 @@
 }
 
 .c-search-form__submit {
-  @include button-icon(1rem);
+  span > svg {
+    fill: currentColor;
+
+    display: block;
+    height: 1rem;
+    aspect-ratio: 1/1;
+  }
 
   display: flex;
 

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -1,95 +1,97 @@
-.c-search-form__row {
+.c-search-form {
   display: flex;
-
-  &:not(:last-child) {
-    margin-bottom: 1rem;
-  }
+  flex-flow: column nowrap;
+  gap: 1rem;
 }
 
-.c-search-form__text {
+.c-search-form__search-control {
+  // Make control area match designs
+  height: 2.25rem;
+}
+
+.c-search-form__search-input-container {
+  // Layout floating `input-controls` over the `search-input-container`
   position: relative;
-  flex: 1 1 auto;
+
+  // Use bootstrap control as base for now
+  @extend .form-control;
+
+  // fill control defined valid area
+  height: 100%;
+  // Make space for `input-controls`
+  padding-right: calc(2.25rem * 2);
+  // Ignore bootstrap padding due to `input-controls`
+  padding-block: 0;
+
+  border-color: $color-gray-400;
+
+  &:focus,
+  &:focus-within,
+  &:active {
+    border: 1px solid $color-eggplant-500;
+    box-shadow: 0px 0px 0px 2px #aa4ef22b;
+    color: $color-gray-800;
+  }
 }
 
 .c-search-form__input {
+  // Align self within parent boundaries
   width: 100%;
-  height: 2.375rem;
-  box-sizing: border-box;
+  height: 100%;
 
-  border-radius: 4px 0 0 4px;
+  // Match font size from the Route Picker Search
+  @include font-small;
+
+  // Remove default displays
   border: none;
+}
 
-  padding: 7px 0 7px 13px;
+// #region Search Input Buttons
+.c-search-form__input-controls {
+  position: absolute;
+  // Stick to right side of box, do not intercept mouse events to the text input
+  inset-block: 0;
+  right: 0;
+  width: 0;
 
-  font-size: var(--font-size-s);
-  font-weight: var(--font-weight-reg);
-  color: var(--font-color-on-light-600);
-
-  &:focus {
-    border: 1px solid $color-eggplant-500;
-  }
+  // Layout controls from the right side
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: end;
 }
 
 .c-search-form__clear {
   @include button-icon(0.875rem);
-  right: 0.75rem;
-  position: absolute;
-  top: 0.75rem;
 
-  color: $color-gray-600;
-
-  &:hover,
-  &:focus-within {
-    color: $color-eggplant-500;
-  }
+  // Reserve space around icon in flex container
+  flex: 0;
+  height: 100%;
+  aspect-ratio: 1/1;
 }
 
 .c-search-form__submit {
   @include button-icon(1rem);
+  color: $color-eggplant-700;
 
-  flex: 1 0 auto;
-  max-width: 2.625rem;
-  max-height: 2.375rem;
+  &[disabled] {
+    color: var(--ui-grays-gray-700, #3c3f4c);
+  }
 
-  border-radius: 0 4px 4px 0;
+  // flex: 0 0 2.25rem;
+  // flex: 0;
+  height: 100%;
+  aspect-ratio: 1/1;
+
+  border-radius: 0.375rem;
+
+  &:focus {
+    border: 1px solid $color-eggplant-500;
+    box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
+  }
 
   display: flex;
 
   justify-content: center;
   align-items: center;
 }
-
-.c-search-form__property-buttons {
-  display: flex;
-  flex: 1 0 auto;
-  list-style-type: none;
-  margin: 0;
-}
-
-.c-search-form__property-button {
-  flex: 1 0 0;
-  margin-right: 0.75rem;
-
-  &:last-child {
-    margin-right: 0;
-  }
-}
-
-.c-search-form__property-input {
-  display: none;
-}
-
-.c-search-form__property-label {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  height: 1.5625rem;
-
-  text-transform: capitalize;
-
-  // Override base button-search-filter style by giving a more specific selector
-  &.button-search-filter {
-    font-size: var(--font-size-xs);
-  }
-}
+// #endregion Search Input Buttons

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -99,5 +99,9 @@
     border: 1px solid $color-eggplant-500;
     box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
   }
+
+  &:hover svg {
+    color: $color-eggplant-500;
+  }
 }
 // #endregion Search Input Buttons

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -7,12 +7,12 @@
 .c-search-form__search-control {
   // Make control area match designs
   height: 2.25rem;
+
+  // Layout floating `input-controls` over the `search-input-container`
+  position: relative;
 }
 
 .c-search-form__search-input-container {
-  // Layout floating `input-controls` over the `search-input-container`
-  position: relative;
-
   // Use bootstrap control as base for now
   @extend .form-control;
 

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -65,33 +65,32 @@
 
   // Reserve space around icon in flex container
   flex: 0;
+
   height: 100%;
   aspect-ratio: 1/1;
 }
 
 .c-search-form__submit {
   @include button-icon(1rem);
-  color: $color-eggplant-700;
-
-  &[disabled] {
-    color: var(--ui-grays-gray-700, #3c3f4c);
-  }
-
-  // flex: 0 0 2.25rem;
-  // flex: 0;
-  height: 100%;
-  aspect-ratio: 1/1;
-
-  border-radius: 0.375rem;
-
-  &:focus {
-    border: 1px solid $color-eggplant-500;
-    box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
-  }
 
   display: flex;
 
   justify-content: center;
   align-items: center;
+
+  height: 100%;
+  aspect-ratio: 1/1;
+
+  color: $color-eggplant-700;
+  border-radius: 0.375rem;
+
+  &[disabled] {
+    color: $color-gray-700;
+  }
+
+  &:focus {
+    border: 1px solid $color-eggplant-500;
+    box-shadow: 0px 0px 0px 2px rgba(170, 78, 242, 0.17);
+  }
 }
 // #endregion Search Input Buttons

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -66,6 +66,7 @@ $list-group-border-color: $color-gray-300;
 @import "data_status_banner";
 @import "disconnected_modal";
 @import "drawer_tab";
+@import "filter_accordion";
 @import "garage_filter";
 @import "icon_alert_circle";
 @import "inactive_notification_modal";

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -59,6 +59,7 @@ $list-group-border-color: $color-gray-300;
 @import "leaflet";
 @import "skate_ui";
 
+@import "circle_x_icon";
 @import "card";
 @import "close_button";
 @import "crowding";

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -92,6 +92,7 @@ $list-group-border-color: $color-gray-300;
 @import "notification_drawer";
 @import "notifications";
 @import "old_close_button";
+@import "old_search_form";
 @import "page";
 @import "picker_container";
 @import "presets";

--- a/assets/src/components/circleXIcon.tsx
+++ b/assets/src/components/circleXIcon.tsx
@@ -1,5 +1,10 @@
 import React, { ComponentPropsWithoutRef } from "react"
 
+/**
+ * Interactive variant of the `CircleXIcon`.
+ *
+ * Implements focus and hover states via CSS and SVG.
+ */
 export const CircleXIcon = (props: ComponentPropsWithoutRef<"svg">) => (
   <svg
     className="c-circle-x-icon"

--- a/assets/src/components/circleXIcon.tsx
+++ b/assets/src/components/circleXIcon.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentPropsWithoutRef } from "react"
+
+export const CircleXIcon = (props: ComponentPropsWithoutRef<"svg">) => (
+  <svg
+    className="c-circle-x-icon"
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <circle
+      cx="50%"
+      cy="50%"
+      r="75%"
+      className="c-circle-x-icon__focus-circle"
+    />
+    <circle cx="50%" cy="50%" r="75%" className="c-circle-x-icon__white-fill" />
+    <path
+      className="c-circle-x-icon__path"
+      d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+    />
+  </svg>
+)

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -2,7 +2,8 @@ import React, { ReactNode } from "react"
 import { useState } from "react"
 import { joinClasses } from "../helpers/dom"
 
-import { CollapseIcon, ExpandIcon, ToggleOffIcon, ToggleOnIcon } from "../helpers/icon"
+import { CollapseIcon, ExpandIcon } from "../helpers/icon"
+import { ToggleIcon } from "./toggleIcon"
 
 interface FilterAccordionProps {
   /**
@@ -84,7 +85,7 @@ export const FilterAccordionToggle = ({
 }: FilterAccordionToggleProps) => (
   <button className="c-filter-accordion__filter-toggle" onClick={onClick}>
     <span>{name}</span>
-    {active ? <ToggleOnIcon className="c-filter-accordion__toggle-icon" /> : <ToggleOffIcon className="c-filter-accordion__toggle-icon" />}
+    <ToggleIcon active={active} className="c-filter-accordion__toggle-icon" />
   </button>
 )
 

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -9,7 +9,7 @@ interface FilterAccordionProps {
   /**
    * The title of the Filter Accordion.
    */
-  heading: String
+  heading: string
   /**
    * Whether the accordion should be expanded or not.
    */

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -99,10 +99,18 @@ export const FilterAccordionToggleFilter = (
   )
 }
 
-export const FilterAccordionWithState = (
-  props: Omit<FilterAccordionProps, "showFilters" | "setShowFilters">
-) => {
-  const [showFilters, setShowFilters] = useState(true)
+export interface FilterAccordionWithExpansionStateProps
+  extends Omit<FilterAccordionProps, "showFilters" | "setShowFilters"> {
+  initialActiveState?: boolean
+}
+
+export const FilterAccordionWithExpansionState = ({
+  initialActiveState,
+  ...props
+}: FilterAccordionWithExpansionStateProps) => {
+  const [showFilters, setShowFilters] = useState<boolean>(
+    initialActiveState || true
+  )
   return (
     <FilterAccordion
       {...props}
@@ -134,4 +142,4 @@ export const FilterAccordionFilterWithState = ({
 FilterAccordion.ToggleFilter = FilterAccordionToggleFilter
 
 FilterAccordionToggleFilter.WithState = FilterAccordionFilterWithState
-FilterAccordion.WithState = FilterAccordionWithState
+FilterAccordion.WithExpansionState = FilterAccordionWithExpansionState

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -1,0 +1,136 @@
+import React, { ReactNode } from "react"
+import { useState } from "react"
+import { joinClasses } from "../helpers/dom"
+
+import { CollapseIcon, ExpandIcon, ToggleOffIcon, ToggleOnIcon } from "../helpers/icon"
+
+interface FilterAccordionProps {
+  /**
+   * The title of the Filter Accordion.
+   */
+  heading: String
+  /**
+   * Whether the accordion should be expanded or not.
+   */
+  showFilters: boolean
+  /**
+   * Callback invoked when the show-hide button is clicked.
+   */
+  setShowFilters: (currentValue: boolean) => void
+  /**
+   * Allows adding a className to the top level element
+   */
+  className?: string
+  /**
+   * Elements to show within the expanding section of the accordion
+   */
+  children: ReactNode
+}
+
+/**
+ * A accordion that provides a configurable header and contents.
+ * Specifically implements the designs for Filter Accordions within Skate.
+ */
+export const FilterAccordion = ({
+  heading,
+  showFilters,
+  setShowFilters,
+  className,
+  children,
+}: FilterAccordionProps) => {
+  return (
+    <div
+      className={joinClasses(["c-filter-accordion", className])}
+      aria-expanded={showFilters}
+    >
+      <button
+        className="c-filter-accordion__toggle-button"
+        onClick={() => setShowFilters(showFilters)}
+      >
+        <div className="c-filter-accordion__header">{heading}</div>
+        <div className="c-filter-accordion__show-hide-icon">
+          {showFilters ? <CollapseIcon /> : <ExpandIcon />}
+        </div>
+      </button>
+      <div className="c-filter-accordion__body" hidden={!showFilters}>
+        <ul className="c-filter-accordion__filters">{children}</ul>
+      </div>
+    </div>
+  )
+}
+
+export interface FilterAccordionToggleProps {
+  /**
+   * The name text to display next to the toggle control.
+   */
+  name: string
+  /**
+   * On/Off state of the toggle.
+   */
+  active?: boolean
+  /**
+   * Callback invoked when toggle is clicked
+   */
+  onClick?: () => void
+}
+
+/**
+ *
+ */
+export const FilterAccordionToggle = ({
+  name,
+  active = false,
+  onClick,
+}: FilterAccordionToggleProps) => (
+  <button className="c-filter-accordion__filter-toggle" onClick={onClick}>
+    <span>{name}</span>
+    {active ? <ToggleOnIcon className="c-filter-accordion__toggle-icon" /> : <ToggleOffIcon className="c-filter-accordion__toggle-icon" />}
+  </button>
+)
+
+export const FilterAccordionToggleFilter = (
+  props: FilterAccordionToggleProps
+) => {
+  return (
+    <li className="c-filter-accordion__filter">
+      <FilterAccordionToggle {...props} />
+    </li>
+  )
+}
+
+export const FilterAccordionWithState = (
+  props: Omit<FilterAccordionProps, "showFilters" | "setShowFilters">
+) => {
+  const [showFilters, setShowFilters] = useState(true)
+  return (
+    <FilterAccordion
+      {...props}
+      showFilters={showFilters}
+      setShowFilters={() => setShowFilters(!showFilters)}
+    />
+  )
+}
+
+export interface FilterAccordionFilterWithStateProps
+  extends Omit<FilterAccordionToggleProps, "active"> {
+  initialActiveState?: boolean
+}
+
+export const FilterAccordionFilterWithState = ({
+  initialActiveState = false,
+  ...props
+}: FilterAccordionFilterWithStateProps) => {
+  const [active, setActive] = useState(initialActiveState)
+  return (
+    <FilterAccordionToggleFilter
+      {...props}
+      active={active}
+      onClick={() => setActive((value) => !value)}
+    />
+  )
+}
+
+FilterAccordion.ToggleFilter = FilterAccordionToggleFilter
+
+FilterAccordionToggleFilter.WithState = FilterAccordionFilterWithState
+FilterAccordion.WithState = FilterAccordionWithState

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -29,8 +29,12 @@ interface FilterAccordionProps {
 }
 
 /**
- * A accordion that provides a configurable header and contents.
+ * A accordion that provides a configurable header and filter contents.
  * Specifically implements the designs for Filter Accordions within Skate.
+ *
+ * ---
+ *
+ * Split off from `<GarageFilter/>`
  */
 export const FilterAccordion = ({
   heading,
@@ -76,7 +80,7 @@ export interface FilterAccordionToggleProps {
 }
 
 /**
- *
+ * {@link FilterAccordion} Toggle button component.
  */
 export const FilterAccordionToggle = ({
   name,
@@ -89,6 +93,9 @@ export const FilterAccordionToggle = ({
   </button>
 )
 
+/**
+ * {@link FilterAccordion} Toggle Button list item
+ */
 export const FilterAccordionToggleFilter = (
   props: FilterAccordionToggleProps
 ) => {
@@ -104,6 +111,13 @@ export interface FilterAccordionWithExpansionStateProps
   initialActiveState?: boolean
 }
 
+/**
+ * {@link FilterAccordion} which contains it's own expanded state.
+ *
+ * ---
+ *
+ * Useful for prototyping and debugging.
+ */
 export const FilterAccordionWithExpansionState = ({
   initialActiveState,
   ...props
@@ -125,7 +139,16 @@ export interface FilterAccordionFilterWithStateProps
   initialActiveState?: boolean
 }
 
-export const FilterAccordionFilterWithState = ({
+/**
+ * {@link FilterAccordionToggleFilter} with self contained active state.
+ *
+ * ---
+ *
+ * There is not a good way to get the data out of this component, although it's
+ * useful for prototyping, you probably want {@link FilterAccordionToggleFilter}
+ * to receive events and control the state from another component.
+ */
+export const FilterAccordionToggleFilterWithState = ({
   initialActiveState = false,
   ...props
 }: FilterAccordionFilterWithStateProps) => {
@@ -139,7 +162,11 @@ export const FilterAccordionFilterWithState = ({
   )
 }
 
+/** @see {@link FilterAccordionToggleFilterWithState } */
+FilterAccordionToggleFilter.WithState = FilterAccordionToggleFilterWithState
+
+/** @see {@link FilterAccordionToggleFilter } */
 FilterAccordion.ToggleFilter = FilterAccordionToggleFilter
 
-FilterAccordionToggleFilter.WithState = FilterAccordionFilterWithState
+/** @see {@link FilterAccordionWithExpansionState } */
 FilterAccordion.WithExpansionState = FilterAccordionWithExpansionState

--- a/assets/src/components/filterAccordion.tsx
+++ b/assets/src/components/filterAccordion.tsx
@@ -53,7 +53,7 @@ export const FilterAccordion = ({
           {showFilters ? <CollapseIcon /> : <ExpandIcon />}
         </div>
       </button>
-      <div className="c-filter-accordion__body" hidden={!showFilters}>
+      <div className="c-filter-accordion__body">
         <ul className="c-filter-accordion__filters">{children}</ul>
       </div>
     </div>

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -23,7 +23,7 @@ import {
 import DrawerTab from "./drawerTab"
 import MapDisplay from "./mapPage/mapDisplay"
 import RecentSearches from "./recentSearches"
-import SearchForm from "./searchForm"
+import OldSearchForm from "./oldSearchForm"
 import SearchResults from "./searchResults"
 import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
 import Loading from "./loading"
@@ -59,7 +59,7 @@ const SearchMode = ({
   return (
     <>
       <div className="c-map-page__input u-hideable">
-        <SearchForm
+        <OldSearchForm
           formTitle="Search Map"
           inputTitle="Search Map Query"
           submitEvent="Search submitted from map page"

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -36,6 +36,8 @@ import RecentSearches from "./recentSearches"
 import SearchForm from "./searchForm"
 import SearchResults from "./searchResults"
 import { VisualSeparator } from "./visualSeparator"
+import OldSearchForm from "./oldSearchForm"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 
 const thereIsAnActiveSearch = (
   vehicles: (Vehicle | Ghost)[] | null,
@@ -56,10 +58,14 @@ const SearchMode = ({
     searchPageState.isActive ? searchPageState.query : null
   )
 
+  const CurrentSearchForm = inTestGroup(TestGroups.LocationSearch)
+    ? SearchForm
+    : OldSearchForm
+
   return (
     <>
       <div className="c-map-page__input u-hideable">
-        <SearchForm
+        <CurrentSearchForm
           formTitle="Search Map"
           inputTitle="Search Map Query"
           submitEvent="Search submitted from map page"

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -23,7 +23,6 @@ import {
 import DrawerTab from "./drawerTab"
 import MapDisplay from "./mapPage/mapDisplay"
 import RecentSearches from "./recentSearches"
-import OldSearchForm from "./oldSearchForm"
 import SearchResults from "./searchResults"
 import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
 import Loading from "./loading"
@@ -36,6 +35,7 @@ import RoutePropertiesCard from "./mapPage/routePropertiesCard"
 import usePatternsByIdForRoute from "../hooks/usePatternsByIdForRoute"
 import { RoutePattern } from "../schedule"
 import { VisualSeparator } from "./visualSeparator"
+import SearchForm from "./searchForm"
 
 const thereIsAnActiveSearch = (
   vehicles: (Vehicle | Ghost)[] | null,
@@ -59,7 +59,7 @@ const SearchMode = ({
   return (
     <>
       <div className="c-map-page__input u-hideable">
-        <OldSearchForm
+        <SearchForm
           formTitle="Search Map"
           inputTitle="Search Map Query"
           submitEvent="Search submitted from map page"

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -5,6 +5,8 @@ import React, {
   useEffect,
   useState,
 } from "react"
+import { Socket } from "phoenix"
+
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { joinClasses } from "../helpers/dom"
@@ -26,10 +28,8 @@ import RecentSearches from "./recentSearches"
 import SearchResults from "./searchResults"
 import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
 import Loading from "./loading"
-
 import useSocket from "../hooks/useSocket"
 import { ChevronLeftIcon, SearchIcon } from "../helpers/icon"
-import { Socket } from "phoenix"
 import useMostRecentVehicleById from "../hooks/useMostRecentVehicleById"
 import RoutePropertiesCard from "./mapPage/routePropertiesCard"
 import usePatternsByIdForRoute from "../hooks/usePatternsByIdForRoute"

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -1,3 +1,4 @@
+import { Socket } from "phoenix"
 import React, {
   ReactElement,
   useCallback,
@@ -5,37 +6,36 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { Socket } from "phoenix"
 
 import { SocketContext } from "../contexts/socketContext"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { joinClasses } from "../helpers/dom"
+import { ChevronLeftIcon, SearchIcon } from "../helpers/icon"
+import useMostRecentVehicleById from "../hooks/useMostRecentVehicleById"
+import usePatternsByIdForRoute from "../hooks/usePatternsByIdForRoute"
 import useSearchResults from "../hooks/useSearchResults"
+import useSocket from "../hooks/useSocket"
 import { Ghost, Vehicle, VehicleId } from "../realtime"
-import { OpenView, closeView } from "../state"
+import { RoutePattern } from "../schedule"
+import { closeView, OpenView } from "../state"
 import {
+  goBack,
+  newSearchSession,
   SearchPageState,
   SelectedEntity,
   SelectedEntityType,
   SelectedRoutePattern,
-  goBack,
-  newSearchSession,
   setSelectedEntity,
 } from "../state/searchPageState"
 import DrawerTab from "./drawerTab"
-import MapDisplay from "./mapPage/mapDisplay"
-import RecentSearches from "./recentSearches"
-import SearchResults from "./searchResults"
-import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
 import Loading from "./loading"
-import useSocket from "../hooks/useSocket"
-import { ChevronLeftIcon, SearchIcon } from "../helpers/icon"
-import useMostRecentVehicleById from "../hooks/useMostRecentVehicleById"
+import MapDisplay from "./mapPage/mapDisplay"
 import RoutePropertiesCard from "./mapPage/routePropertiesCard"
-import usePatternsByIdForRoute from "../hooks/usePatternsByIdForRoute"
-import { RoutePattern } from "../schedule"
-import { VisualSeparator } from "./visualSeparator"
+import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
+import RecentSearches from "./recentSearches"
 import SearchForm from "./searchForm"
+import SearchResults from "./searchResults"
+import { VisualSeparator } from "./visualSeparator"
 
 const thereIsAnActiveSearch = (
   vehicles: (Vehicle | Ghost)[] | null,

--- a/assets/src/components/oldSearchForm.tsx
+++ b/assets/src/components/oldSearchForm.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { CircleXIcon, SearchIcon } from "../helpers/icon"
-import { isValidSearchQuery } from "../models/searchQuery"
+import { filterToAlphanumeric } from "../models/searchQuery"
 import {
   setSearchProperty,
   setSearchText,
@@ -91,7 +91,7 @@ const OldSearchForm = ({
           title="Submit"
           className="c-old-search-form__submit button-submit"
           onClick={subscribeToSearch}
-          disabled={!isValidSearchQuery(query)}
+          disabled={!(filterToAlphanumeric(query.text).length >= 2)}
         >
           <SearchIcon />
         </button>

--- a/assets/src/components/oldSearchForm.tsx
+++ b/assets/src/components/oldSearchForm.tsx
@@ -1,0 +1,130 @@
+import React, { useContext } from "react"
+import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import { CircleXIcon, SearchIcon } from "../helpers/icon"
+import { isValidSearchQuery } from "../models/searchQuery"
+import {
+  setSearchProperty,
+  setSearchText,
+  submitSearch,
+} from "../state/searchPageState"
+
+const SEARCH_PROPERTIES = ["all", "run", "vehicle", "operator"]
+
+const OldSearchForm = ({
+  onSubmit,
+  onClear,
+  inputTitle,
+  formTitle,
+  submitEvent,
+}: {
+  onSubmit?: () => void
+  onClear?: () => void
+  inputTitle?: string
+  formTitle?: string
+  submitEvent?: string
+}) => {
+  const [
+    {
+      searchPageState: { query },
+    },
+    dispatch,
+  ] = useContext(StateDispatchContext)
+  const handleTextInput = (event: React.FormEvent<HTMLInputElement>): void => {
+    const value = event.currentTarget.value
+    dispatch(setSearchText(value))
+  }
+
+  const clearTextInput = (event: React.FormEvent<EventTarget>): void => {
+    event.preventDefault()
+    dispatch(setSearchText(""))
+    if (onClear) {
+      onClear()
+    }
+  }
+
+  const handlePropertyChange = (
+    event: React.FormEvent<HTMLInputElement>
+  ): void => {
+    dispatch(setSearchProperty(event.currentTarget.value))
+    dispatch(submitSearch())
+  }
+
+  const subscribeToSearch = (event: React.FormEvent<EventTarget>) => {
+    event.preventDefault()
+
+    submitEvent && window.FS?.event(submitEvent)
+
+    dispatch(submitSearch())
+    if (onSubmit) {
+      onSubmit()
+    }
+  }
+
+  return (
+    <form
+      onSubmit={subscribeToSearch}
+      className="c-old-search-form"
+      aria-label={formTitle || "Submit Search"}
+    >
+      <div className="c-old-search-form__row">
+        <div className="c-old-search-form__text">
+          <input
+            type="text"
+            className="c-old-search-form__input"
+            placeholder="Search"
+            aria-label={inputTitle || "Search"}
+            value={query.text}
+            onChange={handleTextInput}
+          />
+          <button
+            type="reset"
+            title="Clear Search"
+            className="c-old-search-form__clear"
+            onClick={clearTextInput}
+          >
+            <CircleXIcon />
+          </button>
+        </div>
+
+        <button
+          type="submit"
+          title="Submit"
+          className="c-old-search-form__submit button-submit"
+          onClick={subscribeToSearch}
+          disabled={!isValidSearchQuery(query)}
+        >
+          <SearchIcon />
+        </button>
+      </div>
+
+      <div className="c-old-search-form__row">
+        <ul className="c-old-search-form__property-buttons">
+          {SEARCH_PROPERTIES.map((property) => (
+            <li
+              className="c-old-search-form__property-button"
+              key={`search-property-${property}`}
+            >
+              <input
+                id={`property-${property}`}
+                className="c-old-search-form__property-input"
+                type="radio"
+                name="property"
+                value={property}
+                checked={query.property === property}
+                onChange={handlePropertyChange}
+              />
+              <label
+                htmlFor={`property-${property}`}
+                className="c-old-search-form__property-label button-search-filter"
+              >
+                {property}
+              </label>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </form>
+  )
+}
+
+export default OldSearchForm

--- a/assets/src/components/oldSearchForm.tsx
+++ b/assets/src/components/oldSearchForm.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { CircleXIcon, SearchIcon } from "../helpers/icon"
-import { filterToAlphanumeric } from "../models/searchQuery"
+import { isValidSearchQuery } from "../models/searchQuery"
 import {
   setSearchProperty,
   setSearchText,
@@ -91,7 +91,7 @@ const OldSearchForm = ({
           title="Submit"
           className="c-old-search-form__submit button-submit"
           onClick={subscribeToSearch}
-          disabled={!(filterToAlphanumeric(query.text).length >= 2)}
+          disabled={!isValidSearchQuery(query)}
         >
           <SearchIcon />
         </button>

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -81,27 +81,27 @@ const SearchForm = ({
             onChange={handleTextInput}
             ref={formSearchInput}
           />
-          <div className="c-search-form__input-controls">
-            <button
-              hidden={query.text.length === 0}
-              type="reset"
-              title="Clear Search"
-              className="c-search-form__clear c-circle-x-icon-container"
-              onClick={clearTextInput}
-            >
-              <CircleXIcon />
-            </button>
-            <button
-              type="submit"
-              title="Submit"
-              className="c-search-form__submit"
-              onClick={subscribeToSearch}
-              // TODO(design): add error states instead of using `disabled`
-              disabled={!isValidSearchQuery(query)}
-            >
-              <SearchIcon />
-            </button>
-          </div>
+        </div>
+        <div className="c-search-form__input-controls">
+          <button
+            hidden={query.text.length === 0}
+            type="reset"
+            title="Clear Search"
+            className="c-search-form__clear c-circle-x-icon-container"
+            onClick={clearTextInput}
+          >
+            <CircleXIcon />
+          </button>
+          <button
+            type="submit"
+            title="Submit"
+            className="c-search-form__submit"
+            onClick={subscribeToSearch}
+            // TODO(design): add error states instead of using `disabled`
+            disabled={!isValidSearchQuery(query)}
+          >
+            <SearchIcon />
+          </button>
         </div>
       </div>
       <FilterAccordion.WithExpansionState heading="Filter results">

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -10,6 +10,13 @@ import {
 } from "../state/searchPageState"
 
 const SEARCH_PROPERTIES = ["all", "run", "vehicle", "operator"]
+type SearchFormProps = {
+  onSubmit?: () => void
+  onClear?: () => void
+  inputTitle?: string
+  formTitle?: string
+  submitEvent?: string
+}
 
 const SearchForm = ({
   onSubmit,
@@ -17,13 +24,7 @@ const SearchForm = ({
   inputTitle,
   formTitle,
   submitEvent,
-}: {
-  onSubmit?: () => void
-  onClear?: () => void
-  inputTitle?: string
-  formTitle?: string
-  submitEvent?: string
-}) => {
+}: SearchFormProps) => {
   const [
     {
       searchPageState: { query },

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -1,6 +1,7 @@
-import React, { useContext } from "react"
+import React, { useContext, useRef } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
-import { CircleXIcon, SearchIcon } from "../helpers/icon"
+import { SearchIcon } from "../helpers/icon"
+import { CircleXIcon } from "./circleXIcon"
 import { isValidSearchQuery } from "../models/searchQuery"
 import {
   setSearchProperty,
@@ -34,9 +35,12 @@ const SearchForm = ({
     dispatch(setSearchText(value))
   }
 
+  const formSearchInput = useRef<HTMLInputElement | null>(null)
   const clearTextInput = (event: React.FormEvent<EventTarget>): void => {
     event.preventDefault()
     dispatch(setSearchText(""))
+    // Focus text box after clearing input
+    formSearchInput.current?.focus()
     if (onClear) {
       onClear()
     }
@@ -66,8 +70,8 @@ const SearchForm = ({
       className="c-search-form"
       aria-label={formTitle || "Submit Search"}
     >
-      <div className="c-search-form__row">
-        <div className="c-search-form__text">
+      <div className="c-search-form__search-control">
+        <div className="c-search-form__search-input-container">
           <input
             type="text"
             className="c-search-form__input"
@@ -75,26 +79,30 @@ const SearchForm = ({
             aria-label={inputTitle || "Search"}
             value={query.text}
             onChange={handleTextInput}
+            ref={formSearchInput}
           />
-          <button
-            type="reset"
-            title="Clear Search"
-            className="c-search-form__clear"
-            onClick={clearTextInput}
-          >
-            <CircleXIcon />
-          </button>
+          <div className="c-search-form__input-controls">
+            <button
+              hidden={query.text.length === 0}
+              type="reset"
+              title="Clear Search"
+              className="c-search-form__clear c-circle-x-icon-container"
+              onClick={clearTextInput}
+            >
+              <CircleXIcon />
+            </button>
+            <button
+              type="submit"
+              title="Submit"
+              className="c-search-form__submit"
+              onClick={subscribeToSearch}
+              // TODO(design): add error states instead of using `disabled`
+              disabled={!isValidSearchQuery(query)}
+            >
+              <SearchIcon />
+            </button>
+          </div>
         </div>
-
-        <button
-          type="submit"
-          title="Submit"
-          className="c-search-form__submit button-submit"
-          onClick={subscribeToSearch}
-          disabled={!isValidSearchQuery(query)}
-        >
-          <SearchIcon />
-        </button>
       </div>
 
       <div className="c-search-form__row">
@@ -112,7 +120,7 @@ const SearchForm = ({
                 value={property}
                 checked={query.property === property}
                 onChange={handlePropertyChange}
-              />
+        />
               <label
                 htmlFor={`property-${property}`}
                 className="c-search-form__property-label button-search-filter"

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -2,14 +2,14 @@ import React, { useContext, useRef } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
 import { CircleXIcon } from "./circleXIcon"
-import { isValidSearchQuery } from "../models/searchQuery"
+import { FilterAccordion } from "./filterAccordion"
+import { isValidSearchQuery, SearchQueryType } from "../models/searchQuery"
 import {
   setSearchProperty,
   setSearchText,
   submitSearch,
 } from "../state/searchPageState"
 
-const SEARCH_PROPERTIES = ["all", "run", "vehicle", "operator"]
 type SearchFormProps = {
   onSubmit?: () => void
   onClear?: () => void
@@ -31,10 +31,6 @@ const SearchForm = ({
     },
     dispatch,
   ] = useContext(StateDispatchContext)
-  const handleTextInput = (event: React.FormEvent<HTMLInputElement>): void => {
-    const value = event.currentTarget.value
-    dispatch(setSearchText(value))
-  }
 
   const formSearchInput = useRef<HTMLInputElement | null>(null)
   const clearTextInput = (event: React.FormEvent<EventTarget>): void => {
@@ -47,10 +43,13 @@ const SearchForm = ({
     }
   }
 
-  const handlePropertyChange = (
-    event: React.FormEvent<HTMLInputElement>
-  ): void => {
-    dispatch(setSearchProperty(event.currentTarget.value))
+  const handleTextInput = (event: React.FormEvent<HTMLInputElement>): void => {
+    const value = event.currentTarget.value
+    dispatch(setSearchText(value))
+  }
+
+  const handlePropertyChange = (value: SearchQueryType): void => {
+    dispatch(setSearchProperty(value))
     dispatch(submitSearch())
   }
 
@@ -105,33 +104,28 @@ const SearchForm = ({
           </div>
         </div>
       </div>
-
-      <div className="c-search-form__row">
-        <ul className="c-search-form__property-buttons">
-          {SEARCH_PROPERTIES.map((property) => (
-            <li
-              className="c-search-form__property-button"
-              key={`search-property-${property}`}
-            >
-              <input
-                id={`property-${property}`}
-                className="c-search-form__property-input"
-                type="radio"
-                name="property"
-                value={property}
-                checked={query.property === property}
-                onChange={handlePropertyChange}
+      <FilterAccordion.WithExpansionState heading="Filter results">
+        <FilterAccordion.ToggleFilter
+          name={"Vehicles"}
+          active={query.property === "vehicle"}
+          onClick={() => handlePropertyChange("vehicle")}
         />
-              <label
-                htmlFor={`property-${property}`}
-                className="c-search-form__property-label button-search-filter"
-              >
-                {property}
-              </label>
-            </li>
-          ))}
-        </ul>
-      </div>
+        <FilterAccordion.ToggleFilter
+          name={"Operators"}
+          active={query.property === "operator"}
+          onClick={() => handlePropertyChange("operator")}
+        />
+        <FilterAccordion.ToggleFilter
+          name={"Runs"}
+          active={query.property === "run"}
+          onClick={() => handlePropertyChange("run")}
+        />
+        <FilterAccordion.ToggleFilter
+          name={"Locations"}
+          active={false}
+          onClick={() => handlePropertyChange("all")}
+        />
+      </FilterAccordion.WithExpansionState>
     </form>
   )
 }

--- a/assets/src/components/searchPage.tsx
+++ b/assets/src/components/searchPage.tsx
@@ -11,7 +11,7 @@ import { selectVehicle } from "../state"
 import { SearchPageState } from "../state/searchPageState"
 import { MapFollowingPrimaryVehicles } from "./map"
 import RecentSearches from "./recentSearches"
-import SearchForm from "./searchForm"
+import OldSearchForm from "./oldSearchForm"
 import SearchResults from "./searchResults"
 import { LayersControl } from "./map/controls/layersControl"
 import { TileType } from "../tilesetUrls"
@@ -89,7 +89,7 @@ const SearchPage = (): ReactElement<HTMLDivElement> => {
     >
       <div className="c-search-page__input-and-results">
         <div className="c-search-page__input">
-          <SearchForm />
+          <OldSearchForm />
 
           <ToggleMobileDisplayButton
             mobileDisplay={mobileDisplay}

--- a/assets/src/components/toggleIcon.tsx
+++ b/assets/src/components/toggleIcon.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { ToggleOnIcon, ToggleOffIcon } from "../helpers/icon"
+import { SvgIconWrapperProps } from "../helpers/svgIcon"
+
+export interface ToggleIconProps extends SvgIconWrapperProps {
+  active: boolean
+}
+
+export const ToggleIcon = ({ active, ...props }: ToggleIconProps) =>
+  active ? <ToggleOnIcon {...props} /> : <ToggleOffIcon {...props} />

--- a/assets/src/helpers/svgIcon.tsx
+++ b/assets/src/helpers/svgIcon.tsx
@@ -1,7 +1,9 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from "react"
 
+export type SvgIconWrapperProps = ComponentPropsWithoutRef<"span">
+
 // https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring
-interface SvgIconProps extends ComponentPropsWithoutRef<"span"> {
+interface SvgIconProps extends SvgIconWrapperProps {
   svgText: string
 }
 

--- a/assets/src/models/searchQuery.ts
+++ b/assets/src/models/searchQuery.ts
@@ -18,4 +18,4 @@ export const filterToAlphanumeric = (text: string): string =>
   text.replace(/[^0-9a-zA-Z]/g, "")
 
 export const isValidSearchQuery = ({ text }: SearchQuery): boolean =>
-  filterToAlphanumeric(text).length >= 2
+  filterToAlphanumeric(text).length >= 3

--- a/assets/src/models/searchQuery.ts
+++ b/assets/src/models/searchQuery.ts
@@ -18,4 +18,4 @@ export const filterToAlphanumeric = (text: string): string =>
   text.replace(/[^0-9a-zA-Z]/g, "")
 
 export const isValidSearchQuery = ({ text }: SearchQuery): boolean =>
-  filterToAlphanumeric(text).length >= 3
+  filterToAlphanumeric(text).length >= 2

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -23,158 +23,118 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__search-control"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__search-input-container"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
-              <div
-                class="c-search-form__input-controls"
-              >
-                <button
-                  class="c-search-form__clear c-circle-x-icon-container"
-                  hidden=""
-                  title="Clear Search"
-                  type="reset"
-                >
-                  <svg
-                    class="c-circle-x-icon"
-                    viewBox="0 0 48 48"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      class="c-circle-x-icon__focus-circle"
-                      cx="50%"
-                      cy="50%"
-                      r="75%"
-                    />
-                    <circle
-                      class="c-circle-x-icon__white-fill"
-                      cx="50%"
-                      cy="50%"
-                      r="75%"
-                    />
-                    <path
-                      class="c-circle-x-icon__path"
-                      d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  class="c-search-form__submit"
-                  disabled=""
-                  title="Submit"
-                  type="submit"
-                >
-                  <span>
-                    <svg />
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-expanded="true"
-            class="c-filter-accordion"
-          >
-            <button
-              class="c-filter-accordion__toggle-button"
-            >
-              <div
-                class="c-filter-accordion__header"
-              >
-                Filter results
-              </div>
-              <div
-                class="c-filter-accordion__show-hide-icon"
+              <button
+                class="c-old-search-form__clear"
+                title="Clear Search"
+                type="reset"
               >
                 <span>
                   <svg />
                 </span>
-              </div>
-            </button>
-            <div
-              class="c-filter-accordion__body"
-            >
-              <ul
-                class="c-filter-accordion__filters"
-              >
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Vehicles
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Operators
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Runs
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Locations
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-              </ul>
+              </button>
             </div>
+            <button
+              class="c-old-search-form__submit button-submit"
+              disabled=""
+              title="Submit"
+              type="submit"
+            >
+              <span>
+                <svg />
+              </span>
+            </button>
+          </div>
+          <div
+            class="c-old-search-form__row"
+          >
+            <ul
+              class="c-old-search-form__property-buttons"
+            >
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  checked=""
+                  class="c-old-search-form__property-input"
+                  id="property-all"
+                  name="property"
+                  type="radio"
+                  value="all"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-all"
+                >
+                  all
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-run"
+                  name="property"
+                  type="radio"
+                  value="run"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-run"
+                >
+                  run
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-vehicle"
+                  name="property"
+                  type="radio"
+                  value="vehicle"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-vehicle"
+                >
+                  vehicle
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-operator"
+                  name="property"
+                  type="radio"
+                  value="operator"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-operator"
+                >
+                  operator
+                </label>
+              </li>
+            </ul>
           </div>
         </form>
       </div>
@@ -441,158 +401,118 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__search-control"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__search-input-container"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
-              <div
-                class="c-search-form__input-controls"
-              >
-                <button
-                  class="c-search-form__clear c-circle-x-icon-container"
-                  hidden=""
-                  title="Clear Search"
-                  type="reset"
-                >
-                  <svg
-                    class="c-circle-x-icon"
-                    viewBox="0 0 48 48"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      class="c-circle-x-icon__focus-circle"
-                      cx="50%"
-                      cy="50%"
-                      r="75%"
-                    />
-                    <circle
-                      class="c-circle-x-icon__white-fill"
-                      cx="50%"
-                      cy="50%"
-                      r="75%"
-                    />
-                    <path
-                      class="c-circle-x-icon__path"
-                      d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  class="c-search-form__submit"
-                  disabled=""
-                  title="Submit"
-                  type="submit"
-                >
-                  <span>
-                    <svg />
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            aria-expanded="true"
-            class="c-filter-accordion"
-          >
-            <button
-              class="c-filter-accordion__toggle-button"
-            >
-              <div
-                class="c-filter-accordion__header"
-              >
-                Filter results
-              </div>
-              <div
-                class="c-filter-accordion__show-hide-icon"
+              <button
+                class="c-old-search-form__clear"
+                title="Clear Search"
+                type="reset"
               >
                 <span>
                   <svg />
                 </span>
-              </div>
-            </button>
-            <div
-              class="c-filter-accordion__body"
-            >
-              <ul
-                class="c-filter-accordion__filters"
-              >
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Vehicles
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Operators
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Runs
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-                <li
-                  class="c-filter-accordion__filter"
-                >
-                  <button
-                    class="c-filter-accordion__filter-toggle"
-                  >
-                    <span>
-                      Locations
-                    </span>
-                    <span
-                      class="c-filter-accordion__toggle-icon"
-                    >
-                      <svg />
-                    </span>
-                  </button>
-                </li>
-              </ul>
+              </button>
             </div>
+            <button
+              class="c-old-search-form__submit button-submit"
+              disabled=""
+              title="Submit"
+              type="submit"
+            >
+              <span>
+                <svg />
+              </span>
+            </button>
+          </div>
+          <div
+            class="c-old-search-form__row"
+          >
+            <ul
+              class="c-old-search-form__property-buttons"
+            >
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  checked=""
+                  class="c-old-search-form__property-input"
+                  id="property-all"
+                  name="property"
+                  type="radio"
+                  value="all"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-all"
+                >
+                  all
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-run"
+                  name="property"
+                  type="radio"
+                  value="run"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-run"
+                >
+                  run
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-vehicle"
+                  name="property"
+                  type="radio"
+                  value="vehicle"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-vehicle"
+                >
+                  vehicle
+                </label>
+              </li>
+              <li
+                class="c-old-search-form__property-button"
+              >
+                <input
+                  class="c-old-search-form__property-input"
+                  id="property-operator"
+                  name="property"
+                  type="radio"
+                  value="operator"
+                />
+                <label
+                  class="c-old-search-form__property-label button-search-filter"
+                  for="property-operator"
+                >
+                  operator
+                </label>
+              </li>
+            </ul>
           </div>
         </form>
       </div>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -23,23 +23,23 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__text"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-search-form__clear"
+                class="c-old-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -49,7 +49,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
               </button>
             </div>
             <button
-              class="c-search-form__submit button-submit"
+              class="c-old-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -60,75 +60,75 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </button>
           </div>
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <ul
-              class="c-search-form__property-buttons"
+              class="c-old-search-form__property-buttons"
             >
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator
@@ -401,23 +401,23 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__text"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-search-form__clear"
+                class="c-old-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -427,7 +427,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
               </button>
             </div>
             <button
-              class="c-search-form__submit button-submit"
+              class="c-old-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -438,75 +438,75 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </button>
           </div>
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <ul
-              class="c-search-form__property-buttons"
+              class="c-old-search-form__property-buttons"
             >
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -84,81 +84,97 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </div>
           </div>
           <div
-            class="c-search-form__row"
+            aria-expanded="true"
+            class="c-filter-accordion"
           >
-            <ul
-              class="c-search-form__property-buttons"
+            <button
+              class="c-filter-accordion__toggle-button"
             >
-              <li
-                class="c-search-form__property-button"
+              <div
+                class="c-filter-accordion__header"
               >
-                <input
-                  checked=""
-                  class="c-search-form__property-input"
-                  id="property-all"
-                  name="property"
-                  type="radio"
-                  value="all"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-all"
-                >
-                  all
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
+                Filter results
+              </div>
+              <div
+                class="c-filter-accordion__show-hide-icon"
               >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-run"
-                  name="property"
-                  type="radio"
-                  value="run"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-run"
-                >
-                  run
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
+                <span>
+                  <svg />
+                </span>
+              </div>
+            </button>
+            <div
+              class="c-filter-accordion__body"
+            >
+              <ul
+                class="c-filter-accordion__filters"
               >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-vehicle"
-                  name="property"
-                  type="radio"
-                  value="vehicle"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-vehicle"
+                <li
+                  class="c-filter-accordion__filter"
                 >
-                  vehicle
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
-              >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-operator"
-                  name="property"
-                  type="radio"
-                  value="operator"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-operator"
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Vehicles
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
                 >
-                  operator
-                </label>
-              </li>
-            </ul>
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Operators
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
+                >
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Runs
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
+                >
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Locations
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
           </div>
         </form>
       </div>
@@ -486,81 +502,97 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </div>
           </div>
           <div
-            class="c-search-form__row"
+            aria-expanded="true"
+            class="c-filter-accordion"
           >
-            <ul
-              class="c-search-form__property-buttons"
+            <button
+              class="c-filter-accordion__toggle-button"
             >
-              <li
-                class="c-search-form__property-button"
+              <div
+                class="c-filter-accordion__header"
               >
-                <input
-                  checked=""
-                  class="c-search-form__property-input"
-                  id="property-all"
-                  name="property"
-                  type="radio"
-                  value="all"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-all"
-                >
-                  all
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
+                Filter results
+              </div>
+              <div
+                class="c-filter-accordion__show-hide-icon"
               >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-run"
-                  name="property"
-                  type="radio"
-                  value="run"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-run"
-                >
-                  run
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
+                <span>
+                  <svg />
+                </span>
+              </div>
+            </button>
+            <div
+              class="c-filter-accordion__body"
+            >
+              <ul
+                class="c-filter-accordion__filters"
               >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-vehicle"
-                  name="property"
-                  type="radio"
-                  value="vehicle"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-vehicle"
+                <li
+                  class="c-filter-accordion__filter"
                 >
-                  vehicle
-                </label>
-              </li>
-              <li
-                class="c-search-form__property-button"
-              >
-                <input
-                  class="c-search-form__property-input"
-                  id="property-operator"
-                  name="property"
-                  type="radio"
-                  value="operator"
-                />
-                <label
-                  class="c-search-form__property-label button-search-filter"
-                  for="property-operator"
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Vehicles
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
                 >
-                  operator
-                </label>
-              </li>
-            </ul>
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Operators
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
+                >
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Runs
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+                <li
+                  class="c-filter-accordion__filter"
+                >
+                  <button
+                    class="c-filter-accordion__filter-toggle"
+                  >
+                    <span>
+                      Locations
+                    </span>
+                    <span
+                      class="c-filter-accordion__toggle-icon"
+                    >
+                      <svg />
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </div>
           </div>
         </form>
       </div>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -23,23 +23,23 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-old-search-form"
+          class="c-search-form"
         >
           <div
-            class="c-old-search-form__row"
+            class="c-search-form__row"
           >
             <div
-              class="c-old-search-form__text"
+              class="c-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-old-search-form__input"
+                class="c-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-old-search-form__clear"
+                class="c-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -49,7 +49,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
               </button>
             </div>
             <button
-              class="c-old-search-form__submit button-submit"
+              class="c-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -60,75 +60,75 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             </button>
           </div>
           <div
-            class="c-old-search-form__row"
+            class="c-search-form__row"
           >
             <ul
-              class="c-old-search-form__property-buttons"
+              class="c-search-form__property-buttons"
             >
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator
@@ -401,23 +401,23 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
       >
         <form
           aria-label="Search Map"
-          class="c-old-search-form"
+          class="c-search-form"
         >
           <div
-            class="c-old-search-form__row"
+            class="c-search-form__row"
           >
             <div
-              class="c-old-search-form__text"
+              class="c-search-form__text"
             >
               <input
                 aria-label="Search Map Query"
-                class="c-old-search-form__input"
+                class="c-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-old-search-form__clear"
+                class="c-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -427,7 +427,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
               </button>
             </div>
             <button
-              class="c-old-search-form__submit button-submit"
+              class="c-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -438,75 +438,75 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             </button>
           </div>
           <div
-            class="c-old-search-form__row"
+            class="c-search-form__row"
           >
             <ul
-              class="c-old-search-form__property-buttons"
+              class="c-search-form__property-buttons"
             >
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-old-search-form__property-button"
+                class="c-search-form__property-button"
               >
                 <input
-                  class="c-old-search-form__property-input"
+                  class="c-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-old-search-form__property-label button-search-filter"
+                  class="c-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -26,10 +26,10 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
           class="c-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-search-form__search-control"
           >
             <div
-              class="c-search-form__text"
+              class="c-search-form__search-input-container"
             >
               <input
                 aria-label="Search Map Query"
@@ -38,26 +38,50 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
                 type="text"
                 value=""
               />
-              <button
-                class="c-search-form__clear"
-                title="Clear Search"
-                type="reset"
+              <div
+                class="c-search-form__input-controls"
               >
-                <span>
-                  <svg />
-                </span>
-              </button>
+                <button
+                  class="c-search-form__clear c-circle-x-icon-container"
+                  hidden=""
+                  title="Clear Search"
+                  type="reset"
+                >
+                  <svg
+                    class="c-circle-x-icon"
+                    viewBox="0 0 48 48"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      class="c-circle-x-icon__focus-circle"
+                      cx="50%"
+                      cy="50%"
+                      r="75%"
+                    />
+                    <circle
+                      class="c-circle-x-icon__white-fill"
+                      cx="50%"
+                      cy="50%"
+                      r="75%"
+                    />
+                    <path
+                      class="c-circle-x-icon__path"
+                      d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  class="c-search-form__submit"
+                  disabled=""
+                  title="Submit"
+                  type="submit"
+                >
+                  <span>
+                    <svg />
+                  </span>
+                </button>
+              </div>
             </div>
-            <button
-              class="c-search-form__submit button-submit"
-              disabled=""
-              title="Submit"
-              type="submit"
-            >
-              <span>
-                <svg />
-              </span>
-            </button>
           </div>
           <div
             class="c-search-form__row"
@@ -404,10 +428,10 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
           class="c-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-search-form__search-control"
           >
             <div
-              class="c-search-form__text"
+              class="c-search-form__search-input-container"
             >
               <input
                 aria-label="Search Map Query"
@@ -416,26 +440,50 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
                 type="text"
                 value=""
               />
-              <button
-                class="c-search-form__clear"
-                title="Clear Search"
-                type="reset"
+              <div
+                class="c-search-form__input-controls"
               >
-                <span>
-                  <svg />
-                </span>
-              </button>
+                <button
+                  class="c-search-form__clear c-circle-x-icon-container"
+                  hidden=""
+                  title="Clear Search"
+                  type="reset"
+                >
+                  <svg
+                    class="c-circle-x-icon"
+                    viewBox="0 0 48 48"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      class="c-circle-x-icon__focus-circle"
+                      cx="50%"
+                      cy="50%"
+                      r="75%"
+                    />
+                    <circle
+                      class="c-circle-x-icon__white-fill"
+                      cx="50%"
+                      cy="50%"
+                      r="75%"
+                    />
+                    <path
+                      class="c-circle-x-icon__path"
+                      d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  class="c-search-form__submit"
+                  disabled=""
+                  title="Submit"
+                  type="submit"
+                >
+                  <span>
+                    <svg />
+                  </span>
+                </button>
+              </div>
             </div>
-            <button
-              class="c-search-form__submit button-submit"
-              disabled=""
-              title="Submit"
-              type="submit"
-            >
-              <span>
-                <svg />
-              </span>
-            </button>
           </div>
           <div
             class="c-search-form__row"

--- a/assets/tests/components/__snapshots__/oldSearchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/oldSearchForm.test.tsx.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchForm renders 1`] = `
+<form
+  aria-label="Submit Search"
+  className="c-old-search-form"
+  onSubmit={[Function]}
+>
+  <div
+    className="c-old-search-form__row"
+  >
+    <div
+      className="c-old-search-form__text"
+    >
+      <input
+        aria-label="Search"
+        className="c-old-search-form__input"
+        onChange={[Function]}
+        placeholder="Search"
+        type="text"
+        value=""
+      />
+      <button
+        className="c-old-search-form__clear"
+        onClick={[Function]}
+        title="Clear Search"
+        type="reset"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<svg/>",
+            }
+          }
+        />
+      </button>
+    </div>
+    <button
+      className="c-old-search-form__submit button-submit"
+      disabled={true}
+      onClick={[Function]}
+      title="Submit"
+      type="submit"
+    >
+      <span
+        dangerouslySetInnerHTML={
+          {
+            "__html": "<svg/>",
+          }
+        }
+      />
+    </button>
+  </div>
+  <div
+    className="c-old-search-form__row"
+  >
+    <ul
+      className="c-old-search-form__property-buttons"
+    >
+      <li
+        className="c-old-search-form__property-button"
+      >
+        <input
+          checked={true}
+          className="c-old-search-form__property-input"
+          id="property-all"
+          name="property"
+          onChange={[Function]}
+          type="radio"
+          value="all"
+        />
+        <label
+          className="c-old-search-form__property-label button-search-filter"
+          htmlFor="property-all"
+        >
+          all
+        </label>
+      </li>
+      <li
+        className="c-old-search-form__property-button"
+      >
+        <input
+          checked={false}
+          className="c-old-search-form__property-input"
+          id="property-run"
+          name="property"
+          onChange={[Function]}
+          type="radio"
+          value="run"
+        />
+        <label
+          className="c-old-search-form__property-label button-search-filter"
+          htmlFor="property-run"
+        >
+          run
+        </label>
+      </li>
+      <li
+        className="c-old-search-form__property-button"
+      >
+        <input
+          checked={false}
+          className="c-old-search-form__property-input"
+          id="property-vehicle"
+          name="property"
+          onChange={[Function]}
+          type="radio"
+          value="vehicle"
+        />
+        <label
+          className="c-old-search-form__property-label button-search-filter"
+          htmlFor="property-vehicle"
+        >
+          vehicle
+        </label>
+      </li>
+      <li
+        className="c-old-search-form__property-button"
+      >
+        <input
+          checked={false}
+          className="c-old-search-form__property-input"
+          id="property-operator"
+          name="property"
+          onChange={[Function]}
+          type="radio"
+          value="operator"
+        />
+        <label
+          className="c-old-search-form__property-label button-search-filter"
+          htmlFor="property-operator"
+        >
+          operator
+        </label>
+      </li>
+    </ul>
+  </div>
+</form>
+`;

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -98,7 +98,6 @@ exports[`SearchForm renders 1`] = `
     </button>
     <div
       className="c-filter-accordion__body"
-      hidden={false}
     >
       <ul
         className="c-filter-accordion__filters"

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -20,55 +20,55 @@ exports[`SearchForm renders 1`] = `
         type="text"
         value=""
       />
-      <div
-        className="c-search-form__input-controls"
+    </div>
+    <div
+      className="c-search-form__input-controls"
+    >
+      <button
+        className="c-search-form__clear c-circle-x-icon-container"
+        hidden={true}
+        onClick={[Function]}
+        title="Clear Search"
+        type="reset"
       >
-        <button
-          className="c-search-form__clear c-circle-x-icon-container"
-          hidden={true}
-          onClick={[Function]}
-          title="Clear Search"
-          type="reset"
+        <svg
+          className="c-circle-x-icon"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            className="c-circle-x-icon"
-            viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              className="c-circle-x-icon__focus-circle"
-              cx="50%"
-              cy="50%"
-              r="75%"
-            />
-            <circle
-              className="c-circle-x-icon__white-fill"
-              cx="50%"
-              cy="50%"
-              r="75%"
-            />
-            <path
-              className="c-circle-x-icon__path"
-              d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
-            />
-          </svg>
-        </button>
-        <button
-          className="c-search-form__submit"
-          disabled={true}
-          onClick={[Function]}
-          title="Submit"
-          type="submit"
-        >
-          <span
-            dangerouslySetInnerHTML={
-              {
-                "__html": "<svg/>",
-              }
-            }
+          <circle
+            className="c-circle-x-icon__focus-circle"
+            cx="50%"
+            cy="50%"
+            r="75%"
           />
-        </button>
-      </div>
+          <circle
+            className="c-circle-x-icon__white-fill"
+            cx="50%"
+            cy="50%"
+            r="75%"
+          />
+          <path
+            className="c-circle-x-icon__path"
+            d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+          />
+        </svg>
+      </button>
+      <button
+        className="c-search-form__submit"
+        disabled={true}
+        onClick={[Function]}
+        title="Submit"
+        type="submit"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<svg/>",
+            }
+          }
+        />
+      </button>
     </div>
   </div>
   <div

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -72,88 +72,119 @@ exports[`SearchForm renders 1`] = `
     </div>
   </div>
   <div
-    className="c-search-form__row"
+    aria-expanded={true}
+    className="c-filter-accordion"
   >
-    <ul
-      className="c-search-form__property-buttons"
+    <button
+      className="c-filter-accordion__toggle-button"
+      onClick={[Function]}
     >
-      <li
-        className="c-search-form__property-button"
+      <div
+        className="c-filter-accordion__header"
       >
-        <input
-          checked={true}
-          className="c-search-form__property-input"
-          id="property-all"
-          name="property"
-          onChange={[Function]}
-          type="radio"
-          value="all"
-        />
-        <label
-          className="c-search-form__property-label button-search-filter"
-          htmlFor="property-all"
-        >
-          all
-        </label>
-      </li>
-      <li
-        className="c-search-form__property-button"
+        Filter results
+      </div>
+      <div
+        className="c-filter-accordion__show-hide-icon"
       >
-        <input
-          checked={false}
-          className="c-search-form__property-input"
-          id="property-run"
-          name="property"
-          onChange={[Function]}
-          type="radio"
-          value="run"
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<svg/>",
+            }
+          }
         />
-        <label
-          className="c-search-form__property-label button-search-filter"
-          htmlFor="property-run"
-        >
-          run
-        </label>
-      </li>
-      <li
-        className="c-search-form__property-button"
+      </div>
+    </button>
+    <div
+      className="c-filter-accordion__body"
+      hidden={false}
+    >
+      <ul
+        className="c-filter-accordion__filters"
       >
-        <input
-          checked={false}
-          className="c-search-form__property-input"
-          id="property-vehicle"
-          name="property"
-          onChange={[Function]}
-          type="radio"
-          value="vehicle"
-        />
-        <label
-          className="c-search-form__property-label button-search-filter"
-          htmlFor="property-vehicle"
+        <li
+          className="c-filter-accordion__filter"
         >
-          vehicle
-        </label>
-      </li>
-      <li
-        className="c-search-form__property-button"
-      >
-        <input
-          checked={false}
-          className="c-search-form__property-input"
-          id="property-operator"
-          name="property"
-          onChange={[Function]}
-          type="radio"
-          value="operator"
-        />
-        <label
-          className="c-search-form__property-label button-search-filter"
-          htmlFor="property-operator"
+          <button
+            className="c-filter-accordion__filter-toggle"
+            onClick={[Function]}
+          >
+            <span>
+              Vehicles
+            </span>
+            <span
+              className="c-filter-accordion__toggle-icon"
+              dangerouslySetInnerHTML={
+                {
+                  "__html": "<svg/>",
+                }
+              }
+            />
+          </button>
+        </li>
+        <li
+          className="c-filter-accordion__filter"
         >
-          operator
-        </label>
-      </li>
-    </ul>
+          <button
+            className="c-filter-accordion__filter-toggle"
+            onClick={[Function]}
+          >
+            <span>
+              Operators
+            </span>
+            <span
+              className="c-filter-accordion__toggle-icon"
+              dangerouslySetInnerHTML={
+                {
+                  "__html": "<svg/>",
+                }
+              }
+            />
+          </button>
+        </li>
+        <li
+          className="c-filter-accordion__filter"
+        >
+          <button
+            className="c-filter-accordion__filter-toggle"
+            onClick={[Function]}
+          >
+            <span>
+              Runs
+            </span>
+            <span
+              className="c-filter-accordion__toggle-icon"
+              dangerouslySetInnerHTML={
+                {
+                  "__html": "<svg/>",
+                }
+              }
+            />
+          </button>
+        </li>
+        <li
+          className="c-filter-accordion__filter"
+        >
+          <button
+            className="c-filter-accordion__filter-toggle"
+            onClick={[Function]}
+          >
+            <span>
+              Locations
+            </span>
+            <span
+              className="c-filter-accordion__toggle-icon"
+              dangerouslySetInnerHTML={
+                {
+                  "__html": "<svg/>",
+                }
+              }
+            />
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
 </form>
 `;

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`SearchForm renders 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="c-search-form__row"
+    className="c-search-form__search-control"
   >
     <div
-      className="c-search-form__text"
+      className="c-search-form__search-input-container"
     >
       <input
         aria-label="Search"
@@ -20,36 +20,56 @@ exports[`SearchForm renders 1`] = `
         type="text"
         value=""
       />
-      <button
-        className="c-search-form__clear"
-        onClick={[Function]}
-        title="Clear Search"
-        type="reset"
+      <div
+        className="c-search-form__input-controls"
       >
-        <span
-          dangerouslySetInnerHTML={
-            {
-              "__html": "<svg/>",
+        <button
+          className="c-search-form__clear c-circle-x-icon-container"
+          hidden={true}
+          onClick={[Function]}
+          title="Clear Search"
+          type="reset"
+        >
+          <svg
+            className="c-circle-x-icon"
+            viewBox="0 0 48 48"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              className="c-circle-x-icon__focus-circle"
+              cx="50%"
+              cy="50%"
+              r="75%"
+            />
+            <circle
+              className="c-circle-x-icon__white-fill"
+              cx="50%"
+              cy="50%"
+              r="75%"
+            />
+            <path
+              className="c-circle-x-icon__path"
+              d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+            />
+          </svg>
+        </button>
+        <button
+          className="c-search-form__submit"
+          disabled={true}
+          onClick={[Function]}
+          title="Submit"
+          type="submit"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              {
+                "__html": "<svg/>",
+              }
             }
-          }
-        />
-      </button>
+          />
+        </button>
+      </div>
     </div>
-    <button
-      className="c-search-form__submit button-submit"
-      disabled={true}
-      onClick={[Function]}
-      title="Submit"
-      type="submit"
-    >
-      <span
-        dangerouslySetInnerHTML={
-          {
-            "__html": "<svg/>",
-          }
-        }
-      />
-    </button>
   </div>
   <div
     className="c-search-form__row"

--- a/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchPage.test.tsx.snap
@@ -13,23 +13,23 @@ exports[`SearchPage renders the empty state 1`] = `
       >
         <form
           aria-label="Submit Search"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__text"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-search-form__clear"
+                class="c-old-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -39,7 +39,7 @@ exports[`SearchPage renders the empty state 1`] = `
               </button>
             </div>
             <button
-              class="c-search-form__submit button-submit"
+              class="c-old-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -50,75 +50,75 @@ exports[`SearchPage renders the empty state 1`] = `
             </button>
           </div>
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <ul
-              class="c-search-form__property-buttons"
+              class="c-old-search-form__property-buttons"
             >
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator
@@ -348,23 +348,23 @@ exports[`SearchPage renders vehicle data 1`] = `
       >
         <form
           aria-label="Submit Search"
-          class="c-search-form"
+          class="c-old-search-form"
         >
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <div
-              class="c-search-form__text"
+              class="c-old-search-form__text"
             >
               <input
                 aria-label="Search"
-                class="c-search-form__input"
+                class="c-old-search-form__input"
                 placeholder="Search"
                 type="text"
                 value=""
               />
               <button
-                class="c-search-form__clear"
+                class="c-old-search-form__clear"
                 title="Clear Search"
                 type="reset"
               >
@@ -374,7 +374,7 @@ exports[`SearchPage renders vehicle data 1`] = `
               </button>
             </div>
             <button
-              class="c-search-form__submit button-submit"
+              class="c-old-search-form__submit button-submit"
               disabled=""
               title="Submit"
               type="submit"
@@ -385,75 +385,75 @@ exports[`SearchPage renders vehicle data 1`] = `
             </button>
           </div>
           <div
-            class="c-search-form__row"
+            class="c-old-search-form__row"
           >
             <ul
-              class="c-search-form__property-buttons"
+              class="c-old-search-form__property-buttons"
             >
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
                   checked=""
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-all"
                   name="property"
                   type="radio"
                   value="all"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-all"
                 >
                   all
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-run"
                   name="property"
                   type="radio"
                   value="run"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-run"
                 >
                   run
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-vehicle"
                   name="property"
                   type="radio"
                   value="vehicle"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-vehicle"
                 >
                   vehicle
                 </label>
               </li>
               <li
-                class="c-search-form__property-button"
+                class="c-old-search-form__property-button"
               >
                 <input
-                  class="c-search-form__property-input"
+                  class="c-old-search-form__property-input"
                   id="property-operator"
                   name="property"
                   type="radio"
                   value="operator"
                 />
                 <label
-                  class="c-search-form__property-label button-search-filter"
+                  class="c-old-search-form__property-label button-search-filter"
                   for="property-operator"
                 >
                   operator

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -14,6 +14,7 @@ import { TestGroups } from "../../src/userInTestGroup"
 import getTestGroups from "../../src/userTestGroups"
 import { MemoryRouter } from "react-router-dom"
 import appData from "../../src/appData"
+import { vehiclePropertiesPanelHeader } from "../testHelpers/selectors/components/vehiclePropertiesPanel"
 
 jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
@@ -117,7 +118,7 @@ describe("App", () => {
             </MemoryRouter>
           </StateDispatchProvider>
         )
-        expect(screen.getByText("Vehicles")).toBeInTheDocument()
+        expect(vehiclePropertiesPanelHeader.get()).toBeInTheDocument()
       })
       test.each([
         ["Late View", OpenView.Late],
@@ -164,7 +165,7 @@ describe("App", () => {
           </MemoryRouter>
         </StateDispatchProvider>
       )
-      expect(screen.queryByText("Vehicles")).not.toBeInTheDocument()
+      expect(vehiclePropertiesPanelHeader.query()).not.toBeInTheDocument()
     })
 
     test.each([

--- a/assets/tests/components/oldSearchForm.test.tsx
+++ b/assets/tests/components/oldSearchForm.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import React from "react"
+import renderer from "react-test-renderer"
+import "@testing-library/jest-dom"
+import OldSearchForm from "../../src/components/oldSearchForm"
+import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
+import { initialState } from "../../src/state"
+import {
+  SearchPageState,
+  setSearchProperty,
+  setSearchText,
+  submitSearch,
+} from "../../src/state/searchPageState"
+import { mockFullStoryEvent } from "../testHelpers/mockHelpers"
+import { searchPageStateFactory } from "../factories/searchPageState"
+
+const mockDispatch = jest.fn()
+
+describe("SearchForm", () => {
+  test("renders", () => {
+    const tree = renderer
+      .create(
+        <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
+          <OldSearchForm />
+        </StateDispatchProvider>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test("submit button is disabled if there are fewer than 2 characters in the text field", () => {
+    const invalidSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "1", property: "run" },
+    })
+    const invalidSearchState = {
+      ...initialState,
+      searchPageState: invalidSearch,
+    }
+    const result = render(
+      <StateDispatchProvider state={invalidSearchState} dispatch={mockDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    expect(result.getByPlaceholderText("Search")).toHaveValue("1")
+
+    expect(result.getByTitle("Submit")).toBeDisabled()
+  })
+
+  test("submit button is enabled if there are at least 2 characters in the text field", () => {
+    const validSearch = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    const result = render(
+      <StateDispatchProvider state={validSearchState} dispatch={mockDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    expect(result.getByPlaceholderText("Search")).toHaveValue("12")
+
+    expect(result.getByTitle("Submit")).not.toBeDisabled()
+  })
+
+  test("clicking the submit button submits the query", async () => {
+    const testDispatch = jest.fn()
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    const result = render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByTitle("Submit"))
+    expect(testDispatch).toHaveBeenCalledWith(submitSearch())
+  })
+
+  test("clicking the submit button also calls onSubmit when set", async () => {
+    const testDispatch = jest.fn()
+    const onSubmit = jest.fn()
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm onSubmit={onSubmit} />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByTitle("Submit"))
+    expect(testDispatch).toHaveBeenCalledWith(submitSearch())
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test("clicking the submit button logs a FullStory event when provided", async () => {
+    const testDispatch = jest.fn()
+    const onSubmit = jest.fn()
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    mockFullStoryEvent()
+
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm onSubmit={onSubmit} submitEvent="Test event" />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByTitle("Submit"))
+
+    expect(window.FS!.event).toHaveBeenCalledWith("Test event")
+  })
+
+  test("entering text sets it as the search text", async () => {
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+
+    const testDispatch = jest.fn()
+
+    const result = render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.type(result.getByPlaceholderText("Search"), "3")
+
+    expect(testDispatch).toHaveBeenCalledWith(setSearchText("123"))
+  })
+
+  test("clicking the clear button empties the search text", async () => {
+    const testDispatch = jest.fn()
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /clear search/i }))
+
+    expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
+  })
+
+  test("clicking the clear button also calls onClear when set", async () => {
+    const testDispatch = jest.fn()
+    const onClear = jest.fn()
+    const validSearch: SearchPageState = searchPageStateFactory.build({
+      query: { text: "12", property: "run" },
+    })
+    const validSearchState = {
+      ...initialState,
+      searchPageState: validSearch,
+    }
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={testDispatch}>
+        <OldSearchForm onClear={onClear} />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /clear search/i }))
+
+    expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  test("clicking a search property selects it", async () => {
+    const testDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={testDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByRole("radio", { name: "run" }))
+
+    expect(testDispatch).toHaveBeenCalledWith(setSearchProperty("run"))
+  })
+
+  test("clicking a search property submits the search", async () => {
+    const testDispatch = jest.fn()
+    const result = render(
+      <StateDispatchProvider state={initialState} dispatch={testDispatch}>
+        <OldSearchForm />
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(result.getByRole("radio", { name: "run" }))
+
+    expect(testDispatch).toHaveBeenCalledWith(submitSearch())
+  })
+})

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -14,6 +14,8 @@ import {
 } from "../../src/state/searchPageState"
 import { mockFullStoryEvent } from "../testHelpers/mockHelpers"
 import { searchPageStateFactory } from "../factories/searchPageState"
+import stateFactory from "../factories/applicationState"
+import { searchFormClearSearchButton } from "../testHelpers/selectors/components/searchForm"
 
 const mockDispatch = jest.fn()
 
@@ -157,6 +159,34 @@ describe("SearchForm", () => {
     )
   })
 
+  test("when search input is empty, should not display clear button", () => {
+    const validSearchState = stateFactory.build({
+      searchPageState: { query: { text: "", property: "run" } },
+    })
+
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={jest.fn()}>
+        <SearchForm />
+      </StateDispatchProvider>
+    )
+
+    expect(searchFormClearSearchButton.query()).not.toBeInTheDocument()
+  })
+
+  test("when search input is not empty, should display clear button", () => {
+    const validSearchState = stateFactory.build({
+      searchPageState: { query: { text: "1", property: "run" } },
+    })
+
+    render(
+      <StateDispatchProvider state={validSearchState} dispatch={jest.fn()}>
+        <SearchForm />
+      </StateDispatchProvider>
+    )
+
+    expect(searchFormClearSearchButton.get()).toBeInTheDocument()
+  })
+
   test("clicking the clear button empties the search text", async () => {
     const testDispatch = jest.fn()
     const validSearch: SearchPageState = searchPageStateFactory.build({
@@ -172,7 +202,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(screen.getByRole("button", { name: /clear search/i }))
+    await userEvent.click(searchFormClearSearchButton.get())
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
   })
@@ -193,7 +223,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(screen.getByRole("button", { name: /clear search/i }))
+    await userEvent.click(searchFormClearSearchButton.get())
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
     expect(onClear).toHaveBeenCalledTimes(1)

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -32,7 +32,7 @@ describe("SearchForm", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("submit button is disabled if there are fewer than 3 characters in the text field", () => {
+  test("when search input has less than the minimum amount of characters, should disable submit button", () => {
     const invalidSearch: SearchPageState = searchPageStateFactory.build({
       query: { text: "1", property: "run" },
     })
@@ -51,8 +51,8 @@ describe("SearchForm", () => {
     expect(result.getByTitle("Submit")).toBeDisabled()
   })
 
-  test("submit button is enabled if there are at least 3 characters in the text field", () => {
-    const searchText = "123"
+  test("when search input has the minimum amount of characters, should enable submit button", () => {
+    const searchText = "12"
     const validSearch = searchPageStateFactory.build({
       query: { text: searchText, property: "run" },
     })

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -30,7 +30,7 @@ describe("SearchForm", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("submit button is disabled if there are fewer than 2 characters in the text field", () => {
+  test("submit button is disabled if there are fewer than 3 characters in the text field", () => {
     const invalidSearch: SearchPageState = searchPageStateFactory.build({
       query: { text: "1", property: "run" },
     })
@@ -49,9 +49,10 @@ describe("SearchForm", () => {
     expect(result.getByTitle("Submit")).toBeDisabled()
   })
 
-  test("submit button is enabled if there are at least 2 characters in the text field", () => {
+  test("submit button is enabled if there are at least 3 characters in the text field", () => {
+    const searchText = "123"
     const validSearch = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: searchText, property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -63,7 +64,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    expect(result.getByPlaceholderText("Search")).toHaveValue("12")
+    expect(result.getByPlaceholderText("Search")).toHaveValue(searchText)
 
     expect(result.getByTitle("Submit")).not.toBeDisabled()
   })
@@ -71,7 +72,7 @@ describe("SearchForm", () => {
   test("clicking the submit button submits the query", async () => {
     const testDispatch = jest.fn()
     const validSearch: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: "123", property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -91,7 +92,7 @@ describe("SearchForm", () => {
     const testDispatch = jest.fn()
     const onSubmit = jest.fn()
     const validSearch: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: "123", property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -112,7 +113,7 @@ describe("SearchForm", () => {
     const testDispatch = jest.fn()
     const onSubmit = jest.fn()
     const validSearch: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: "123", property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -125,15 +126,16 @@ describe("SearchForm", () => {
         <SearchForm onSubmit={onSubmit} submitEvent="Test event" />
       </StateDispatchProvider>
     )
-
     await userEvent.click(screen.getByTitle("Submit"))
 
     expect(window.FS!.event).toHaveBeenCalledWith("Test event")
   })
 
   test("entering text sets it as the search text", async () => {
+    const searchText = "12"
+    const searchInput = "3"
     const validSearch: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: searchText, property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -148,15 +150,17 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.type(result.getByPlaceholderText("Search"), "3")
+    await userEvent.type(result.getByPlaceholderText("Search"), searchInput)
 
-    expect(testDispatch).toHaveBeenCalledWith(setSearchText("123"))
+    expect(testDispatch).toHaveBeenCalledWith(
+      setSearchText(searchText + searchInput)
+    )
   })
 
   test("clicking the clear button empties the search text", async () => {
     const testDispatch = jest.fn()
     const validSearch: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: "123", property: "run" },
     })
     const validSearchState = {
       ...initialState,
@@ -203,7 +207,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(result.getByRole("radio", { name: "run" }))
+    await userEvent.click(result.getByRole("button", { name: "Runs" }))
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchProperty("run"))
   })
@@ -216,7 +220,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(result.getByRole("radio", { name: "run" }))
+    await userEvent.click(result.getByRole("button", { name: "Runs" }))
 
     expect(testDispatch).toHaveBeenCalledWith(submitSearch())
   })

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -15,7 +15,7 @@ import {
 import { mockFullStoryEvent } from "../testHelpers/mockHelpers"
 import { searchPageStateFactory } from "../factories/searchPageState"
 import stateFactory from "../factories/applicationState"
-import { searchFormClearSearchButton } from "../testHelpers/selectors/components/searchForm"
+import { clearButton } from "../testHelpers/selectors/components/searchForm"
 
 const mockDispatch = jest.fn()
 
@@ -170,7 +170,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    expect(searchFormClearSearchButton.query()).not.toBeInTheDocument()
+    expect(clearButton.query()).not.toBeInTheDocument()
   })
 
   test("when search input is not empty, should display clear button", () => {
@@ -184,7 +184,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    expect(searchFormClearSearchButton.get()).toBeInTheDocument()
+    expect(clearButton.get()).toBeInTheDocument()
   })
 
   test("clicking the clear button empties the search text", async () => {
@@ -202,7 +202,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(searchFormClearSearchButton.get())
+    await userEvent.click(clearButton.get())
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
   })
@@ -223,7 +223,7 @@ describe("SearchForm", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(searchFormClearSearchButton.get())
+    await userEvent.click(clearButton.get())
 
     expect(testDispatch).toHaveBeenCalledWith(setSearchText(""))
     expect(onClear).toHaveBeenCalledTimes(1)

--- a/assets/tests/models/searchQuery.test.ts
+++ b/assets/tests/models/searchQuery.test.ts
@@ -19,7 +19,7 @@ describe("isValidSearchQuery", () => {
     expect(isValidSearchQuery(invalidQuery)).toBeFalsy()
   })
 
-  test("returns false if the query contains more than 2 characters but they're not alphanumeric", () => {
+  test("returns false if the query contains more than 3 characters but they're not alphanumeric", () => {
     const invalidQuery: SearchQuery = {
       text: " -1 -",
       property: "run",

--- a/assets/tests/models/searchQuery.test.ts
+++ b/assets/tests/models/searchQuery.test.ts
@@ -3,7 +3,7 @@ import { isValidSearchQuery, SearchQuery } from "../../src/models/searchQuery"
 describe("isValidSearchQuery", () => {
   test("returns true if the query text contains at least 2 characters", () => {
     const validQuery: SearchQuery = {
-      text: "12",
+      text: "123",
       property: "run",
     }
 

--- a/assets/tests/state/searchPageState.test.ts
+++ b/assets/tests/state/searchPageState.test.ts
@@ -60,7 +60,7 @@ describe("reducer", () => {
 
   test("submitSearch sets isActive to true if the query is valid", () => {
     const validQuery: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: "123", property: "run" },
       isActive: false,
     })
     const newSearch = reducer(validQuery, submitSearch())
@@ -79,14 +79,15 @@ describe("reducer", () => {
   })
 
   test("submitSearch saves the query if it's valid", () => {
+    const searchText = "123"
     const validQuery: SearchPageState = searchPageStateFactory.build({
-      query: { text: "12", property: "run" },
+      query: { text: searchText, property: "run" },
       isActive: false,
       savedQueries: [],
     })
     const newSearch = reducer(validQuery, submitSearch())
 
-    expect(newSearch.savedQueries).toEqual([{ text: "12" }])
+    expect(newSearch.savedQueries).toEqual([{ text: searchText }])
   })
 
   test("submitSearch does not save the query if it's not valid", () => {

--- a/assets/tests/testHelpers/selectors/components/map/markers/stopIcon.ts
+++ b/assets/tests/testHelpers/selectors/components/map/markers/stopIcon.ts
@@ -3,6 +3,6 @@ export const stopIcon = {
   get: (container: HTMLElement) => {
     const maybeStop = container.querySelector(".c-stop-icon")
     expect(maybeStop).not.toBeNull()
-    return maybeStop!
+    return maybeStop as Element
   },
 }

--- a/assets/tests/testHelpers/selectors/components/searchForm.tsx
+++ b/assets/tests/testHelpers/selectors/components/searchForm.tsx
@@ -1,0 +1,5 @@
+import { byRole } from "testing-library-selector"
+
+export const searchFormClearSearchButton = byRole("button", {
+  name: /clear search/i,
+})

--- a/assets/tests/testHelpers/selectors/components/searchForm.tsx
+++ b/assets/tests/testHelpers/selectors/components/searchForm.tsx
@@ -1,5 +1,5 @@
 import { byRole } from "testing-library-selector"
 
-export const searchFormClearSearchButton = byRole("button", {
+export const clearButton = byRole("button", {
   name: /clear search/i,
 })

--- a/assets/tests/testHelpers/selectors/components/vehiclePropertiesPanel.tsx
+++ b/assets/tests/testHelpers/selectors/components/vehiclePropertiesPanel.tsx
@@ -1,0 +1,6 @@
+import { byRole } from "testing-library-selector"
+
+export const vehiclePropertiesPanelHeader = byRole("heading", {
+  name: "Vehicles",
+  level: 2,
+})


### PR DESCRIPTION
This does a few things to create new components based on old components, while avoiding accidentally modifying the old components.
- Copy `SearchForm` to `OldSearchForm`, update references to point to `OldSearchForm`
- Update `SearchForm` to match new designs, use on Map Page.
- Create `FilterAccordion` mostly from `GarageFilter`
	- It's not _exactly_ the same, so I didn't feel comfortable making the `GarageFilter` depend on this component. But I do think we could. Will either implement here or open a ticket based on dev feedback.
- Build a "interactive"(focus state, similar to the bus stop icons) `CircleXIcon`
	- note: I don't like that this component name matches that of our `CircleXIcon` from our `icons.tsx` file, but I was unsure what to name it otherwise.

Additionally, the Filter currently acts like the old ratio buttons. Because the application reducer that remembers these settings needs to change to accommodate this, I've left this to be changed in another PR. If Design pushes back on this, I'll update this PR with those changes.

---

Asana Ticket: https://app.asana.com/0/0/1204650425301364