### PR TITLE
feat:fix(ts/components/routePropertiesCard): make direction selector label stretch to size of button

### DIFF
--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -124,11 +124,12 @@ const DirectionPicker = ({
       {directionIds.map((directionId) => (
         <div
           key={directionId}
-          className={`direction-button${
-            selectedRoutePattern.directionId === directionId
-              ? " direction-button--selected"
-              : ""
-          }`}
+          className={joinClasses([
+            "direction-button",
+            selectedRoutePattern.directionId === directionId &&
+              "direction-button--selected",
+            "position-relative",
+          ])}
         >
           <input
             type="radio"
@@ -147,7 +148,10 @@ const DirectionPicker = ({
               }
             }}
           />
-          <label htmlFor={`direction-radio-${directionId}`}>
+          <label
+            htmlFor={`direction-radio-${directionId}`}
+            className="stretched-link"
+          >
             {directionNames[directionId]}
           </label>
         </div>


### PR DESCRIPTION
Given we have planning Monday, I figured I'd get this done since it was fairly easy and to avoid digging into something deeper at the end of the week.

---

Asana Ticket: https://app.asana.com/0/1200180014510248/1204807646620475/f