### PR TITLE
feat: Fix sentry source maps

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -1,0 +1,75 @@
+on:
+  workflow_call:
+    inputs:
+      env:
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      DOCKER_REPO:
+        required: true
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    env:
+      ECS_CLUSTER: skate
+      ECS_SERVICE: skate-${{ inputs.env }}
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get version ids
+        id: version-ids
+        run: |
+          echo "sentry-release=${{github.ref}}_${{github.sha}}" | tr / - >> "$GITHUB_OUTPUT"
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: ${{ inputs.env }}
+          version: ${{steps.version-ids.outputs.sentry-release}}
+          set_commits: "skip"
+          ignore_missing: true
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: --build-arg SENTRY_RELEASE=${{steps.version-ids.outputs.sentry-release}}
+      - name: Upload static assets to S3
+        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }} ${{steps.version-ids.outputs.sentry-release}}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - uses: mbta/actions/deploy-ecs@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -2,6 +2,8 @@ name: Deploy to Dev-blue (ECS)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [kb-sentry-include-release]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -1,4 +1,4 @@
-name: Deploy to Dev-Blue ECS
+name: Deploy to Dev-blue (ECS)
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy to Dev-Blue
+    name: Deploy to Dev-blue (ECS)
     concurrency:
       group: dev-blue
       cancel-in-progress: true

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -1,61 +1,20 @@
-name: Deploy to Dev-blue (ECS)
+name: Deploy to Dev-Blue ECS
 
 on:
   workflow_dispatch:
-  push:
-    branches: [kb-sentry-include-release]
+  pull_request:
+    types:
+      - synchronize
+      - labeled
 
 jobs:
   deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: dev-blue
-    concurrency: dev-blue
-    env:
-      ECS_CLUSTER: skate
-      ECS_SERVICE: skate-dev-blue
-      AWS_DEFAULT_REGION: us-east-1
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get version ids
-        id: version-ids
-        run: |
-          echo "sentry-release=${{github.ref}}_${{github.sha}}" | tr / - >> "$GITHUB_OUTPUT"
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          environment: dev-blue
-          version: ${{steps.version-ids.outputs.sentry-release}}
-          set_commits: "skip"
-          ignore_missing: true
-      - uses: mbta/actions/build-push-ecr@v1
-        id: build-push
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          docker-repo: ${{ secrets.DOCKER_REPO }}
-          docker-additional-args: --build-arg SENTRY_RELEASE=${{steps.version-ids.outputs.sentry-release}}
-      - name: Upload static assets to S3
-        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }} ${{steps.version-ids.outputs.sentry-release}}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - uses: mbta/actions/deploy-ecs@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ecs-cluster: ${{ env.ECS_CLUSTER }}
-          ecs-service: ${{ env.ECS_SERVICE }}
-          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v1
-        if: ${{ !cancelled() }}
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          job-status: ${{ job.status }}
+    name: Deploy to Dev-Blue
+    concurrency:
+      group: dev-blue
+      cancel-in-progress: true
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'deploy-to-dev-blue') }}
+    uses: ./.github/workflows/deploy-base.yml
+    with:
+      env: dev-blue
+    secrets: inherit

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -12,7 +12,6 @@ jobs:
     name: Deploy to Dev-blue (ECS)
     concurrency:
       group: dev-blue
-      cancel-in-progress: true
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'deploy-to-dev-blue') }}
     uses: ./.github/workflows/deploy-base.yml
     with:

--- a/.github/workflows/deploy-dev-blue.yml
+++ b/.github/workflows/deploy-dev-blue.yml
@@ -15,14 +15,29 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
+      - name: Get version ids
+        id: version-ids
+        run: |
+          echo "sentry-release=${{github.ref}}_${{github.sha}}" | tr / - >> "$GITHUB_OUTPUT"
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: dev-blue
+          version: ${{steps.version-ids.outputs.sentry-release}}
+          set_commits: "skip"
+          ignore_missing: true
       - uses: mbta/actions/build-push-ecr@v1
         id: build-push
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: --build-arg SENTRY_RELEASE=${{steps.version-ids.outputs.sentry-release}}
       - name: Upload static assets to S3
