### PR TITLE
testing(ts/components/[New]SearchForm): refactor search form to expose properties for testing

### DIFF
--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -33,7 +33,7 @@ import MapDisplay from "./mapPage/mapDisplay"
 import RoutePropertiesCard from "./mapPage/routePropertiesCard"
 import VehiclePropertiesCard from "./mapPage/vehiclePropertiesCard"
 import RecentSearches from "./recentSearches"
-import SearchForm from "./searchForm"
+import SearchFormFromStateDispatchContext from "./searchForm"
 import SearchResults from "./searchResults"
 import { VisualSeparator } from "./visualSeparator"
 import OldSearchForm from "./oldSearchForm"
@@ -59,7 +59,7 @@ const SearchMode = ({
   )
 
   const CurrentSearchForm = inTestGroup(TestGroups.LocationSearch)
-    ? SearchForm
+    ? SearchFormFromStateDispatchContext
     : OldSearchForm
 
   return (
@@ -68,7 +68,9 @@ const SearchMode = ({
         <CurrentSearchForm
           formTitle="Search Map"
           inputTitle="Search Map Query"
-          submitEvent="Search submitted from map page"
+          onSubmit={() => {
+            window.FS?.event("Search submitted from map page")
+          }}
         />
       </div>
 

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -3,28 +3,187 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
 import { CircleXIcon } from "./circleXIcon"
 import { FilterAccordion } from "./filterAccordion"
-import { isValidSearchQuery, SearchQueryType } from "../models/searchQuery"
+import { SearchQueryType, isValidSearchText } from "../models/searchQuery"
 import {
   setSearchProperty,
   setSearchText,
   submitSearch,
 } from "../state/searchPageState"
 
-type SearchFormProps = {
-  onSubmit?: () => void
-  onClear?: () => void
-  inputTitle?: string
-  formTitle?: string
-  submitEvent?: string
+// #region Search Filters
+/**
+ * Unordered enumeration of the UI exposed controls.
+ *
+ * ---
+ *
+ * TODO: merge with {@link SearchQueryType}
+ */
+enum SearchFilters {
+  Vehicles,
+  Operators,
+  Runs,
+  Locations,
 }
 
-const SearchForm = ({
+/**
+ * Union type of {@link SearchFilters} as strings.
+ *
+ * Useful for defining objects in terms of possible search filters.
+ */
+type SearchFilterKeys = keyof typeof SearchFilters
+
+/**
+ * Object describing the current toggle state of the possible
+ * {@link SearchFilters}.
+ */
+type SearchFiltersState = {
+  [K in SearchFilterKeys]: boolean
+}
+
+/**
+ * Temporary function to convert {@link SearchFiltersState} to
+ * {@link SearchQueryType}.
+ *
+ * ---
+ *
+ * This should be removed when {@link SearchFormFromStateDispatchContext} and
+ * it's context are refactored to use the new filter requirements.
+ */
+function filterNameToSearchProperty(
+  name: keyof SearchFiltersState
+): SearchQueryType {
+  switch (name) {
+    case "Locations":
+      return "all"
+    case "Operators":
+      return "operator"
+    case "Runs":
+      return "run"
+    case "Vehicles":
+      return "vehicle"
+  }
+}
+// #endregion search filters
+
+type SearchFormEventProps = {
+  /**
+   * Callback to run when the form is submitted.
+   */
+  onSubmit?: React.ReactEventHandler
+  /**
+   * Callback to run when the form input is cleared via the clear button.
+   */
+  onClear?: React.ReactEventHandler
+}
+
+type SearchFormProps = SearchFormEventProps & {
+  /**
+   * Text to show in the search input box.
+   */
+  inputText: string
+  /**
+   * Callback to run when {@link inputText} should be updated.
+   */
+  onInputTextChanged?: React.ChangeEventHandler<HTMLInputElement>
+
+  /**
+   * The state of the search filters.
+   */
+  filters: SearchFiltersState
+  /**
+   * Callback to run when {@link filters} should be updated.
+   */
+  onFiltersChanged: (name: SearchFilterKeys, currentValue: boolean) => void
+}
+
+/**
+ * Search form which exposes all configurable state and callbacks via props.
+ */
+export const SearchForm = ({
+  inputText,
+  onInputTextChanged,
+
+  filters,
+  onFiltersChanged,
+
+  onClear,
+  onSubmit,
+}: SearchFormProps) => {
+  const formSearchInput = useRef<HTMLInputElement | null>(null)
+
+  return (
+    <form onSubmit={onSubmit} className="c-search-form" autoComplete="off">
+      <div className="c-search-form__search-control">
+        <div className="c-search-form__search-input-container">
+          <input
+            type="text"
+            className="c-search-form__input"
+            placeholder="Search"
+            value={inputText}
+            onChange={onInputTextChanged}
+            ref={formSearchInput}
+          />
+          <div className="c-search-form__input-controls">
+            <button
+              hidden={inputText.length === 0}
+              className="c-search-form__clear c-circle-x-icon-container"
+              type="button"
+              title="Clear Search"
+              onClick={(e) => {
+                // Set focus on input after input is cleared
+                formSearchInput.current?.focus()
+                onClear?.(e)
+              }}
+            >
+              <CircleXIcon />
+            </button>
+            <button
+              type="submit"
+              title="Submit"
+              className="c-search-form__submit"
+              onClick={onSubmit}
+              // TODO(design): add error states instead of using `disabled`
+              disabled={!isValidSearchText(inputText)}
+            >
+              <SearchIcon />
+            </button>
+          </div>
+        </div>
+      </div>
+      <FilterAccordion.WithExpansionState heading="Filter results">
+        <FilterAccordion.ToggleFilter
+          name={"Vehicles"}
+          active={filters.Vehicles}
+          onClick={() => onFiltersChanged("Vehicles", filters.Vehicles)}
+        />
+        <FilterAccordion.ToggleFilter
+          name={"Operators"}
+          active={filters.Operators}
+          onClick={() => onFiltersChanged("Operators", filters.Operators)}
+        />
+        <FilterAccordion.ToggleFilter
+          name={"Runs"}
+          active={filters.Runs}
+          onClick={() => onFiltersChanged("Runs", filters.Runs)}
+        />
+        <FilterAccordion.ToggleFilter
+          name={"Locations"}
+          active={filters.Locations}
+          onClick={() => onFiltersChanged("Locations", filters.Locations)}
+        />
+      </FilterAccordion.WithExpansionState>
+    </form>
+  )
+}
+
+/**
+ * {@link SearchForm `SearchForm`} which gets and saves it's state into the
+ * {@link StateDispatchContext}.
+ */
+const SearchFormFromStateDispatchContext = ({
   onSubmit,
   onClear,
-  inputTitle,
-  formTitle,
-  submitEvent,
-}: SearchFormProps) => {
+}: SearchFormEventProps) => {
   const [
     {
       searchPageState: { query },
@@ -32,102 +191,36 @@ const SearchForm = ({
     dispatch,
   ] = useContext(StateDispatchContext)
 
-  const formSearchInput = useRef<HTMLInputElement | null>(null)
-  const clearTextInput = (event: React.FormEvent<EventTarget>): void => {
-    event.preventDefault()
-    dispatch(setSearchText(""))
-    // Focus text box after clearing input
-    formSearchInput.current?.focus()
-    if (onClear) {
-      onClear()
-    }
-  }
-
-  const handleTextInput = (event: React.FormEvent<HTMLInputElement>): void => {
-    const value = event.currentTarget.value
-    dispatch(setSearchText(value))
-  }
-
-  const handlePropertyChange = (value: SearchQueryType): void => {
-    dispatch(setSearchProperty(value))
-    dispatch(submitSearch())
-  }
-
-  const subscribeToSearch = (event: React.FormEvent<EventTarget>) => {
-    event.preventDefault()
-
-    submitEvent && window.FS?.event(submitEvent)
-
-    dispatch(submitSearch())
-    if (onSubmit) {
-      onSubmit()
-    }
-  }
-
   return (
-    <form
-      onSubmit={subscribeToSearch}
-      className="c-search-form"
-      aria-label={formTitle || "Submit Search"}
-    >
-      <div className="c-search-form__search-control">
-        <div className="c-search-form__search-input-container">
-          <input
-            type="text"
-            className="c-search-form__input"
-            placeholder="Search"
-            aria-label={inputTitle || "Search"}
-            value={query.text}
-            onChange={handleTextInput}
-            ref={formSearchInput}
-          />
-        </div>
-        <div className="c-search-form__input-controls">
-          <button
-            hidden={query.text.length === 0}
-            type="reset"
-            title="Clear Search"
-            className="c-search-form__clear c-circle-x-icon-container"
-            onClick={clearTextInput}
-          >
-            <CircleXIcon />
-          </button>
-          <button
-            type="submit"
-            title="Submit"
-            className="c-search-form__submit"
-            onClick={subscribeToSearch}
-            // TODO(design): add error states instead of using `disabled`
-            disabled={!isValidSearchQuery(query)}
-          >
-            <SearchIcon />
-          </button>
-        </div>
-      </div>
-      <FilterAccordion.WithExpansionState heading="Filter results">
-        <FilterAccordion.ToggleFilter
-          name={"Vehicles"}
-          active={query.property === "vehicle"}
-          onClick={() => handlePropertyChange("vehicle")}
-        />
-        <FilterAccordion.ToggleFilter
-          name={"Operators"}
-          active={query.property === "operator"}
-          onClick={() => handlePropertyChange("operator")}
-        />
-        <FilterAccordion.ToggleFilter
-          name={"Runs"}
-          active={query.property === "run"}
-          onClick={() => handlePropertyChange("run")}
-        />
-        <FilterAccordion.ToggleFilter
-          name={"Locations"}
-          active={false}
-          onClick={() => handlePropertyChange("all")}
-        />
-      </FilterAccordion.WithExpansionState>
-    </form>
+    <SearchForm
+      inputText={query.text}
+      filters={{
+        Locations: query.property === "all",
+        Operators: query.property === "operator",
+        Runs: query.property === "run",
+        Vehicles: query.property === "vehicle",
+      }}
+      onInputTextChanged={({ currentTarget: { value } }) => {
+        dispatch(setSearchText(value))
+      }}
+      onSubmit={(event) => {
+        event.preventDefault()
+
+        dispatch(submitSearch())
+
+        onSubmit?.(event)
+      }}
+      onClear={(event) => {
+        event.preventDefault()
+        dispatch(setSearchText(""))
+        onClear?.(event)
+      }}
+      onFiltersChanged={(name, _) => {
+        dispatch(setSearchProperty(filterNameToSearchProperty(name)))
+        dispatch(submitSearch())
+      }}
+    />
   )
 }
 
-export default SearchForm
+export default SearchFormFromStateDispatchContext

--- a/assets/src/models/searchQuery.ts
+++ b/assets/src/models/searchQuery.ts
@@ -18,4 +18,7 @@ export const filterToAlphanumeric = (text: string): string =>
   text.replace(/[^0-9a-zA-Z]/g, "")
 
 export const isValidSearchQuery = ({ text }: SearchQuery): boolean =>
+  isValidSearchText(text)
+
+export const isValidSearchText = (text: string): boolean =>
   filterToAlphanumeric(text).length >= 2

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchForm renders 1`] = `
 <form
-  aria-label="Submit Search"
+  autoComplete="off"
   className="c-search-form"
   onSubmit={[Function]}
 >
@@ -13,62 +13,61 @@ exports[`SearchForm renders 1`] = `
       className="c-search-form__search-input-container"
     >
       <input
-        aria-label="Search"
         className="c-search-form__input"
         onChange={[Function]}
         placeholder="Search"
         type="text"
         value=""
       />
-    </div>
-    <div
-      className="c-search-form__input-controls"
-    >
-      <button
-        className="c-search-form__clear c-circle-x-icon-container"
-        hidden={true}
-        onClick={[Function]}
-        title="Clear Search"
-        type="reset"
+      <div
+        className="c-search-form__input-controls"
       >
-        <svg
-          className="c-circle-x-icon"
-          viewBox="0 0 48 48"
-          xmlns="http://www.w3.org/2000/svg"
+        <button
+          className="c-search-form__clear c-circle-x-icon-container"
+          hidden={true}
+          onClick={[Function]}
+          title="Clear Search"
+          type="button"
         >
-          <circle
-            className="c-circle-x-icon__focus-circle"
-            cx="50%"
-            cy="50%"
-            r="75%"
-          />
-          <circle
-            className="c-circle-x-icon__white-fill"
-            cx="50%"
-            cy="50%"
-            r="75%"
-          />
-          <path
-            className="c-circle-x-icon__path"
-            d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
-          />
-        </svg>
-      </button>
-      <button
-        className="c-search-form__submit"
-        disabled={true}
-        onClick={[Function]}
-        title="Submit"
-        type="submit"
-      >
-        <span
-          dangerouslySetInnerHTML={
-            {
-              "__html": "<svg/>",
+          <svg
+            className="c-circle-x-icon"
+            viewBox="0 0 48 48"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              className="c-circle-x-icon__focus-circle"
+              cx="50%"
+              cy="50%"
+              r="75%"
+            />
+            <circle
+              className="c-circle-x-icon__white-fill"
+              cx="50%"
+              cy="50%"
+              r="75%"
+            />
+            <path
+              className="c-circle-x-icon__path"
+              d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+            />
+          </svg>
+        </button>
+        <button
+          className="c-search-form__submit"
+          disabled={true}
+          onClick={[Function]}
+          title="Submit"
+          type="submit"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              {
+                "__html": "<svg/>",
+              }
             }
-          }
-        />
-      </button>
+          />
+        </button>
+      </div>
     </div>
   </div>
   <div

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -61,6 +61,10 @@ import {
   layersControlButton,
   zoomInButton,
 } from "../testHelpers/selectors/components/map"
+import {
+  searchInput as searchFormSearchInput,
+  submitButton as searchFormSubmitButton,
+} from "../testHelpers/selectors/components/searchForm"
 
 jest.mock("../../src/hooks/useSearchResults", () => ({
   __esModule: true,
@@ -377,10 +381,39 @@ describe("<MapPage />", () => {
       </StateDispatchProvider>
     )
 
-    await userEvent.click(screen.getByRole("button", { name: /submit/i }))
+    await userEvent.click(searchFormSubmitButton.get())
     expect(
       container.querySelector(".c-vehicle-map__route-shape")
     ).not.toBeInTheDocument()
+  })
+
+  test("when a search is submitted, should fire FS event for map page", async () => {
+    mockFullStoryEvent()
+    jest.spyOn(global, "scrollTo").mockImplementationOnce(jest.fn())
+    ;(useSearchResults as jest.Mock).mockReturnValue([])
+    const mockDispatch = jest.fn()
+
+    render(
+      <StateDispatchProvider
+        state={stateFactory.build({
+          searchPageState: {
+            query: { text: "123" },
+            isActive: true,
+          },
+        })}
+        dispatch={mockDispatch}
+      >
+        <BrowserRouter>
+          <MapPage />
+        </BrowserRouter>
+      </StateDispatchProvider>
+    )
+
+    await userEvent.click(searchFormSubmitButton.get())
+
+    expect(window.FS!.event).toHaveBeenCalledWith(
+      "Search submitted from map page"
+    )
   })
 
   test("when new search button is clicked, then the search query and map selection is cleared", async () => {
@@ -901,7 +934,7 @@ describe("<MapPage />", () => {
           </StateDispatchProvider>
         )
 
-        const searchInput = screen.getByRole("textbox", { name: /search map/i })
+        const searchInput = searchFormSearchInput.get()
         expect(searchInput).toHaveTextContent("")
         expect(searchInput).toHaveAttribute("placeholder", "Search")
 
@@ -934,7 +967,7 @@ describe("<MapPage />", () => {
           </StateDispatchProvider>
         )
 
-        const searchInput = screen.getByRole("textbox", { name: /search map/i })
+        const searchInput = searchFormSearchInput.get()
         expect(searchInput).toHaveTextContent("")
         expect(searchInput).toHaveAttribute("placeholder", "Search")
 

--- a/assets/tests/testHelpers/selectors/components/searchForm.tsx
+++ b/assets/tests/testHelpers/selectors/components/searchForm.tsx
@@ -1,5 +1,9 @@
-import { byRole } from "testing-library-selector"
+import { byPlaceholderText, byRole } from "testing-library-selector"
 
 export const clearButton = byRole("button", {
-  name: /clear search/i,
+  name: /clear/i,
 })
+
+export const submitButton = byRole("button", { name: "Submit" })
+
+export const searchInput = byPlaceholderText("Search")


### PR DESCRIPTION
I refactored this component to be able to provide access to the state of the search form for more concise testing.

While building the autocomplete component in the search form, I found that I needed to be able to control the filters and other autocomplete states, but did not want to run into other devs by editing the `StateDispatchContext` reducer just yet.
