### PR TITLE
Provide autocomplete-related data for location search

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -29,6 +29,7 @@ import * as Sentry from "@sentry/react"
 import { LocationSearchResult } from "./models/locationSearchResult"
 import {
   LocationSearchResultData,
+  locationSearchResultFromData,
   locationSearchResultsFromData,
 } from "./models/locationSearchResultData"
 
@@ -225,6 +226,16 @@ export const fetchLocationSearchResults = (
     dataStruct: array(LocationSearchResultData),
     parser: nullableParser(locationSearchResultsFromData),
     defaultResult: [],
+  })
+
+export const fetchLocationSearchResultById = (
+  placeId: string
+): Promise<LocationSearchResult | null> =>
+  checkedApiCall<LocationSearchResultData, LocationSearchResult | null>({
+    url: `api/location_search/place/${placeId}`,
+    dataStruct: LocationSearchResultData,
+    parser: nullableParser(locationSearchResultFromData),
+    defaultResult: null,
   })
 
 export const putNotificationReadState = (

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -32,6 +32,11 @@ import {
   locationSearchResultFromData,
   locationSearchResultsFromData,
 } from "./models/locationSearchResultData"
+import {
+  LocationSearchSuggestionData,
+  locationSearchSuggestionsFromData,
+} from "./models/locationSearchSuggestionData"
+import { LocationSearchSuggestion } from "./models/locationSearchSuggestion"
 
 export interface RouteData {
   id: string
@@ -235,6 +240,19 @@ export const fetchLocationSearchResultById = (
     url: `api/location_search/place/${placeId}`,
     dataStruct: LocationSearchResultData,
     parser: nullableParser(locationSearchResultFromData),
+    defaultResult: null,
+  })
+
+export const fetchLocationSearchSuggestions = (
+  searchText: string
+): Promise<LocationSearchSuggestion[] | null> =>
+  checkedApiCall<
+    LocationSearchSuggestionData[],
+    LocationSearchSuggestion[] | null
+  >({
+    url: `api/location_search/suggest?query=${searchText}`,
+    dataStruct: array(LocationSearchSuggestionData),
+    parser: nullableParser(locationSearchSuggestionsFromData),
     defaultResult: null,
   })
 

--- a/assets/src/hooks/useLocationSearchResultById.ts
+++ b/assets/src/hooks/useLocationSearchResultById.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { fetchLocationSearchResultById } from "../api"
+import { LocationSearchResult } from "../models/locationSearchResult"
+
+export const useLocationSearchResultById = (
+  placeId: string | null
+): LocationSearchResult | null => {
+  const [searchResult, setSearchResult] = useState<LocationSearchResult | null>(
+    null
+  )
+
+  useEffect(() => {
+    let shouldUpdate = true
+
+    if (placeId) {
+      fetchLocationSearchResultById(placeId).then((results) => {
+        if (shouldUpdate) {
+          setSearchResult(results)
+        }
+      })
+    } else {
+      setSearchResult(null)
+    }
+
+    return () => {
+      shouldUpdate = false
+    }
+  }, [placeId])
+
+  return searchResult
+}

--- a/assets/src/hooks/useLocationSearchSuggestions.ts
+++ b/assets/src/hooks/useLocationSearchSuggestions.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { fetchLocationSearchSuggestions } from "../api"
+import { LocationSearchSuggestion } from "../models/locationSearchSuggestion"
+
+export const useLocationSearchSuggestions = (
+  text: string | null
+): LocationSearchSuggestion[] | null => {
+  const [searchSuggestions, setSearchSuggestions] = useState<
+    LocationSearchSuggestion[] | null
+  >(null)
+
+  useEffect(() => {
+    let shouldUpdate = true
+
+    if (text) {
+      fetchLocationSearchSuggestions(text).then((results) => {
+        if (shouldUpdate) {
+          setSearchSuggestions(results)
+        }
+      })
+    } else {
+      setSearchSuggestions(null)
+    }
+
+    return () => {
+      shouldUpdate = false
+    }
+  }, [text])
+
+  return searchSuggestions
+}

--- a/assets/src/models/locationSearchSuggestion.ts
+++ b/assets/src/models/locationSearchSuggestion.ts
@@ -1,0 +1,4 @@
+export interface LocationSearchSuggestion {
+  text: string
+  placeId: string | null
+}

--- a/assets/src/models/locationSearchSuggestionData.ts
+++ b/assets/src/models/locationSearchSuggestionData.ts
@@ -16,3 +16,8 @@ export const locationSearchSuggestionFromData = ({
   text,
   placeId: place_id,
 })
+
+export const locationSearchSuggestionsFromData = (
+  locationSearchSuggestionsData: LocationSearchSuggestionData[]
+): LocationSearchSuggestion[] =>
+  locationSearchSuggestionsData.map(locationSearchSuggestionFromData)

--- a/assets/src/models/locationSearchSuggestionData.ts
+++ b/assets/src/models/locationSearchSuggestionData.ts
@@ -1,0 +1,18 @@
+import { Infer, nullable, string, type } from "superstruct"
+import { LocationSearchSuggestion } from "./locationSearchSuggestion"
+
+export const LocationSearchSuggestionData = type({
+  text: string(),
+  place_id: nullable(string()),
+})
+export type LocationSearchSuggestionData = Infer<
+  typeof LocationSearchSuggestionData
+>
+
+export const locationSearchSuggestionFromData = ({
+  text,
+  place_id,
+}: LocationSearchSuggestionData): LocationSearchSuggestion => ({
+  text,
+  placeId: place_id,
+})

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -16,6 +16,7 @@ import {
   fetchRoutePatterns,
   fetchLocationSearchResults,
   fetchLocationSearchResultById,
+  fetchLocationSearchSuggestions,
 } from "../src/api"
 import routeFactory from "./factories/route"
 import routeTabFactory from "./factories/routeTab"
@@ -26,6 +27,8 @@ import { LocationType } from "../src/models/stopData"
 import * as Sentry from "@sentry/react"
 import locationSearchResultDataFactory from "./factories/locationSearchResultData"
 import locationSearchResultFactory from "./factories/locationSearchResult"
+import locationSearchSuggestionDataFactory from "./factories/locationSearchSuggestionData"
+import locationSearchSuggestionFactory from "./factories/locationSearchSuggestion"
 
 jest.mock("@sentry/react", () => ({
   __esModule: true,
@@ -766,7 +769,7 @@ describe("fetchLocationSearchResults", () => {
 })
 
 describe("fetchLocationSearchResultById", () => {
-  test("parses location search results", (done) => {
+  test("parses location returned", (done) => {
     const result = locationSearchResultDataFactory.build({
       name: "Some Landmark",
       address: "123 Test St",
@@ -787,6 +790,29 @@ describe("fetchLocationSearchResultById", () => {
           longitude: 2,
         })
       )
+      done()
+    })
+  })
+})
+
+describe("fetchLocationSearchSuggestions", () => {
+  test("parses location search suggestions", (done) => {
+    const result = locationSearchSuggestionDataFactory.build({
+      text: "Some Landmark",
+      place_id: "test-place",
+    })
+
+    mockFetch(200, {
+      data: [result],
+    })
+
+    fetchLocationSearchSuggestions("query").then((result) => {
+      expect(result).toEqual([
+        locationSearchSuggestionFactory.build({
+          text: "Some Landmark",
+          placeId: "test-place",
+        }),
+      ])
       done()
     })
   })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -15,6 +15,7 @@ import {
   fetchStations,
   fetchRoutePatterns,
   fetchLocationSearchResults,
+  fetchLocationSearchResultById,
 } from "../src/api"
 import routeFactory from "./factories/route"
 import routeTabFactory from "./factories/routeTab"
@@ -759,6 +760,33 @@ describe("fetchLocationSearchResults", () => {
           longitude: 2,
         }),
       ])
+      done()
+    })
+  })
+})
+
+describe("fetchLocationSearchResultById", () => {
+  test("parses location search results", (done) => {
+    const result = locationSearchResultDataFactory.build({
+      name: "Some Landmark",
+      address: "123 Test St",
+      latitude: 1,
+      longitude: 2,
+    })
+
+    mockFetch(200, {
+      data: result,
+    })
+
+    fetchLocationSearchResultById("query").then((results) => {
+      expect(results).toEqual(
+        locationSearchResultFactory.build({
+          name: "Some Landmark",
+          address: "123 Test St",
+          latitude: 1,
+          longitude: 2,
+        })
+      )
       done()
     })
   })

--- a/assets/tests/factories/locationSearchSuggestion.ts
+++ b/assets/tests/factories/locationSearchSuggestion.ts
@@ -1,0 +1,10 @@
+import { Factory } from "fishery"
+import { LocationSearchSuggestion } from "../../src/models/locationSearchSuggestion"
+
+const locationSearchSuggestionFactory =
+  Factory.define<LocationSearchSuggestion>(({ sequence }) => ({
+    text: "Some Search Term",
+    placeId: `${sequence}`,
+  }))
+
+export default locationSearchSuggestionFactory

--- a/assets/tests/factories/locationSearchSuggestionData.ts
+++ b/assets/tests/factories/locationSearchSuggestionData.ts
@@ -1,0 +1,10 @@
+import { Factory } from "fishery"
+import { LocationSearchSuggestionData } from "../../src/models/locationSearchSuggestionData"
+
+const locationSearchSuggestionDataFactory =
+  Factory.define<LocationSearchSuggestionData>(({ sequence }) => ({
+    text: "Some Search Term",
+    place_id: `${sequence}`,
+  }))
+
+export default locationSearchSuggestionDataFactory

--- a/assets/tests/hooks/useLocationSearchResultById.test.ts
+++ b/assets/tests/hooks/useLocationSearchResultById.test.ts
@@ -1,0 +1,47 @@
+import { useLocationSearchResultById } from "../../src/hooks/useLocationSearchResultById"
+import { renderHook } from "@testing-library/react"
+import * as Api from "../../src/api"
+import { instantPromise } from "../testHelpers/mockHelpers"
+import locationSearchResultFactory from "../factories/locationSearchResult"
+
+jest.mock("../../src/api", () => ({
+  __esModule: true,
+
+  fetchLocationSearchResultById: jest.fn(() => new Promise(() => {})),
+}))
+
+describe("useLocationSearchResultById", () => {
+  test("returns null if no search query is given", () => {
+    const mockFetchLocationSearchResultById: jest.Mock =
+      Api.fetchLocationSearchResultById as jest.Mock
+
+    const { result } = renderHook(() => useLocationSearchResultById(null))
+
+    expect(result.current).toBeNull()
+    expect(mockFetchLocationSearchResultById).not.toHaveBeenCalled()
+  })
+
+  test("returns null while loading", () => {
+    const mockFetchLocationSearchResultById: jest.Mock =
+      Api.fetchLocationSearchResultById as jest.Mock
+
+    const { result } = renderHook(() => useLocationSearchResultById("place_id"))
+
+    expect(result.current).toBeNull()
+    expect(mockFetchLocationSearchResultById).toHaveBeenCalled()
+  })
+
+  test("returns results", () => {
+    const results = [locationSearchResultFactory.build()]
+    const mockFetchLocationSearchResultById: jest.Mock =
+      Api.fetchLocationSearchResultById as jest.Mock
+    mockFetchLocationSearchResultById.mockImplementationOnce(() =>
+      instantPromise(results)
+    )
+
+    const { result } = renderHook(() => useLocationSearchResultById("place_id"))
+
+    expect(result.current).toEqual(results)
+    expect(mockFetchLocationSearchResultById).toHaveBeenCalled()
+  })
+})

--- a/assets/tests/hooks/useLocationSearchSuggestions.test.ts
+++ b/assets/tests/hooks/useLocationSearchSuggestions.test.ts
@@ -1,0 +1,51 @@
+import { useLocationSearchSuggestions } from "../../src/hooks/useLocationSearchSuggestions"
+import { renderHook } from "@testing-library/react"
+import * as Api from "../../src/api"
+import { instantPromise } from "../testHelpers/mockHelpers"
+import locationSearchSuggestionFactory from "../factories/locationSearchSuggestion"
+
+jest.mock("../../src/api", () => ({
+  __esModule: true,
+
+  fetchLocationSearchSuggestions: jest.fn(() => new Promise(() => {})),
+}))
+
+describe("useLocationSearchSuggestions", () => {
+  test("returns null if no search query is given", () => {
+    const mockFetchLocationSearchSuggestions: jest.Mock =
+      Api.fetchLocationSearchSuggestions as jest.Mock
+
+    const { result } = renderHook(() => useLocationSearchSuggestions(null))
+
+    expect(result.current).toBeNull()
+    expect(mockFetchLocationSearchSuggestions).not.toHaveBeenCalled()
+  })
+
+  test("returns null while loading", () => {
+    const mockFetchLocationSearchSuggestions: jest.Mock =
+      Api.fetchLocationSearchSuggestions as jest.Mock
+
+    const { result } = renderHook(() =>
+      useLocationSearchSuggestions("search string")
+    )
+
+    expect(result.current).toBeNull()
+    expect(mockFetchLocationSearchSuggestions).toHaveBeenCalled()
+  })
+
+  test("returns results", () => {
+    const results = [locationSearchSuggestionFactory.build()]
+    const mockFetchLocationSearchSuggestions: jest.Mock =
+      Api.fetchLocationSearchSuggestions as jest.Mock
+    mockFetchLocationSearchSuggestions.mockImplementationOnce(() =>
+      instantPromise(results)
+    )
+
+    const { result } = renderHook(() =>
+      useLocationSearchSuggestions("search string")
+    )
+
+    expect(result.current).toEqual(results)
+    expect(mockFetchLocationSearchSuggestions).toHaveBeenCalled()
+  })
+})

--- a/assets/tests/models/locationSearchSuggestionData.test.ts
+++ b/assets/tests/models/locationSearchSuggestionData.test.ts
@@ -1,4 +1,7 @@
-import { locationSearchSuggestionFromData } from "../../src/models/locationSearchSuggestionData"
+import {
+  locationSearchSuggestionFromData,
+  locationSearchSuggestionsFromData,
+} from "../../src/models/locationSearchSuggestionData"
 import locationSearchSuggestionFactory from "../factories/locationSearchSuggestion"
 import locationSearchSuggestionDataFactory from "../factories/locationSearchSuggestionData"
 
@@ -15,5 +18,23 @@ describe("locationSearchSuggestionFromData", () => {
         placeId: "test-id",
       })
     )
+  })
+})
+
+describe("locationSearchSuggestionsFromData", () => {
+  test("passes supplied data through", () => {
+    const data = [
+      locationSearchSuggestionDataFactory.build({
+        text: "Some Landmark",
+        place_id: "test-id",
+      }),
+    ]
+
+    expect(locationSearchSuggestionsFromData(data)).toEqual([
+      locationSearchSuggestionFactory.build({
+        text: "Some Landmark",
+        placeId: "test-id",
+      }),
+    ])
   })
 })