-        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
+        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }} ${{steps.version-ids.outputs.sentry-release}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -10,7 +10,6 @@ jobs:
     name: Deploy to Dev (ECS)
     concurrency:
       group: dev
-      cancel-in-progress: true
     uses: ./.github/workflows/deploy-base.yml
     with:
       env: dev

--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -7,40 +7,11 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: dev
-    concurrency: dev
-    env:
-      ECS_CLUSTER: skate
-      ECS_SERVICE: skate-dev
-      AWS_DEFAULT_REGION: us-east-1
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mbta/actions/build-push-ecr@v1
-        id: build-push
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Upload static assets to S3
-        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - uses: mbta/actions/deploy-ecs@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ecs-cluster: ${{ env.ECS_CLUSTER }}
-          ecs-service: ${{ env.ECS_SERVICE }}
-          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v1
-        if: ${{ !cancelled() }}
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          job-status: ${{ job.status }}
+    name: Deploy to Dev (ECS)
+    concurrency:
+      group: dev
+      cancel-in-progress: true
+    uses: ./.github/workflows/deploy-base.yml
+    with:
+      env: dev
+    secrets: inherit

--- a/.github/workflows/deploy-dev-green.yml
+++ b/.github/workflows/deploy-dev-green.yml
@@ -12,7 +12,6 @@ jobs:
     name: Deploy to Dev-green (ECS)
     concurrency:
       group: dev-green
-      cancel-in-progress: true
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'deploy-to-dev-green') }}
     uses: ./.github/workflows/deploy-base.yml
     with:

--- a/.github/workflows/deploy-dev-green.yml
+++ b/.github/workflows/deploy-dev-green.yml
@@ -2,43 +2,19 @@ name: Deploy to Dev-green (ECS)
 
 on:
   workflow_dispatch:
+  pull_request:
+    types:
+      - synchronize
+      - labeled
 
 jobs:
   deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: dev-green
-    concurrency: dev-green
-    env:
-      ECS_CLUSTER: skate
-      ECS_SERVICE: skate-dev-green
-      AWS_DEFAULT_REGION: us-east-1
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mbta/actions/build-push-ecr@v1
-        id: build-push
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Upload static assets to S3
-        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - uses: mbta/actions/deploy-ecs@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ecs-cluster: ${{ env.ECS_CLUSTER }}
-          ecs-service: ${{ env.ECS_SERVICE }}
-          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v1
-        if: ${{ !cancelled() }}
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          job-status: ${{ job.status }}
+    name: Deploy to Dev-green (ECS)
+    concurrency:
+      group: dev-green
+      cancel-in-progress: true
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'deploy-to-dev-green') }}
+    uses: ./.github/workflows/deploy-base.yml
+    with:
+      env: dev-green
+    secrets: inherit

