### PR TITLE
feat(StopController): endpoint for all stops / stations

### DIFF
--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -159,6 +159,10 @@ defmodule Schedule do
     call_with_data(persistent_term_key, [], :stations, [])
   end
 
+  def all_stops(persistent_term_key \\ __MODULE__) do
+    call_with_data(persistent_term_key, [], :all_stops, [])
+  end
+
   @spec first_route_pattern_for_route_and_direction(Route.id(), Direction.id()) ::
           RoutePattern.t() | nil
   @spec first_route_pattern_for_route_and_direction(
@@ -216,6 +220,19 @@ defmodule Schedule do
       persistent_term_key,
       [route_id, start_time, end_time],
       :swings_for_route,
+      nil
+    )
+  end
+
+  @doc """
+  Get the version for the loaded schedule data
+  """
+  @spec version(persistent_term_key()) :: String.t() | nil
+  def version(persistent_term_key \\ __MODULE__) do
+    call_with_data(
+      persistent_term_key,
+      [],
+      :version,
       nil
     )
   end

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -68,7 +68,8 @@ defmodule Schedule.Data do
 
   @type all_files :: %{
           gtfs: %{String.t() => binary()},
-          hastus: %{String.t() => binary()}
+          hastus: %{String.t() => binary()},
+          version: String.t()
         }
 
   @typep gtfs_files :: %{String.t() => binary()}
@@ -357,7 +358,7 @@ defmodule Schedule.Data do
   # Initialization
 
   @spec parse_files(all_files()) :: t()
-  def parse_files(%{gtfs: gtfs_files, hastus: hastus_files} = all_files) do
+  def parse_files(%{gtfs: gtfs_files, hastus: hastus_files, version: version}) do
     gtfs_data = parse_gtfs_files(gtfs_files)
     hastus_data = parse_hastus_files(hastus_files, gtfs_data.bus_only.trip_ids)
 
@@ -382,8 +383,6 @@ defmodule Schedule.Data do
         gtfs_data.all_modes.route_patterns,
         gtfs_data.all_modes.stop_times_by_trip_id
       )
-
-    version = :crypto.hash(:sha256, :erlang.term_to_binary(all_files))
 
     %__MODULE__{
       routes: bus_routes,

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -411,7 +411,7 @@ defmodule Schedule.Data do
   # keys depending on how it needs to be used.
   @spec parse_gtfs_files(gtfs_files()) :: %{
           bus_only: map(),
-          all_modes: map(),
+          all_modes: map()
         }
   defp parse_gtfs_files(gtfs_files) do
     gtfs_files["feed_info.txt"]

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -39,7 +39,8 @@ defmodule Schedule.Data do
           blocks: Block.by_id(),
           calendar: Calendar.t(),
           runs: Run.by_id(),
-          swings: Swing.by_schedule_id_and_route_id()
+          swings: Swing.by_schedule_id_and_route_id(),
+          version: String.t()
         }
 
   @type shapes_by_route_id :: %{Route.id() => [Shape.t()]}
@@ -60,7 +61,8 @@ defmodule Schedule.Data do
             blocks: %{},
             calendar: %{},
             runs: %{},
-            swings: %{}
+            swings: %{},
+            version: nil
 
   @type files :: %{String.t() => binary()}
 
@@ -249,10 +251,14 @@ defmodule Schedule.Data do
   end
 
   @spec stations(t()) :: [Stop.t()]
-  def stations(%__MODULE__{stops: stops}) do
-    stops
-    |> Map.values()
-    |> Enum.filter(&Stop.is_station?/1)
+  def stations(data) do
+    data
+    |> all_stops()
+    |> Enum.filter(&(&1.location_type == :station))
+  end
+
+  def all_stops(%__MODULE__{stops: stops}) do
+    Map.values(stops)
   end
 
   @spec stops_for_trip(t(), Schedule.Trip.id()) :: [Stop.t()]
@@ -339,6 +345,15 @@ defmodule Schedule.Data do
     end)
   end
 
+  @doc """
+  Get the version of the schedule data
+  """
+  @spec version(t()) :: String.t() | nil
+  def version(%__MODULE__{
+        version: version
+      }),
+      do: version
+
   # Initialization
 
   @spec parse_files(all_files()) :: t()