--- a/assets/tests/models/locationSearchSuggestionData.test.ts
+++ b/assets/tests/models/locationSearchSuggestionData.test.ts
@@ -1,0 +1,19 @@
+import { locationSearchSuggestionFromData } from "../../src/models/locationSearchSuggestionData"
+import locationSearchSuggestionFactory from "../factories/locationSearchSuggestion"
+import locationSearchSuggestionDataFactory from "../factories/locationSearchSuggestionData"
+
+describe("locationSearchSuggestionFromData", () => {
+  test("passes supplied data through", () => {
+    const data = locationSearchSuggestionDataFactory.build({
+      text: "Some Landmark",
+      place_id: "test-id",
+    })
+
+    expect(locationSearchSuggestionFromData(data)).toEqual(
+      locationSearchSuggestionFactory.build({
+        text: "Some Landmark",
+        placeId: "test-id",
+      })
+    )
+  })
+})

--- a/lib/skate/location_search/aws_location_request.ex
+++ b/lib/skate/location_search/aws_location_request.ex
@@ -10,12 +10,11 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
       "/places/v0/indexes/" <>
         Application.get_env(:skate, :aws_place_index) <> "/places/" <> place_id
 
-    case %ExAws.Operation.RestQuery{
+    case request_fn.(%ExAws.Operation.RestQuery{
            http_method: :get,
            path: path,
            service: :places
-         }
-         |> request_fn.() do
+         }) do
       {:ok, response} -> {:ok, parse_get_response(response, place_id)}
       {:error, error} -> {:error, error}
     end
