### PR TITLE
feat: sort limited search results the same way we sort on frontend

### DIFF
--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -249,7 +249,9 @@ defmodule Realtime.Server do
         logged_in_vehicles
       end
 
-    VehicleOrGhost.take_limited_matches(vehicles_to_search, search_params)
+    vehicles_to_search
+    |> VehicleOrGhost.take_limited_matches(search_params)
+    |> Map.update!(:matching_vehicles, &VehicleOrGhost.sort_for_search_results/1)
   end
 
   def lookup({table, {:run_ids, run_ids}}) do

--- a/lib/realtime/vehicle_or_ghost.ex
+++ b/lib/realtime/vehicle_or_ghost.ex
@@ -32,6 +32,33 @@ defmodule Realtime.VehicleOrGhost do
     )
   end
 
+  @spec sort_for_search_results([t()]) :: [t()]
+  def sort_for_search_results(vehicles) do
+    Enum.sort(vehicles, fn v1, v2 ->
+      case {v1, v2} do
+        {%Vehicle{}, %Ghost{}} ->
+          false
+
+        {%Vehicle{operator_logon_time: nil}, %Vehicle{operator_logon_time: t}}
+        when not is_nil(t) ->
+          false
+
+        {%Vehicle{} = v1, %Vehicle{} = v2} ->
+          v1_logon_time = Map.get(v1, :operator_logon_time)
+          v2_logon_time = Map.get(v2, :operator_logon_time)
+
+          cond do
+            is_nil(v1_logon_time) or is_nil(v2_logon_time) -> true
+            v1_logon_time > v2_logon_time -> false
+            true -> true
+          end
+
+        {_, _} ->
+          true
+      end
+    end)
+  end
+
   @spec prop_names_for_search_prop(Server.search_property()) :: [atom()]
   defp prop_names_for_search_prop(:operator),
     do: [:operator_id, :operator_first_name, :operator_last_name]

--- a/test/realtime/vehicle_or_ghost_test.exs
+++ b/test/realtime/vehicle_or_ghost_test.exs
@@ -215,4 +215,23 @@ defmodule Realtime.VehicleOrGhostTest do
                )
     end
   end
+
+  describe "sort_for_search_results/1" do
+    test "puts results in correct order" do
+      vehicle1 = build(:vehicle, %{operator_logon_time: 100})
+      vehicle2 = build(:vehicle, %{operator_logon_time: 200})
+      vehicle3 = build(:vehicle, %{operator_logon_time: 300})
+      ghost = build(:ghost)
+      logged_out_vehicle = build(:vehicle, %{operator_logon_time: nil})
+
+      assert [^ghost, ^vehicle1, ^vehicle2, ^vehicle3, ^logged_out_vehicle] =
+               VehicleOrGhost.sort_for_search_results([
+                 vehicle2,
+                 vehicle3,
+                 ghost,
+                 logged_out_vehicle,
+                 vehicle1
+               ])
+    end
+  end
 end

--- a/test/skate_web/channels/vehicles_search_channel_test.exs
+++ b/test/skate_web/channels/vehicles_search_channel_test.exs
@@ -26,11 +26,11 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
      socket: socket,
      user: user,
      vehicles: [
-       build(:vehicle, %{id: "1", label: "0001", route_id: "1"}),
+       build(:vehicle, %{id: "1", label: "0001", route_id: "1", operator_logon_time: 100}),
        build(:vehicle, %{id: "2", label: "not_match_2", route_id: "1"}),
-       build(:vehicle, %{id: "3", label: "0002", route_id: "1"}),
+       build(:vehicle, %{id: "3", label: "0002", route_id: "1", operator_logon_time: 200}),
        build(:vehicle, %{id: "4", label: "not_match_3", route_id: "1"}),
-       build(:vehicle, %{id: "5", label: "0003", route_id: "1"})
+       build(:vehicle, %{id: "5", label: "0003", route_id: "1", operator_logon_time: 300})
      ]}
   end
 
@@ -118,7 +118,9 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
       vehicles: vehicles
     } do
       [match_1, _other, match_2, _other_2, match_3] = vehicles
-      new_match = build(:vehicle, %{id: "6", label: "0004", route_id: "1"})
+
+      new_match =
+        build(:vehicle, %{id: "6", label: "0004", route_id: "1", operator_logon_time: 400})
 
       assert :ok = Realtime.Server.update_vehicles({%{"1" => vehicles}, [], []})
 
@@ -145,7 +147,7 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
                Realtime.Server.update_vehicles({%{"1" => [new_match, match_1, match_2]}, [], []})
 
       assert_push("limited_search", %{
-        data: %{matching_vehicles: [^new_match, ^match_1, ^match_2], has_more_matches: false}
+        data: %{matching_vehicles: [^match_1, ^match_2, ^new_match], has_more_matches: false}
       })
     end
   end


### PR DESCRIPTION
Asana ticket: [Sort by relevance before returning those results](https://app.asana.com/0/0/1205058225158721/f)

There's a potential for minor merge conflicts with other ongoing work but I think the main search logic should be fairly well-separated from everything else. For now I'm going with the existing functionality of sorting ghosts to the front, but I can always change that if need be.