### PR TITLE
feat(ex/SkateWeb): add `ConfigPagesController` to redirect url's in config to external resources

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -104,6 +104,12 @@ config :skate, SkateWeb.AuthManager,
   issuer: "skate",
   secret_key: nil
 
+config :skate, SkateWeb.ConfigPagesController,
+  pages: %{
+    "/agency-policies/AUP" =>
+      "https://mbta.sharepoint.com/:b:/s/CTD/ER2vUlgzH_xMuNTwKZHsvb0B80yH5XIQFLX7A4e6crycMA?e=GwAHOn"
+  }
+
 config :skate, Skate.Repo,
   database: "skate_dev",
   username: System.get_env("POSTGRES_USERNAME", System.get_env("USER")),

--- a/lib/skate_web/controllers/config_pages_controller.ex
+++ b/lib/skate_web/controllers/config_pages_controller.ex
@@ -1,0 +1,14 @@
+defmodule SkateWeb.ConfigPagesController do
+  @moduledoc """
+  Redirects requests to the `:external` parameter in the connection's
+  `SkateWeb.ConfigPagesController` private data.
+  """
+
+  use SkateWeb, :controller
+
+  def index(conn, _params) do
+    url = conn.private[__MODULE__].external
+
+    redirect(conn, external: url)
+  end
+end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -40,6 +40,13 @@ defmodule SkateWeb.Router do
     plug :put_secure_browser_headers
   end
 
+  scope "/docs" do
+    for {key, value} <- Application.compile_env(:skate, SkateWeb.ConfigPagesController)[:pages] do
+      get key, SkateWeb.ConfigPagesController, :index,
+        private: %{SkateWeb.ConfigPagesController => %{external: value}}
+    end
+  end
+
   scope "/auth", SkateWeb do
     pipe_through([:redirect_prod_http, :accepts_html, :browser])
 


### PR DESCRIPTION
I think this is a fairly simple approach to redirecting to external url's, unsure if this is what we _should_ do, and I'm not quite sure how to test it yet (suggestions welcome).

See comments for other considerations. 

## TODO:
- [ ] Add Tests for `ConfigPagesController`

---

Asana Ticket: https://app.asana.com/0/1200180014510248/1205074914378399/f