--- a/.github/workflows/deploy-prod-ecs.yml
+++ b/.github/workflows/deploy-prod-ecs.yml
@@ -5,40 +5,11 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: prod
-    concurrency: prod
-    env:
-      ECS_CLUSTER: skate
-      ECS_SERVICE: skate-prod
-      AWS_DEFAULT_REGION: us-east-1
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mbta/actions/build-push-ecr@v1
-        id: build-push
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          docker-repo: ${{ secrets.DOCKER_REPO }}
-      - name: Upload static assets to S3
-        run: bash upload_assets.sh ${{ steps.build-push.outputs.docker-tag }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      - uses: mbta/actions/deploy-ecs@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ecs-cluster: ${{ env.ECS_CLUSTER }}
-          ecs-service: ${{ env.ECS_SERVICE }}
-          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v1
-        if: ${{ !cancelled() }}
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          job-status: ${{ job.status }}
+    name: Deploy to Prod (ECS)
+    concurrency:
+      group: prod
+      cancel-in-progress: true
+    uses: ./.github/workflows/deploy-base.yml
+    with:
+      env: prod
+    secrets: inherit

--- a/.github/workflows/deploy-prod-ecs.yml
+++ b/.github/workflows/deploy-prod-ecs.yml
@@ -8,7 +8,6 @@ jobs:
     name: Deploy to Prod (ECS)
     concurrency:
       group: prod
-      cancel-in-progress: true
     uses: ./.github/workflows/deploy-base.yml
     with:
       env: prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN echo "2c151768edd48e9ef6719de74fdcbdebe290d1e87bc02ce9014ea6eea557d2a0  aws-
 
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
 RUN mix do compile --force, phx.digest, release
 

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react"
+import * as Sentry from "@sentry/react"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
@@ -342,6 +343,7 @@ const SearchFormFromStateDispatchContext = ({
       onPropertyChange={(property: SearchPropertyQuery) => {
         dispatch(setOldSearchProperty(property))
         dispatch(submitSearch())
+        Sentry.captureException({ error: "ohNo! Test error hit" })
       }}
       onSelectVehicleOption={(vehicle) => {
         dispatch(

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from "react"
-import * as Sentry from "@sentry/react"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
@@ -343,7 +342,6 @@ const SearchFormFromStateDispatchContext = ({
       onPropertyChange={(property: SearchPropertyQuery) => {
         dispatch(setOldSearchProperty(property))
         dispatch(submitSearch())
-        Sentry.captureException({ error: "ohNo! Test error hit" })
       }}
       onSelectVehicleOption={(vehicle) => {
         dispatch(

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,6 +9,9 @@ config :skate,
   record_sentry: true,
   static_href: {SkateWeb.Router.Helpers, :static_url}
 
+config :sentry,
+  release: System.get_env("SENTRY_RELEASE")
+
 # For production, don't forget to configure the url host
 # to something meaningful, Phoenix uses this information
 # when generating URLs.

--- a/lib/skate_web/templates/layout/_sentry.html.eex
+++ b/lib/skate_web/templates/layout/_sentry.html.eex
@@ -1,6 +1,7 @@
 <script>
   window.sentry = {
     dsn: "<%= Application.get_env(:skate, :sentry_frontend_dsn) %>",
-    environment: "<%= Application.get_env(:skate, :sentry_environment) %>"
+    environment: "<%= Application.get_env(:skate, :sentry_environment) %>",
+    release: "<%= Application.get_env(:sentry, :release) %>"
   }
 </script>

--- a/upload_assets.sh
+++ b/upload_assets.sh
@@ -27,5 +27,5 @@ aws s3 sync "$STATIC_DIR/fonts" "$S3_DIR/fonts" --size-only --exclude "*" --incl
 aws s3 sync $STATIC_DIR $S3_DIR --size-only
 
 # upload source maps to Sentry
-SENTRY_RELEASE=$(npx @sentry/cli@2.3.1 releases propose-version)
-npx @sentry/cli@2.3.1 releases files "$SENTRY_RELEASE" upload-sourcemaps "$STATIC_DIR/js"
+SENTRY_RELEASE=${2-$(npx @sentry/cli@2.3.1 releases propose-version)}
+npx @sentry/cli@2.3.1 releases files "$SENTRY_RELEASE" upload-sourcemaps "$STATIC_DIR/js" --url-prefix "~/${APP}/js"


### PR DESCRIPTION
ticket: https://app.asana.com/0/1152340551558956/1205212771706510/f

This is largely based on Glides' setup of releases https://github.com/mbta/glides/pull/936. There are some differences in this approach in order to limit the scope of this PR based on Skate's existing setup, but I'll call those out with specific comments.

Note: It seems that Sentry may be moving towards "Artifact Bundles" using debug IDs (see [What are Artifact Bundles](https://docs.sentry.io/platforms/node/sourcemaps/troubleshooting_js/artifact-bundles/), debug ID as mandatory and releases as optional in [Uploading Source Maps](https://docs.sentry.io/platforms/node/sourcemaps/uploading/typescript/)). I attempted to take that approach in [kb-sentry-stack-fix](https://github.com/mbta/skate/tree/kb-sentry-stack-fix) but was not able to get it to work: `debug_meta` was not present on the[ error event JSON](https://mbtace.sentry.io/issues/4396730422/?query=is%3Aunresolved&referrer=issue-stream&stream_index=0) when it is expected based on the [troubleshooting docs](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-your-sdk-is-up-to-date) across a few variations of attempts. In favor of fixing the problem at hand, I've opted to stop pursuing the debug ID approach in favor of the working releases approach, but we may want to revisit that approach down the line! 