### PR TITLE
feat(Skate.WarmUp): Increase number of attempts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -114,7 +114,7 @@ config :skate, Skate.Repo,
 
 config :skate, Skate.WarmUp,
   minimum_percent_queries_to_succeed: 0.6,
-  max_attempts: 3,
+  max_attempts: 5,
   seconds_between_attempts: 3
 
 config :laboratory,


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204925487890874/f

Over the last 30 days, there were 18 occurrences logged where the warmup succeeded in the first 3 attempts and 14 where it did not. Increasing the number of attempts to 5 to hopefully further reduce those failures, which can cause ECS tasks to churn.

<details>
  <summary>Tangent investigation to possibly remove Skate.Warmup entirely</summary>

I also looked into whether making `Ecto.Migrator` a child of the supervisor on startup could remove the need for this `Skate.Warmup` all together. Using `Ecto.Migrator` was a change proposed for the [original ticket ](https://app.asana.com/0/1148853526253434/1204865954744424/f)b/c the way migrations were previously run might have been hiding meaningful logs. I didn't explore that change for the initial PR to minimize the scope. 

It seems the logs have improved with the addition of `Skate.Warmup` (those 14 failed warmups log failures before the migrations are run). But looking more at `Ecto.Migrator` docs got me curious about whether it could also remove the need for `Skate.Warmup` entirely because it uses [with_repo](https://app.asana.com/0/1148853526253420/1205067894630933/f) to run migrations. From the docs:

> If the repo has not yet been started, it is manually started, with a :pool_size of 2, before the given function is executed, and the repo is then terminated. If the repo was already started, then the function is directly executed, without terminating the repo afterwards.

With that description, I _think_ `Ecto.Migrator` wouldn't replace the need for `Skate.WarmUp`; we would still need the warmup to ensure we don't run into the situation that has historically caused application startup issues where the repo _has_ started but connections are not yet available. So I think we still should consider using `Ecto.Migrator` to make the way we run migrations more typical, but we still might need this WarmUp step for those migrations and to succeed. I may be missing a nuance of repo startup though!
</details>