@@ -28,13 +27,12 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
     path =
       "/places/v0/indexes/" <> Application.get_env(:skate, :aws_place_index) <> "/search/text"
 
-    case %ExAws.Operation.RestQuery{
+    case request_fn.(%ExAws.Operation.RestQuery{
            http_method: :post,
            path: path,
            body: Map.merge(base_arguments(), %{Text: text}),
            service: :places
-         }
-         |> request_fn.() do
+         }) do
       {:ok, response} -> {:ok, parse_search_response(response)}
       {:error, error} -> {:error, error}
     end
@@ -48,13 +46,12 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
       "/places/v0/indexes/" <>
         Application.get_env(:skate, :aws_place_index) <> "/search/suggestions"
 
-    case %ExAws.Operation.RestQuery{
+    case request_fn.(%ExAws.Operation.RestQuery{
            http_method: :post,
            path: path,
            body: Map.merge(base_arguments(), %{Text: text}),
            service: :places
-         }
-         |> request_fn.() do
+         }) do
       {:ok, response} -> {:ok, parse_suggest_response(response)}
       {:error, error} -> {:error, error}
     end

--- a/lib/skate/location_search/aws_location_request.ex
+++ b/lib/skate/location_search/aws_location_request.ex
@@ -1,5 +1,5 @@
 defmodule Skate.LocationSearch.AwsLocationRequest do
