### PR TITLE
feat(StopCard): If there is a routes field, use that rather than connections

### DIFF
--- a/assets/css/_stop_card.scss
+++ b/assets/css/_stop_card.scss
@@ -40,7 +40,7 @@ $stop-card-popup-box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16),
   font-weight: 400;
 }
 
-.c-stop-card__connections {
+.c-stop-card__routes {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -52,13 +52,13 @@ $stop-card-popup-box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16),
   border-radius: 4px;
 }
 
-.c-stop-card__connections-label {
+.c-stop-card__routes-label {
   color: $color-gray-700;
   font-size: 14px;
   font-weight: 400;
 }
 
-.c-stop-card__connections-pills {
+.c-stop-card__routes-pills {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -28,7 +28,7 @@ const sortRoutes = (
     // exclude commuter rail
     .filter((c) => c.type !== 2)
     .sort((a, b) => {
-      // non-bubs (i.e. rapid transit) routes go before bus
+      // non-bus (i.e. rapid transit) routes go before bus
       if (a.type === 3 && b.type !== 3) {
         return 1
       } else if (a.type !== 3 && b.type === 3) {

--- a/assets/src/components/stopCard.tsx
+++ b/assets/src/components/stopCard.tsx
@@ -1,7 +1,7 @@
 import { PointExpression } from "leaflet"
 import React, { useContext, useId } from "react"
 import { Popup } from "react-leaflet"
-import { DirectionId, Stop } from "../schedule"
+import { DirectionId, RouteId, Stop } from "../schedule"
 import { MapSafeAreaContext } from "../contexts/mapSafeAreaContext"
 import { RoutePill } from "./routePill"
 import StreetViewButton from "./streetViewButton"
@@ -21,47 +21,53 @@ type AutoPanProps = {
   autoPanPadding?: LeafletPaddingOptions
 }
 
+const sortRoutes = (
+  routes: { type: number; id: RouteId; name: string }[]
+): { type: number; id: RouteId; name: string }[] =>
+  routes
+    // exclude commuter rail
+    .filter((c) => c.type !== 2)
+    .sort((a, b) => {
+      // non-bubs (i.e. rapid transit) routes go before bus
+      if (a.type === 3 && b.type !== 3) {
+        return 1
+      } else if (a.type !== 3 && b.type === 3) {
+        return -1
+      } else {
+        const aNumeric = Number(a.name)
+        const bNumeric = Number(b.name)
+
+        // SL comes before CT, other than that use localeCompare for non-numeric routes
+        if (isNaN(aNumeric) && isNaN(bNumeric)) {
+          if (a.name.match(/^SL*/) && b.name.match(/^CT*/)) {
+            return -1
+          } else if (a.name.match(/^CT*/) && b.name.match(/^SL*/)) {
+            return 1
+          } else {
+            return a.name.localeCompare(b.name)
+          }
+        } else if (isNaN(aNumeric)) {
+          // purely numeric routes come last
+          return -1
+        } else if (isNaN(bNumeric)) {
+          return 1
+        }
+
+        return aNumeric - bNumeric
+      }
+    })
+
 const StopCard = ({
   stop,
   direction,
   autoPanPadding,
 }: StopCardProps & AutoPanProps): JSX.Element => {
-  const connectionsLabelId = "stop-card-connections-label-" + useId()
+  const routesLabelId = "stop-card-routes-label-" + useId()
 
-  const connections = stop.connections
-    ? stop.connections
-        // exclude commuter rail
-        .filter((c) => c.type !== 2)
-        .sort((a, b) => {
-          // non-bubs (i.e. rapid transit) routes go before bus
-          if (a.type === 3 && b.type !== 3) {
-            return 1
-          } else if (a.type !== 3 && b.type === 3) {
-            return -1
-          } else {
-            const aNumeric = Number(a.name)
-            const bNumeric = Number(b.name)
-
-            // SL comes before CT, other than that use localeCompare for non-numeric routes
-            if (isNaN(aNumeric) && isNaN(bNumeric)) {
-              if (a.name.match(/^SL*/) && b.name.match(/^CT*/)) {
-                return -1
-              } else if (a.name.match(/^CT*/) && b.name.match(/^SL*/)) {
-                return 1
-              } else {
-                return a.name.localeCompare(b.name)
-              }
-            } else if (isNaN(aNumeric)) {
-              // purely numeric routes come last
-              return -1
-            } else if (isNaN(bNumeric)) {
-              return 1
-            }
-
-            return aNumeric - bNumeric
-          }
-        })
-    : []
+  const hasRouteField = stop.routes !== undefined
+  const sortedDisplayRoutes = hasRouteField
+    ? sortRoutes(stop.routes || [])
+    : sortRoutes(stop.connections || [])
 
   return (
     <Popup
@@ -81,19 +87,16 @@ const StopCard = ({
           </div>
         )}
       </div>
-      {connections.length > 0 ? (
-        <div className="c-stop-card__connections">
-          <div
-            className="c-stop-card__connections-label"
-            id={connectionsLabelId}
-          >
-            Connections
+      {sortedDisplayRoutes.length > 0 ? (
+        <div className="c-stop-card__routes">
+          <div className="c-stop-card__routes-label" id={routesLabelId}>
+            {hasRouteField ? "Routes" : "Connections"}
           </div>
           <ul
-            className="c-stop-card__connections-pills"
-            aria-labelledby={connectionsLabelId}
+            className="c-stop-card__routes-pills"
+            aria-labelledby={routesLabelId}
           >
-            {connections.map((c) => (
+            {sortedDisplayRoutes.map((c) => (
               <li key={c.id}>
                 <RoutePill routeName={c.name} />
               </li>

--- a/assets/src/models/shapeData.ts
+++ b/assets/src/models/shapeData.ts
@@ -27,6 +27,15 @@ export const ShapeData = type({
             })
           )
         ),
+        routes: optional(
+          array(
+            type({
+              type: number(),
+              id: string(),
+              name: string(),
+            })
+          )
+        ),
       })
     )
   ),

--- a/assets/src/schedule.d.ts
+++ b/assets/src/schedule.d.ts
@@ -15,6 +15,7 @@ export interface Stop {
   lat: number
   lon: number
   connections?: { type: number; id: RouteId; name: string }[]
+  routes?: { type: number; id: RouteId; name: string }[]
   locationType?: LocationType
 }
 

--- a/assets/tests/components/stopCard.test.tsx
+++ b/assets/tests/components/stopCard.test.tsx
@@ -21,6 +21,16 @@ describe("StopCard", () => {
     ).not.toBeInTheDocument()
   })
 
+  test("doesn't render routes when none are present", () => {
+    const stop = stopFactory.build()
+
+    render(<StopCard stop={stop} />)
+
+    expect(
+      screen.queryByRole("list", { name: "Routes" })
+    ).not.toBeInTheDocument()
+  })
+
   test("doesn't render direction when none is present", () => {
     const stop = stopFactory.build()
 
@@ -47,7 +57,7 @@ describe("StopCard", () => {
     expect(screen.getByText(/Outbound/)).toBeInTheDocument()
   })
 
-  test("renders connections", () => {
+  test("when routes aren't present but connections are, renders connections", () => {
     const stop = stopFactory.build({
       connections: [{ type: 1, name: "Red", id: "Red" }],
     })
@@ -57,6 +67,32 @@ describe("StopCard", () => {
     expect(
       screen.getByRole("list", { name: "Connections" })
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("list", { name: "Routes" })
+    ).not.toBeInTheDocument()
+  })
+
+  test("when routes are present, renders the routes", () => {
+    const stop = stopFactory.build({
+      routes: [{ type: 1, name: "Red", id: "Red" }],
+      connections: [{ type: 1, name: "Blue", id: "Blue" }],
+    })
+
+    render(<StopCard stop={stop} />)
+
+    expect(screen.getByRole("list", { name: "Routes" })).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("listitem").find((item) => item.textContent === "Red")
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole("list", { name: "Connections" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen
+        .getAllByRole("listitem")
+        .find((item) => item.textContent === "Blue")
+    ).toBeUndefined()
   })
 
   test("sorts rendered connections and excludes commuter rail", () => {


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1205139488063013/f

PR 1 / 3 in transitioning to read `routes` for a stop, which includes all routes, rather than `connections`, which omits the current route in view.
1 - This
2 - https://github.com/mbta/skate/pull/2165
3 - https://github.com/mbta/skate/pull/2166

Each PR will be merged and deployed separately to prevent a mismatch of fields between the frontend and backend.

Please leave any overarching concerns about this 3 step deployment approach on this PR! 