### PR TITLE
fix(usePersistedStateReducer.test): Fix flaky test of push tab retry

### DIFF
--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -6,7 +6,7 @@ import {
   beforeEach,
   afterAll,
 } from "@jest/globals"
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 import { putUserSetting, putRouteTabs } from "../../src/api"
 import appData from "../../src/appData"
 import usePersistedStateReducer, {
@@ -351,16 +351,13 @@ describe("usePersistedStateReducer", () => {
       .mockImplementationOnce(() => fakePromise)
       .mockImplementationOnce(() => fakePromise)
 
-    act(() => {
+    await act(async () => {
       dispatch(createRouteTab())
-    })
-    const initialValue = result.current
-    await waitFor(() => {
-      expect(result.current).not.toBe(initialValue)
     })
 
     const [state] = result.current
 
+    expect(putRouteTabs).toHaveBeenCalledTimes(3)
     expect(state.routeTabs).toMatchObject([
       {
         ordering: 0,
@@ -370,7 +367,6 @@ describe("usePersistedStateReducer", () => {
     expect(state.routeTabsToPush).toBeNull()
     expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
-    expect(putRouteTabs).toHaveBeenCalledTimes(3)
   })
 })
 

--- a/assets/tests/hooks/usePersistedStateReducer.test.ts
+++ b/assets/tests/hooks/usePersistedStateReducer.test.ts
@@ -320,24 +320,13 @@ describe("usePersistedStateReducer", () => {
       .mockImplementationOnce(() => fakePromise)
       .mockImplementationOnce(() => fakePromise)
 
-    const firstValue = result.current
-
-    act(() => {
+    await act(async () => {
       dispatch(createRouteTab())
-    })
-    await waitFor(() => {
-      expect(result.current).not.toBe(firstValue)
-    })
-
-    // wait for changes from dispatch call in catch handler
-    const secondValue = result.current
-
-    await waitFor(() => {
-      expect(result.current).not.toBe(secondValue)
     })
 
     const [state] = result.current
 
+    expect(putRouteTabs).toHaveBeenCalledTimes(3)
     expect(state.routeTabs).toMatchObject([
       {
         ordering: 0,
@@ -347,7 +336,6 @@ describe("usePersistedStateReducer", () => {
     expect(state.routeTabsToPush).toBeNull()
     expect(state.routeTabsToPushNext).toBeNull()
     expect(state.routeTabsPushInProgress).toEqual(false)
-    expect(putRouteTabs).toHaveBeenCalledTimes(3)
   })
 
   test("retries at most two more times, with final failure being a client error", async () => {


### PR DESCRIPTION
ticket: https://app.asana.com/0/1148853526253437/1204432665252080/f

I was unable to reproduce the flaky test's failure across 1000+ runs, so it has been tricky confirming if these two changes address the root of the problem, but it seems to me that both of these changes would reduce the likeliness of flaky behavior. 

1. awaiting `act`-  this allows us to remove the use of intermediate state variables & `waitFor` in the tests by waiting until all side effects are resolved. Act is still a bit mysterious to me, but I referenced [this explanation](https://github.com/threepointone/react-act-examples/blob/master/sync.md#promises) linked from[ the rtl docs](https://testing-library.com/docs/preact-testing-library/api/#act) for this approach.
2. `useRef` instead of `useState` in the `usePersistedStateReducer` so that updates to `routeTabsPushRetriesLeft` are synchronous. This prevents a possible race conditions between updating `routeTabsPushRetriesLeft` and dispatching the retry action.