@@ -384,18 +399,22 @@ defmodule Schedule.Data do
       blocks: blocks,
       calendar: gtfs_data.all_modes.calendar,
       runs: runs,
-      swings: swings
+      swings: swings,
+      version: gtfs_data.version
     }
   end
 
   # Parse GTFS files. Returns files parsed without filtering under the key `all_modes`.
   # Data filtered to only include bus is under the key `bus_only`. Data may appear under one or both
   # keys depending on how it needs to be used.
-  @spec parse_gtfs_files(gtfs_files()) :: %{bus_only: map(), all_modes: map()}
+  @spec parse_gtfs_files(gtfs_files()) :: %{
+          bus_only: map(),
+          all_modes: map(),
+          version: String.t()
+        }
   defp parse_gtfs_files(gtfs_files) do
-    gtfs_files["feed_info.txt"]
-    |> FeedInfo.parse()
-    |> FeedInfo.log_gtfs_version()
+    feed_info = FeedInfo.parse(gtfs_files["feed_info.txt"])
+    FeedInfo.log_gtfs_version(feed_info)
 
     directions_by_route_id = directions_by_route_id(gtfs_files["directions.txt"])
 
@@ -424,6 +443,7 @@ defmodule Schedule.Data do
     bus_shapes = shapes_by_route_id(gtfs_files["shapes.txt"], bus_trips)
 
     %{
+      version: feed_info[:version],
       bus_only: %{
         routes: bus_routes,
         route_ids: bus_route_ids,

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -255,7 +255,7 @@ defmodule Schedule.Data do
   def stations(data) do
     data
     |> all_stops()
-    |> Enum.filter(&(&1.location_type == :station))
+    |> Enum.filter(&Stop.is_station?/1)
   end
 
   def all_stops(%__MODULE__{stops: stops}) do

--- a/lib/schedule/fetcher.ex
+++ b/lib/schedule/fetcher.ex
@@ -225,7 +225,8 @@ defmodule Schedule.Fetcher do
           {:files,
            %{
              gtfs: gtfs_files,
-             hastus: hastus_files
+             hastus: hastus_files,
+             version: "#{gtfs_timestamp}_#{hastus_timestamp}"
            }, gtfs_timestamp, hastus_timestamp}
         else
           {:error, error} -> {:error, error}
@@ -275,7 +276,7 @@ defmodule Schedule.Fetcher do
 
   @spec files_from_mocked(Schedule.mocked_files()) :: Data.all_files()
   defp files_from_mocked(mocked_files) do
-    for key <- [:gtfs, :hastus], into: %{} do
+    for key <- [:gtfs, :hastus], into: %{version: "mocked_version"} do
       {key,
        case mocked_files[key] do
          nil ->

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -23,7 +23,7 @@ defmodule SkateWeb.StopController do
     etag = String.replace(version_fn.(), ",", "-")
 
     if etag === none_match do
-      send_resp(conn, 304, "")
+      send_resp(conn, :not_modified, "")
     else
       stops_fn = Application.get_env(:skate_web, :stops_fn, &Schedule.all_stops/0)
       stops = stops_fn.()

--- a/lib/skate_web/controllers/stop_controller.ex
+++ b/lib/skate_web/controllers/stop_controller.ex
@@ -11,4 +11,27 @@ defmodule SkateWeb.StopController do
 
     json(conn, %{data: stations})
   end
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @doc """
+  Get all stops
+  """
+  def index(conn, _params) do
+    none_match = List.first(Plug.Conn.get_req_header(conn, "if-none-match"))
+    version_fn = Application.get_env(:skate_web, :version_fn, &Schedule.version/0)
+
+    etag = String.replace(version_fn.(), ",", "-")
+
+    if etag === none_match do
+      send_resp(conn, 304, "")
+    else
+      stops_fn = Application.get_env(:skate_web, :stops_fn, &Schedule.all_stops/0)
+      stops = stops_fn.()
+
+      conn
+      |> put_resp_header("cache-control", "stale-while-revalidate")
+      |> put_resp_header("etag", etag)
+      |> json(%{data: stops})
+    end
+  end
 end

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -119,6 +119,7 @@ defmodule SkateWeb.Router do
     get "/shapes/route/:route_id", ShapeController, :route
     get "/shapes/trip/:trip_id", ShapeController, :trip
     get "/stops/stations", StopController, :stations
+    get "/stops", StopController, :index
     get "/shuttles", ShuttleController, :index
     get "/schedule/run", ScheduleController, :run
     get "/schedule/block", ScheduleController, :block

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -902,12 +902,17 @@ defmodule Schedule.DataTest do
   describe "parse_files/1" do
     test "includes certain hardcoded garage IDs as checkpoints" do
       hardcoded_garage_ids =
-        Data.parse_files(%{gtfs: %{}, hastus: %{}})
+        Data.parse_files(%{gtfs: %{}, hastus: %{}, version: "test_version"})
         |> Map.get(:timepoint_names_by_id)
         |> Map.keys()
         |> Enum.sort()
 
       assert hardcoded_garage_ids == ~w[albny arbor cabot charl fell lynn ncamb prwb soham somvl]
+    end
+
+    test "includes version" do
+      assert %{version: "test_version"} =
+               Data.parse_files(%{gtfs: %{}, hastus: %{}, version: "test_version"})
     end
   end
 

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -648,6 +648,24 @@ defmodule Schedule.DataTest do
     end
   end
 
+  describe "all_stops/0" do
+    test "returns both stops and stations" do
+      [station_1, station_2, stop_1] = [
+        build(:gtfs_stop, %{id: "station-1", location_type: :station}),
+        build(:gtfs_stop, %{id: "station-2", location_type: :station}),
+        build(:gtfs_stop, %{id: "stop-1", location_type: :stop})
+      ]
+
+      stops = %{
+        station_1.id => station_1,
+        station_2.id => station_2,
+        stop_1.id => stop_1
+      }
+
+      assert [station_1, station_2, stop_1] == Data.all_stops(%Data{stops: stops})
+    end
+  end
+
   describe "first_route_pattern_for_route_and_direction/3" do
     setup do
       route_patterns = [

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -376,6 +376,33 @@ defmodule ScheduleTest do
     end
   end
 
+  describe "stops/0" do
+    test "returns stops and stations" do
+      pid =
+        Schedule.start_mocked(%{
+          gtfs: %{
+            "stops.txt" => [
+              "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type",
+              "stop-1,No Location Type,1.0,1.5,,",
+              "stop-2,Stop,2.0,2.5,,0",
+              "stop-3,Platform,2.0,2.5,stop-4,0",
+              "stop-4,Station,2.0,2.5,,1",
+              "stop-5,Enterance,2.0,2.5,,2",
+              "stop-6,Generic Node,2.0,2.5,,3",
+              "stop-7,Boarding Area,2.0,2.5,,4"
+            ]
+          }
+        })
+
+      assert [
+               %Stop{id: "stop-1", location_type: :stop},
+               %Stop{id: "stop-2", location_type: :stop},
+               %Stop{id: "stop-3", location_type: :stop},
+               %Stop{id: "stop-4", location_type: :station}
+             ] = Schedule.all_stops(pid)
+    end
+  end
+
   describe "trip" do
     test "returns the trip, including stop_times" do
       pid =

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -57,4 +57,118 @@ defmodule SkateWeb.StopControllerTest do
              } == json_response(conn, 200)
     end
   end
+
+  describe "GET /api/stops" do
+    setup do
+      reassign_env(:skate_web, :stops_fn, fn ->
+        [
+          build(:gtfs_stop, %{location_type: :station, routes: [build(:gtfs_route)]}),
+          build(:gtfs_stop, %{
+            id: "stop2",
+            name: "Stop 2",
+            location_type: :stop
+          })
+        ]
+      end)
+
+      reassign_env(:skate_web, :version_fn, fn -> "latest_version" end)
+    end
+
+    test "when logged out, redirects you to cognito auth", %{conn: conn} do
+      conn = get(conn, SkateWeb.Router.Helpers.stop_path(conn, :index))
+
+      assert redirected_to(conn) == "/auth/cognito"
+    end
+
+    @tag :authenticated
+    test "when logged in, returns all stops", %{conn: conn} do
+      conn = get(conn, SkateWeb.Router.Helpers.stop_path(conn, :index))
+
+      assert %{
+               "data" => [
+                 %{
+                   "id" => "stop1",
+                   "lat" => 42.01,
+                   "location_type" => "station",
+                   "lon" => -71.01,
+                   "name" => "Stop 1",
+                   "routes" => [
+                     %{
+                       "description" => "Key Bus",
+                       "direction_names" => %{
+                         "0" => "Outbound",
+                         "1" => "Inbound"
+                       },
+                       "garages" => [],
+                       "id" => "route",
+                       "name" => "Point A - Point B",
+                       "type" => 3
+                     }
+                   ]
+                 },
+                 %{
+                   "id" => "stop2",
+                   "lat" => 42.01,
+                   "location_type" => "stop",
+                   "lon" => -71.01,
+                   "name" => "Stop 2",
+                   "routes" => []
+                 }
+               ]
+             } == json_response(conn, 200)
+    end
+
+    @tag :authenticated
+    test "when sent if-none-match header that matches current version, returns 304", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("if-none-match", "latest_version")
+        |> get(SkateWeb.Router.Helpers.stop_path(conn, :index))
+
+      assert "" == response(conn, 304)
+    end
+
+    @tag :authenticated
+    test "when sent if-none-match header that doesn't match current version, returns data", %{
+      conn: conn
+    } do
+      conn =
+        conn
+        |> put_req_header("if-none-match", "old_version")
+        |> get(SkateWeb.Router.Helpers.stop_path(conn, :index))
+
+      assert %{
+               "data" => [
+                 %{
+                   "id" => "stop1",
+                   "lat" => 42.01,
+                   "location_type" => "station",
+                   "lon" => -71.01,
+                   "name" => "Stop 1",
+                   "routes" => [
+                     %{
+                       "description" => "Key Bus",
+                       "direction_names" => %{
+                         "0" => "Outbound",
+                         "1" => "Inbound"
+                       },
+                       "garages" => [],
+                       "id" => "route",
+                       "name" => "Point A - Point B",
+                       "type" => 3
+                     }
+                   ]
+                 },
+                 %{
+                   "id" => "stop2",
+                   "lat" => 42.01,
+                   "location_type" => "stop",
+                   "lon" => -71.01,
+                   "name" => "Stop 2",
+                   "routes" => []
+                 }
+               ]
+             } == json_response(conn, 200)
+    end
+  end
 end

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -116,10 +116,15 @@ defmodule SkateWeb.StopControllerTest do
                  }
                ]
              } == json_response(conn, 200)
