### PR TITLE
feat(ts/components/GroupedAutocomplete): introduce autocomplete component

### DIFF
--- a/assets/css/_grouped_autocomplete.scss
+++ b/assets/css/_grouped_autocomplete.scss
@@ -1,0 +1,93 @@
+// #region Autocomplete
+.c-autocomplete {
+  padding: 1rem;
+  padding-bottom: 0.875rem;
+
+  color: $color-gray-700;
+
+  background-color: $white;
+
+  border: 1px solid $color-gray-400;
+  border-top-color: transparent;
+  border-radius: 0 0 4px 4px;
+
+  box-shadow: 0 0 10px $color-gray-400;
+  box-shadow: 0 5px 5px $color-gray-400;
+
+  &__list &__group-heading:not(:empty) {
+    // make space between heading and list content
+    margin-bottom: 0.625rem;
+  }
+
+  &__group-list {
+    // Remove default styling on margin for lists
+    margin: 0;
+  }
+
+  &__group-heading {
+    margin: 0;
+
+    // All heading text must be on one line, with no extra space between it and
+    // it's list items. All text must be a similar style.
+    > * {
+      display: inline-block;
+      margin-top: 0;
+      margin-bottom: 0;
+
+      color: $color-gray-700;
+      font-size: var(--font-size-xs);
+      font-weight: normal;
+    }
+  }
+
+  &__group-heading:not(:first-of-type) {
+    // Display a line between each group
+    border-top: 1px solid $color-gray-100;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    line-height: 1;
+  }
+
+  &__option {
+    --horizontal-padding: 0.5rem;
+    --negative-horizontal-padding: calc(var(--horizontal-padding) * -1);
+
+    display: block;
+    // Size content area to available width
+    width: 100%;
+    box-sizing: content-box !important;
+
+    position: relative;
+    // Widen tap, hover, and focus area
+    right: var(--negative-horizontal-padding);
+    left: var(--negative-horizontal-padding);
+    // Pad the contents back into the "available space"
+    padding: 0.5rem var(--horizontal-padding) 0.5rem var(--horizontal-padding);
+
+    font-size: var(--font-size-s);
+    line-height: 1;
+    text-align: left;
+
+    border-radius: 4px;
+
+    &:hover {
+      background-color: $color-gray-100;
+    }
+
+    &:focus {
+      // When focused, bring to front of stack,
+      // So that hover's `background-color` does not overlap the focus ring
+      isolation: isolate;
+      z-index: 1;
+      outline: $color-eggplant-600 solid 1.5px;
+    }
+  }
+
+  &:focus,
+  &:active {
+    border: 1px solid $color-eggplant-500;
+    box-shadow: 0 5px 5px $color-gray-400, 0 0 0 2px #aa4ef22b;
+  }
+}
+
+// #endregion Autocomplete

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -129,7 +129,8 @@
     display: block;
   }
 
-  // -- Round out the bottom of the input bar
+  // -- Visually join the bottom of the input bar with autocomplete by squaring
+  //    off the bottom
   .c-search-form__search-input-container {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;

--- a/assets/css/_search_form.scss
+++ b/assets/css/_search_form.scss
@@ -2,6 +2,16 @@
   display: flex;
   flex-flow: column nowrap;
   gap: 1rem;
+
+  // Prevent intersection between accordion and autocomplete popup
+  .c-filter-accordion,
+  .c-search-form__search-control {
+    isolation: isolate;
+  }
+  .c-search-form__search-control {
+    // Stack items within search-control on top of accordion
+    z-index: 1;
+  }
 }
 
 .c-search-form__search-control {
@@ -105,3 +115,40 @@
   }
 }
 // #endregion Search Input Buttons
