### PR TITLE
feat(ShapeWithStops): Return all routes on routes field. No more conn…

### DIFF
--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -228,22 +228,7 @@ defmodule Schedule.Data do
 
   @spec shape_with_stops_for_trip(t(), Schedule.Trip.id()) :: Schedule.ShapeWithStops.t()
   def shape_with_stops_for_trip(data, trip_id) do
-    %{trips: trips_by_id} = data
-
-    trip = Map.get(trips_by_id, trip_id)
-    trip_route_id = if trip, do: trip.route_id, else: nil
-
-    stops_for_trip =
-      case trip_route_id do
-        # This trip doesn't have a route - no connections to filter
-        nil ->
-          stops_for_trip(data, trip_id)
-
-        trip_route_id ->
-          data
-          |> stops_for_trip(trip_id)
-          |> Enum.map(&Stop.reject_connections_for_route(&1, trip_route_id))
-      end
+    stops_for_trip = stops_for_trip(data, trip_id)
 
     case shape_for_trip(data, trip_id) do
       nil -> nil
@@ -376,7 +361,7 @@ defmodule Schedule.Data do
     bus_routes = Garage.add_garages_to_routes(gtfs_data.bus_only.routes, schedule_trips_by_id)
 
     stops =
-      Stop.stops_with_connections(
+      Stop.stops_with_routes(
         gtfs_data.all_modes.stops_by_id,
         gtfs_data.all_modes.routes,
         gtfs_data.all_modes.route_patterns,

--- a/test/schedule/gtfs/stop_test.exs
+++ b/test/schedule/gtfs/stop_test.exs
@@ -128,35 +128,7 @@ defmodule Schedule.Gtfs.StopTest do
     end
   end
 
-  describe "reject_connections_for_route/2" do
-    test "only rejects connections with the matching route id " do
-      matching_route = %Route{
-        id: "39",
-        name: "first_bus",
-        description: "bus_route",
-        direction_names: %{}
-      }
-
-      other_route = %Route{
-        id: "86",
-        name: "second_bus",
-        description: "bus_route",
-        direction_names: %{}
-      }
-
-      stop = %Stop{
-        id: "1",
-        name: "name",
-        parent_station_id: nil,
-        connections: [matching_route, other_route]
-      }
-
-      assert %{connections: [^other_route]} =
-               Stop.reject_connections_for_route(stop, matching_route.id)
-    end
-  end
-
-  describe "stops_with_connections/4" do
+  describe "stops_with_routes/4" do
     setup do
       %{
         stop_1: %Stop{id: 1, name: "stop 1", parent_station_id: nil},
@@ -213,12 +185,12 @@ defmodule Schedule.Gtfs.StopTest do
       }
     end
 
-    test "connections is empty for a stop when no connections found", data do
+    test "routes is empty for a stop when no routes found", data do
       trip_id = data.route_1_pattern_1.representative_trip_id
       stop_id = data.stop_1.id
 
-      assert %{^stop_id => %{connections: []}} =
-               Stop.stops_with_connections(
+      assert %{^stop_id => %{routes: []}} =
+               Stop.stops_with_routes(
                  %{stop_id => data.stop_1},
                  [data.route_1, data.route_2],
                  [data.route_1_pattern_1],
@@ -237,10 +209,10 @@ defmodule Schedule.Gtfs.StopTest do
       route_2_trip_id = data.route_2_pattern_1.representative_trip_id
 
       assert %{
-               ^stop_1_id => %{connections: [^route_1, ^route_2]},
-               ^stop_2_id => %{connections: [^route_1]}
+               ^stop_1_id => %{routes: [^route_1, ^route_2]},
+               ^stop_2_id => %{routes: [^route_1]}
              } =
-               Stop.stops_with_connections(
+               Stop.stops_with_routes(
                  %{stop_1_id => data.stop_1, stop_2_id => data.stop_2},
                  [data.route_1, data.route_2],
                  [data.route_1_pattern_1, data.route_2_pattern_1],
@@ -266,9 +238,9 @@ defmodule Schedule.Gtfs.StopTest do
       route_2_trip_id = data.shuttle_route_pattern_1.representative_trip_id
 
       assert %{
-               ^stop_1_id => %{connections: [^route_1]}
+               ^stop_1_id => %{routes: [^route_1]}
              } =
-               Stop.stops_with_connections(
+               Stop.stops_with_routes(
                  %{stop_1_id => data.stop_1},
                  [route_1, route_2],
                  [data.route_1_pattern_1, data.shuttle_route_pattern_1],
@@ -279,7 +251,7 @@ defmodule Schedule.Gtfs.StopTest do
                )
     end
 
-    test "connections include routes that stop at sibling stops", data do
+    test "routes include routes that stop at sibling stops", data do
       sibling_stop_1_id = data.child_stop_1.id
       sibling_stop_2_id = data.child_stop_2.id
 
@@ -290,10 +262,10 @@ defmodule Schedule.Gtfs.StopTest do
       route_2_trip_id = data.route_2_pattern_1.representative_trip_id
 
       assert %{
-               ^sibling_stop_1_id => %{connections: [^route_1, ^route_2]},
-               ^sibling_stop_2_id => %{connections: [^route_1, ^route_2]}
+               ^sibling_stop_1_id => %{routes: [^route_1, ^route_2]},
+               ^sibling_stop_2_id => %{routes: [^route_1, ^route_2]}
              } =
-               Stop.stops_with_connections(
+               Stop.stops_with_routes(
                  %{
                    sibling_stop_1_id => data.child_stop_1,
                    sibling_stop_2_id => data.child_stop_2
@@ -311,7 +283,7 @@ defmodule Schedule.Gtfs.StopTest do
                )
     end
 
-    test "connections include routes that stop at parent stops", data do
+    test "routes include routes that stop at parent stops", data do
       child_stop_id = data.child_stop_1.id
       parent_stop_id = data.parent_stop.id
 
@@ -322,10 +294,10 @@ defmodule Schedule.Gtfs.StopTest do
       route_2_trip_id = data.route_2_pattern_1.representative_trip_id
 
       assert %{
-               ^child_stop_id => %{connections: [^route_1, ^route_2]},
-               ^parent_stop_id => %{connections: [^route_1, ^route_2]}
+               ^child_stop_id => %{routes: [^route_1, ^route_2]},
+               ^parent_stop_id => %{routes: [^route_1, ^route_2]}
              } =
-               Stop.stops_with_connections(
+               Stop.stops_with_routes(
                  %{child_stop_id => data.child_stop_1, parent_stop_id => data.parent_stop},
                  [data.route_1, data.route_2],
                  [data.route_1_pattern_1, data.route_2_pattern_1],
@@ -340,7 +312,7 @@ defmodule Schedule.Gtfs.StopTest do
                )
     end
 
-    test "connections are unique when multiple route patterns go to same stop", data do
+    test "routes are unique when multiple route patterns go to same stop", data do
       stop_1_id = data.stop_1.id
 
       route_1 = data.route_1
@@ -349,9 +321,9 @@ defmodule Schedule.Gtfs.StopTest do
       route_1_trip_id_2 = data.route_1_pattern_2.representative_trip_id
 
       assert %{
-               ^stop_1_id => %{connections: [^route_1]}
+               ^stop_1_id => %{routes: [^route_1]}
              } =
-               Stop.stops_with_connections(
+               Stop.stops_with_routes(
                  %{stop_1_id => data.stop_1},
                  [data.route_1],
                  [data.route_1_pattern_1, data.route_1_pattern_2],

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -269,7 +269,7 @@ defmodule ScheduleTest do
       assert Schedule.stop("id", pid) == nil
     end
 
-    test "bus stop has included bus and subway connections" do
+    test "bus stop has included bus and subway routes" do
       pid =
         Schedule.start_mocked(%{
           gtfs: %{
@@ -307,7 +307,7 @@ defmodule ScheduleTest do
       %Stop{
         id: "stop1_id",
         name: "One",
-        connections: [
+        routes: [
           %Route{
             id: "route",
             name: "route",
@@ -796,7 +796,7 @@ defmodule ScheduleTest do
   end
 
   describe "shape_with_stops_for_trip" do
-    test "returns the shape for the trip with stops and connections excluding the trip's route" do
+    test "returns the shape for the trip with stops and routes" do
       pid =
         Schedule.start_mocked(%{
           gtfs: %{
@@ -847,7 +847,14 @@ defmodule ScheduleTest do
                    name: "One",
                    latitude: 1.0,
                    longitude: 1.5,
-                   connections: [
+                   routes: [
+                     %Schedule.Gtfs.Route{
+                       description: "Key Bus",
+                       direction_names: %{0 => nil, 1 => nil},
+                       id: "route",
+                       name: "route",
+                       type: 3
+                     },
                      %Schedule.Gtfs.Route{
                        id: "subway_route",
                        name: "subway_route_name",

--- a/test/skate_web/controllers/route_pattern_controller_test.exs
+++ b/test/skate_web/controllers/route_pattern_controller_test.exs
@@ -24,7 +24,7 @@ defmodule SkateWeb.RoutePatternControllerTest do
           name: "One",
           latitude: 42.01,
           longitude: -71.01,
-          connections: [
+          routes: [
             %Route{
               id: "route_1",
               name: "route_1_name",
@@ -33,7 +33,7 @@ defmodule SkateWeb.RoutePatternControllerTest do
             }
           ]
         },
-        %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02, connections: []}
+        %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02, routes: []}
       ]
     }
 
@@ -54,7 +54,7 @@ defmodule SkateWeb.RoutePatternControllerTest do
           "lat" => 42.01,
           "lon" => -71.01,
           "location_type" => "stop",
-          "connections" => [
+          "routes" => [
             %{
               "id" => "route_1",
               "name" => "route_1_name",
@@ -71,7 +71,7 @@ defmodule SkateWeb.RoutePatternControllerTest do
           "lat" => 42.02,
           "lon" => -71.02,
           "location_type" => "stop",
-          "connections" => []
+          "routes" => []
         }
       ]
     }

--- a/test/skate_web/controllers/shape_controller_test.exs
+++ b/test/skate_web/controllers/shape_controller_test.exs
@@ -46,7 +46,7 @@ defmodule SkateWeb.ShapeControllerTest do
         name: "One",
         latitude: 42.01,
         longitude: -71.01,
-        connections: [
+        routes: [
           %Route{
             id: "route_1",
             name: "route_1_name",
@@ -55,7 +55,7 @@ defmodule SkateWeb.ShapeControllerTest do
           }
         ]
       },
-      %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02, connections: []}
+      %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02, routes: []}
     ]
   }
 
@@ -76,7 +76,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "lat" => 42.01,
         "lon" => -71.01,
         "location_type" => "stop",
-        "connections" => [
+        "routes" => [
           %{
             "id" => "route_1",
             "name" => "route_1_name",
@@ -93,7 +93,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "lat" => 42.02,
         "lon" => -71.02,
         "location_type" => "stop",
-        "connections" => []
+        "routes" => []
       }
     ]
   }

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -4,7 +4,7 @@ defmodule SkateWeb.StopControllerTest do
   import Skate.Factory
 
   @stations [
-    build(:gtfs_stop, %{location_type: :station, connections: [build(:gtfs_route)]}),
+    build(:gtfs_stop, %{location_type: :station, routes: [build(:gtfs_route)]}),
     build(:gtfs_stop, %{
       id: "stop2",
       name: "Stop 2",
@@ -29,7 +29,7 @@ defmodule SkateWeb.StopControllerTest do
       assert %{
                "data" => [
                  %{
-                   "connections" => [
+                   "routes" => [
                      %{
                        "description" => "Key Bus",
                        "direction_names" => %{"0" => "Outbound", "1" => "Inbound"},
@@ -46,7 +46,7 @@ defmodule SkateWeb.StopControllerTest do
                    "name" => "Stop 1"
                  },
                  %{
-                   "connections" => [],
+                   "routes" => [],
                    "id" => "stop2",
                    "lat" => 42.01,
                    "location_type" => "station",


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1205139488063013/f

PR 2 / 3 in transitioning to read routes for a stop, which includes all routes, rather than connections, which omits the current route in view.
1 - https://github.com/mbta/skate/pull/2164
2  - This
3 - https://github.com/mbta/skate/pull/2166

Each PR will be merged and deployed separately to prevent a mismatch of fields between the frontend and backend.