+
+      assert ["stale-while-revalidate"] == get_resp_header(conn, "cache-control")
+      assert ["latest_version"] == get_resp_header(conn, "etag")
     end
 
     @tag :authenticated
-    test "when sent if-none-match header that matches current version, returns :not_modified", %{conn: conn} do
+    test "when sent if-none-match header that matches current version, returns :not_modified", %{
+      conn: conn
+    } do
       conn =
         conn
         |> put_req_header("if-none-match", "latest_version")

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -119,13 +119,13 @@ defmodule SkateWeb.StopControllerTest do
     end
 
     @tag :authenticated
-    test "when sent if-none-match header that matches current version, returns 304", %{conn: conn} do
+    test "when sent if-none-match header that matches current version, returns :not_modified", %{conn: conn} do
       conn =
         conn
         |> put_req_header("if-none-match", "latest_version")
         |> get(SkateWeb.Router.Helpers.stop_path(conn, :index))
 
-      assert "" == response(conn, 304)
+      assert "" == response(conn, :not_modified)
     end
 
     @tag :authenticated


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204906972532767/f

As-is, the response data for all stops is 2.77kB and can take ~0.75s for the initial load. I am considering doing a performance improvement to store only `route_ids` on a `stop` rather than `routes` so that less data is returned, which would require separate backend + frontend changes. But sharing now to get initial feedback on this approach! 