### PR TITLE
fix: add build dependencies to assets-builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ ADD . .
 # Copy in elixir deps required to build node modules for phoenix
 COPY --from=elixir-builder /root/deps ./deps
 
+# Build dependencies in case certain packages don't have prebuild binaries
+RUN apk add --no-cache --update python3 build-base
+
 RUN npm --prefix assets ci
 RUN npm --prefix assets run deploy
 


### PR DESCRIPTION
This is just a random one-off change based on playing around with getting the Skate Dockerfile to build on an ARM system. Currently Skate only runs on Intel systems in production and we don't do a ton of local development inside of Docker, but I think it's good practice to make our build as architecture-independent as possible. It would also be possible to actually do some conditional shell logic to only add the dependencies on non-amd64 systems instead of just `RUN`ing `apk add` unconditionally, but I think that logic could actually be kind of brittle and the added dependencies are only present in the intermediate build image anyway. I'm open to feedback on whether we should do this at all or the specifics of the approach!