### PR TITLE
refactor+feat(ts/testGroups): refactor test groups to use enum

### DIFF
--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -19,9 +19,11 @@ import sentryInit from "./helpers/sentryInit"
 import AppStateWrapper from "./components/appStateWrapper"
 import { tagManagerIdentify } from "./helpers/googleTagManager"
 import { fullStoryIdentify } from "./helpers/fullStory"
-import inTestGroup from "./userInTestGroup"
+import inTestGroup, { TestGroups } from "./userInTestGroup"
 
-document.documentElement.dataset.demoMode = inTestGroup("demo-mode").toString()
+document.documentElement.dataset.demoMode = inTestGroup(
+  TestGroups.DemoMode
+).toString()
 
 const username = document
   .querySelector("meta[name=username]")

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -37,7 +37,7 @@ import { joinClasses } from "../helpers/dom"
 import { TrainVehicle, Vehicle, VehicleId } from "../realtime.d"
 import { DirectionId, Shape, Stop } from "../schedule"
 import { equalByElements } from "../helpers/array"
-import inTestGroup, { MAP_BETA_GROUP_NAME } from "../userInTestGroup"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 import {
   GarageMarkers,
   RouteShape,
@@ -422,8 +422,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
                       zoomLevel={zoomLevel}
                       direction={props.stopCardDirection}
                       includeStopCard={
-                        props.includeStopCard &&
-                        inTestGroup(MAP_BETA_GROUP_NAME)
+                        props.includeStopCard && inTestGroup(TestGroups.MapBeta)
                       }
                     />
                   </Pane>

--- a/assets/src/components/propertiesPanel/miniMap.tsx
+++ b/assets/src/components/propertiesPanel/miniMap.tsx
@@ -9,7 +9,7 @@ import {
   SelectedEntityType,
   newSearchSession,
 } from "../../state/searchPageState"
-import inTestGroup, { MAP_BETA_GROUP_NAME } from "../../userInTestGroup"
+import inTestGroup, { TestGroups } from "../../userInTestGroup"
 import { mapModeForUser } from "../../util/mapMode"
 import { MapFollowingPrimaryVehicles } from "../map"
 
@@ -53,7 +53,7 @@ const MiniMap = ({
 }) => {
   const stations: Stop[] | null = useStations()
 
-  const inMapBetaGroup = inTestGroup(MAP_BETA_GROUP_NAME)
+  const inMapBetaGroup = inTestGroup(TestGroups.MapBeta)
 
   return (
     <MapFollowingPrimaryVehicles

--- a/assets/src/components/searchResults.tsx
+++ b/assets/src/components/searchResults.tsx
@@ -3,7 +3,7 @@ import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { isLoggedOut, isVehicle } from "../models/vehicle"
 import { Ghost, Vehicle } from "../realtime"
 import { setSearchText } from "../state/searchPageState"
-import inTestGroup from "../userInTestGroup"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 import { Card, CardProperties } from "./card"
 import { vehicleOrGhostProperties } from "./propertiesList"
 import { RouteVariantName } from "./routeVariantName"
@@ -133,7 +133,9 @@ const NoResults = () => {
     dispatch,
   ] = useContext(StateDispatchContext)
 
-  const inLoggedOutVehiclesTestGroup = inTestGroup("search-logged-out-vehicles")
+  const inLoggedOutVehiclesTestGroup = inTestGroup(
+    TestGroups.SearchLoggedOutVehicles
+  )
 
   return (
     <div className="c-search-results__none">

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -2,6 +2,7 @@ import getTestGroups from "./userTestGroups"
 
 export enum TestGroups {
   DemoMode = "demo-mode",
+  LocationSearch = "location-search",
   MapBeta = "map-beta",
   SearchLoggedOutVehicles = "search-logged-out-vehicles",
 }

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -1,8 +1,12 @@
 import getTestGroups from "./userTestGroups"
 
-export const MAP_BETA_GROUP_NAME = "map-beta"
+export enum TestGroups {
+  DemoMode = "demo-mode",
+  MapBeta = "map-beta",
+  SearchLoggedOutVehicles = "search-logged-out-vehicles",
+}
 
-const inTestGroup = (key: string): boolean => {
+const inTestGroup = (key: TestGroups): boolean => {
   return getTestGroups().includes(key)
 }
 

--- a/assets/src/userTestGroups.ts
+++ b/assets/src/userTestGroups.ts
@@ -1,8 +1,8 @@
 import { array, create, Infer, string } from "superstruct"
 import appData from "./appData"
 
-const TestGroups = array(string())
-type TestGroups = Infer<typeof TestGroups>
+const TestGroupStrings = array(string())
+type TestGroupStrings = Infer<typeof TestGroupStrings>
 
 const getTestGroups = (): string[] => {
   const testGroupsJson = appData()?.userTestGroups
@@ -11,7 +11,10 @@ const getTestGroups = (): string[] => {
     return []
   }
 
-  const testGroups = create(JSON.parse(testGroupsJson) as unknown, TestGroups)
+  const testGroups = create(
+    JSON.parse(testGroupsJson) as unknown,
+    TestGroupStrings
+  )
 
   return testGroups
 }

--- a/assets/src/util/mapMode.tsx
+++ b/assets/src/util/mapMode.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from "react"
 import MapPage from "../components/mapPage"
 import SearchPage from "../components/searchPage"
 import { SearchIcon, SearchMapIcon } from "../helpers/icon"
-import inTestGroup, { MAP_BETA_GROUP_NAME } from "../userInTestGroup"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 
 type HTMLElementProps = React.PropsWithoutRef<React.HTMLAttributes<HTMLElement>>
 
@@ -34,4 +34,4 @@ export const searchMapConfig = {
 }
 
 export const mapModeForUser = (): NavMode =>
-  inTestGroup(MAP_BETA_GROUP_NAME) ? searchMapConfig : legacyMapConfig
+  inTestGroup(TestGroups.MapBeta) ? searchMapConfig : legacyMapConfig

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -10,7 +10,7 @@ import { initialState, OpenView, State } from "../../src/state"
 import routeTabFactory from "../factories/routeTab"
 import useVehicles from "../../src/hooks/useVehicles"
 import vehicleFactory from "../factories/vehicle"
-import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
+import { TestGroups } from "../../src/userInTestGroup"
 import getTestGroups from "../../src/userTestGroups"
 import { MemoryRouter } from "react-router-dom"
 import appData from "../../src/appData"
@@ -143,7 +143,7 @@ describe("App", () => {
     const mockDispatch = jest.fn()
 
     beforeAll(() => {
-      ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
+      ;(getTestGroups as jest.Mock).mockReturnValue([TestGroups.MapBeta])
     })
 
     afterAll(() => {
@@ -155,7 +155,7 @@ describe("App", () => {
         ...initialState,
         selectedVehicleOrGhost: vehicleFactory.build(),
       }
-      ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+      ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
 
       render(
         <StateDispatchProvider state={mockState} dispatch={mockDispatch}>
@@ -189,7 +189,7 @@ describe("App", () => {
   })
 
   test("disables view nav entries on search map page", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
     ;(appData as jest.Mock).mockImplementationOnce(() => {
       return {
         dispatcherFlag: "true",
@@ -228,7 +228,7 @@ describe("App", () => {
   })
 
   test("renders new map page for users in map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
 
     render(
       <MemoryRouter initialEntries={["/map"]}>

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -18,7 +18,7 @@ import userEvent from "@testing-library/user-event"
 import { runIdToLabel } from "../../src/helpers/vehicleLabel"
 
 import getTestGroups from "../../src/userTestGroups"
-import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
+import { TestGroups } from "../../src/userInTestGroup"
 import { LocationType } from "../../src/models/stopData"
 import { setHtmlDefaultWidthHeight } from "../testHelpers/leafletMapWidth"
 import { mockFullStoryEvent, mockTileUrls } from "../testHelpers/mockHelpers"
@@ -280,7 +280,7 @@ describe("<MapFollowingPrimaryVehicles />", () => {
   })
 
   test("renders street view link from stop if in maps test group", async () => {
-    ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValue([TestGroups.MapBeta])
 
     const { container } = render(
       <MapFollowingPrimaryVehicles

--- a/assets/tests/components/nav.test.tsx
+++ b/assets/tests/components/nav.test.tsx
@@ -6,7 +6,7 @@ import "@testing-library/jest-dom"
 import Nav from "../../src/components/nav"
 import useScreenSize from "../../src/hooks/useScreenSize"
 import getTestGroups from "../../src/userTestGroups"
-import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
+import { TestGroups } from "../../src/userInTestGroup"
 
 jest.mock("../../src/hooks/useScreenSize", () => ({
   __esModule: true,
@@ -65,7 +65,7 @@ describe("Nav", () => {
   })
 
   test("renders nav item with title 'Search Map' if in map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValue([TestGroups.MapBeta])
 
     render(
       <BrowserRouter>

--- a/assets/tests/components/nav/bottomNavMobile.test.tsx
+++ b/assets/tests/components/nav/bottomNavMobile.test.tsx
@@ -7,7 +7,7 @@ import { initialState } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import { tagManagerEvent } from "../../../src/helpers/googleTagManager"
 import getTestGroups from "../../../src/userTestGroups"
-import { MAP_BETA_GROUP_NAME } from "../../../src/userInTestGroup"
+import { TestGroups } from "../../../src/userInTestGroup"
 import { mockFullStoryEvent } from "../../testHelpers/mockHelpers"
 jest.mock("../../../src/helpers/googleTagManager", () => ({
   __esModule: true,
@@ -41,7 +41,7 @@ describe("BottomNavMobile", () => {
   })
 
   test("renders nav item with title 'Search Map' if in map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValue([TestGroups.MapBeta])
 
     render(
       <BrowserRouter>

--- a/assets/tests/components/nav/leftNav.test.tsx
+++ b/assets/tests/components/nav/leftNav.test.tsx
@@ -16,7 +16,7 @@ import {
   OpenView,
   togglePickerContainer,
 } from "../../../src/state"
-import { MAP_BETA_GROUP_NAME } from "../../../src/userInTestGroup"
+import { TestGroups } from "../../../src/userInTestGroup"
 import getTestGroups from "../../../src/userTestGroups"
 import { mockFullStoryEvent } from "../../testHelpers/mockHelpers"
 
@@ -94,7 +94,7 @@ describe("LeftNav", () => {
   })
 
   test("renders nav item with title 'Search Map' if in map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
 
     render(
       <BrowserRouter>
@@ -112,7 +112,7 @@ describe("LeftNav", () => {
 
   test("clicking 'Search Map' nav item triggers FullStory event", async () => {
     mockFullStoryEvent()
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
 
     render(
       <BrowserRouter>

--- a/assets/tests/components/propertiesPanel/miniMap.test.tsx
+++ b/assets/tests/components/propertiesPanel/miniMap.test.tsx
@@ -4,7 +4,7 @@ import vehicleFactory from "../../factories/vehicle"
 import { render, screen } from "@testing-library/react"
 import "@testing-library/jest-dom"
 import getTestGroups from "../../../src/userTestGroups"
-import { MAP_BETA_GROUP_NAME } from "../../../src/userInTestGroup"
+import { TestGroups } from "../../../src/userInTestGroup"
 import MiniMap from "../../../src/components/propertiesPanel/miniMap"
 import "@testing-library/jest-dom"
 import { MemoryRouter } from "react-router"
@@ -50,7 +50,7 @@ afterAll(() => {
 describe("MiniMap", () => {
   describe("For users in map test group", () => {
     beforeAll(() => {
-      ;(getTestGroups as jest.Mock).mockReturnValue([MAP_BETA_GROUP_NAME])
+      ;(getTestGroups as jest.Mock).mockReturnValue([TestGroups.MapBeta])
     })
     test("Map includes link to open vehicle in search map page", async () => {
       const mockDispatch = jest.fn()

--- a/assets/tests/userInTestGroup.test.ts
+++ b/assets/tests/userInTestGroup.test.ts
@@ -1,4 +1,4 @@
-import inTestGroup from "../src/userInTestGroup"
+import inTestGroup, { TestGroups } from "../src/userInTestGroup"
 import getTestGroups from "../src/userTestGroups"
 
 jest.mock("userTestGroups", () => ({
@@ -12,15 +12,15 @@ describe("inTestGroup", () => {
     const group_2 = "user-test-group-2"
     ;(getTestGroups as jest.Mock).mockReturnValue([group_1, group_2])
 
-    expect(inTestGroup(group_1)).toBe(true)
-    expect(inTestGroup(group_2)).toBe(true)
-    expect(inTestGroup(group_1 + group_2)).toBe(false)
+    expect(inTestGroup(group_1 as TestGroups)).toBe(true)
+    expect(inTestGroup(group_2 as TestGroups)).toBe(true)
+    expect(inTestGroup((group_1 + group_2) as TestGroups)).toBe(false)
   })
 
   test("returns false if the test group information is not found", () => {
     // Missing data key
     ;(getTestGroups as jest.Mock).mockReturnValue(["a-test-group"])
 
-    expect(inTestGroup("non-existent-group")).toBe(false)
+    expect(inTestGroup("non-existent-group" as TestGroups)).toBe(false)
   })
 })

--- a/assets/tests/util/mapMode.test.tsx
+++ b/assets/tests/util/mapMode.test.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import MapPage from "../../src/components/mapPage"
 import SearchPage from "../../src/components/searchPage"
 import { SearchIcon, SearchMapIcon } from "../../src/helpers/icon"
-import { MAP_BETA_GROUP_NAME } from "../../src/userInTestGroup"
+import { TestGroups } from "../../src/userInTestGroup"
 import getTestGroups from "../../src/userTestGroups"
 import { mapModeForUser } from "../../src/util/mapMode"
 
@@ -13,7 +13,7 @@ jest.mock("userTestGroups", () => ({
 
 describe("mapModeForUser", () => {
   test("returns new map mode when a part of new map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([MAP_BETA_GROUP_NAME])
+    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
     expect(mapModeForUser()).toEqual({
       path: "/map",
       title: "Search Map",


### PR DESCRIPTION
By using an enum we can change the symbol name, without affecting the test group name, or change the test group name without changing the symbol name.

Also introduces the location search test group in a separate commit, can be pulled out into it's own PR if desired, please let me know if you'd like a different name for either the enum symbol or the test group name string.