+
+// #region Autocomplete Control
+// Hide the autocomplete control by default
+.c-search-form__autocomplete-container {
+  display: none;
+}
+
+// When input controls have focus --
+.c-search-form__search-control[data-autocomplete-visible="true"]:focus-within {
+  // -- Show Autocomplete control
+  .c-search-form__autocomplete-container {
+    display: block;
+  }
+
+  // -- Round out the bottom of the input bar
+  .c-search-form__search-input-container {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+
+.c-search-form__autocomplete-container {
+  // Isolate to ensure that floating on top of other elements doesn't intersect
+  // in the Z axis.
+  isolation: isolate;
+  // Move behind the input control so focus styles overlap the autocomplete
+  // control
+  position: relative;
+  z-index: -1;
+
+  &:focus-within {
+    // Attempt to put the autocomplete control on top of the input control if
+    // the autocomplete control has focus
+    z-index: 1;
+  }
+}
+// #endregion Autocomplete Control

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -74,6 +74,7 @@ $list-group-border-color: $color-gray-300;
 @import "incoming_box";
 @import "input_modal";
 @import "ladder_page";
+@import "grouped_autocomplete";
 @import "ladder";
 @import "late_view";
 @import "loading_modal";
@@ -145,7 +146,7 @@ $list-group-border-color: $color-gray-300;
   box-sizing: border-box;
 }
 
-.inherit-box :is(*, *::before, *::after) {
+.inherit-box :where(*, *::before, *::after) {
   box-sizing: inherit;
 }
 

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -703,41 +703,35 @@ export const GroupedAutocompleteFromSearchTextResults = ({
 
   // Build groups and options from search results.
   const groups = [
-    {
-      group: {
-        title: <h2>{searchPropertyDisplayConfig.vehicle.name}</h2>,
-        options: vehicles
-          .slice(0, maxElementsPerGroup)
-          .map((v) =>
-            autocompleteOption(
-              (isVehicle(v) && v.label) || v.id,
-              onSelectVehicleOption(v)
-            )
-          ),
-      },
-    },
-    {
-      group: {
-        title: <h2>{searchPropertyDisplayConfig.operator.name}</h2>,
-        options: operators
-          .filter(isVehicle)
-          .slice(0, maxElementsPerGroup)
-          .map((v) =>
-            autocompleteOption(
-              formatOperatorNameFromVehicle(v),
-              onSelectVehicleOption(v)
-            )
-          ),
-      },
-    },
-    {
-      group: {
-        title: <h2>{searchPropertyDisplayConfig.run.name}</h2>,
-        options: runs
-          .slice(0, maxElementsPerGroup)
-          .map((v) => autocompleteOption(v.runId, onSelectVehicleOption(v))),
-      },
-    },
+    autocompleteGroup(
+      <h2>{searchPropertyDisplayConfig.vehicle.name}</h2>,
+      ...vehicles
+        .slice(0, maxElementsPerGroup)
+        .map((v) =>
+          autocompleteOption(
+            (isVehicle(v) && v.label) || v.id,
+            onSelectVehicleOption(v)
+          )
+        )
+    ),
+    autocompleteGroup(
+      <h2>{searchPropertyDisplayConfig.operator.name}</h2>,
+      ...operators
+        .filter(isVehicle)
+        .slice(0, maxElementsPerGroup)
+        .map((v) =>
+          autocompleteOption(
+            formatOperatorNameFromVehicle(v),
+            onSelectVehicleOption(v)
+          )
+        )
+    ),
+    autocompleteGroup(
+      <h2>{searchPropertyDisplayConfig.run.name}</h2>,
+      ...runs
+        .slice(0, maxElementsPerGroup)
+        .map((v) => autocompleteOption(v.runId, onSelectVehicleOption(v)))
+    ),
   ].filter(({ group: { options } }) => options.length > 0)
 
   return <GroupedAutocomplete {...props} optionGroups={groups} />

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -410,13 +410,33 @@ export const autocompleteOption = (
   },
 })
 
-export type AutocompleteDataGroup = {
+/**
+ * Use {@link autocompleteGroup} to construct this type.
+ */
+type AutocompleteDataGroup = {
   group: {
     title: ReactNode
     options: AutocompleteOptionData[]
   }
 }
 
+/**
+ *
+ *
+ * @param title Group Heading
+ * @param options Options belonging to the group
+ */
+export function autocompleteGroup(
+  title: ReactNode,
+  ...options: AutocompleteOptionData[]
+): AutocompleteDataGroup {
+  return {
+    group: {
+      title,
+      options,
+    },
+  }
+}
 /**
  * A keyboard & mouse navigable control containing a list of list of options.
  * Provides callbacks when options are selected.

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -388,6 +388,9 @@ interface AutocompleteCursorEventProps {
   onCursorExitEdge?: (direction: CursorExitDirection) => void
 }
 
+/**
+ * Use {@link autocompleteOption} to construct this type.
+ */
 type AutocompleteOptionData = {
   option: {
     label: ReactNode
@@ -397,7 +400,7 @@ type AutocompleteOptionData = {
 /**
  * {@link AutocompleteOptionData} constructor.
  */
-export const autocompleteOptionData = (
+export const autocompleteOption = (
   label: ReactNode,
   onSelectOption?: ReactEventHandler
 ): AutocompleteOptionData => ({
@@ -686,7 +689,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
         options: vehicles
           .slice(0, maxElementsPerGroup)
           .map((v) =>
-            autocompleteOptionData(
+            autocompleteOption(
               (isVehicle(v) && v.label) || v.id,
               onSelectVehicleOption(v)
             )
@@ -700,7 +703,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
           .filter(isVehicle)
           .slice(0, maxElementsPerGroup)
           .map((v) =>
-            autocompleteOptionData(
+            autocompleteOption(
               formatOperatorNameFromVehicle(v),
               onSelectVehicleOption(v)
             )
@@ -712,9 +715,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
         title: <h2>{searchPropertyDisplayConfig.run.name}</h2>,
         options: runs
           .slice(0, maxElementsPerGroup)
-          .map((v) =>
-            autocompleteOptionData(v.runId, onSelectVehicleOption(v))
-          ),
+          .map((v) => autocompleteOption(v.runId, onSelectVehicleOption(v))),
       },
     },
   ].filter(({ group: { options } }) => options.length > 0)

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -704,8 +704,8 @@ export const GroupedAutocompleteFromSearchTextResults = ({
       group: {
         title: <h2>{searchPropertyDisplayConfig.operator.name}</h2>,
         options: operators
-          .slice(0, maxElementsPerGroup)
           .filter(isVehicle)
+          .slice(0, maxElementsPerGroup)
           .map((v) =>
             autocompleteOptionData(
               formatOperatorNameFromVehicle(v),

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -353,15 +353,15 @@ export interface GroupedAutocompleteProps
    */
   fallbackOption: ReactNode
   /**
-   * Callback when the {@link fallbackOption} is chosen in the autocomplete.
+   * Callback when the {@link fallbackOption} is selected in the autocomplete.
    */
-  onFallbackOptionChosen?: React.ReactEventHandler
+  onSelectFallbackOption?: React.ReactEventHandler
 }
 
 type AutocompleteOptionData = {
   option: {
     label: ReactNode
-    onOptionChosen: ReactEventHandler
+    onSelectOption: ReactEventHandler
   }
 }
 
@@ -382,7 +382,7 @@ export const GroupedAutocomplete = ({
   groups,
   controllerRef,
   fallbackOption,
-  onFallbackOptionChosen,
+  onSelectFallbackOption,
   Heading = "h2",
 }: GroupedAutocompleteProps) => {
   const listHeadingId = useId()
@@ -397,7 +397,7 @@ export const GroupedAutocomplete = ({
             {
               option: {
                 label: fallbackOption,
-                onOptionChosen: (e) => onFallbackOptionChosen?.(e),
+                onSelectOption: (e) => onSelectFallbackOption?.(e),
               },
             },
           ],
@@ -488,7 +488,7 @@ export const GroupedAutocomplete = ({
         {groups.map(({ group: { title, options } }, groupIndex) => (
           <GroupOptionList key={groupIndex} heading={title}>
             {options.map(
-              ({ option: { label, onOptionChosen } }, optionIndex) => {
+              ({ option: { label, onSelectOption } }, optionIndex) => {
                 const selected =
                   cursorLocation &&
                   cursorLocation.group === groupIndex &&
@@ -508,15 +508,15 @@ export const GroupedAutocomplete = ({
                         })
                       e.stopPropagation()
                     }}
-                    onClick={onOptionChosen}
+                    onClick={onSelectOption}
                     onKeyDown={(e) => {
-                      // Fire `optionChosen` if enter is pressed
+                      // Fire `onSelectOption` if enter is pressed
                       if (!["Enter"].includes(e.key)) {
                         return
                       }
                       e.preventDefault()
                       e.stopPropagation()
-                      onOptionChosen?.(e)
+                      onSelectOption?.(e)
                     }}
                     // If this element is selected by the cursor,
                     // set document focus to this element when mounted.
@@ -605,7 +605,7 @@ interface GroupedAutocompleteFromSearchTextResultsProps
   maxElementsPerGroup?: number
   /**
    * Callback when a autocomplete vehicle option is selected.
-   * @param chosenOption The selected option vehicle
+   * @param selectedOption The selected option vehicle
    *
    * ---
    * @todo
@@ -614,7 +614,7 @@ interface GroupedAutocompleteFromSearchTextResultsProps
    *   Alternatively provide more callbacks for specific types to avoid
    *   type deduction.
    */
-  onVehicleOptionChosen: (chosenOption: Vehicle | Ghost) => void
+  onSelectVehicleOption: (selectedOption: Vehicle | Ghost) => void
 }
 
 /**
@@ -622,7 +622,7 @@ interface GroupedAutocompleteFromSearchTextResultsProps
  * {@link searchText} provided and {@link useAutocompleteResults}.
  */
 export const GroupedAutocompleteFromSearchTextResults = ({
-  onVehicleOptionChosen: onVehicleOptionChosenProp,
+  onSelectVehicleOption: onSelectVehicleOptionProp,
   searchText,
   searchFilters,
   maxElementsPerGroup = 5,
@@ -634,8 +634,8 @@ export const GroupedAutocompleteFromSearchTextResults = ({
     operator: operators,
   } = useAutocompleteResults(searchText, searchFilters, maxElementsPerGroup)
 
-  const onVehicleOptionChosen = (chosenOption: Vehicle | Ghost) => () => {
-    onVehicleOptionChosenProp(chosenOption)
+  const onSelectVehicleOption = (selectedOption: Vehicle | Ghost) => () => {
+    onSelectVehicleOptionProp(selectedOption)
   }
 
   // Build groups and options from search results.
@@ -645,7 +645,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
         title: <h2>{searchPropertyDisplayConfig.vehicle.name}</h2>,
         options: vehicles.slice(0, maxElementsPerGroup).map((v) => ({
           option: {
-            onOptionChosen: onVehicleOptionChosen(v),
+            onSelectOption: onSelectVehicleOption(v),
             label: (isVehicle(v) && v.label) || v.id,
           },
         })),
@@ -659,7 +659,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
           .filter(isVehicle)
           .map((v) => ({
             option: {
-              onOptionChosen: onVehicleOptionChosen(v),
+              onSelectOption: onSelectVehicleOption(v),
               label: formatOperatorNameFromVehicle(v),
             },
           })),
@@ -670,7 +670,7 @@ export const GroupedAutocompleteFromSearchTextResults = ({
         title: <h2>{searchPropertyDisplayConfig.run.name}</h2>,
         options: runs.slice(0, maxElementsPerGroup).map((v) => ({
           option: {
-            onOptionChosen: onVehicleOptionChosen(v),
+            onSelectOption: onSelectVehicleOption(v),
             label: v.runId,
           },
         })),

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -4,6 +4,7 @@ import React, {
   MutableRefObject,
   ReactEventHandler,
   ReactNode,
+  useContext,
   useId,
   useImperativeHandle,
   useReducer,
@@ -18,6 +19,7 @@ import { isVehicle } from "../models/vehicle"
 import { Ghost, Vehicle } from "../realtime"
 import { clamp } from "../util/math"
 import { formatOperatorNameFromVehicle } from "../util/operatorFormatting"
+import { SocketContext } from "../contexts/socketContext"
 
 // #region Autocomplete Control
 // #region Cursor Reducer
@@ -667,11 +669,17 @@ export const GroupedAutocompleteFromSearchTextResults = ({
   maxElementsPerGroup = 5,
   ...props
 }: GroupedAutocompleteFromSearchTextResultsProps) => {
+  const { socket } = useContext(SocketContext)
   const {
     vehicle: vehicles,
     run: runs,
     operator: operators,
-  } = useAutocompleteResults(searchText, searchFilters, maxElementsPerGroup)
+  } = useAutocompleteResults(
+    socket,
+    searchText,
+    searchFilters,
+    maxElementsPerGroup
+  )
 
   const onSelectVehicleOption = (selectedOption: Vehicle | Ghost) => () => {
     onSelectVehicleOptionProp(selectedOption)

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -551,7 +551,7 @@ export const GroupedAutocomplete = ({
                     onClick={onSelectOption}
                     onKeyDown={(e) => {
                       // Fire `onSelectOption` if enter is pressed
-                      if (!["Enter"].includes(e.key)) {
+                      if (e.key != "Enter") {
                         return
                       }
                       e.preventDefault()

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -1,0 +1,577 @@
+import { captureException } from "@sentry/react"
+import React, {
+  ComponentPropsWithoutRef,
+  MutableRefObject,
+  ReactEventHandler,
+  ReactNode,
+  useId,
+  useImperativeHandle,
+  useReducer,
+} from "react"
+
+import { clamp } from "../util/math"
+
+// #region Autocomplete Control
+// #region Cursor Reducer
+
+/**
+ * Represents the 2D jagged array of groups and options per group.
+ *
+ * The length of the array is the number of groups.
+ * The element of the array is the number of options within that group.
+ */
+type LengthsContext = number[]
+
+/**
+ * The possible cursor states.
+ *
+ * - `undefined` when there is no cursor state.
+ * - Group and Option are defined to be a position contained within a
+ * {@link LengthsContext}.
+ */
+type CursorState = { group: number; option: number } | undefined
+
+/**
+ * Check if the {@link proposedLocation} is a valid location within
+ * {@link lengthsContext}.
+ *
+ * @param proposedLocation The {@link CursorState} to test if it is valid
+ * @param lengthsContext The {@link LengthsContext} used to bounds check {@link proposedLocation}
+ * @returns `true` if the {@link proposedLocation} is within the {@link lengthsContext}, otherwise `false`
+ */
+const isValidLocation = (
+  proposedLocation: CursorState,
+  lengthsContext: LengthsContext
+): boolean => {
+  if (!proposedLocation) {
+    return false
+  }
+
+  const { group: x, option: y } = proposedLocation
+  return Boolean(
+    0 <= x && 0 <= y && x < lengthsContext.length && y < lengthsContext[x]
+  )
+}
+
+/**
+ * Checks if the {@link proposedLocation} is valid and returns a
+ * {@link CursorState} based on the {@link isValidLocation} validity check.
+ *
+ * @param proposedLocation The {@link CursorState} to test and return if it is valid.
+ * @param lengthsContext The {@link LengthsContext} used to bounds check {@link proposedLocation}.
+ * @returns {} {@link proposedLocation} if {@link proposedLocation} is valid, otherwise `undefined`.
+ */
+const getValidLocationOrUnset = (
+  proposedLocation: CursorState,
+  lengthsContext: LengthsContext
+): CursorState => {
+  return isValidLocation(proposedLocation, lengthsContext)
+    ? proposedLocation
+    : undefined
+}
+
+/**
+ * Valid {@link cursorLocationReducer} commands.
+ */
+enum CursorLocationAction {
+  MoveToStart = "MoveToStart",
+  MoveToEnd = "MoveToEnd",
+  ForceCursorTo = "ForceCursorTo",
+  DeleteCursor = "DeleteCursor",
+  MoveNext = "MoveNext",
+  MovePrev = "MovePrev",
+  FindNearestValidLocation = "FindNearestValidLocation",
+}
+
+/**
+ * {@link cursorLocationReducer} commands and arguments.
+ */
+type CursorStateAction = {
+  lengthsContext: LengthsContext
+} & (
+  | {
+      action: CursorLocationAction
+    }
+  | {
+      forceLocation: CursorState
+    }
+)
+
+/**
+ * A State Reducer that moves a {@link CursorState cursor} to leaf coordinates
+ * within a 2d jagged array defined by a {@link LengthsContext}.
+ */
+const cursorLocationReducer = (
+  cursorState: CursorState,
+  nextAction: CursorStateAction
+): CursorState => {
+  const { lengthsContext } = nextAction
+
+  // Curry `lengthsContext` into `getValidLocationOrUnset`
+  const getValidLocationOrUnsetWithLengthsContext = (
+    proposedLocation: CursorState
+  ) => getValidLocationOrUnset(proposedLocation, lengthsContext)
+
+  // Early exit if we're simply setting the position
+  if ("forceLocation" in nextAction) {
+    return getValidLocationOrUnsetWithLengthsContext(nextAction.forceLocation)
+  }
+
+  const { action } = nextAction
+
+  // Do actions that don't require knowing the type of the `cursorState`
+  switch (action) {
+    case CursorLocationAction.DeleteCursor: {
+      return undefined
+    }
+
+    case CursorLocationAction.MoveToStart: {
+      // In case the length of the arrays are zero
+      // Check if the first value is valid
+      return getValidLocationOrUnsetWithLengthsContext({ group: 0, option: 0 })
+    }
+
+    case CursorLocationAction.MoveToEnd: {
+      // Check if the last value of each length is valid
+      return getValidLocationOrUnsetWithLengthsContext({
+        group: lengthsContext.length - 1,
+        // move out of bounds ( < 0) if it doesn't exist
+        option: lengthsContext[lengthsContext.length - 1] - 1,
+      })
+    }
+  }
+
+  // Do actions that require the `cursorState`
+
+  // Return the current state if it's invalid
+  if (!cursorState) {
+    return cursorState
+  }
+
+  switch (action) {
+    case CursorLocationAction.FindNearestValidLocation: {
+      // Constrain current cursor to bounds of `lengthsContext`
+      const group = clamp(cursorState.group, 0, lengthsContext.length - 1)
+      return getValidLocationOrUnsetWithLengthsContext({
+        group,
+        option: clamp(cursorState.option, 0, lengthsContext[group] - 1),
+      })
+    }
+
+    case CursorLocationAction.MoveNext: {
+      return (
+        // Try the option index after the current option
+        getValidLocationOrUnsetWithLengthsContext({
+          ...cursorState,
+          option: cursorState.option + 1,
+        }) ||
+        // Then the first option in the next group
+        getValidLocationOrUnsetWithLengthsContext({
+          group: cursorState.group + 1,
+          option: 0,
+        }) ||
+        // If the cursor state no longer matches up with the `lengthsContext`
+        // Move cursor to nearest valid location
+        cursorLocationReducer(cursorState, {
+          lengthsContext,
+          action: CursorLocationAction.FindNearestValidLocation,
+        }) ||
+        // Otherwise return the current state as we've reached the end
+        cursorState
+      )
+    }
+
+    case CursorLocationAction.MovePrev: {
+      return (
+        // Try the option index before the current option
+        getValidLocationOrUnsetWithLengthsContext({
+          ...cursorState,
+          option: cursorState.option - 1,
+        }) ||
+        // Try the last option of the previous group
+        getValidLocationOrUnsetWithLengthsContext({
+          group: cursorState.group - 1,
+          option: lengthsContext[cursorState.group - 1] - 1,
+        }) ||
+        // If the cursor state no longer matches up with the `lengthsContext`
+        // Move cursor to nearest valid location
+        cursorLocationReducer(cursorState, {
+          lengthsContext,
+          action: CursorLocationAction.FindNearestValidLocation,
+        }) ||
+        // Otherwise return the current cursor, as we've reached the beginning
+        cursorState
+      )
+    }
+  }
+
+  // We really shouldn't reach this point, so for safety we'll return the
+  // current state
+  captureException(
+    new Error(
+      "internal error: entered unreachable code: end of `cursorLocationReducer`"
+    ),
+    {
+      extra: {
+        cursorState,
+        lengthsContext,
+        action,
+      },
+    }
+  )
+  return cursorState
+}
+
+/**
+ * {@link cursorLocationReducer} return state with helper functions.
+ */
+interface CursorReducerControls {
+  /**
+   * The current {@link CursorState `cursorLocation`}
+   */
+  cursorLocation: CursorState
+
+  /**
+   * Function to move the {@link CursorState `cursorLocation`} relatively
+   * within the {@link LengthsContext}
+   */
+  updateCursorLocation: (action: CursorLocationAction) => void
+
+  /**
+   * Set the {@link CursorState}, if the {@link CursorState} is valid
+   * within the {@link LengthsContext}.
+   */
+  setCursorLocation: (forceLocation: CursorState) => void
+}
+
+/**
+ * Helper hook to pre-configure functions with {@link LengthsContext} from the
+ * {@link groups groups parameter} and a few specialty functions.
+ *
+ * @param groups The {@link AutocompleteDataGroup} array used to bounds check
+ * {@link CursorState} arguments and changes.
+ *
+ * @returns The current cursor state and functions to modify the state.
+ */
+const useCursorLocationFromGroups = (
+  groups: AutocompleteDataGroup[]
+): CursorReducerControls => {
+  const lengthsContext = groups.map(({ group }) => group.options.length)
+
+  const [cursorLocation, dispatchCursorLocation] = useReducer(
+    cursorLocationReducer,
+    undefined
+  )
+
+  return {
+    /**
+     * The current {@link CursorLocation `cursorLocation`}
+     */
+    cursorLocation,
+    /**
+     * Function to move the {@link CursorLocation `cursorLocation`} relatively
+     * within the {@link LengthsContext}
+     */
+    updateCursorLocation: (action: CursorLocationAction) =>
+      dispatchCursorLocation({ action, lengthsContext }),
+    /**
+     * Set the {@link CursorLocation}, if the {@link CursorLocation} is valid
+     * within the {@link LengthsContext}.
+     */
+    setCursorLocation: (forceLocation: CursorState) =>
+      dispatchCursorLocation({ forceLocation, lengthsContext }),
+  }
+}
+// #endregion Cursor Reducer
+
+// #region Autocomplete Control Impl
+/**
+ * Props which expose references for controlling the {@link GroupedAutocomplete}
+ */
+export type GroupedAutocompleteControlRefProps = {
+  /**
+   * Reference object containing functions for controlling the
+   * {@link GroupedAutocomplete}.
+   */
+  controllerRef?: MutableRefObject<GroupedAutocompleteControls | null>
+}
+
+/**
+ * Functions to control the cursor state of the {@link GroupedAutocomplete}
+ */
+export interface GroupedAutocompleteControls {
+  /**
+   * Moves focus to first available option if it exists.
+   */
+  focusCursorToFirstOption: () => void
+  /**
+   * Deletes the cursor in the control, relinquish's focus control.
+   */
+  forgetCursor: () => void
+}
+
+/**
+ * General configuration props for the {@link GroupedAutocomplete} control.
+ */
+export interface GroupedAutocompleteProps
+  extends GroupedAutocompleteControlRefProps {
+  /**
+   * The ID of the `listbox` control.
+   *
+   * Mainly used for aria compatibility.
+   */
+  id?: string
+  /**
+   * The groups and options to render as clickable elements in the control.
+   */
+  groups: AutocompleteDataGroup[]
+  /**
+   * The name of the control. Read to screen readers when control receives focus.
+   */
+  controlName: ReactNode
+  /**
+   * React Component to use as the heading and aria-label for the results list.
+   *
+   * This component must expose the following props
+   * - `aria-hidden`
+   * - `className`
+   * - `id`
+   *
+   * Defaults to "h2".
+   */
+  Heading?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+  /**
+   * Component to display when there are 0 search results.
+   */
+  fallbackOption: ReactNode
+  /**
+   * Callback when the {@link fallbackOption} is chosen in the autocomplete.
+   */
+  onFallbackOptionChosen?: React.ReactEventHandler
+}
+
+type AutocompleteOptionData = {
+  option: {
+    label: ReactNode
+    onOptionChosen: ReactEventHandler
+  }
+}
+
+export type AutocompleteDataGroup = {
+  group: {
+    title: ReactNode
+    options: AutocompleteOptionData[]
+  }
+}
+
+/**
+ * A keyboard & mouse navigable control containing a list of list of options.
+ * Provides callbacks when options are selected.
+ */
+export const GroupedAutocomplete = ({
+  id,
+  controlName,
+  groups,
+  controllerRef,
+  fallbackOption,
+  onFallbackOptionChosen,
+  Heading = "h2",
+}: GroupedAutocompleteProps) => {
+  const listHeadingId = useId()
+
+  // Fallback option and group
+  if (groups.length === 0) {
+    groups = [
+      {
+        group: {
+          title: null,
+          options: [
+            {
+              option: {
+                label: fallbackOption,
+                onOptionChosen: (e) => onFallbackOptionChosen?.(e),
+              },
+            },
+          ],
+        },
+      },
+    ]
+  }
+
+  const { cursorLocation, updateCursorLocation, setCursorLocation } =
+    useCursorLocationFromGroups(groups)
+
+  useImperativeHandle(
+    controllerRef,
+    (): GroupedAutocompleteControls => ({
+      focusCursorToFirstOption() {
+        updateCursorLocation(CursorLocationAction.MoveToStart)
+      },
+      forgetCursor() {
+        updateCursorLocation(CursorLocationAction.DeleteCursor)
+      },
+    })
+  )
+
+  return (
+    <div className="c-autocomplete">
+      <Heading
+        className="visually-hidden"
+        role="presentation"
+        aria-hidden={true}
+        id={listHeadingId}
+      >
+        {controlName}
+      </Heading>
+
+      <div
+        id={id}
+        role="listbox"
+        className="c-autocomplete__list"
+        onFocus={(event) => {
+          // Check if the previously focused element is a child of this element.
+          const autocompleteControlAlreadyHadFocus =
+            event.currentTarget.contains(event.relatedTarget)
+          // set the cursor to the first element if:
+          // - the user focused an element in the autocomplete control that is not an option
+          //   (option focus event prevents propagation).
+          // - the cursor is unset or the autocomplete control does not contain the previously focused element.
+          if (
+            cursorLocation === undefined ||
+            autocompleteControlAlreadyHadFocus === false
+          ) {
+            updateCursorLocation(CursorLocationAction.MoveToStart)
+          }
+        }}
+        onBlur={(event) => {
+          // Delete the cursor state if the user's focus exits the autocomplete
+          // control.
+          if (event.currentTarget.contains(event.relatedTarget)) {
+            return
+          }
+
+          updateCursorLocation(CursorLocationAction.DeleteCursor)
+        }}
+        onKeyDown={(e) => {
+          // Handle cursor movement by keyboard.
+          // If the key is not a movement key, allow event to bubble up.
+          switch (e.key) {
+            case "ArrowDown":
+              updateCursorLocation(CursorLocationAction.MoveNext)
+              break
+            case "ArrowUp":
+              updateCursorLocation(CursorLocationAction.MovePrev)
+              break
+            case "Home":
+              updateCursorLocation(CursorLocationAction.MoveToStart)
+              break
+            case "End":
+              updateCursorLocation(CursorLocationAction.MoveToEnd)
+              break
+            default:
+              return
+          }
+          e.preventDefault()
+          e.stopPropagation()
+        }}
+        aria-labelledby={listHeadingId}
+        tabIndex={-1}
+      >
+        {groups.map(({ group: { title, options } }, groupIndex) => (
+          <GroupOptionList key={groupIndex} heading={title}>
+            {options.map(
+              ({ option: { label, onOptionChosen } }, optionIndex) => {
+                const selected =
+                  cursorLocation &&
+                  cursorLocation.group === groupIndex &&
+                  cursorLocation.option === optionIndex
+                return (
+                  <li
+                    key={optionIndex}
+                    className="c-autocomplete__option"
+                    role="option"
+                    aria-selected={selected}
+                    onFocus={(e) => {
+                      // Set cursor to this location if focused.
+                      !selected &&
+                        setCursorLocation({
+                          group: groupIndex,
+                          option: optionIndex,
+                        })
+                      e.stopPropagation()
+                    }}
+                    onClick={onOptionChosen}
+                    onKeyDown={(e) => {
+                      // Fire `optionChosen` if enter is pressed
+                      if (!["Enter"].includes(e.key)) {
+                        return
+                      }
+                      e.preventDefault()
+                      e.stopPropagation()
+                      onOptionChosen?.(e)
+                    }}
+                    // If this element is selected by the cursor,
+                    // set document focus to this element when mounted.
+                    ref={(selected || null) && ((r) => r?.focus())}
+                    // Allow user to tab into the first option and out of
+                    // the autocomplete control on next `Tab` key.
+                    tabIndex={groupIndex === 0 && optionIndex === 0 ? 0 : -1}
+                  >
+                    {label}
+                  </li>
+                )
+              }
+            )}
+          </GroupOptionList>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// #region LabelledList Components
+type LabelledListProps = {
+  heading: ReactNode
+  headingProps?: ComponentPropsWithoutRef<"div">
+} & ComponentPropsWithoutRef<"ul">
+
+/**
+ * Component which binds a list aria-label to the supplied {@link heading} as a
+ * sibling so that screen readers to not count the heading as a option or group.
+ */
+const LabelledListboxGroup = ({
+  heading,
+  headingProps,
+  ...props
+}: LabelledListProps) => {
+  const id = useId()
+
+  return (
+    <>
+      <div
+        role="presentation"
+        {...headingProps}
+        aria-hidden={true}
+        id={id}
+        style={{ userSelect: "none" }}
+      >
+        {heading}
+      </div>
+      <ul role="group" {...props} aria-labelledby={id} />
+    </>
+  )
+}
+
+/**
+ * {@link GroupedAutocomplete} {@link LabelledListboxGroup} component.
+ */
+const GroupOptionList = (props: LabelledListProps) => (
+  <LabelledListboxGroup
+    {...props}
+    headingProps={{ className: "c-autocomplete__group-heading" }}
+    className="c-autocomplete__group-list"
+  />
+)
+// #endregion LabelledList Components
+// #endregion Autocomplete Control Impl
+// #endregion Autocomplete Control

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -359,11 +359,6 @@ export interface GroupedAutocompleteProps
   /**
    * React Component to use as the heading and aria-label for the results list.
    *
-   * This component must expose the following props
-   * - `aria-hidden`
-   * - `className`
-   * - `id`
-   *
    * Defaults to "h2".
    */
   Heading?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6"

--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -561,10 +561,8 @@ export const GroupedAutocomplete = ({
                     // If this element is selected by the cursor,
                     // set document focus to this element when mounted.
                     ref={(selected || null) && ((r) => r?.focus())}
-                    // Allow user to tab into the first option and out of
-                    // the autocomplete control on next `Tab` key.
-                    // > Composite controls should have one tab stop
-                    tabIndex={groupIndex === 0 && optionIndex === 0 ? 0 : -1}
+                    // Allow element to be focused as a control.
+                    tabIndex={-1}
                   >
                     {label}
                   </li>

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -301,6 +301,9 @@ export const SearchForm = ({
             fallbackOption={autocompleteOptionData(inputText, onSubmit)}
             onSelectVehicleOption={onSelectVehicleOption}
             controllerRef={autocompleteController}
+              onCursor={{
+                onCursorExitEdge: () => formSearchInput.current?.focus(),
+              }}
           />
         </div>
       </div>

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -28,7 +28,7 @@ import { FilterAccordion } from "./filterAccordion"
 import {
   GroupedAutocompleteControls,
   GroupedAutocompleteFromSearchTextResults,
-  autocompleteOptionData,
+  autocompleteOption,
 } from "./groupedAutocomplete"
 import { SocketContext } from "../contexts/socketContext"
 import useSocket from "../hooks/useSocket"
@@ -301,7 +301,7 @@ export const SearchForm = ({
               maxElementsPerGroup={5}
               searchFilters={filters}
               searchText={inputText}
-              fallbackOption={autocompleteOptionData(inputText, onSubmit)}
+              fallbackOption={autocompleteOption(inputText, onSubmit)}
               onSelectVehicleOption={onSelectVehicleOption}
               controllerRef={autocompleteController}
               onCursor={{

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -84,9 +84,9 @@ type SearchFormProps = SearchFormEventProps &
      */
     onFiltersChanged: (searchFilterState: SearchFiltersState) => void
     /**
-     * Callback to run when a autocomplete option is chosen.
+     * Callback to run when a autocomplete vehicle option is selected.
      */
-    onVehicleOptionChosen: (chosenOption: Vehicle | Ghost) => void
+    onSelectVehicleOption: (selectedOption: Vehicle | Ghost) => void
   }
 
 const allFiltersOn: SearchFiltersState = {
@@ -176,7 +176,7 @@ export const SearchForm = ({
 
   onClear: onClearProp,
   onSubmit: onSubmitProp,
-  onVehicleOptionChosen,
+  onSelectVehicleOption,
 
   showAutocomplete: showAutocompleteProp = true,
 }: SearchFormProps) => {
@@ -300,8 +300,8 @@ export const SearchForm = ({
             searchFilters={filters}
             searchText={inputText}
             fallbackOption={inputText}
-            onFallbackOptionChosen={onSubmit}
-            onVehicleOptionChosen={onVehicleOptionChosen}
+            onSelectFallbackOption={onSubmit}
+            onSelectVehicleOption={onSelectVehicleOption}
             controllerRef={autocompleteController}
           />
         </div>
@@ -362,7 +362,7 @@ const SearchFormFromStateDispatchContext = ({
         dispatch(setSearchProperties(newProperties))
         dispatch(submitSearch())
       }}
-      onVehicleOptionChosen={(vehicle) => {
+      onSelectVehicleOption={(vehicle) => {
         dispatch(
           setSelectedEntity({
             type: SelectedEntityType.Vehicle,

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -212,6 +212,12 @@ export const SearchForm = ({
         data-autocomplete-visible={autocompleteVisible}
         role="presentation"
         onKeyDown={(event) => {
+          if (event.key === "ArrowDown") {
+            autocompleteController.current?.focusCursorToFirstOption()
+
+            event.preventDefault()
+            event.stopPropagation()
+          }
           const ignoredKeysList = [
             "ArrowDown",
             "ArrowUp",
@@ -228,18 +234,7 @@ export const SearchForm = ({
           }
         }}
       >
-        <div
-          className="c-search-form__search-input-container"
-          role="presentation"
-          onKeyDown={(e) => {
-            if (e.key === "ArrowDown") {
-              autocompleteController.current?.focusCursorToFirstOption()
-
-              e.preventDefault()
-              e.stopPropagation()
-            }
-          }}
-        >
+        <div className="c-search-form__search-input-container">
           <input
             className="c-search-form__input"
             placeholder="Search"

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -28,6 +28,7 @@ import { FilterAccordion } from "./filterAccordion"
 import {
   GroupedAutocompleteControls,
   GroupedAutocompleteFromSearchTextResults,
+  autocompleteOptionData,
 } from "./groupedAutocomplete"
 
 // #region Search Filters
@@ -302,8 +303,7 @@ export const SearchForm = ({
             maxElementsPerGroup={5}
             searchFilters={filters}
             searchText={inputText}
-            fallbackOption={inputText}
-            onSelectFallbackOption={onSubmit}
+            fallbackOption={autocompleteOptionData(inputText, onSubmit)}
             onSelectVehicleOption={onSelectVehicleOption}
             controllerRef={autocompleteController}
           />

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -292,7 +292,10 @@ export const SearchForm = ({
             <SearchIcon />
           </button>
         </div>
-        <div className="c-search-form__autocomplete-container">
+        <div
+          className="c-search-form__autocomplete-container"
+          hidden={!autocompleteVisible}
+        >
           <GroupedAutocompleteFromSearchTextResults
             id={autocompleteId}
             controlName="Search Suggestions"

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -1,18 +1,34 @@
-import React, { useContext, useRef, useState } from "react"
+import React, {
+  SyntheticEvent,
+  useContext,
+  useId,
+  useRef,
+  useState,
+} from "react"
+
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
+import {
+  SearchProperties,
+  SearchProperty,
+  isValidSearchText,
+  searchPropertyDisplayConfig,
+} from "../models/searchQuery"
+import { Ghost, Vehicle } from "../realtime"
+import {
+  SelectedEntityType,
+  setSearchProperties,
+  setSearchText,
+  setSelectedEntity,
+  submitSearch,
+} from "../state/searchPageState"
+
 import { CircleXIcon } from "./circleXIcon"
 import { FilterAccordion } from "./filterAccordion"
 import {
-  isValidSearchText,
-  SearchProperty,
-  searchPropertyDisplayConfig,
-} from "../models/searchQuery"
-import {
-  setSearchProperties,
-  setSearchText,
-  submitSearch,
-} from "../state/searchPageState"
+  GroupedAutocompleteControls,
+  GroupedAutocompleteFromSearchTextResults,
+} from "./groupedAutocomplete"
 
 // #region Search Filters
 
@@ -20,12 +36,23 @@ import {
  * Object describing the current toggle state of the possible
  * {@link SearchProperty}.
  */
-type SearchFiltersState = {
-  [K in SearchProperty]: boolean
-}
+export type SearchFiltersState = SearchProperties<boolean>
 
 // #endregion search filters
 
+/**
+ * Non-Essential configuration props related to {@link SearchForm}.
+ */
+type SearchFormConfigProps = {
+  /**
+   * Whether to show the autocomplete box or not
+   */
+  showAutocomplete?: boolean
+}
+
+/**
+ * Event props related to {@link SearchForm}.
+ */
 type SearchFormEventProps = {
   /**
    * Callback to run when the form is submitted.
@@ -37,25 +64,30 @@ type SearchFormEventProps = {
   onClear?: React.ReactEventHandler
 }
 
-type SearchFormProps = SearchFormEventProps & {
-  /**
-   * Text to show in the search input box.
-   */
-  inputText: string
-  /**
-   * Callback to run when {@link inputText} should be updated.
-   */
-  onInputTextChanged?: React.ChangeEventHandler<HTMLInputElement>
+type SearchFormProps = SearchFormEventProps &
+  SearchFormConfigProps & {
+    /**
+     * Text to show in the search input box.
+     */
+    inputText: string
+    /**
+     * Callback to run when {@link inputText} should be updated.
+     */
+    onInputTextChange?: React.ChangeEventHandler<HTMLInputElement>
 
-  /**
-   * The state of the search filters.
-   */
-  filters: SearchFiltersState
-  /**
-   * Callback to run when {@link filters} should be updated.
-   */
-  onFiltersChanged: (searchFilterState: SearchFiltersState) => void
-}
+    /**
+     * The state of the search filters.
+     */
+    filters: SearchFiltersState
+    /**
+     * Callback to run when {@link filters} should be updated.
+     */
+    onFiltersChanged: (searchFilterState: SearchFiltersState) => void
+    /**
+     * Callback to run when a autocomplete option is chosen.
+     */
+    onVehicleOptionChosen: (chosenOption: Vehicle | Ghost) => void
+  }
 
 const allFiltersOn: SearchFiltersState = {
   vehicle: true,
@@ -133,57 +165,145 @@ const Filters = ({
 }
 
 /**
- * Search form which exposes all configurable state and callbacks via props.
+ * Search form which exposes all configurable state and callbacks via {@link SearchFormProps props}.
  */
 export const SearchForm = ({
   inputText,
-  onInputTextChanged,
+  onInputTextChange,
 
   filters,
   onFiltersChanged,
 
-  onClear,
-  onSubmit,
+  onClear: onClearProp,
+  onSubmit: onSubmitProp,
+  onVehicleOptionChosen,
+
+  showAutocomplete: showAutocompleteProp = true,
 }: SearchFormProps) => {
   const formSearchInput = useRef<HTMLInputElement | null>(null)
+  const [autocompleteEnabled, setAutocompleteEnabled] = useState(true)
+
+  const onSubmit = (e: SyntheticEvent) => {
+    // Hide autocomplete on submit, should show when next character is entered
+    // or next time the input is focused.
+    setAutocompleteEnabled(false)
+    onSubmitProp?.(e)
+  }
+
+  const onClear = (e: SyntheticEvent) => {
+    // Set focus on input after input is cleared
+    formSearchInput.current?.focus()
+    onClearProp?.(e)
+  }
+
+  const autocompleteController = useRef<null | GroupedAutocompleteControls>(
+    null
+  )
+
+  const autocompleteVisible =
+    autocompleteEnabled && showAutocompleteProp && inputText.length >= 3
+  const autocompleteId = useId()
 
   return (
     <form onSubmit={onSubmit} className="c-search-form" autoComplete="off">
-      <div className="c-search-form__search-control">
-        <div className="c-search-form__search-input-container">
+      <div
+        className="c-search-form__search-control"
+        data-autocomplete-visible={autocompleteVisible}
+        role="presentation"
+        onKeyDown={(event) => {
+          const ignoredKeysList = [
+            "ArrowDown",
+            "ArrowUp",
+            "Control",
+            "Shift",
+            "Tab",
+            "Enter",
+          ]
+          if (
+            !ignoredKeysList.includes(event.key) &&
+            document.activeElement !== formSearchInput.current
+          ) {
+            formSearchInput.current?.focus()
+          }
+        }}
+      >
+        <div
+          className="c-search-form__search-input-container"
+          role="presentation"
+          onKeyDown={(e) => {
+            if (e.key === "ArrowDown") {
+              autocompleteController.current?.focusCursorToFirstOption()
+
+              e.preventDefault()
+              e.stopPropagation()
+            }
+          }}
+        >
           <input
-            type="text"
             className="c-search-form__input"
             placeholder="Search"
+            type="text"
+            role="combobox"
+            aria-haspopup="listbox"
+            aria-controls={autocompleteId}
+            aria-owns={autocompleteId}
+            aria-expanded={autocompleteVisible}
             value={inputText}
-            onChange={onInputTextChanged}
+            onChange={(e) => {
+              // Show autocomplete again on next change
+              setAutocompleteEnabled(true)
+              onInputTextChange?.(e)
+            }}
             ref={formSearchInput}
+            onFocus={() => setAutocompleteEnabled(true)}
           />
-          <div className="c-search-form__input-controls">
-            <button
-              hidden={inputText.length === 0}
-              className="c-search-form__clear c-circle-x-icon-container"
-              type="button"
-              title="Clear Search"
-              onClick={(e) => {
-                // Set focus on input after input is cleared
-                formSearchInput.current?.focus()
-                onClear?.(e)
-              }}
-            >
-              <CircleXIcon />
-            </button>
-            <button
-              type="submit"
-              title="Submit"
-              className="c-search-form__submit"
-              onClick={onSubmit}
-              // TODO(design): add error states instead of using `disabled`
-              disabled={!isValidSearchText(inputText)}
-            >
-              <SearchIcon />
-            </button>
-          </div>
+        </div>
+        <div
+          className="c-search-form__input-controls"
+          role="presentation"
+          onKeyDown={(e) => {
+            // Allow buttons to be pressed by space bar by preventing the parent
+            // keydown handler
+            if (e.key === " ") {
+              e.stopPropagation()
+            }
+          }}
+        >
+          <button
+            hidden={inputText.length === 0}
+            className="c-search-form__clear c-circle-x-icon-container"
+            type="button"
+            title="Clear Search"
+            onClick={(e) => {
+              e.stopPropagation()
+              onClear?.(e)
+            }}
+          >
+            <CircleXIcon />
+          </button>
+          <button
+            type="submit"
+            title="Submit"
+            className="c-search-form__submit"
+            onClick={onSubmit}
+            // TODO(design): add error states instead of using `disabled`
+            disabled={!isValidSearchText(inputText)}
+          >
+            <SearchIcon />
+          </button>
+        </div>
+        <div className="c-search-form__autocomplete-container">
+          <GroupedAutocompleteFromSearchTextResults
+            id={autocompleteId}
+            controlName="Search Suggestions"
+            maxElementsPerGroup={5}
+            searchFilters={filters}
+            searchText={inputText}
+            fallbackOption={inputText}
+            onFallbackOptionChosen={onSubmit}
+            onVehicleOptionChosen={onVehicleOptionChosen}
+            controllerRef={autocompleteController}
+          />
         </div>
       </div>
       <Filters filters={filters} onFiltersChanged={onFiltersChanged} />
@@ -198,7 +318,8 @@ export const SearchForm = ({
 const SearchFormFromStateDispatchContext = ({
   onSubmit,
   onClear,
-}: SearchFormEventProps) => {
+  ...props
+}: SearchFormEventProps & SearchFormConfigProps) => {
   const [
     {
       searchPageState: { query },
@@ -215,9 +336,10 @@ const SearchFormFromStateDispatchContext = ({
 
   return (
     <SearchForm
+      {...props}
       inputText={query.text}
       filters={filters}
-      onInputTextChanged={({ currentTarget: { value } }) => {
+      onInputTextChange={({ currentTarget: { value } }) => {
         dispatch(setSearchText(value))
       }}
       onSubmit={(event) => {
@@ -239,6 +361,14 @@ const SearchFormFromStateDispatchContext = ({
 
         dispatch(setSearchProperties(newProperties))
         dispatch(submitSearch())
+      }}
+      onVehicleOptionChosen={(vehicle) => {
+        dispatch(
+          setSelectedEntity({
+            type: SelectedEntityType.Vehicle,
+            vehicleId: vehicle.id,
+          })
+        )
       }}
     />
   )

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -30,6 +30,8 @@ import {
   GroupedAutocompleteFromSearchTextResults,
   autocompleteOptionData,
 } from "./groupedAutocomplete"
+import { SocketContext } from "../contexts/socketContext"
+import useSocket from "../hooks/useSocket"
 
 // #region Search Filters
 
@@ -292,19 +294,21 @@ export const SearchForm = ({
           className="c-search-form__autocomplete-container"
           hidden={!autocompleteVisible}
         >
-          <GroupedAutocompleteFromSearchTextResults
-            id={autocompleteId}
-            controlName="Search Suggestions"
-            maxElementsPerGroup={5}
-            searchFilters={filters}
-            searchText={inputText}
-            fallbackOption={autocompleteOptionData(inputText, onSubmit)}
-            onSelectVehicleOption={onSelectVehicleOption}
-            controllerRef={autocompleteController}
+          <SocketContext.Provider value={useSocket()}>
+            <GroupedAutocompleteFromSearchTextResults
+              id={autocompleteId}
+              controlName="Search Suggestions"
+              maxElementsPerGroup={5}
+              searchFilters={filters}
+              searchText={inputText}
+              fallbackOption={autocompleteOptionData(inputText, onSubmit)}
+              onSelectVehicleOption={onSelectVehicleOption}
+              controllerRef={autocompleteController}
               onCursor={{
                 onCursorExitEdge: () => formSearchInput.current?.focus(),
               }}
-          />
+            />
+          </SocketContext.Provider>
         </div>
       </div>
       <Filters filters={filters} onFiltersChanged={onFiltersChanged} />

--- a/assets/src/hooks/useAutocompleteResults.ts
+++ b/assets/src/hooks/useAutocompleteResults.ts
@@ -1,6 +1,5 @@
-import { useContext } from "react"
+import { Socket } from "phoenix"
 
-import { SocketContext } from "../contexts/socketContext"
 import { SearchProperties, SearchProperty } from "../models/searchQuery"
 import { Ghost, Vehicle } from "../realtime"
 import {
@@ -22,12 +21,11 @@ type AutocompleteResults = Record<
  * Filtered properties return an empty list
  */
 export const useAutocompleteResults = (
+  socket: Socket | undefined,
   searchText: string,
   searchFilters: SearchProperties<boolean>,
   maxResults = 5
 ): AutocompleteResults => {
-  const { socket } = useContext(SocketContext)
-
   const fallback: LimitedSearchResults = {
     hasMoreMatches: false,
     matchingVehicles: [],

--- a/assets/src/hooks/useAutocompleteResults.ts
+++ b/assets/src/hooks/useAutocompleteResults.ts
@@ -1,0 +1,74 @@
+import { useContext } from "react"
+
+import { SocketContext } from "../contexts/socketContext"
+import { SearchProperties, SearchProperty } from "../models/searchQuery"
+import { Ghost, Vehicle } from "../realtime"
+import {
+  LimitedSearchResults,
+  useLimitedSearchResults,
+} from "./useSearchResults"
+
+type AutocompleteResults = Record<
+  Exclude<SearchProperty, "location">,
+  (Vehicle | Ghost)[]
+>
+
+/**
+ * A hook to search for multiple properties at once for use in Autocomplete.
+ * @param searchText The text to search for.
+ * @param searchFilters The properties to search for.
+ * @param maxResults The max number of results to return per property.
+ * @returns An object containing the results of the search for each property.
+ * Filtered properties return an empty list
+ */
+export const useAutocompleteResults = (
+  searchText: string,
+  searchFilters: SearchProperties<boolean>,
+  maxResults = 5
+): AutocompleteResults => {
+  const { socket } = useContext(SocketContext)
+
+  const fallback: LimitedSearchResults = {
+    hasMoreMatches: false,
+    matchingVehicles: [],
+  }
+
+  // Search for all the properties we need to return, but if it's filtered,
+  // set `query` parameter to `null`
+  // If there are no results, use fallback containing zero results.
+  const { matchingVehicles: operator } =
+    useLimitedSearchResults(
+      socket,
+      (searchFilters.vehicle || null) && {
+        property: "operator",
+        text: searchText,
+        limit: maxResults,
+      }
+    ) || fallback
+
+  const { matchingVehicles: vehicle } =
+    useLimitedSearchResults(
+      socket,
+      (searchFilters.run || null) && {
+        property: "vehicle",
+        text: searchText,
+        limit: maxResults,
+      }
+    ) || fallback
+
+  const { matchingVehicles: run } =
+    useLimitedSearchResults(
+      socket,
+      (searchFilters.operator || null) && {
+        property: "run",
+        text: searchText,
+        limit: maxResults,
+      }
+    ) || fallback
+
+  return {
+    vehicle,
+    run,
+    operator,
+  }
+}

--- a/assets/src/hooks/useAutocompleteResults.ts
+++ b/assets/src/hooks/useAutocompleteResults.ts
@@ -26,47 +26,47 @@ export const useAutocompleteResults = (
   searchFilters: SearchProperties<boolean>,
   maxResults = 5
 ): AutocompleteResults => {
-  const fallback: LimitedSearchResults = {
-    hasMoreMatches: false,
-    matchingVehicles: [],
-  }
-
   // Search for all the properties we need to return, but if it's filtered,
   // set `query` parameter to `null`
   // If there are no results, use fallback containing zero results.
-  const { matchingVehicles: operator } =
-    useLimitedSearchResults(
-      socket,
-      (searchFilters.vehicle || null) && {
-        property: "operator",
-        text: searchText,
-        limit: maxResults,
-      }
-    ) || fallback
+  const { matchingVehicles: operator } = useLimitedSearchResultsForProperty(
+    searchFilters.operator,
+    "operator"
+  )
 
-  const { matchingVehicles: vehicle } =
-    useLimitedSearchResults(
-      socket,
-      (searchFilters.run || null) && {
-        property: "vehicle",
-        text: searchText,
-        limit: maxResults,
-      }
-    ) || fallback
+  const { matchingVehicles: vehicle } = useLimitedSearchResultsForProperty(
+    searchFilters.vehicle,
+    "vehicle"
+  )
 
-  const { matchingVehicles: run } =
-    useLimitedSearchResults(
-      socket,
-      (searchFilters.operator || null) && {
-        property: "run",
-        text: searchText,
-        limit: maxResults,
-      }
-    ) || fallback
+  const { matchingVehicles: run } = useLimitedSearchResultsForProperty(
+    searchFilters.run,
+    "run"
+  )
 
   return {
     vehicle,
     run,
     operator,
+  }
+
+  function useLimitedSearchResultsForProperty(
+    enableSearch: boolean,
+    property: SearchProperty
+  ) {
+    const fallback: LimitedSearchResults = {
+      hasMoreMatches: false,
+      matchingVehicles: [],
+    }
+    return (
+      useLimitedSearchResults(
+        socket,
+        (enableSearch || null) && {
+          property,
+          text: searchText,
+          limit: maxResults,
+        }
+      ) || fallback
+    )
   }
 }

--- a/assets/src/models/searchQuery.ts
+++ b/assets/src/models/searchQuery.ts
@@ -9,7 +9,11 @@ export const searchPropertyDisplayConfig = {
 
 export type SearchProperty = keyof typeof searchPropertyDisplayConfig
 
-export type PropertyLimits = { [K in SearchProperty]: number | null }
+export type SearchProperties<T> = {
+  [K in SearchProperty]: T
+}
+
+export type PropertyLimits = SearchProperties<number | null>
 
 export interface SearchQuery {
   text: string

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -1,0 +1,9 @@
+/**
+ * A helper function to help clarify code when clamping a value between a range.
+ * (Remove when tc39 implements `Math.clamp`)
+ *
+ * @returns {} {@link value} limited to the range defined by {@link min} and
+ * {@link max}
+ */
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(min, value), max)

--- a/assets/src/util/operatorFormatting.tsx
+++ b/assets/src/util/operatorFormatting.tsx
@@ -11,7 +11,7 @@ export const formatOperatorName = (
   operatorFirstName: string | null,
   operatorLastName: string | null,
   operatorId: string | null,
-  _options?: OptionParameters
+  options?: OptionParameters
 ): string => {
   return (
     joinTruthy([
@@ -19,7 +19,7 @@ export const formatOperatorName = (
       operatorLastName,
       operatorId && `#${operatorId}`,
     ]) ||
-    _options?.fallbackText ||
+    options?.fallbackText ||
     defaultFallbackString
   )
 }

--- a/assets/src/util/operatorFormatting.tsx
+++ b/assets/src/util/operatorFormatting.tsx
@@ -1,0 +1,21 @@
+import { Vehicle } from "../realtime"
+import { joinTruthy } from "../helpers/dom"
+
+export const formatOperatorName = (
+  operatorFirstName: string | null,
+  operatorLastName: string | null,
+  operatorId: string | null
+): string => {
+  return joinTruthy(
+    [operatorFirstName, operatorLastName, `#${operatorId}`],
+    " "
+  )
+}
+
+export const formatOperatorNameFromVehicle = (value: Vehicle): string => {
+  return formatOperatorName(
+    value.operatorFirstName,
+    value.operatorLastName,
+    value.operatorId
+  )
+}

--- a/assets/src/util/operatorFormatting.tsx
+++ b/assets/src/util/operatorFormatting.tsx
@@ -1,7 +1,7 @@
 import { joinTruthy } from "../helpers/dom"
 import { Vehicle } from "../realtime"
 
-export const DefaultFallbackString = "Not Available"
+export const defaultFallbackString = "Not Available"
 
 type OptionParameters = {
   fallbackText?: string
@@ -20,7 +20,7 @@ export const formatOperatorName = (
       operatorId && `#${operatorId}`,
     ]) ||
     _options?.fallbackText ||
-    DefaultFallbackString
+    defaultFallbackString
   )
 }
 

--- a/assets/src/util/operatorFormatting.tsx
+++ b/assets/src/util/operatorFormatting.tsx
@@ -1,21 +1,37 @@
-import { Vehicle } from "../realtime"
 import { joinTruthy } from "../helpers/dom"
+import { Vehicle } from "../realtime"
+
+export const DefaultFallbackString = "Not Available"
+
+type OptionParameters = {
+  fallbackText?: string
+}
 
 export const formatOperatorName = (
   operatorFirstName: string | null,
   operatorLastName: string | null,
-  operatorId: string | null
+  operatorId: string | null,
+  _options?: OptionParameters
 ): string => {
-  return joinTruthy(
-    [operatorFirstName, operatorLastName, `#${operatorId}`],
-    " "
+  return (
+    joinTruthy([
+      operatorFirstName,
+      operatorLastName,
+      operatorId && `#${operatorId}`,
+    ]) ||
+    _options?.fallbackText ||
+    DefaultFallbackString
   )
 }
 
-export const formatOperatorNameFromVehicle = (value: Vehicle): string => {
+export const formatOperatorNameFromVehicle = (
+  value: Vehicle,
+  options?: OptionParameters
+): string => {
   return formatOperatorName(
     value.operatorFirstName,
     value.operatorLastName,
-    value.operatorId
+    value.operatorId,
+    options
   )
 }

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`SearchForm renders 1`] = `
     </div>
     <div
       className="c-search-form__autocomplete-container"
+      hidden={true}
     >
       <div
         className="c-autocomplete"

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`SearchForm renders 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               role="option"
-              tabIndex={0}
+              tabIndex={-1}
             />
           </ul>
         </div>

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -8,65 +8,130 @@ exports[`SearchForm renders 1`] = `
 >
   <div
     className="c-search-form__search-control"
+    data-autocomplete-visible={false}
+    onKeyDown={[Function]}
+    role="presentation"
   >
     <div
       className="c-search-form__search-input-container"
+      onKeyDown={[Function]}
+      role="presentation"
     >
       <input
+        aria-controls=":r0:"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-owns=":r0:"
         className="c-search-form__input"
         onChange={[Function]}
+        onFocus={[Function]}
         placeholder="Search"
+        role="combobox"
         type="text"
         value=""
       />
-      <div
-        className="c-search-form__input-controls"
+    </div>
+    <div
+      className="c-search-form__input-controls"
+      onKeyDown={[Function]}
+      role="presentation"
+    >
+      <button
+        className="c-search-form__clear c-circle-x-icon-container"
+        hidden={true}
+        onClick={[Function]}
+        title="Clear Search"
+        type="button"
       >
-        <button
-          className="c-search-form__clear c-circle-x-icon-container"
-          hidden={true}
-          onClick={[Function]}
-          title="Clear Search"
-          type="button"
+        <svg
+          className="c-circle-x-icon"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            className="c-circle-x-icon"
-            viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              className="c-circle-x-icon__focus-circle"
-              cx="50%"
-              cy="50%"
-              r="75%"
-            />
-            <circle
-              className="c-circle-x-icon__white-fill"
-              cx="50%"
-              cy="50%"
-              r="75%"
-            />
-            <path
-              className="c-circle-x-icon__path"
-              d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
-            />
-          </svg>
-        </button>
-        <button
-          className="c-search-form__submit"
-          disabled={true}
-          onClick={[Function]}
-          title="Submit"
-          type="submit"
+          <circle
+            className="c-circle-x-icon__focus-circle"
+            cx="50%"
+            cy="50%"
+            r="75%"
+          />
+          <circle
+            className="c-circle-x-icon__white-fill"
+            cx="50%"
+            cy="50%"
+            r="75%"
+          />
+          <path
+            className="c-circle-x-icon__path"
+            d="m24 .05a24 24 0 1 0 24 23.95 24 24 0 0 0 -24-23.95zm13.19 32.54a3.33 3.33 0 1 1 -4.73 4.69l-8.46-8.57-8.57 8.48a3.33 3.33 0 1 1 -4.69-4.73l8.55-8.46-8.48-8.57a3.33 3.33 0 1 1 4.73-4.69l8.46 8.55 8.57-8.48a3.33 3.33 0 0 1 2.35-1 3.35 3.35 0 0 1 3.33 3.35 3.33 3.33 0 0 1 -1 2.35l-8.54 8.49z"
+          />
+        </svg>
+      </button>
+      <button
+        className="c-search-form__submit"
+        disabled={true}
+        onClick={[Function]}
+        title="Submit"
+        type="submit"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "<svg/>",
+            }
+          }
+        />
+      </button>
+    </div>
+    <div
+      className="c-search-form__autocomplete-container"
+    >
+      <div
+        className="c-autocomplete"
+      >
+        <h2
+          aria-hidden={true}
+          className="visually-hidden"
+          id=":r1:"
+          role="presentation"
         >
-          <span
-            dangerouslySetInnerHTML={
+          Search Suggestions
+        </h2>
+        <div
+          aria-labelledby=":r1:"
+          className="c-autocomplete__list"
+          id=":r0:"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          role="listbox"
+          tabIndex={-1}
+        >
+          <div
+            aria-hidden={true}
+            className="c-autocomplete__group-heading"
+            id=":r2:"
+            role="presentation"
+            style={
               {
-                "__html": "<svg/>",
+                "userSelect": "none",
               }
             }
           />
-        </button>
+          <ul
+            aria-labelledby=":r2:"
+            className="c-autocomplete__group-list"
+            role="group"
+          >
+            <li
+              className="c-autocomplete__option"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+              tabIndex={0}
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/searchForm.test.tsx.snap
@@ -14,8 +14,6 @@ exports[`SearchForm renders 1`] = `
   >
     <div
       className="c-search-form__search-input-container"
-      onKeyDown={[Function]}
-      role="presentation"
     >
       <input
         aria-controls=":r0:"

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -3,7 +3,6 @@ import { getAllByRole, render, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import React, { MutableRefObject } from "react"
 import { act } from "react-dom/test-utils"
-import { byRole } from "testing-library-selector"
 
 import {
   GroupedAutocomplete,
@@ -28,7 +27,7 @@ const autocompleteOption = (name: string) => byRole("option", { name })
 
 describe("<SearchAutocomplete/>", () => {
   test("when rendered, should show results", () => {
-    const onOptionChosen = jest.fn()
+    const onSelectOption = jest.fn()
 
     const group1Title = "Group 1"
     const group2Title = "Group 2"
@@ -49,19 +48,19 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option1Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: <div>Option 2</div>,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: <em>Option 3</em>,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -74,7 +73,7 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option4Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -87,31 +86,31 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: "Option 5",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Option 6",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Option 7",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Option 8",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: <label>{option9Label}</label>,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -160,7 +159,7 @@ describe("<SearchAutocomplete/>", () => {
   })
 
   test("when autocomplete is focused, should move cursor and focus to first result", async () => {
-    const onOptionChosen = jest.fn()
+    const onSelectOption = jest.fn()
 
     const option1Label = "Option 1"
 
@@ -176,7 +175,7 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option1Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -227,7 +226,7 @@ describe("<SearchAutocomplete/>", () => {
 
   describe("when down arrow is pressed, should select next result", () => {
     test("in same group", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const group1Title = "Group 1"
       const option1Label = "Option 1"
       const option2Label = "Option 2"
@@ -244,13 +243,13 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option1Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                   {
                     option: {
                       label: option2Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -271,7 +270,7 @@ describe("<SearchAutocomplete/>", () => {
     })
 
     test("in next group", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const option1Label = "Option 1"
       const option2Label = "Option 2"
 
@@ -289,7 +288,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option1Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -302,7 +301,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option2Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -330,7 +329,7 @@ describe("<SearchAutocomplete/>", () => {
 
   describe("when up arrow is pressed, should select previous result", () => {
     test("in same group", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const group1Title = "Group 1"
       const option1Label = "Option 1"
       const option2Label = "Option 2"
@@ -347,13 +346,13 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option1Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                   {
                     option: {
                       label: option2Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -374,7 +373,7 @@ describe("<SearchAutocomplete/>", () => {
     })
 
     test("in next group", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const option1Label = "Option 1"
       const option2Label = "Option 2"
 
@@ -392,7 +391,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option1Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -405,7 +404,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: option2Label,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -431,7 +430,7 @@ describe("<SearchAutocomplete/>", () => {
   })
 
   test("when home is pressed, should select first result", async () => {
-    const onOptionChosen = jest.fn()
+    const onSelectOption = jest.fn()
     const option1Label = "Option 1"
     const option2Label = "Option 2"
 
@@ -449,13 +448,13 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option1Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Unrelated Option",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -468,7 +467,7 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option2Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -493,7 +492,7 @@ describe("<SearchAutocomplete/>", () => {
   })
 
   test("when end is pressed, should select last result", async () => {
-    const onOptionChosen = jest.fn()
+    const onSelectOption = jest.fn()
     const firstOptionLabel = "Option First"
     const lastOptionLabel = "Option Last"
 
@@ -511,13 +510,13 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: firstOptionLabel,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Unrelated Option",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -530,7 +529,7 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: lastOptionLabel,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -554,9 +553,9 @@ describe("<SearchAutocomplete/>", () => {
     await waitFor(() => expect(lastOption).toHaveFocus())
   })
 
-  describe("should fire event `onOptionChosen`", () => {
+  describe("should fire event `onSelectOption`", () => {
     test("when enter is pressed", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const optionLabel = "Option Label"
 
       render(
@@ -571,7 +570,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: optionLabel,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -586,12 +585,12 @@ describe("<SearchAutocomplete/>", () => {
       await userEvent.type(btn, "{Enter}")
 
       await waitFor(() => {
-        expect(onOptionChosen).toHaveBeenCalled()
+        expect(onSelectOption).toHaveBeenCalled()
       })
     })
 
     test("when item is clicked", async () => {
-      const onOptionChosen = jest.fn()
+      const onSelectOption = jest.fn()
       const [idVehicle] = vehicleFactory.buildList(1)
 
       render(
@@ -606,7 +605,7 @@ describe("<SearchAutocomplete/>", () => {
                   {
                     option: {
                       label: idVehicle.label!,
-                      onOptionChosen,
+                      onSelectOption,
                     },
                   },
                 ],
@@ -622,30 +621,30 @@ describe("<SearchAutocomplete/>", () => {
 
       await userEvent.click(btn)
 
-      expect(onOptionChosen).toHaveBeenCalled()
+      expect(onSelectOption).toHaveBeenCalled()
     })
   })
 
-  test("when fallback option is clicked, should fire `onFallbackOptionChosen`", async () => {
-    const onFallbackOptionChosen = jest.fn()
+  test("when fallback option is clicked, should fire `onSelectFallbackOption`", async () => {
+    const onSelectFallbackOption = jest.fn()
     const fallbackLabel = "Fallback Option"
 
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
         fallbackOption={fallbackLabel}
-        onFallbackOptionChosen={onFallbackOptionChosen}
+        onSelectFallbackOption={onSelectFallbackOption}
         groups={[]}
       />
     )
 
     await userEvent.click(autocompleteOption(fallbackLabel).get())
 
-    expect(onFallbackOptionChosen).toHaveBeenCalledTimes(1)
+    expect(onSelectFallbackOption).toHaveBeenCalledTimes(1)
   })
 
   test("when controller function `focusCursorToFirstOption` is called, should move cursor and focus to first option", () => {
-    const onOptionChosen = jest.fn()
+    const onSelectOption = jest.fn()
     const option1Label = "Option 1"
 
     const controller: MutableRefObject<GroupedAutocompleteControls | null> = {
@@ -664,13 +663,13 @@ describe("<SearchAutocomplete/>", () => {
                 {
                   option: {
                     label: option1Label,
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
                 {
                   option: {
                     label: "Option 2",
-                    onOptionChosen,
+                    onSelectOption,
                   },
                 },
               ],
@@ -718,7 +717,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
       <GroupedAutocompleteFromSearchTextResults
         controlName="Search Suggestions"
         fallbackOption={null}
-        onVehicleOptionChosen={() => {}}
+        onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={{
           location: false,
@@ -772,7 +771,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
         controlName="Search Suggestions"
         maxElementsPerGroup={maxLength}
         fallbackOption={null}
-        onVehicleOptionChosen={() => {}}
+        onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={{
           location: false,

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -51,81 +51,26 @@ describe("<GroupedAutocomplete/>", () => {
         controlName="Autocomplete List"
         fallbackOption={autocompleteOption(null)}
         optionGroups={[
-          {
-            group: {
-              title: <h1>{group1Title}</h1>,
-              options: [
-                {
-                  option: {
-                    label: option1Label,
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: <div>Option 2</div>,
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: <em>Option 3</em>,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
-          {
-            group: {
-              title: <h1>{group2Title}</h1>,
-              options: [
-                {
-                  option: {
-                    label: option4Label,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
-          {
-            group: {
-              title: <h1>{group3Title}</h1>,
-              options: [
-                {
-                  option: {
-                    label: "Option 5",
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Option 6",
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Option 7",
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Option 8",
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: <label>{option9Label}</label>,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
+          autocompleteGroup(
+            <h1>{group1Title}</h1>,
+            autocompleteOption(option1Label, onSelectOption),
+            autocompleteOption(<div>Option 2</div>, onSelectOption),
+            autocompleteOption(<em>Option 3</em>, onSelectOption)
+          ),
+
+          autocompleteGroup(
+            <h1>{group2Title}</h1>,
+            autocompleteOption(option4Label, onSelectOption)
+          ),
+
+          autocompleteGroup(
+            <h1>{group3Title}</h1>,
+            autocompleteOption("Option 5", onSelectOption),
+            autocompleteOption("Option 6", onSelectOption),
+            autocompleteOption("Option 7", onSelectOption),
+            autocompleteOption("Option 8", onSelectOption),
+            autocompleteOption(<label>{option9Label}</label>, onSelectOption)
+          ),
         ]}
       />
     )
@@ -245,19 +190,10 @@ describe("<GroupedAutocomplete/>", () => {
         controlName="Search Suggestions"
         fallbackOption={autocompleteOption(null)}
         optionGroups={[
-          {
-            group: {
-              title: null,
-              options: [
-                {
-                  option: {
-                    label: option1Label,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
+          autocompleteGroup(
+            null,
+            autocompleteOption(option1Label, onSelectOption)
+          ),
         ]}
       />
     )
@@ -307,25 +243,11 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: group1Title,
-                options: [
-                  {
-                    option: {
-                      label: option1Label,
-                      onSelectOption,
-                    },
-                  },
-                  {
-                    option: {
-                      label: option2Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              group1Title,
+              autocompleteOption(option1Label, onSelectOption),
+              autocompleteOption(option2Label, onSelectOption)
+            ),
           ]}
         />
       )
@@ -352,32 +274,14 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: group1Title,
-                options: [
-                  {
-                    option: {
-                      label: option1Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
-            {
-              group: {
-                title: group2Title,
-                options: [
-                  {
-                    option: {
-                      label: option2Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              group1Title,
+              autocompleteOption(option1Label, onSelectOption)
+            ),
+            autocompleteGroup(
+              group2Title,
+              autocompleteOption(option2Label, onSelectOption)
+            ),
           ]}
         />
       )
@@ -410,25 +314,11 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: group1Title,
-                options: [
-                  {
-                    option: {
-                      label: option1Label,
-                      onSelectOption,
-                    },
-                  },
-                  {
-                    option: {
-                      label: option2Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              group1Title,
+              autocompleteOption(option1Label, onSelectOption),
+              autocompleteOption(option2Label, onSelectOption)
+            ),
           ]}
         />
       )
@@ -455,32 +345,14 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: group1Title,
-                options: [
-                  {
-                    option: {
-                      label: option1Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
-            {
-              group: {
-                title: group2Title,
-                options: [
-                  {
-                    option: {
-                      label: option2Label,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              group1Title,
+              autocompleteOption(option1Label, onSelectOption)
+            ),
+            autocompleteGroup(
+              group2Title,
+              autocompleteOption(option2Label, onSelectOption)
+            ),
           ]}
         />
       )
@@ -512,38 +384,15 @@ describe("<GroupedAutocomplete/>", () => {
         controlName="Search Suggestions"
         fallbackOption={autocompleteOption(null)}
         optionGroups={[
-          {
-            group: {
-              title: group1Title,
-              options: [
-                {
-                  option: {
-                    label: option1Label,
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Unrelated Option",
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
-          {
-            group: {
-              title: group2Title,
-              options: [
-                {
-                  option: {
-                    label: option2Label,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
+          autocompleteGroup(
+            group1Title,
+            autocompleteOption(option1Label, onSelectOption),
+            autocompleteOption("Unrelated Option", onSelectOption)
+          ),
+          autocompleteGroup(
+            group2Title,
+            autocompleteOption(option2Label, onSelectOption)
+          ),
         ]}
       />
     )
@@ -574,38 +423,16 @@ describe("<GroupedAutocomplete/>", () => {
         controlName="Search Suggestions"
         fallbackOption={autocompleteOption(null)}
         optionGroups={[
-          {
-            group: {
-              title: group1Title,
-              options: [
-                {
-                  option: {
-                    label: firstOptionLabel,
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Unrelated Option",
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
-          {
-            group: {
-              title: group2Title,
-              options: [
-                {
-                  option: {
-                    label: lastOptionLabel,
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
+          autocompleteGroup(
+            group1Title,
+            autocompleteOption(firstOptionLabel, onSelectOption),
+            autocompleteOption("Unrelated Option", onSelectOption)
+          ),
+
+          autocompleteGroup(
+            group2Title,
+            autocompleteOption(lastOptionLabel, onSelectOption)
+          ),
         ]}
       />
     )
@@ -634,19 +461,10 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: null,
-                options: [
-                  {
-                    option: {
-                      label: optionLabel,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              null,
+              autocompleteOption(optionLabel, onSelectOption)
+            ),
           ]}
         />
       )
@@ -669,19 +487,10 @@ describe("<GroupedAutocomplete/>", () => {
           controlName="Search Suggestions"
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: null,
-                options: [
-                  {
-                    option: {
-                      label: idVehicle.label!,
-                      onSelectOption,
-                    },
-                  },
-                ],
-              },
-            },
+            autocompleteGroup(
+              null,
+              autocompleteOption(idVehicle.label!, onSelectOption)
+            ),
           ]}
         />
       )
@@ -727,25 +536,11 @@ describe("<GroupedAutocomplete/>", () => {
         controlName="Search Suggestions"
         fallbackOption={autocompleteOption(null)}
         optionGroups={[
-          {
-            group: {
-              title: null,
-              options: [
-                {
-                  option: {
-                    label: option1Label,
-                    onSelectOption,
-                  },
-                },
-                {
-                  option: {
-                    label: "Option 2",
-                    onSelectOption,
-                  },
-                },
-              ],
-            },
-          },
+          autocompleteGroup(
+            null,
+            autocompleteOption(option1Label, onSelectOption),
+            autocompleteOption("Option 2", onSelectOption)
+          ),
         ]}
       />
     )
@@ -783,15 +578,11 @@ describe("<GroupedAutocomplete/>", () => {
           controlName=""
           fallbackOption={autocompleteOption(null)}
           optionGroups={[
-            {
-              group: {
-                title: null,
-                options: [
-                  autocompleteOption(option1Label),
-                  autocompleteOption(option2Label),
-                ],
-              },
-            },
+            autocompleteGroup(
+              null,
+              autocompleteOption(option1Label),
+              autocompleteOption(option2Label)
+            ),
           ]}
           onCursor={{
             onCursorExitEdge,

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -35,7 +35,7 @@ jest.mock("../../src/hooks/useAutocompleteResults", () => ({
   })),
 }))
 
-describe("<SearchAutocomplete/>", () => {
+describe("<GroupedAutocomplete/>", () => {
   test("when rendered, should show results", () => {
     const onSelectOption = jest.fn()
 
@@ -144,6 +144,81 @@ describe("<SearchAutocomplete/>", () => {
     expect(option(option4Label).get(group2Results)).toBeInTheDocument()
 
     expect(option(option9Label).get(group3Results)).toBeInTheDocument()
+  })
+
+  test("when rerendered with new options, should show new options", () => {
+    const persistentGroupTitle = "Group 1"
+    const firstRenderGroup2Title = "Group 2.1"
+    const secondRenderGroup2Title = "Group 2.2"
+
+    const option1Label = "Option 1"
+    const option2Label = "Option 2"
+    const option3Label = "Option 3"
+    const option4Label = "Option 4"
+
+    const { rerender } = render(
+      <GroupedAutocomplete
+        controlName="Autocomplete List"
+        fallbackOption={autocompleteOption(null)}
+        optionGroups={[
+          autocompleteGroup(
+            persistentGroupTitle,
+            autocompleteOption(option1Label),
+            autocompleteOption(option2Label)
+          ),
+          autocompleteGroup(
+            firstRenderGroup2Title,
+            autocompleteOption(option1Label),
+            autocompleteOption(option2Label)
+          ),
+        ]}
+      />
+    )
+
+    const persistentGroup = optionGroup(persistentGroupTitle).get()
+    const option1Selector = option(option1Label)
+    const option2Selector = option(option2Label)
+    const option3Selector = option(option3Label)
+    const option4Selector = option(option4Label)
+
+    expect(option1Selector.get(persistentGroup)).toBeInTheDocument()
+    expect(option2Selector.get(persistentGroup)).toBeInTheDocument()
+
+    expect(
+      option1Selector.get(optionGroup(firstRenderGroup2Title).get())
+    ).toBeInTheDocument()
+    expect(
+      option2Selector.get(optionGroup(firstRenderGroup2Title).get())
+    ).toBeInTheDocument()
+
+    rerender(
+      <GroupedAutocomplete
+        controlName="Autocomplete List"
+        fallbackOption={autocompleteOption(null)}
+        optionGroups={[
+          autocompleteGroup(
+            persistentGroupTitle,
+            autocompleteOption(option3Label),
+            autocompleteOption(option4Label)
+          ),
+          autocompleteGroup(
+            secondRenderGroup2Title,
+            autocompleteOption(option2Label),
+            autocompleteOption(option4Label)
+          ),
+        ]}
+      />
+    )
+
+    expect(option3Selector.get(persistentGroup)).toBeInTheDocument()
+    expect(option4Selector.get(persistentGroup)).toBeInTheDocument()
+
+    expect(
+      option2Selector.get(optionGroup(secondRenderGroup2Title).get())
+    ).toBeInTheDocument()
+    expect(
+      option4Selector.get(optionGroup(secondRenderGroup2Title).get())
+    ).toBeInTheDocument()
   })
 
   test("when rendered with an empty list of groups, should show fallback option", async () => {

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -13,17 +13,21 @@ import { useAutocompleteResults } from "../../src/hooks/useAutocompleteResults"
 import { searchPropertyDisplayConfig } from "../../src/models/searchQuery"
 import vehicleFactory from "../factories/vehicle"
 import { formatOperatorNameFromVehicle } from "../../src/util/operatorFormatting"
+import {
+  listbox,
+  optionGroup,
+  option,
+} from "../testHelpers/selectors/components/groupedAutocomplete"
 
 jest.mock("../../src/hooks/useAutocompleteResults", () => ({
-  useAutocompleteResults: jest.fn(),
+  useAutocompleteResults: jest.fn().mockImplementation(() => ({
+    operator: [],
+    run: [],
+    vehicle: [],
+  })),
 }))
 
-const autocompleteList = (name = "Search Suggestions") =>
-  byRole("listbox", { name })
-
-const makeAutocompleteGroup = (name: string) => byRole("group", { name })
-
-const autocompleteOption = (name: string) => byRole("option", { name })
+// FIXME: make accessible https://adamsilver.io/blog/building-an-accessible-autocomplete-control/
 
 describe("<SearchAutocomplete/>", () => {
   test("when rendered, should show results", () => {
@@ -122,24 +126,18 @@ describe("<SearchAutocomplete/>", () => {
 
     // Render form and autocomplete results
 
-    const autocompleteResults = autocompleteList("Autocomplete List").get()
+    const autocompleteResults = listbox("Autocomplete List").get()
     expect(getAllByRole(autocompleteResults, "group")).toHaveLength(3)
 
-    const group1Results = makeAutocompleteGroup(group1Title).get()
-    const group2Results = makeAutocompleteGroup(group2Title).get()
-    const group3Results = makeAutocompleteGroup(group3Title).get()
+    const group1Results = optionGroup(group1Title).get()
+    const group2Results = optionGroup(group2Title).get()
+    const group3Results = optionGroup(group3Title).get()
 
-    expect(
-      autocompleteOption(option1Label).get(group1Results)
-    ).toBeInTheDocument()
+    expect(option(option1Label).get(group1Results)).toBeInTheDocument()
 
-    expect(
-      autocompleteOption(option4Label).get(group2Results)
-    ).toBeInTheDocument()
+    expect(option(option4Label).get(group2Results)).toBeInTheDocument()
 
-    expect(
-      autocompleteOption(option9Label).get(group3Results)
-    ).toBeInTheDocument()
+    expect(option(option9Label).get(group3Results)).toBeInTheDocument()
   })
 
   test("when rendered with an empty list of groups, should show fallback option", async () => {
@@ -153,9 +151,7 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    expect(
-      autocompleteOption(fallbackLabel).get(autocompleteList().get())
-    ).toBeInTheDocument()
+    expect(option(fallbackLabel).get(listbox().get())).toBeInTheDocument()
   })
 
   test("when autocomplete is focused, should move cursor and focus to first result", async () => {
@@ -185,14 +181,14 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    const autocomplete = autocompleteList().get()
+    const autocomplete = listbox().get()
 
     act(() => {
       autocomplete.focus()
     })
 
     await waitFor(() =>
-      expect(autocompleteOption(option1Label).get(autocomplete)).toHaveFocus()
+      expect(option(option1Label).get(autocomplete)).toHaveFocus()
     )
   })
 
@@ -211,16 +207,14 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    const autocomplete = autocompleteList().get()
+    const autocomplete = listbox().get()
 
     act(() => {
       autocomplete.focus()
     })
 
     await waitFor(() =>
-      expect(
-        autocompleteOption(fallbackOptionLabel).get(autocomplete)
-      ).toHaveFocus()
+      expect(option(fallbackOptionLabel).get(autocomplete)).toHaveFocus()
     )
   })
 
@@ -259,8 +253,8 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const option1 = autocompleteOption(option1Label).get()
-      const option2 = autocompleteOption(option2Label).get()
+      const option1 = option(option1Label).get()
+      const option2 = option(option2Label).get()
 
       act(() => option1.focus())
 
@@ -311,11 +305,11 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const group1 = makeAutocompleteGroup(group1Title).get()
-      const group2 = makeAutocompleteGroup(group2Title).get()
+      const group1 = optionGroup(group1Title).get()
+      const group2 = optionGroup(group2Title).get()
 
-      const option1 = autocompleteOption(option1Label).get(group1)
-      const option2 = autocompleteOption(option2Label).get(group2)
+      const option1 = option(option1Label).get(group1)
+      const option2 = option(option2Label).get(group2)
 
       act(() => {
         option1.focus()
@@ -362,8 +356,8 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const option1 = autocompleteOption(option1Label).get()
-      const option2 = autocompleteOption(option2Label).get()
+      const option1 = option(option1Label).get()
+      const option2 = option(option2Label).get()
 
       act(() => option2.focus())
 
@@ -414,11 +408,11 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const group1 = makeAutocompleteGroup(group1Title).get()
-      const group2 = makeAutocompleteGroup(group2Title).get()
+      const group1 = optionGroup(group1Title).get()
+      const group2 = optionGroup(group2Title).get()
 
-      const option1 = autocompleteOption(option1Label).get(group1)
-      const option2 = autocompleteOption(option2Label).get(group2)
+      const option1 = option(option1Label).get(group1)
+      const option2 = option(option2Label).get(group2)
 
       act(() => {
         option2.focus()
@@ -477,11 +471,11 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    const group1 = makeAutocompleteGroup(group1Title).get()
-    const group2 = makeAutocompleteGroup(group2Title).get()
+    const group1 = optionGroup(group1Title).get()
+    const group2 = optionGroup(group2Title).get()
 
-    const option1 = autocompleteOption(option1Label).get(group1)
-    const option2 = autocompleteOption(option2Label).get(group2)
+    const option1 = option(option1Label).get(group1)
+    const option2 = option(option2Label).get(group2)
 
     act(() => {
       option2.focus()
@@ -539,11 +533,11 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    const group1 = makeAutocompleteGroup(group1Title).get()
-    const group2 = makeAutocompleteGroup(group2Title).get()
+    const group1 = optionGroup(group1Title).get()
+    const group2 = optionGroup(group2Title).get()
 
-    const firstOption = autocompleteOption(firstOptionLabel).get(group1)
-    const lastOption = autocompleteOption(lastOptionLabel).get(group2)
+    const firstOption = option(firstOptionLabel).get(group1)
+    const lastOption = option(lastOptionLabel).get(group2)
 
     act(() => {
       firstOption.focus()
@@ -580,7 +574,7 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const btn = autocompleteOption(optionLabel).get(autocompleteList().get())
+      const btn = option(optionLabel).get(listbox().get())
 
       await userEvent.type(btn, "{Enter}")
 
@@ -615,9 +609,7 @@ describe("<SearchAutocomplete/>", () => {
         />
       )
 
-      const btn = autocompleteOption(idVehicle.label!).get(
-        autocompleteList().get()
-      )
+      const btn = option(idVehicle.label!).get(listbox().get())
 
       await userEvent.click(btn)
 
@@ -638,7 +630,7 @@ describe("<SearchAutocomplete/>", () => {
       />
     )
 
-    await userEvent.click(autocompleteOption(fallbackLabel).get())
+    await userEvent.click(option(fallbackLabel).get())
 
     expect(onSelectFallbackOption).toHaveBeenCalledTimes(1)
   })
@@ -683,18 +675,16 @@ describe("<SearchAutocomplete/>", () => {
       controller.current?.focusCursorToFirstOption()
     })
 
-    expect(autocompleteOption(option1Label).get()).toHaveFocus()
+    expect(option(option1Label).get()).toHaveFocus()
   })
 })
 
 describe("<SearchAutocomplete.FromHook/>", () => {
-  const vehiclesResultsGroup = makeAutocompleteGroup(
+  const vehiclesResultsGroup = optionGroup(
     searchPropertyDisplayConfig.vehicle.name
   )
-  const runResultsGroup = makeAutocompleteGroup(
-    searchPropertyDisplayConfig.run.name
-  )
-  const operatorsResultsGroup = makeAutocompleteGroup(
+  const runResultsGroup = optionGroup(searchPropertyDisplayConfig.run.name)
+  const operatorsResultsGroup = optionGroup(
     searchPropertyDisplayConfig.operator.name
   )
 
@@ -729,23 +719,19 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     )
 
     // Render form and autocomplete results
-    const autocompleteResults = autocompleteList().get()
+    const autocompleteResults = listbox().get()
     expect(getAllByRole(autocompleteResults, "group")).toHaveLength(3)
 
     const vehiclesResults = vehiclesResultsGroup.get()
     const runResults = runResultsGroup.get()
     const operatorsResults = operatorsResultsGroup.get()
 
-    expect(
-      autocompleteOption(idVehicle.label!).get(vehiclesResults)
-    ).toBeInTheDocument()
+    expect(option(idVehicle.label!).get(vehiclesResults)).toBeInTheDocument()
+
+    expect(option(runVehicle.runId!).get(runResults)).toBeInTheDocument()
 
     expect(
-      autocompleteOption(runVehicle.runId!).get(runResults)
-    ).toBeInTheDocument()
-
-    expect(
-      autocompleteOption(formatOperatorNameFromVehicle(operatorVehicle)).get(
+      option(formatOperatorNameFromVehicle(operatorVehicle)).get(
         operatorsResults
       )
     ).toBeInTheDocument()
@@ -783,7 +769,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     )
 
     // Render form and autocomplete results
-    const autocompleteResults = autocompleteList().get()
+    const autocompleteResults = listbox().get()
     expect(getAllByRole(autocompleteResults, "group")).toHaveLength(1)
 
     const vehiclesResults = vehiclesResultsGroup.get()
@@ -791,13 +777,91 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     expect(vehiclesResults.children).toHaveLength(maxLength)
   })
 
-  test.todo("when searchText changes, should show new results")
+  test.todo(
+    "when searchText changes, should show new results"
+    // , () => {
+    //   const searchText = "12345"
+    //   const updatedSearchText = searchText + "123"
+    //   const { rerender } = render(<SearchAutocomplete searchText={searchText} />)
+    //   rerender(<SearchAutocomplete searchText={updatedSearchText} />)
+    //   // Render form and autocomplete results
+
+    //   const autocompleteContainer = autocomplete.get()
+    //   expect(autocompleteContainer).toBeInTheDocument()
+
+    //   expect(
+    //     within(autocompleteContainer).getByRole("listitem", {
+    //       name: "New Search Result",
+    //     })
+    //   ).not.toBeInTheDocument()
+    //   expect(
+    //     within(autocompleteContainer).getByRole("listitem", {
+    //       name: "Old Search Result",
+    //     })
+    //   ).toBeInTheDocument()
+
+    //   // Update search
+
+    //   expect(
+    //     within(autocompleteContainer).getByRole("listitem", {
+    //       name: "New Search Result",
+    //     })
+    //   ).toBeInTheDocument()
+    //   expect(
+    //     within(autocompleteContainer).getByRole("listitem", {
+    //       name: "Old Search Result",
+    //     })
+    //   ).not.toBeInTheDocument()
+    // }
+  )
 
   test.todo(
     "when showing results, should not show a category if there are no results"
+    //   () => {
+    //     const validSearchState = validSearchFactory.build()
+
+    //     const autocompleteContainer = autocomplete.get()
+    //     expect(autocompleteContainer).toBeInTheDocument()
+
+    //     function validateGroup(groupName: string) {
+    //       const group = within(autocompleteContainer).getByRole("group", {
+    //         name: groupName,
+    //       })
+    //       expect(group).toBeInTheDocument()
+    //       expect(within(group).getAllByRole("listitem")).toHaveLength(5)
+    //     }
+
+    //     expect(
+    //       within(autocompleteContainer).queryByRole("group", { name: "Vehicles" })
+    //     ).not.toBeInTheDocument()
+    //     validateGroup("Operators")
+    //     validateGroup("Runs")
+    //     validateGroup("Locations")
+    //   }
   )
 
   test.todo(
     "when supplied with search filters, should not show disabled categories"
+    //   () => {
+    //     const validSearchState = validSearchFactory.build()
+
+    //     const autocompleteContainer = autocomplete.get()
+    //     expect(autocompleteContainer).toBeInTheDocument()
+
+    //     function validateGroup(groupName: string) {
+    //       const group = within(autocompleteContainer).getByRole("group", {
+    //         name: groupName,
+    //       })
+    //       expect(group).toBeInTheDocument()
+    //       expect(within(group).getAllByRole("listitem")).toHaveLength(5)
+    //     }
+
+    //     expect(
+    //       within(autocompleteContainer).queryByRole("group", { name: "Vehicles" })
+    //     ).not.toBeInTheDocument()
+    //     validateGroup("Operators")
+    //     validateGroup("Runs")
+    //     validateGroup("Locations")
+    //   }
   )
 })

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -9,7 +9,8 @@ import {
   GroupedAutocomplete,
   GroupedAutocompleteControls,
   GroupedAutocompleteFromSearchTextResults,
-  autocompleteOptionData,
+  autocompleteGroup,
+  autocompleteOption,
 } from "../../src/components/groupedAutocomplete"
 import { useAutocompleteResults } from "../../src/hooks/useAutocompleteResults"
 import {
@@ -48,7 +49,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Autocomplete List"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         optionGroups={[
           {
             group: {
@@ -151,7 +152,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(fallbackLabel)}
+        fallbackOption={autocompleteOption(fallbackLabel)}
         optionGroups={[]}
       />
     )
@@ -167,7 +168,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         optionGroups={[
           {
             group: {
@@ -203,7 +204,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(fallbackOptionLabel)}
+        fallbackOption={autocompleteOption(fallbackOptionLabel)}
         optionGroups={[]}
       />
     )
@@ -229,7 +230,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -274,7 +275,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -332,7 +333,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -377,7 +378,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -434,7 +435,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         optionGroups={[
           {
             group: {
@@ -496,7 +497,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         optionGroups={[
           {
             group: {
@@ -556,7 +557,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -591,7 +592,7 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName="Search Suggestions"
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
@@ -625,7 +626,7 @@ describe("<SearchAutocomplete/>", () => {
     render(
       <GroupedAutocomplete
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(
+        fallbackOption={autocompleteOption(
           fallbackLabel,
           onSelectFallbackOption
         )}
@@ -649,7 +650,7 @@ describe("<SearchAutocomplete/>", () => {
       <GroupedAutocomplete
         controllerRef={controller}
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         optionGroups={[
           {
             group: {
@@ -705,14 +706,14 @@ describe("<SearchAutocomplete/>", () => {
       render(
         <GroupedAutocomplete
           controlName=""
-          fallbackOption={autocompleteOptionData(null)}
+          fallbackOption={autocompleteOption(null)}
           optionGroups={[
             {
               group: {
                 title: null,
                 options: [
-                  autocompleteOptionData(option1Label),
-                  autocompleteOptionData(option2Label),
+                  autocompleteOption(option1Label),
+                  autocompleteOption(option2Label),
                 ],
               },
             },
@@ -740,7 +741,7 @@ describe("<SearchAutocomplete/>", () => {
   )
 })
 
-describe("<SearchAutocomplete.FromHook/>", () => {
+describe("<GroupedAutocompleteFromSearchTextResults/>", () => {
   const vehiclesResultsGroup = optionGroup(
     searchPropertyDisplayConfig.vehicle.name
   )
@@ -767,7 +768,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     render(
       <GroupedAutocompleteFromSearchTextResults
         controlName="Search Suggestions"
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={searchFiltersFactory.build()}
@@ -812,7 +813,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
       <GroupedAutocompleteFromSearchTextResults
         controlName="Search Suggestions"
         maxElementsPerGroup={maxLength}
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={searchFiltersFactory.build()}
@@ -850,7 +851,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
       <GroupedAutocompleteFromSearchTextResults
         controlName="Search Suggestions"
         maxElementsPerGroup={maxLength}
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={searchFiltersFactory.build()}
@@ -905,7 +906,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     const Autocomplete = ({ searchText }: { searchText: string }) => (
       <GroupedAutocompleteFromSearchTextResults
         controlName=""
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
         searchFilters={searchFiltersFactory.build()}
@@ -942,7 +943,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     const Autocomplete = () => (
       <GroupedAutocompleteFromSearchTextResults
         controlName=""
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={""}
         searchFilters={searchFiltersFactory.build()}
@@ -995,7 +996,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     }) => (
       <GroupedAutocompleteFromSearchTextResults
         controlName=""
-        fallbackOption={autocompleteOptionData(null)}
+        fallbackOption={autocompleteOption(null)}
         onSelectVehicleOption={() => {}}
         searchText={""}
         searchFilters={filters}

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -756,7 +756,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     const [idVehicle, runVehicle, operatorVehicle] = vehicleFactory.buildList(3)
 
     ;(useAutocompleteResults as jest.Mock).mockImplementation(
-      (text: string, _) =>
+      (_socket, text: string, _filters) =>
         ({
           [searchText]: {
             vehicle: [idVehicle],
@@ -805,7 +805,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     const maxLength = 5
 
     ;(useAutocompleteResults as jest.Mock).mockImplementation(
-      (text: string, _) =>
+      (_socket, text: string, _) =>
         ({
           [searchText]: {
             vehicle: vehicleFactory.buildList(maxLength + 2),
@@ -846,7 +846,10 @@ describe("<SearchAutocomplete.FromHook/>", () => {
 
     const [vehicle, nextVehicle] = vehicleFactory.buildList(2)
 
-    ;(useAutocompleteResults as jest.Mock).mockImplementation(((searchText) => {
+    ;(useAutocompleteResults as jest.Mock).mockImplementation(((
+      _socket,
+      searchText
+    ) => {
       switch (searchText) {
         case inputText: {
           return {
@@ -957,7 +960,11 @@ describe("<SearchAutocomplete.FromHook/>", () => {
   test("when supplied with search filters, should not show disabled categories", () => {
     const [vehicle, runVehicle] = vehicleFactory.buildList(2)
 
-    ;(useAutocompleteResults as jest.Mock).mockImplementation(((_, filters) => {
+    ;(useAutocompleteResults as jest.Mock).mockImplementation(((
+      _socket,
+      _searchText,
+      filters
+    ) => {
       return {
         vehicle: filters.vehicle ? [vehicle] : [],
         operator: [],

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -195,10 +195,6 @@ describe("<SearchAutocomplete/>", () => {
     )
   })
 
-  test.todo(
-    "when a user focuses autocomplete option {} and then presses {}, should move cursor to the {} result"
-  )
-
   test("when there are no results and autocomplete is focused, should move cursor and focus to fallback option", async () => {
     const fallbackOptionLabel = "Option 1"
 

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -23,6 +23,7 @@ import {
   optionGroup,
   option,
 } from "../testHelpers/selectors/components/groupedAutocomplete"
+import { searchFiltersFactory } from "../factories/searchProperties"
 
 jest.mock("../../src/hooks/useAutocompleteResults", () => ({
   useAutocompleteResults: jest.fn().mockImplementation(() => ({
@@ -768,12 +769,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
         fallbackOption={autocompleteOptionData(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
-        searchFilters={{
-          location: false,
-          operator: true,
-          run: true,
-          vehicle: true,
-        }}
+        searchFilters={searchFiltersFactory.build()}
       />
     )
 
@@ -818,12 +814,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
         fallbackOption={autocompleteOptionData(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
-        searchFilters={{
-          location: false,
-          operator: true,
-          run: true,
-          vehicle: true,
-        }}
+        searchFilters={searchFiltersFactory.build()}
       />
     )
 
@@ -878,12 +869,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
         fallbackOption={autocompleteOptionData(null)}
         onSelectVehicleOption={() => {}}
         searchText={searchText}
-        searchFilters={{
-          run: true,
-          vehicle: true,
-          operator: false,
-          location: false,
-        }}
+        searchFilters={searchFiltersFactory.build()}
       />
     )
     const { rerender } = render(<Autocomplete searchText={inputText} />)
@@ -920,12 +906,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
         fallbackOption={autocompleteOptionData(null)}
         onSelectVehicleOption={() => {}}
         searchText={""}
-        searchFilters={{
-          location: true,
-          operator: true,
-          run: true,
-          vehicle: true,
-        }}
+        searchFilters={searchFiltersFactory.build()}
       />
     )
     const { rerender } = render(<Autocomplete />)
@@ -982,14 +963,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
       />
     )
     const { rerender } = render(
-      <Autocomplete
-        filters={{
-          location: false,
-          operator: false,
-          run: true,
-          vehicle: true,
-        }}
-      />
+      <Autocomplete filters={searchFiltersFactory.build()} />
     )
 
     const vehicleOptions = vehiclesResultsGroup.get()
@@ -1002,14 +976,7 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     expect(runOption.get(runOptions)).toBeInTheDocument()
 
     rerender(
-      <Autocomplete
-        filters={{
-          location: false,
-          operator: false,
-          run: false,
-          vehicle: true,
-        }}
-      />
+      <Autocomplete filters={searchFiltersFactory.build({ run: false })} />
     )
 
     expect(vehicleOption.get(vehicleOptions)).toBeInTheDocument()

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -1,0 +1,681 @@
+import "@testing-library/jest-dom"
+import { getAllByRole, render, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import React, { MutableRefObject } from "react"
+import { act } from "react-dom/test-utils"
+import { byRole } from "testing-library-selector"
+
+import {
+  GroupedAutocomplete,
+  GroupedAutocompleteControls,
+} from "../../src/components/groupedAutocomplete"
+import vehicleFactory from "../factories/vehicle"
+
+const autocompleteList = (name = "Search Suggestions") =>
+  byRole("listbox", { name })
+
+const makeAutocompleteGroup = (name: string) => byRole("group", { name })
+
+const autocompleteOption = (name: string) => byRole("option", { name })
+
+describe("<SearchAutocomplete/>", () => {
+  test("when rendered, should show results", () => {
+    const onOptionChosen = jest.fn()
+
+    const group1Title = "Group 1"
+    const group2Title = "Group 2"
+    const group3Title = "Group 3"
+    const option1Label = "Option 1"
+    const option4Label = "Option 4"
+    const option9Label = "Option 9"
+
+    render(
+      <GroupedAutocomplete
+        controlName="Autocomplete List"
+        fallbackOption={null}
+        groups={[
+          {
+            group: {
+              title: <h1>{group1Title}</h1>,
+              options: [
+                {
+                  option: {
+                    label: option1Label,
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: <div>Option 2</div>,
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: <em>Option 3</em>,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            group: {
+              title: <h1>{group2Title}</h1>,
+              options: [
+                {
+                  option: {
+                    label: option4Label,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            group: {
+              title: <h1>{group3Title}</h1>,
+              options: [
+                {
+                  option: {
+                    label: "Option 5",
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Option 6",
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Option 7",
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Option 8",
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: <label>{option9Label}</label>,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    // Render form and autocomplete results
+
+    const autocompleteResults = autocompleteList("Autocomplete List").get()
+    expect(getAllByRole(autocompleteResults, "group")).toHaveLength(3)
+
+    const group1Results = makeAutocompleteGroup(group1Title).get()
+    const group2Results = makeAutocompleteGroup(group2Title).get()
+    const group3Results = makeAutocompleteGroup(group3Title).get()
+
+    expect(
+      autocompleteOption(option1Label).get(group1Results)
+    ).toBeInTheDocument()
+
+    expect(
+      autocompleteOption(option4Label).get(group2Results)
+    ).toBeInTheDocument()
+
+    expect(
+      autocompleteOption(option9Label).get(group3Results)
+    ).toBeInTheDocument()
+  })
+
+  test("when rendered with an empty list of groups, should show fallback option", async () => {
+    const fallbackLabel = "Fallback Option"
+
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={fallbackLabel}
+        groups={[]}
+      />
+    )
+
+    expect(
+      autocompleteOption(fallbackLabel).get(autocompleteList().get())
+    ).toBeInTheDocument()
+  })
+
+  test("when autocomplete is focused, should move cursor and focus to first result", async () => {
+    const onOptionChosen = jest.fn()
+
+    const option1Label = "Option 1"
+
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={null}
+        groups={[
+          {
+            group: {
+              title: null,
+              options: [
+                {
+                  option: {
+                    label: option1Label,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    const autocomplete = autocompleteList().get()
+
+    act(() => {
+      autocomplete.focus()
+    })
+
+    await waitFor(() =>
+      expect(autocompleteOption(option1Label).get(autocomplete)).toHaveFocus()
+    )
+  })
+
+  test.todo(
+    "when a user focuses autocomplete option {} and then presses {}, should move cursor to the {} result"
+  )
+
+  test("when there are no results and autocomplete is focused, should move cursor and focus to fallback option", async () => {
+    const fallbackOptionLabel = "Option 1"
+
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={fallbackOptionLabel}
+        groups={[]}
+      />
+    )
+
+    const autocomplete = autocompleteList().get()
+
+    act(() => {
+      autocomplete.focus()
+    })
+
+    await waitFor(() =>
+      expect(
+        autocompleteOption(fallbackOptionLabel).get(autocomplete)
+      ).toHaveFocus()
+    )
+  })
+
+  describe("when down arrow is pressed, should select next result", () => {
+    test("in same group", async () => {
+      const onOptionChosen = jest.fn()
+      const group1Title = "Group 1"
+      const option1Label = "Option 1"
+      const option2Label = "Option 2"
+
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: group1Title,
+                options: [
+                  {
+                    option: {
+                      label: option1Label,
+                      onOptionChosen,
+                    },
+                  },
+                  {
+                    option: {
+                      label: option2Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const option1 = autocompleteOption(option1Label).get()
+      const option2 = autocompleteOption(option2Label).get()
+
+      act(() => option1.focus())
+
+      await userEvent.keyboard("{ArrowDown}")
+
+      expect(option2).toHaveFocus()
+    })
+
+    test("in next group", async () => {
+      const onOptionChosen = jest.fn()
+      const option1Label = "Option 1"
+      const option2Label = "Option 2"
+
+      const group1Title = "Group 1"
+      const group2Title = "Group 2"
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: group1Title,
+                options: [
+                  {
+                    option: {
+                      label: option1Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              group: {
+                title: group2Title,
+                options: [
+                  {
+                    option: {
+                      label: option2Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const group1 = makeAutocompleteGroup(group1Title).get()
+      const group2 = makeAutocompleteGroup(group2Title).get()
+
+      const option1 = autocompleteOption(option1Label).get(group1)
+      const option2 = autocompleteOption(option2Label).get(group2)
+
+      act(() => {
+        option1.focus()
+      })
+
+      await userEvent.keyboard("{ArrowDown}")
+
+      await waitFor(() => expect(option2).toHaveFocus())
+    })
+  })
+
+  describe("when up arrow is pressed, should select previous result", () => {
+    test("in same group", async () => {
+      const onOptionChosen = jest.fn()
+      const group1Title = "Group 1"
+      const option1Label = "Option 1"
+      const option2Label = "Option 2"
+
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: group1Title,
+                options: [
+                  {
+                    option: {
+                      label: option1Label,
+                      onOptionChosen,
+                    },
+                  },
+                  {
+                    option: {
+                      label: option2Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const option1 = autocompleteOption(option1Label).get()
+      const option2 = autocompleteOption(option2Label).get()
+
+      act(() => option2.focus())
+
+      await userEvent.keyboard("{ArrowUp}")
+
+      expect(option1).toHaveFocus()
+    })
+
+    test("in next group", async () => {
+      const onOptionChosen = jest.fn()
+      const option1Label = "Option 1"
+      const option2Label = "Option 2"
+
+      const group1Title = "Group 1"
+      const group2Title = "Group 2"
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: group1Title,
+                options: [
+                  {
+                    option: {
+                      label: option1Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              group: {
+                title: group2Title,
+                options: [
+                  {
+                    option: {
+                      label: option2Label,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const group1 = makeAutocompleteGroup(group1Title).get()
+      const group2 = makeAutocompleteGroup(group2Title).get()
+
+      const option1 = autocompleteOption(option1Label).get(group1)
+      const option2 = autocompleteOption(option2Label).get(group2)
+
+      act(() => {
+        option2.focus()
+      })
+      await userEvent.keyboard("{ArrowUp}")
+
+      await waitFor(() => expect(option1).toHaveFocus())
+    })
+  })
+
+  test("when home is pressed, should select first result", async () => {
+    const onOptionChosen = jest.fn()
+    const option1Label = "Option 1"
+    const option2Label = "Option 2"
+
+    const group1Title = "Group 1"
+    const group2Title = "Group 2"
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={null}
+        groups={[
+          {
+            group: {
+              title: group1Title,
+              options: [
+                {
+                  option: {
+                    label: option1Label,
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Unrelated Option",
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            group: {
+              title: group2Title,
+              options: [
+                {
+                  option: {
+                    label: option2Label,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    const group1 = makeAutocompleteGroup(group1Title).get()
+    const group2 = makeAutocompleteGroup(group2Title).get()
+
+    const option1 = autocompleteOption(option1Label).get(group1)
+    const option2 = autocompleteOption(option2Label).get(group2)
+
+    act(() => {
+      option2.focus()
+    })
+    await userEvent.keyboard("{Home}")
+
+    await waitFor(() => expect(option1).toHaveFocus())
+  })
+
+  test("when end is pressed, should select last result", async () => {
+    const onOptionChosen = jest.fn()
+    const firstOptionLabel = "Option First"
+    const lastOptionLabel = "Option Last"
+
+    const group1Title = "Group 1"
+    const group2Title = "Group 2"
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={null}
+        groups={[
+          {
+            group: {
+              title: group1Title,
+              options: [
+                {
+                  option: {
+                    label: firstOptionLabel,
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Unrelated Option",
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            group: {
+              title: group2Title,
+              options: [
+                {
+                  option: {
+                    label: lastOptionLabel,
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    const group1 = makeAutocompleteGroup(group1Title).get()
+    const group2 = makeAutocompleteGroup(group2Title).get()
+
+    const firstOption = autocompleteOption(firstOptionLabel).get(group1)
+    const lastOption = autocompleteOption(lastOptionLabel).get(group2)
+
+    act(() => {
+      firstOption.focus()
+    })
+    await userEvent.keyboard("{End}")
+
+    await waitFor(() => expect(lastOption).toHaveFocus())
+  })
+
+  describe("should fire event `onOptionChosen`", () => {
+    test("when enter is pressed", async () => {
+      const onOptionChosen = jest.fn()
+      const optionLabel = "Option Label"
+
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: null,
+                options: [
+                  {
+                    option: {
+                      label: optionLabel,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const btn = autocompleteOption(optionLabel).get(autocompleteList().get())
+
+      await userEvent.type(btn, "{Enter}")
+
+      await waitFor(() => {
+        expect(onOptionChosen).toHaveBeenCalled()
+      })
+    })
+
+    test("when item is clicked", async () => {
+      const onOptionChosen = jest.fn()
+      const [idVehicle] = vehicleFactory.buildList(1)
+
+      render(
+        <GroupedAutocomplete
+          controlName="Search Suggestions"
+          fallbackOption={null}
+          groups={[
+            {
+              group: {
+                title: null,
+                options: [
+                  {
+                    option: {
+                      label: idVehicle.label!,
+                      onOptionChosen,
+                    },
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      )
+
+      const btn = autocompleteOption(idVehicle.label!).get(
+        autocompleteList().get()
+      )
+
+      await userEvent.click(btn)
+
+      expect(onOptionChosen).toHaveBeenCalled()
+    })
+  })
+
+  test("when fallback option is clicked, should fire `onFallbackOptionChosen`", async () => {
+    const onFallbackOptionChosen = jest.fn()
+    const fallbackLabel = "Fallback Option"
+
+    render(
+      <GroupedAutocomplete
+        controlName="Search Suggestions"
+        fallbackOption={fallbackLabel}
+        onFallbackOptionChosen={onFallbackOptionChosen}
+        groups={[]}
+      />
+    )
+
+    await userEvent.click(autocompleteOption(fallbackLabel).get())
+
+    expect(onFallbackOptionChosen).toHaveBeenCalledTimes(1)
+  })
+
+  test("when controller function `focusCursorToFirstOption` is called, should move cursor and focus to first option", () => {
+    const onOptionChosen = jest.fn()
+    const option1Label = "Option 1"
+
+    const controller: MutableRefObject<GroupedAutocompleteControls | null> = {
+      current: null,
+    }
+    render(
+      <GroupedAutocomplete
+        controllerRef={controller}
+        controlName="Search Suggestions"
+        fallbackOption={null}
+        groups={[
+          {
+            group: {
+              title: null,
+              options: [
+                {
+                  option: {
+                    label: option1Label,
+                    onOptionChosen,
+                  },
+                },
+                {
+                  option: {
+                    label: "Option 2",
+                    onOptionChosen,
+                  },
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    act(() => {
+      controller.current?.focusCursorToFirstOption()
+    })
+
+    expect(autocompleteOption(option1Label).get()).toHaveFocus()
+  })
+})

--- a/assets/tests/components/groupedAutocomplete.test.tsx
+++ b/assets/tests/components/groupedAutocomplete.test.tsx
@@ -24,6 +24,7 @@ import {
   option,
 } from "../testHelpers/selectors/components/groupedAutocomplete"
 import { searchFiltersFactory } from "../factories/searchProperties"
+import ghostFactory from "../factories/ghost"
 
 jest.mock("../../src/hooks/useAutocompleteResults", () => ({
   useAutocompleteResults: jest.fn().mockImplementation(() => ({
@@ -823,6 +824,44 @@ describe("<SearchAutocomplete.FromHook/>", () => {
     expect(getAllByRole(autocompleteResults, "group")).toHaveLength(1)
 
     const vehiclesResults = vehiclesResultsGroup.get()
+
+    expect(vehiclesResults.children).toHaveLength(maxLength)
+  })
+
+  test("when rendered, should not show more than `maxElementsPerGroup` results", () => {
+    const searchText = "12345"
+    const maxLength = 5
+
+    ;(useAutocompleteResults as jest.Mock).mockImplementation(
+      (_socket, text: string, _) =>
+        ({
+          [searchText]: {
+            vehicle: [],
+            operator: [
+              ...ghostFactory.buildList(maxLength),
+              ...vehicleFactory.buildList(maxLength),
+            ],
+            run: [],
+          },
+        }[text] || {})
+    )
+
+    render(
+      <GroupedAutocompleteFromSearchTextResults
+        controlName="Search Suggestions"
+        maxElementsPerGroup={maxLength}
+        fallbackOption={autocompleteOptionData(null)}
+        onSelectVehicleOption={() => {}}
+        searchText={searchText}
+        searchFilters={searchFiltersFactory.build()}
+      />
+    )
+
+    // Render form and autocomplete results
+    const autocompleteResults = listbox().get()
+    expect(getAllByRole(autocompleteResults, "group")).toHaveLength(1)
+
+    const vehiclesResults = operatorsResultsGroup.get()
 
     expect(vehiclesResults.children).toHaveLength(maxLength)
   })

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -348,4 +348,26 @@ describe("SearchForm", () => {
       expect(testDispatch).toHaveBeenCalledWith(submitSearch())
     })
   })
+
+  test.todo(
+    "when the search text length is more than the minium character count, should show autocomplete"
+  )
+
+  test.todo(
+    "when the search text length is less than the minium character count, should not show autocomplete"
+  )
+
+  test.todo(
+    "when the clear search button is clicked, should not show autocomplete "
+  )
+
+  test.todo("when the search is submitted, should not show autocomplete")
+
+  test.todo(
+    "when a autocomplete option is clicked, should fire event 'onAutocompleteResultSelected'" // THINK: figure out if there's a better name
+  )
+
+  test.todo("when search text is updated, should show new autocomplete results")
+
+  test.todo("when a filter is applied, should not show disabled categories")
 })

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -484,10 +484,17 @@ describe("SearchForm", () => {
   })
 
   test("when search text is updated, should show new autocomplete results", async () => {
-    const onSelectVehicleOption = jest.fn()
+    const [vehicle, nextVehicle] = vehicleFactory.buildList(2)
+
     const inputText = "123"
     const nextInputText = inputText + "456"
-    const [vehicle, nextVehicle] = vehicleFactory.buildList(2)
+    const filters = {
+      location: false,
+      operator: true,
+      run: true,
+      vehicle: true,
+    }
+    const maxElements = 5
 
     ;(useAutocompleteResults as jest.Mock).mockImplementation(((searchText) => {
       switch (searchText) {
@@ -518,19 +525,14 @@ describe("SearchForm", () => {
     const { rerender } = render(
       <SearchForm
         inputText={inputText}
-        filters={{
-          location: false,
-          operator: true,
-          run: true,
-          vehicle: true,
-        }}
+        filters={filters}
         // Prevent the following error by preventing default event.
         // `Error: Not implemented: HTMLFormElement.prototype.requestSubmit`
         onSubmit={(e) => {
           e.preventDefault()
         }}
-        onFiltersChanged={() => {}}
-        onSelectVehicleOption={onSelectVehicleOption}
+        onFiltersChanged={jest.fn()}
+        onSelectVehicleOption={jest.fn()}
       />
     )
 
@@ -541,22 +543,28 @@ describe("SearchForm", () => {
     rerender(
       <SearchForm
         inputText={nextInputText}
-        filters={{
-          location: false,
-          operator: true,
-          run: true,
-          vehicle: true,
-        }}
+        filters={filters}
         // Prevent the following error by preventing default event.
         // `Error: Not implemented: HTMLFormElement.prototype.requestSubmit`
         onSubmit={(e) => {
           e.preventDefault()
         }}
-        onFiltersChanged={() => {}}
-        onSelectVehicleOption={onSelectVehicleOption}
+        onFiltersChanged={jest.fn()}
+        onSelectVehicleOption={jest.fn()}
       />
     )
-
+    expect(useAutocompleteResults).toHaveBeenNthCalledWith(
+      1,
+      inputText,
+      filters,
+      maxElements
+    )
+    expect(useAutocompleteResults).toHaveBeenNthCalledWith(
+      2,
+      nextInputText,
+      filters,
+      maxElements
+    )
     expect(autocompleteOption(nextVehicle.label!).get()).toBeVisible()
     expect(vehicleOption.query()).not.toBeInTheDocument()
   })

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -444,7 +444,10 @@ describe("SearchForm", () => {
     const inputText = "123"
     const vehicle = vehicleFactory.build()
 
-    ;(useAutocompleteResults as jest.Mock).mockImplementation(((searchText) => {
+    ;(useAutocompleteResults as jest.Mock).mockImplementation(((
+      _socket,
+      searchText
+    ) => {
       if (inputText === searchText) {
         return {
           vehicle: [vehicle],
@@ -496,7 +499,10 @@ describe("SearchForm", () => {
     }
     const maxElements = 5
 
-    ;(useAutocompleteResults as jest.Mock).mockImplementation(((searchText) => {
+    ;(useAutocompleteResults as jest.Mock).mockImplementation(((
+      _socket,
+      searchText
+    ) => {
       switch (searchText) {
         case inputText: {
           return {
@@ -555,12 +561,14 @@ describe("SearchForm", () => {
     )
     expect(useAutocompleteResults).toHaveBeenNthCalledWith(
       1,
+      undefined,
       inputText,
       filters,
       maxElements
     )
     expect(useAutocompleteResults).toHaveBeenNthCalledWith(
       2,
+      undefined,
       nextInputText,
       filters,
       maxElements
@@ -574,6 +582,7 @@ describe("SearchForm", () => {
     const [vehicle, runVehicle] = vehicleFactory.buildList(2)
 
     ;(useAutocompleteResults as jest.Mock).mockImplementation(((
+      _socket,
       searchText,
       filters
     ) => {

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -365,17 +365,6 @@ describe("SearchForm", () => {
     })
   })
 
-  // const activeSearchStateFactory = stateFactory.params({
-  //   searchPageState: { isActive: true, query: { property: "all" } },
-  // })
-  // const validSearchFactory = activeSearchStateFactory.params({
-  //   searchPageState: {
-  //     query: {
-  //       text: "123",
-  //     },
-  //   },
-  // })
-
   test("when the search text length is greater than or equal to the minium character count, should show autocomplete", () => {
     render(
       <SearchForm

--- a/assets/tests/components/searchForm.test.tsx
+++ b/assets/tests/components/searchForm.test.tsx
@@ -32,6 +32,7 @@ import {
 } from "../testHelpers/selectors/components/groupedAutocomplete"
 import { useAutocompleteResults } from "../../src/hooks/useAutocompleteResults"
 import vehicleFactory from "../factories/vehicle"
+import useSocket from "../../src/hooks/useSocket"
 
 jest.mock("../../src/hooks/useAutocompleteResults", () => ({
   useAutocompleteResults: jest.fn().mockImplementation(() => ({
@@ -40,6 +41,22 @@ jest.mock("../../src/hooks/useAutocompleteResults", () => ({
     vehicle: [],
   })),
 }))
+
+// Mocking _only_ `useSocket`, for a small number of tests
+jest.mock("../../src/hooks/useSocket", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  readUserToken: jest.requireActual("../../src/hooks/useSocket").readUserToken,
+  ConnectionStatus: jest.requireActual("../../src/hooks/useSocket")
+    .ConnectionStatus,
+  SocketStatus: jest.requireActual("../../src/hooks/useSocket").SocketStatus,
+}))
+
+beforeEach(() => {
+  ;(useSocket as jest.Mock).mockImplementation(
+    jest.requireActual("../../src/hooks/useSocket").default
+  )
+})
 
 const mockDispatch = jest.fn()
 
@@ -476,6 +493,8 @@ describe("SearchForm", () => {
   })
 
   test("when search text is updated, should show new autocomplete results", async () => {
+    ;(useSocket as jest.Mock).mockReturnValue({ socket: undefined })
+
     const [vehicle, nextVehicle] = vehicleFactory.buildList(2)
 
     const inputText = "123"

--- a/assets/tests/factories/searchProperties.ts
+++ b/assets/tests/factories/searchProperties.ts
@@ -1,0 +1,18 @@
+import { Factory } from "fishery"
+import { SearchProperties } from "../../src/models/searchQuery"
+
+export const searchFiltersFactory = Factory.define<SearchProperties<boolean>>(
+  () => ({
+    location: true,
+    operator: true,
+    run: true,
+    vehicle: true,
+  })
+)
+
+export const searchFiltersOffFactory = searchFiltersFactory.params({
+  location: false,
+  operator: false,
+  run: false,
+  vehicle: false,
+})

--- a/assets/tests/hooks/useAutocompleteResults.test.ts
+++ b/assets/tests/hooks/useAutocompleteResults.test.ts
@@ -1,0 +1,15 @@
+describe("useAutocompleteResults", () => {
+  test.todo("returns null initially")
+
+  test.todo("initializing the hook subscribes to the search results")
+
+  test.todo(
+    "initializing the hook without a search query does not subscribe to the search results"
+  )
+
+  test.todo("returns results pushed to the channel")
+
+  test.todo("leaves the channel and joins a new one when the search changes")
+
+  test.todo("leaves the channel when typing even if there is no new channel")
+})

--- a/assets/tests/hooks/useAutocompleteResults.test.ts
+++ b/assets/tests/hooks/useAutocompleteResults.test.ts
@@ -1,25 +1,8 @@
-import { Factory } from "fishery"
 import { useAutocompleteResults } from "../../src/hooks/useAutocompleteResults"
-import { SearchProperties } from "../../src/models/searchQuery"
 import { renderHook } from "@testing-library/react"
 import { makeMockSocket, makeMockChannel } from "../testHelpers/socketHelpers"
 import vehicleDataFactory from "../factories/vehicle_data"
-
-export const searchFiltersFactory = Factory.define<SearchProperties<boolean>>(
-  () => ({
-    location: true,
-    operator: true,
-    run: true,
-    vehicle: true,
-  })
-)
-
-export const searchFiltersOffFactory = searchFiltersFactory.params({
-  location: false,
-  operator: false,
-  run: false,
-  vehicle: false,
-})
+import { searchFiltersFactory } from "../factories/searchProperties"
 
 describe("useAutocompleteResults", () => {
   test("returns empty lists initially", () => {

--- a/assets/tests/hooks/useAutocompleteResults.test.ts
+++ b/assets/tests/hooks/useAutocompleteResults.test.ts
@@ -1,15 +1,103 @@
+import { Factory } from "fishery"
+import { useAutocompleteResults } from "../../src/hooks/useAutocompleteResults"
+import { SearchProperties } from "../../src/models/searchQuery"
+import { renderHook } from "@testing-library/react"
+import { makeMockSocket, makeMockChannel } from "../testHelpers/socketHelpers"
+import vehicleDataFactory from "../factories/vehicle_data"
+
+export const searchFiltersFactory = Factory.define<SearchProperties<boolean>>(
+  () => ({
+    location: true,
+    operator: true,
+    run: true,
+    vehicle: true,
+  })
+)
+
+export const searchFiltersOffFactory = searchFiltersFactory.params({
+  location: false,
+  operator: false,
+  run: false,
+  vehicle: false,
+})
+
 describe("useAutocompleteResults", () => {
-  test.todo("returns null initially")
+  test("returns empty lists initially", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteResults(
+        undefined,
+        "searchText",
+        searchFiltersFactory.build()
+      )
+    )
+    expect(result.current).toEqual({
+      operator: [],
+      run: [],
+      vehicle: [],
+    })
+  })
 
-  test.todo("initializing the hook subscribes to the search results")
+  test("should subscribe all channel types with search query", () => {
+    const vehicleData = vehicleDataFactory.build()
 
-  test.todo(
-    "initializing the hook without a search query does not subscribe to the search results"
-  )
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", {
+      data: { matching_vehicles: [vehicleData], has_more_matches: false },
+    })
+    mockSocket.channel.mockImplementation(() => mockChannel)
 
-  test.todo("returns results pushed to the channel")
+    const searchText = "searchText"
 
-  test.todo("leaves the channel and joins a new one when the search changes")
+    renderHook(() =>
+      useAutocompleteResults(
+        mockSocket,
+        searchText,
+        searchFiltersFactory.build()
+      )
+    )
 
-  test.todo("leaves the channel when typing even if there is no new channel")
+    expect(mockSocket.channel).toHaveBeenCalledWith(
+      `vehicles_search:limited:operator:${searchText}`
+    )
+    expect(mockSocket.channel).toHaveBeenCalledWith(
+      `vehicles_search:limited:vehicle:${searchText}`
+    )
+    expect(mockSocket.channel).toHaveBeenCalledWith(
+      `vehicles_search:limited:run:${searchText}`
+    )
+    expect(mockChannel.join).toHaveBeenCalledTimes(3)
+  })
+
+  test("when category is filtered, should not subscribe to filtered channel", () => {
+    const vehicleData = vehicleDataFactory.build()
+
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", {
+      data: { matching_vehicles: [vehicleData], has_more_matches: false },
+    })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    const searchText = "searchText"
+
+    renderHook(() =>
+      useAutocompleteResults(
+        mockSocket,
+        searchText,
+        searchFiltersFactory.build({
+          vehicle: false,
+        })
+      )
+    )
+
+    expect(mockSocket.channel).toHaveBeenCalledWith(
+      `vehicles_search:limited:operator:${searchText}`
+    )
+    expect(mockSocket.channel).not.toHaveBeenCalledWith(
+      `vehicles_search:limited:vehicle:${searchText}`
+    )
+    expect(mockSocket.channel).toHaveBeenCalledWith(
+      `vehicles_search:limited:run:${searchText}`
+    )
+    expect(mockChannel.join).toHaveBeenCalledTimes(2)
+  })
 })

--- a/assets/tests/testHelpers/selectors/components/groupedAutocomplete.ts
+++ b/assets/tests/testHelpers/selectors/components/groupedAutocomplete.ts
@@ -1,0 +1,8 @@
+import { byRole } from "testing-library-selector"
+
+export const listbox = (name = "Search Suggestions") =>
+  byRole("listbox", { name, hidden: true })
+
+export const optionGroup = (name: string) => byRole("group", { name })
+
+export const option = (name: string) => byRole("option", { name })

--- a/assets/tests/util/math.test.ts
+++ b/assets/tests/util/math.test.ts
@@ -1,0 +1,15 @@
+import { clamp } from "../../src/util/math"
+
+describe("clamp", () => {
+  test("when value is below minimum, returns minimum value", () => {
+    expect(clamp(-11, -10, 0)).toBe(-10)
+  })
+
+  test("when value is above maximum, returns maximum value", () => {
+    expect(clamp(11, 0, 10)).toBe(10)
+  })
+
+  test("when value is between minimum and maximum, returns value", () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+  })
+})

--- a/assets/tests/util/operatorFormatting.test.ts
+++ b/assets/tests/util/operatorFormatting.test.ts
@@ -1,5 +1,5 @@
 import {
-  DefaultFallbackString,
+  defaultFallbackString,
   formatOperatorName,
   formatOperatorNameFromVehicle,
 } from "../../src/util/operatorFormatting"
@@ -42,7 +42,7 @@ describe("formatOperatorName", () => {
   })
 
   test("when all inputs are null and there is no fallback parameter, should return default fallback string", () => {
-    expect(formatOperatorName(null, null, null)).toBe(DefaultFallbackString)
+    expect(formatOperatorName(null, null, null)).toBe(defaultFallbackString)
   })
 
   test("when all inputs are null and there is a fallback parameter, should return fallback parameter", () => {
@@ -84,7 +84,7 @@ describe("formatOperatorNameFromVehicle", () => {
       operatorLastName: null,
       operatorId: null,
     })
-    expect(formatOperatorNameFromVehicle(vehicle)).toBe(DefaultFallbackString)
+    expect(formatOperatorNameFromVehicle(vehicle)).toBe(defaultFallbackString)
   })
 
   test("when given vehicle with all null operator data and fallback parameter, should return fallback parameter", () => {

--- a/assets/tests/util/operatorFormatting.test.ts
+++ b/assets/tests/util/operatorFormatting.test.ts
@@ -1,0 +1,101 @@
+import {
+  DefaultFallbackString,
+  formatOperatorName,
+  formatOperatorNameFromVehicle,
+} from "../../src/util/operatorFormatting"
+import vehicleFactory from "../factories/vehicle"
+
+describe("formatOperatorName", () => {
+  test("when given non-null data, should return formatted operator name", () => {
+    const first = "FirstName"
+    const last = "LastName"
+    const id = "123456789"
+    expect(formatOperatorName(first, last, id)).toBe(`${first} ${last} #${id}`)
+  })
+
+  test("when given null first name, should return formatted operator name without that field", () => {
+    const first = null
+    const last = "LastName"
+    const id = "123456789"
+    expect(formatOperatorName(first, last, id)).toBe(`${last} #${id}`)
+  })
+
+  test("when given null last name, should return formatted operator name without that field", () => {
+    const first = "FirstName"
+    const last = null
+    const id = "123456789"
+    expect(formatOperatorName(first, last, id)).toBe(`${first} #${id}`)
+  })
+
+  test("when given null id, should return formatted operator name without that field", () => {
+    const first = "FirstName"
+    const last = "LastName"
+    const id = null
+    expect(formatOperatorName(first, last, id)).toBe(`${first} ${last}`)
+  })
+
+  test("when given null id, should return formatted operator name without that field", () => {
+    const first = "FirstName"
+    const last = "LastName"
+    const id = null
+    expect(formatOperatorName(first, last, id)).toBe(`${first} ${last}`)
+  })
+
+  test("when all inputs are null and there is no fallback parameter, should return default fallback string", () => {
+    expect(formatOperatorName(null, null, null)).toBe(DefaultFallbackString)
+  })
+
+  test("when all inputs are null and there is a fallback parameter, should return fallback parameter", () => {
+    const fallbackText = "FallbackText"
+    expect(formatOperatorName(null, null, null, { fallbackText })).toBe(
+      fallbackText
+    )
+  })
+})
+
+describe("formatOperatorNameFromVehicle", () => {
+  test("when given vehicle with all operator info, should return formatted string", () => {
+    const vehicle = vehicleFactory.build()
+    const { operatorFirstName, operatorLastName, operatorId } = vehicle
+    expect(formatOperatorNameFromVehicle(vehicle)).toBe(
+      `${operatorFirstName} ${operatorLastName} #${operatorId}`
+    )
+  })
+
+  test("when given vehicle with null operator id, should return formatted string", () => {
+    const vehicle = vehicleFactory.build({ operatorId: null })
+    const { operatorFirstName, operatorLastName } = vehicle
+    expect(formatOperatorNameFromVehicle(vehicle)).toBe(
+      `${operatorFirstName} ${operatorLastName}`
+    )
+  })
+
+  test("when given vehicle with null first name, should return formatted string", () => {
+    const vehicle = vehicleFactory.build({ operatorFirstName: null })
+    const { operatorLastName, operatorId } = vehicle
+    expect(formatOperatorNameFromVehicle(vehicle)).toBe(
+      `${operatorLastName} #${operatorId}`
+    )
+  })
+
+  test("when given vehicle with all null operator data, should return default fallback text", () => {
+    const vehicle = vehicleFactory.build({
+      operatorFirstName: null,
+      operatorLastName: null,
+      operatorId: null,
+    })
+    expect(formatOperatorNameFromVehicle(vehicle)).toBe(DefaultFallbackString)
+  })
+
+  test("when given vehicle with all null operator data and fallback parameter, should return fallback parameter", () => {
+    const fallbackText = "FallbackText"
+    const vehicle = vehicleFactory.build({
+      operatorFirstName: null,
+      operatorLastName: null,
+      operatorId: null,
+    })
+    expect(formatOperatorNameFromVehicle(vehicle, { fallbackText })).toBe(
+      fallbackText
+    )
+  })
+})


### PR DESCRIPTION
This creates a new control component for displaying autocomplete results and navigating that control with keyboard & mouse and moving and listening to the document focus state.

The component is then extended to use a hook to retrieve it's results from the back-end.

The the extended component is then embedded into the search form.

---

Asana Ticket: https://app.asana.com/0/1200180014510248/1204956501632027/f