-  alias Skate.LocationSearch.SearchResult
+  alias Skate.LocationSearch.Place
 
   @spec search(String.t()) :: {:ok, map()} | {:error, term()}
   def search(text) do
@@ -51,7 +51,7 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
       {name, address} =
         separate_label_text(label, Map.get(place, "AddressNumber"), Map.get(place, "Street"))
 
-      %SearchResult{
+      %Place{
         id: id,
         name: name,
         address: address,

--- a/lib/skate/location_search/place.ex
+++ b/lib/skate/location_search/place.ex
@@ -1,4 +1,4 @@
-defmodule Skate.LocationSearch.SearchResult do
+defmodule Skate.LocationSearch.Place do
   @type t :: %__MODULE__{
           id: String.t(),
           name: String.t() | nil,

--- a/lib/skate/location_search/place.ex
+++ b/lib/skate/location_search/place.ex
@@ -1,6 +1,8 @@
 defmodule Skate.LocationSearch.Place do
+  @type id :: String.t()
+
   @type t :: %__MODULE__{
-          id: String.t(),
+          id: id(),
           name: String.t() | nil,
           address: String.t(),
           latitude: float(),

--- a/lib/skate/location_search/suggestion.ex
+++ b/lib/skate/location_search/suggestion.ex
@@ -1,0 +1,15 @@
+defmodule Skate.LocationSearch.Suggestion do
+  @type t :: %__MODULE__{
+          text: String.t(),
+          place_id: String.t() | nil
+        }
+
+  @enforce_keys [:text, :place_id]
+
+  @derive {Jason.Encoder, only: [:text, :place_id]}
+
+  defstruct [
+    :text,
+    :place_id
+  ]
+end

--- a/lib/skate_web/controllers/location_search_controller.ex
+++ b/lib/skate_web/controllers/location_search_controller.ex
@@ -3,6 +3,15 @@ defmodule SkateWeb.LocationSearchController do
 
   alias Skate.LocationSearch.AwsLocationRequest
 
+  @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def get(conn, %{"id" => id}) do
+    seach_fn = Application.get_env(:skate, :location_get_fn, &AwsLocationRequest.get/1)
+
+    {:ok, result} = seach_fn.(id)
+
+    json(conn, %{data: result})
+  end
+
   @spec search(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def search(conn, %{"query" => query}) do
     seach_fn = Application.get_env(:skate, :location_search_fn, &AwsLocationRequest.search/1)

--- a/lib/skate_web/controllers/location_search_controller.ex
+++ b/lib/skate_web/controllers/location_search_controller.ex
@@ -5,18 +5,18 @@ defmodule SkateWeb.LocationSearchController do
 
   @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def get(conn, %{"id" => id}) do
-    seach_fn = Application.get_env(:skate, :location_get_fn, &AwsLocationRequest.get/1)
+    get_fn = Application.get_env(:skate, :location_get_fn, &AwsLocationRequest.get/1)
 
-    {:ok, result} = seach_fn.(id)
+    {:ok, result} = get_fn.(id)
 
     json(conn, %{data: result})
   end
 
   @spec search(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def search(conn, %{"query" => query}) do
-    seach_fn = Application.get_env(:skate, :location_search_fn, &AwsLocationRequest.search/1)
+    search_fn = Application.get_env(:skate, :location_search_fn, &AwsLocationRequest.search/1)
 
-    {:ok, result} = seach_fn.(query)
+    {:ok, result} = search_fn.(query)
 
     json(conn, %{data: result})
   end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -127,6 +127,7 @@ defmodule SkateWeb.Router do
     put "/route_tabs", RouteTabsController, :update
     put "/notification_read_state", NotificationReadStatesController, :update
     get "/swings", SwingsController, :index
+    get "/location_search/place/:id", LocationSearchController, :get
     get "/location_search/search", LocationSearchController, :search
     get "/location_search/suggest", LocationSearchController, :suggest
   end

--- a/test/skate/location_search/aws_location_request_test.exs
+++ b/test/skate/location_search/aws_location_request_test.exs
@@ -5,14 +5,14 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
   import Test.Support.Helpers
 
   alias Skate.LocationSearch.AwsLocationRequest
-  alias Skate.LocationSearch.SearchResult
+  alias Skate.LocationSearch.Place
 
   setup do
     reassign_env(:skate, :aws_place_index, "test-index")
   end
 
   describe "search/1" do
-    test "transforms result with name into SearchResult structs" do
+    test "transforms result with name into Place structs" do
       name = "Some Landmark"
       address_number = "123"
       street = "Test St"
@@ -41,11 +41,11 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
 
       expected_address = "#{address_number} #{street}, #{address_suffix}"
 
-      assert {:ok, [%SearchResult{name: ^name, address: ^expected_address}]} =
+      assert {:ok, [%Place{name: ^name, address: ^expected_address}]} =
                AwsLocationRequest.search("search text")
     end
 
-    test "transforms result without name into SearchResult structs" do
+    test "transforms result without name into Place structs" do
       address_number = "123"
       street = "Test St"
       address_suffix = "MA 02201, United States"
@@ -73,11 +73,11 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
 
       expected_address = "#{address_number} #{street}, #{address_suffix}"
 
-      assert {:ok, [%SearchResult{name: nil, address: ^expected_address}]} =
+      assert {:ok, [%Place{name: nil, address: ^expected_address}]} =
                AwsLocationRequest.search("search text")
     end
 
-    test "transforms result without address prefix information to go on into SearchResult structs" do
+    test "transforms result without address prefix information to go on into Place structs" do
       address_suffix = "Some Neighborhood, Boston, MA"
 
       response = %{
@@ -101,7 +101,7 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
         {:ok, response}
       end)
 
-      assert {:ok, [%SearchResult{name: nil, address: ^address_suffix}]} =
+      assert {:ok, [%Place{name: nil, address: ^address_suffix}]} =
                AwsLocationRequest.search("search text")
     end
 

--- a/test/skate_web/controllers/location_search_controller_test.exs
+++ b/test/skate_web/controllers/location_search_controller_test.exs
@@ -2,7 +2,7 @@ defmodule SkateWeb.LocationSearchControllerTest do
   use SkateWeb.ConnCase
   import Test.Support.Helpers
 
-  alias Skate.LocationSearch.SearchResult
+  alias Skate.LocationSearch.Place
 
   describe "GET /api/location_search/search" do
     test "when logged out, redirects you to cognito auth", %{conn: conn} do
@@ -16,7 +16,7 @@ defmodule SkateWeb.LocationSearchControllerTest do
 
     @tag :authenticated
     test "returns data", %{conn: conn} do
-      result = %SearchResult{
+      result = %Place{
         id: "test_id",
         name: "Landmark",
         address: "123 Fake St",

--- a/test/skate_web/controllers/location_search_controller_test.exs
+++ b/test/skate_web/controllers/location_search_controller_test.exs
@@ -3,6 +3,7 @@ defmodule SkateWeb.LocationSearchControllerTest do
   import Test.Support.Helpers
 
   alias Skate.LocationSearch.Place
+  alias Skate.LocationSearch.Suggestion
 
   describe "GET /api/location_search/search" do
     test "when logged out, redirects you to cognito auth", %{conn: conn} do
@@ -53,7 +54,7 @@ defmodule SkateWeb.LocationSearchControllerTest do
 
     @tag :authenticated
     test "returns data", %{conn: conn} do
-      result = "suggested search"
+      result = %Suggestion{text: "suggested search", place_id: nil}
 
       reassign_env(:skate, :location_suggest_fn, fn _query -> {:ok, [result]} end)
 
@@ -62,7 +63,9 @@ defmodule SkateWeb.LocationSearchControllerTest do
         |> api_headers()
         |> get("/api/location_search/suggest?query=test")
 
-      assert json_response(conn, 200) == %{"data" => [result]}
+      assert json_response(conn, 200) == %{
+               "data" => [%{"text" => "suggested search", "place_id" => nil}]
+             }
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -199,22 +199,26 @@ defmodule Skate.Factory do
     }
   end
 
-  def amazon_location_search_result_factory(attrs) do
+  def amazon_location_place_factory(attrs) do
     address_number = Map.get(attrs, :address_number, sequence(:address_number, &to_string/1))
     street = Map.get(attrs, :street, "Test St")
     name = Map.get(attrs, :name, "Landmark")
     address_suffix = Map.get(attrs, :address_suffix, "MA 02201, United States")
 
-    result = %{
-      "Place" => %{
-        "AddressNumber" => address_number,
-        "Geometry" => %{
-          "Point" => [0, 0]
-        },
-        "Label" =>
-          "#{name && name <> ", "}#{address_number && address_number <> " "}#{street && street <> ", "}#{address_suffix}",
-        "Street" => street
+    %{
+      "AddressNumber" => address_number,
+      "Geometry" => %{
+        "Point" => [0, 0]
       },
+      "Label" =>
+        "#{name && name <> ", "}#{address_number && address_number <> " "}#{street && street <> ", "}#{address_suffix}",
+      "Street" => street
+    }
+  end
+
+  def amazon_location_search_result_factory(attrs) do
+    result = %{
+      "Place" => fn -> build(:amazon_location_place, attrs) end,
       "PlaceId" => "test_id_#{sequence(:place_id, &to_string/1)}"
     }
 


### PR DESCRIPTION
Asana ticket: part of [⚙️ Better Maps | Search | Users can search by location](https://app.asana.com/0/1200180014510248/1204971421569464/f)

Most of this is pretty straightforward data plumbing to get the information we need from Amazon and then provide it to the Skate front-end in the form of hooks.