### PR TITLE
ci: auto associate git commits with release

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           environment: ${{ inputs.env }}
           version: ${{steps.version-ids.outputs.sentry-release}}
-          set_commits: "skip"
           ignore_missing: true
       - uses: mbta/actions/build-push-ecr@v1
         id: build-push

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react"
+import * as Sentry from "@sentry/react"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
@@ -345,6 +346,7 @@ const SearchFormFromStateDispatchContext = ({
       onPropertyChange={(property: SearchPropertyQuery) => {
         dispatch(setOldSearchProperty(property))
         dispatch(submitSearch())
+        Sentry.captureException({ error: "ohNo! Test error hit" })
       }}
       onSelectVehicleOption={(vehicle) => {
         dispatch(

--- a/assets/src/components/searchForm.tsx
+++ b/assets/src/components/searchForm.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from "react"
-import * as Sentry from "@sentry/react"
 
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { SearchIcon } from "../helpers/icon"
@@ -346,7 +345,6 @@ const SearchFormFromStateDispatchContext = ({
       onPropertyChange={(property: SearchPropertyQuery) => {
         dispatch(setOldSearchProperty(property))
         dispatch(submitSearch())
-        Sentry.captureException({ error: "ohNo! Test error hit" })
       }}
       onSelectVehicleOption={(vehicle) => {
         dispatch(


### PR DESCRIPTION
See commits associated with a test release [here](https://mbtace.sentry.io/releases/refs-pull-2194-merge_beac67df4cfa3e831eb2d64463702849e4a79144/commits/?project=5303927)

This [sentry error](https://mbtace.sentry.io/issues/4397615686/?query=is%3Aunresolved&referrer=issue-stream&stream_index=0) shows a "Suspect Commit"  & "Open this line in GitHub" link which now both point to the Skate repo, though neither is quite right (likely because this error is from a PR rather than a commit to the master branch)