### PR TITLE
feat(Skate.Warmup): More logging for failed queries

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -114,8 +114,8 @@ config :skate, Skate.Repo,
 
 config :skate, Skate.WarmUp,
   minimum_percent_queries_to_succeed: 0.6,
-  max_attempts: 5,
-  seconds_between_attempts: 3
+  max_attempts: 20,
+  seconds_between_attempts: 1
 
 config :laboratory,
   features: [


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204925487890874/f

Adding some logging to see why warmups fail. I wanted to increase the query timeout based on [this suggestion](https://mbta.slack.com/archives/G01E809HUF2/p1690406117348129?thread_ts=1690394656.624479&cid=G01E809HUF2), but that seemed more challenging than expected based on the findings below. Instead, I'm tempted to *decrease* the timeout between attempts & increase the maximum attempt count in order to get a better since of how long it would take to get a successful attempt. But we do have`Postgrex.Protocol timed out because it was handshaking for longer than 15000ms` error messages, which is maybe enough of a signal that the connection is taking longer than 15 seconds.

Some alternatives that didn't quite pan out, but interested in other ideas! 
* My first preference would be to directly monitor how many active DB connections there are in the pool and how long they take to spin up, but it seems that isn't directly supported (some relevant elxir forum posts: [1](https://elixirforum.com/t/best-way-to-monitor-ectos-database-connectivity/38314/6), [2](https://elixirforum.com/t/monitoring-connections-pool-of-ecto-repo/25566/4)). Could potentially add some further [DBConnection configuration](https://hexdocs.pm/db_connection/DBConnection.html#start_link/2) like `connection_listeners` or `after_connect`, but I'm not sure those would get us the connection duration that we're looking for. 
* Increase the [queue_target](https://hexdocs.pm/db_connection/DBConnection.html#start_link/2) for this specific query. Unfortunately, this seems like a repo-level setting, and I'm not sure we'd want to significantly tweak it should that hide other errors in the application.
