### PR TITLE
fix(useLimitedSearchResults): Don't subscribe to topic when query is empty

### DIFF
--- a/assets/src/hooks/useSearchResults.ts
+++ b/assets/src/hooks/useSearchResults.ts
@@ -62,7 +62,9 @@ export const useLimitedSearchResults = (
   query: { property: VehiclePropertyQuery; text: string; limit: number } | null
 ): Ok<LimitedSearchResults<Vehicle | Ghost>> | Loading | null => {
   const topic: string | null =
-    query && `vehicles_search:limited:${query.property}:${query.text}`
+    query?.text && query.text != ""
+      ? `vehicles_search:limited:${query.property}:${query.text}`
+      : null
 
   const [state, pushUpdate] = useCheckedTwoWayChannel<
     LimitedSearchResultsData,

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -315,6 +315,7 @@ describe("useLimitedSearchResults", () => {
     )
     expect(result.current).toEqual(null)
   })
+
   test("initializing the hook subscribes to the search results", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok")

--- a/assets/tests/hooks/useSearchResults.test.ts
+++ b/assets/tests/hooks/useSearchResults.test.ts
@@ -302,6 +302,19 @@ describe("useLimitedSearchResults", () => {
     )
     expect(result.current).toEqual(null)
   })
+
+  test("when no query is for empty string, returns null", () => {
+    const mockSocket = makeMockSocket()
+
+    const { result } = renderHook(() =>
+      useLimitedSearchResults(mockSocket, {
+        text: "",
+        property: "run",
+        limit: 5,
+      })
+    )
+    expect(result.current).toEqual(null)
+  })
   test("initializing the hook subscribes to the search results", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok")


### PR DESCRIPTION
When a user lands on the search map page but hasn't performed a search yet, don't subscribe to an empty search.