### PR TITLE
feat(useAllStops): Add hook + update typing to support rendering nearby stops

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -170,6 +170,14 @@ export const fetchStations = (): Promise<Stop[]> =>
     defaultResult: [],
   })
 
+export const fetchAllStops = (): Promise<Stop[]> =>
+  checkedApiCall<StopData[], Stop[]>({
+    url: `/api/stops`,
+    parser: stopsFromData,
+    dataStruct: array(StopData),
+    defaultResult: [],
+  })
+
 export const fetchTimepointsForRoute = (
   routeId: RouteId
 ): Promise<Timepoint[]> =>

--- a/assets/src/data/stopsBlue.ts
+++ b/assets/src/data/stopsBlue.ts
@@ -8,6 +8,7 @@ const stopsBlue: Stop[] = [
     lat: 42.374262,
     lon: -71.030395,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-aqucl",
@@ -15,6 +16,7 @@ const stopsBlue: Stop[] = [
     lat: 42.359784,
     lon: -71.051652,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bmmnl",
@@ -22,6 +24,7 @@ const stopsBlue: Stop[] = [
     lat: 42.397542,
     lon: -70.992319,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bomnl",
@@ -29,6 +32,7 @@ const stopsBlue: Stop[] = [
     lat: 42.361365,
     lon: -71.062037,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-gover",
@@ -36,6 +40,7 @@ const stopsBlue: Stop[] = [
     lat: 42.359705,
     lon: -71.059215,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-mvbcl",
@@ -43,6 +48,7 @@ const stopsBlue: Stop[] = [
     lat: 42.369119,
     lon: -71.03953,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-orhte",
@@ -50,6 +56,7 @@ const stopsBlue: Stop[] = [
     lat: 42.386867,
     lon: -71.004736,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-rbmnl",
@@ -57,6 +64,7 @@ const stopsBlue: Stop[] = [
     lat: 42.407843,
     lon: -70.992533,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sdmnl",
@@ -64,6 +72,7 @@ const stopsBlue: Stop[] = [
     lat: 42.390501,
     lon: -70.997123,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-state",
@@ -71,6 +80,7 @@ const stopsBlue: Stop[] = [
     lat: 42.358978,
     lon: -71.057598,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-wimnl",
@@ -78,6 +88,7 @@ const stopsBlue: Stop[] = [
     lat: 42.37964,
     lon: -71.022865,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-wondl",
@@ -85,6 +96,7 @@ const stopsBlue: Stop[] = [
     lat: 42.41342,
     lon: -70.991648,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
 ]
 

--- a/assets/src/data/stopsGreen.ts
+++ b/assets/src/data/stopsGreen.ts
@@ -8,6 +8,7 @@ const stopsGreen: Stop[] = [
     lat: 42.348701,
     lon: -71.137955,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-armnl",
@@ -15,6 +16,7 @@ const stopsGreen: Stop[] = [
     lat: 42.351902,
     lon: -71.070893,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-babck",
@@ -22,6 +24,7 @@ const stopsGreen: Stop[] = [
     lat: 42.35182,
     lon: -71.12165,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bckhl",
@@ -29,6 +32,7 @@ const stopsGreen: Stop[] = [
     lat: 42.330139,
     lon: -71.111313,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bcnfd",
@@ -36,6 +40,7 @@ const stopsGreen: Stop[] = [
     lat: 42.335846,
     lon: -71.140823,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bcnwa",
@@ -43,6 +48,7 @@ const stopsGreen: Stop[] = [
     lat: 42.339394,
     lon: -71.13533,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bland",
@@ -50,6 +56,7 @@ const stopsGreen: Stop[] = [
     lat: 42.349293,
     lon: -71.100258,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bndhl",
@@ -57,6 +64,7 @@ const stopsGreen: Stop[] = [
     lat: 42.340023,
     lon: -71.129082,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-boyls",
@@ -64,6 +72,7 @@ const stopsGreen: Stop[] = [
     lat: 42.35302,
     lon: -71.06459,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-brico",
@@ -71,6 +80,7 @@ const stopsGreen: Stop[] = [
     lat: 42.351967,
     lon: -71.125031,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-brkhl",
@@ -78,6 +88,7 @@ const stopsGreen: Stop[] = [
     lat: 42.331333,
     lon: -71.126999,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-brmnl",
@@ -85,6 +96,7 @@ const stopsGreen: Stop[] = [
     lat: 42.334229,
     lon: -71.104609,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bucen",
@@ -92,6 +104,7 @@ const stopsGreen: Stop[] = [
     lat: 42.350082,
     lon: -71.106865,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-buest",
@@ -99,6 +112,7 @@ const stopsGreen: Stop[] = [
     lat: 42.349735,
     lon: -71.103889,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-buwst",
@@ -106,6 +120,7 @@ const stopsGreen: Stop[] = [
     lat: 42.350941,
     lon: -71.113876,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bvmnl",
@@ -113,6 +128,7 @@ const stopsGreen: Stop[] = [
     lat: 42.332774,
     lon: -71.116296,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-chhil",
@@ -120,6 +136,7 @@ const stopsGreen: Stop[] = [
     lat: 42.326653,
     lon: -71.165314,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-chill",
@@ -127,6 +144,7 @@ const stopsGreen: Stop[] = [
     lat: 42.338169,
     lon: -71.15316,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-chswk",
@@ -134,6 +152,7 @@ const stopsGreen: Stop[] = [
     lat: 42.340805,
     lon: -71.150711,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-clmnl",
@@ -141,6 +160,7 @@ const stopsGreen: Stop[] = [
     lat: 42.336142,
     lon: -71.149326,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-coecl",
@@ -148,6 +168,7 @@ const stopsGreen: Stop[] = [
     lat: 42.349974,
     lon: -71.077447,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-cool",
@@ -155,6 +176,7 @@ const stopsGreen: Stop[] = [
     lat: 42.342116,
     lon: -71.121263,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-denrd",
@@ -162,6 +184,7 @@ const stopsGreen: Stop[] = [
     lat: 42.337807,
     lon: -71.141853,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-eliot",
@@ -169,6 +192,7 @@ const stopsGreen: Stop[] = [
     lat: 42.319023,
     lon: -71.216713,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-engav",
@@ -176,6 +200,7 @@ const stopsGreen: Stop[] = [
     lat: 42.336971,
     lon: -71.14566,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-fbkst",
@@ -183,6 +208,7 @@ const stopsGreen: Stop[] = [
     lat: 42.339725,
     lon: -71.131073,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-fenwd",
@@ -190,6 +216,7 @@ const stopsGreen: Stop[] = [
     lat: 42.333706,
     lon: -71.105728,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-fenwy",
@@ -197,6 +224,7 @@ const stopsGreen: Stop[] = [
     lat: 42.345394,
     lon: -71.104187,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-gover",
@@ -204,6 +232,7 @@ const stopsGreen: Stop[] = [
     lat: 42.359705,
     lon: -71.059215,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-grigg",
@@ -211,6 +240,7 @@ const stopsGreen: Stop[] = [
     lat: 42.348545,
     lon: -71.134949,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-haecl",
@@ -218,6 +248,7 @@ const stopsGreen: Stop[] = [
     lat: 42.363021,
     lon: -71.05829,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-harvd",
@@ -225,6 +256,7 @@ const stopsGreen: Stop[] = [
     lat: 42.350243,
     lon: -71.131355,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-hsmnl",
@@ -232,6 +264,7 @@ const stopsGreen: Stop[] = [
     lat: 42.328316,
     lon: -71.110252,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-hwsst",
@@ -239,6 +272,7 @@ const stopsGreen: Stop[] = [
     lat: 42.344906,
     lon: -71.111145,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-hymnl",
@@ -246,6 +280,7 @@ const stopsGreen: Stop[] = [
     lat: 42.347888,
     lon: -71.087903,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-kencl",
@@ -253,6 +288,7 @@ const stopsGreen: Stop[] = [
     lat: 42.348949,
     lon: -71.095169,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-kntst",
@@ -260,6 +296,7 @@ const stopsGreen: Stop[] = [
     lat: 42.344074,
     lon: -71.114197,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-lake",
@@ -267,6 +304,7 @@ const stopsGreen: Stop[] = [
     lat: 42.340081,
     lon: -71.166769,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-lech",
@@ -274,6 +312,7 @@ const stopsGreen: Stop[] = [
     lat: 42.371572,
     lon: -71.076584,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-lngmd",
@@ -281,6 +320,7 @@ const stopsGreen: Stop[] = [
     lat: 42.33596,
     lon: -71.100052,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-longw",
@@ -288,6 +328,7 @@ const stopsGreen: Stop[] = [
     lat: 42.341145,
     lon: -71.110451,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-mfa",
@@ -295,6 +336,7 @@ const stopsGreen: Stop[] = [
     lat: 42.337711,
     lon: -71.095512,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-mispk",
@@ -302,6 +344,7 @@ const stopsGreen: Stop[] = [
     lat: 42.333195,
     lon: -71.109756,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-newtn",
@@ -309,6 +352,7 @@ const stopsGreen: Stop[] = [
     lat: 42.321735,
     lon: -71.206116,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-newto",
@@ -316,6 +360,7 @@ const stopsGreen: Stop[] = [
     lat: 42.329391,
     lon: -71.192429,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-north",
@@ -323,6 +368,7 @@ const stopsGreen: Stop[] = [
     lat: 42.365577,
     lon: -71.06129,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-nuniv",
@@ -330,6 +376,7 @@ const stopsGreen: Stop[] = [
     lat: 42.340401,
     lon: -71.088806,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-pktrm",
@@ -337,6 +384,7 @@ const stopsGreen: Stop[] = [
     lat: 42.356395,
     lon: -71.062424,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-plsgr",
@@ -344,6 +392,7 @@ const stopsGreen: Stop[] = [
     lat: 42.351521,
     lon: -71.118889,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-prmnl",
@@ -351,6 +400,7 @@ const stopsGreen: Stop[] = [
     lat: 42.34557,
     lon: -71.081696,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-river",
@@ -358,6 +408,7 @@ const stopsGreen: Stop[] = [
     lat: 42.337059,
     lon: -71.251742,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-rsmnl",
@@ -365,6 +416,7 @@ const stopsGreen: Stop[] = [
     lat: 42.335027,
     lon: -71.148952,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-rvrwy",
@@ -372,6 +424,7 @@ const stopsGreen: Stop[] = [
     lat: 42.331684,
     lon: -71.111931,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-smary",
@@ -379,6 +432,7 @@ const stopsGreen: Stop[] = [
     lat: 42.345974,
     lon: -71.107353,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sougr",
@@ -386,6 +440,7 @@ const stopsGreen: Stop[] = [
     lat: 42.3396,
     lon: -71.157661,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-spmnl",
@@ -393,6 +448,7 @@ const stopsGreen: Stop[] = [
     lat: 42.366664,
     lon: -71.067666,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sthld",
@@ -400,6 +456,7 @@ const stopsGreen: Stop[] = [
     lat: 42.341614,
     lon: -71.146202,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-stplb",
@@ -407,6 +464,7 @@ const stopsGreen: Stop[] = [
     lat: 42.3512,
     lon: -71.116104,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-stpul",
@@ -414,6 +472,7 @@ const stopsGreen: Stop[] = [
     lat: 42.343327,
     lon: -71.116997,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sumav",
@@ -421,6 +480,7 @@ const stopsGreen: Stop[] = [
     lat: 42.34111,
     lon: -71.12561,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-symcl",
@@ -428,6 +488,7 @@ const stopsGreen: Stop[] = [
     lat: 42.342687,
     lon: -71.085056,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-tapst",
@@ -435,6 +496,7 @@ const stopsGreen: Stop[] = [
     lat: 42.338459,
     lon: -71.138702,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-unsqu",
@@ -442,6 +504,7 @@ const stopsGreen: Stop[] = [
     lat: 42.377359,
     lon: -71.094761,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-waban",
@@ -449,6 +512,7 @@ const stopsGreen: Stop[] = [
     lat: 42.325943,
     lon: -71.230728,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-wascm",
@@ -456,6 +520,7 @@ const stopsGreen: Stop[] = [
     lat: 42.343864,
     lon: -71.142853,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-woodl",
@@ -463,6 +528,7 @@ const stopsGreen: Stop[] = [
     lat: 42.333374,
     lon: -71.244301,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-wrnst",
@@ -470,6 +536,7 @@ const stopsGreen: Stop[] = [
     lat: 42.348343,
     lon: -71.140457,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
 ]
 

--- a/assets/src/data/stopsMattapan.ts
+++ b/assets/src/data/stopsMattapan.ts
@@ -8,6 +8,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.284652,
     lon: -71.064489,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-butlr",
@@ -15,6 +16,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.272343,
     lon: -71.062584,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-capst",
@@ -22,6 +24,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.267712,
     lon: -71.087753,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-cedgr",
@@ -29,6 +32,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.279682,
     lon: -71.060432,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-cenav",
@@ -36,6 +40,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.270027,
     lon: -71.073334,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-matt",
@@ -43,6 +48,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.267762,
     lon: -71.092241,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-miltt",
@@ -50,6 +56,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.270306,
     lon: -71.067673,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-valrd",
@@ -57,6 +64,7 @@ const stopsMattapan: Stop[] = [
     lat: 42.268322,
     lon: -71.081566,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
 ]
 

--- a/assets/src/data/stopsOrange.ts
+++ b/assets/src/data/stopsOrange.ts
@@ -8,6 +8,7 @@ const stopsRed: Stop[] = [
     lat: 42.392811,
     lon: -71.077257,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-bbsta",
@@ -15,6 +16,7 @@ const stopsRed: Stop[] = [
     lat: 42.34735,
     lon: -71.075727,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-ccmnl",
@@ -22,6 +24,7 @@ const stopsRed: Stop[] = [
     lat: 42.373622,
     lon: -71.069533,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-chncl",
@@ -29,6 +32,7 @@ const stopsRed: Stop[] = [
     lat: 42.352547,
     lon: -71.062752,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-dwnxg",
@@ -36,6 +40,7 @@ const stopsRed: Stop[] = [
     lat: 42.355518,
     lon: -71.060225,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-forhl",
@@ -43,6 +48,7 @@ const stopsRed: Stop[] = [
     lat: 42.300523,
     lon: -71.113686,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-grnst",
@@ -50,6 +56,7 @@ const stopsRed: Stop[] = [
     lat: 42.310525,
     lon: -71.107414,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-haecl",
@@ -57,6 +64,7 @@ const stopsRed: Stop[] = [
     lat: 42.363021,
     lon: -71.05829,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-jaksn",
@@ -64,6 +72,7 @@ const stopsRed: Stop[] = [
     lat: 42.323132,
     lon: -71.099592,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-masta",
@@ -71,6 +80,7 @@ const stopsRed: Stop[] = [
     lat: 42.341512,
     lon: -71.083423,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-mlmnl",
@@ -78,6 +88,7 @@ const stopsRed: Stop[] = [
     lat: 42.426632,
     lon: -71.07411,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-north",
@@ -85,6 +96,7 @@ const stopsRed: Stop[] = [
     lat: 42.365577,
     lon: -71.06129,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-ogmnl",
@@ -92,6 +104,7 @@ const stopsRed: Stop[] = [
     lat: 42.43668,
     lon: -71.071097,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-rcmnl",
@@ -99,6 +112,7 @@ const stopsRed: Stop[] = [
     lat: 42.331397,
     lon: -71.095451,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-rugg",
@@ -106,6 +120,7 @@ const stopsRed: Stop[] = [
     lat: 42.336377,
     lon: -71.088961,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sbmnl",
@@ -113,6 +128,7 @@ const stopsRed: Stop[] = [
     lat: 42.317062,
     lon: -71.104248,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-state",
@@ -120,6 +136,7 @@ const stopsRed: Stop[] = [
     lat: 42.358978,
     lon: -71.057598,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sull",
@@ -127,6 +144,7 @@ const stopsRed: Stop[] = [
     lat: 42.383975,
     lon: -71.076994,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-tumnl",
@@ -134,6 +152,7 @@ const stopsRed: Stop[] = [
     lat: 42.349662,
     lon: -71.063917,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-welln",
@@ -141,6 +160,7 @@ const stopsRed: Stop[] = [
     lat: 42.40237,
     lon: -71.077082,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
 ]
 

--- a/assets/src/data/stopsRed.ts
+++ b/assets/src/data/stopsRed.ts
@@ -8,6 +8,7 @@ const stopsRed: Stop[] = [
     lat: 42.395428,
     lon: -71.142483,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-andrw",
@@ -15,6 +16,7 @@ const stopsRed: Stop[] = [
     lat: 42.330154,
     lon: -71.057655,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-asmnl",
@@ -22,6 +24,7 @@ const stopsRed: Stop[] = [
     lat: 42.284652,
     lon: -71.064489,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-brdwy",
@@ -29,6 +32,7 @@ const stopsRed: Stop[] = [
     lat: 42.342622,
     lon: -71.056967,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-brntn",
@@ -36,6 +40,7 @@ const stopsRed: Stop[] = [
     lat: 42.207854,
     lon: -71.001138,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-chmnl",
@@ -43,6 +48,7 @@ const stopsRed: Stop[] = [
     lat: 42.361166,
     lon: -71.070628,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-cntsq",
@@ -50,6 +56,7 @@ const stopsRed: Stop[] = [
     lat: 42.365486,
     lon: -71.103802,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-davis",
@@ -57,6 +64,7 @@ const stopsRed: Stop[] = [
     lat: 42.39674,
     lon: -71.121815,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-dwnxg",
@@ -64,6 +72,7 @@ const stopsRed: Stop[] = [
     lat: 42.355518,
     lon: -71.060225,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-fldcr",
@@ -71,6 +80,7 @@ const stopsRed: Stop[] = [
     lat: 42.300093,
     lon: -71.061667,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-harsq",
@@ -78,6 +88,7 @@ const stopsRed: Stop[] = [
     lat: 42.373362,
     lon: -71.118956,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-jfk",
@@ -85,6 +96,7 @@ const stopsRed: Stop[] = [
     lat: 42.320685,
     lon: -71.052391,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-knncl",
@@ -92,6 +104,7 @@ const stopsRed: Stop[] = [
     lat: 42.362491,
     lon: -71.086177,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-nqncy",
@@ -99,6 +112,7 @@ const stopsRed: Stop[] = [
     lat: 42.275275,
     lon: -71.029583,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-pktrm",
@@ -106,6 +120,7 @@ const stopsRed: Stop[] = [
     lat: 42.356395,
     lon: -71.062424,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-portr",
@@ -113,6 +128,7 @@ const stopsRed: Stop[] = [
     lat: 42.3884,
     lon: -71.119149,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-qamnl",
@@ -120,6 +136,7 @@ const stopsRed: Stop[] = [
     lat: 42.233391,
     lon: -71.007153,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-qnctr",
@@ -127,6 +144,7 @@ const stopsRed: Stop[] = [
     lat: 42.251809,
     lon: -71.005409,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-shmnl",
@@ -134,6 +152,7 @@ const stopsRed: Stop[] = [
     lat: 42.31129,
     lon: -71.053331,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-smmnl",
@@ -141,6 +160,7 @@ const stopsRed: Stop[] = [
     lat: 42.293126,
     lon: -71.065738,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-sstat",
@@ -148,6 +168,7 @@ const stopsRed: Stop[] = [
     lat: 42.352271,
     lon: -71.055242,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
   {
     id: "place-wlsta",
@@ -155,6 +176,7 @@ const stopsRed: Stop[] = [
     lat: 42.266514,
     lon: -71.020337,
     locationType: LocationType.Station,
+    vehicleType: null,
   },
 ]
 

--- a/assets/src/hooks/useAllStops.ts
+++ b/assets/src/hooks/useAllStops.ts
@@ -2,8 +2,11 @@ import { useEffect, useState } from "react"
 import { Stop } from "../schedule"
 import { fetchAllStops } from "../api"
 
+/**
+ * A hook to fetch all stops (stations + stops)
+ * @returns a list of {@link Stop}, or null if loading.
+ */
 export const useAllStops = (): Stop[] | null => {
-  // null means loading
   const [stops, setStops] = useState<Stop[] | null>(null)
 
   useEffect(() => {

--- a/assets/src/hooks/useAllStops.ts
+++ b/assets/src/hooks/useAllStops.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react"
+import { Stop } from "../schedule"
+import { fetchAllStops } from "../api"
+
+export const useAllStops = (): Stop[] | null => {
+  // null means loading
+  const [stops, setStops] = useState<Stop[] | null>(null)
+
+  useEffect(() => {
+    fetchAllStops().then(setStops)
+  }, [])
+
+  return stops
+}

--- a/assets/src/models/shapeData.ts
+++ b/assets/src/models/shapeData.ts
@@ -1,5 +1,6 @@
 import { array, Infer, number, optional, string, type } from "superstruct"
 import { Shape } from "../schedule"
+import { StopData, stopsFromData } from "./stopData"
 
 export const ShapeData = type({
   id: string(),
@@ -11,25 +12,7 @@ export const ShapeData = type({
       lon: number(),
     })
   ),
-  stops: optional(
-    array(
-      type({
-        id: string(),
-        name: string(),
-        lat: number(),
-        lon: number(),
-        routes: optional(
-          array(
-            type({
-              type: number(),
-              id: string(),
-              name: string(),
-            })
-          )
-        ),
-      })
-    )
-  ),
+  stops: optional(array(StopData)),
 })
 export type ShapeData = Infer<typeof ShapeData>
 
@@ -38,7 +21,7 @@ export const shapeFromData = (shapeData: ShapeData): Shape => ({
   points: shapeData.points.map((pointData) => {
     return { lat: pointData.lat, lon: pointData.lon }
   }),
-  stops: shapeData.stops,
+  stops: shapeData.stops ? stopsFromData(shapeData.stops) : undefined,
 })
 
 export const shapesFromData = (shapesData: ShapeData[]): Shape[] =>

--- a/assets/src/models/stopData.ts
+++ b/assets/src/models/stopData.ts
@@ -6,6 +6,7 @@ import {
   enums,
   optional,
   array,
+  nullable,
 } from "superstruct"
 import { Stop } from "../schedule"
 
@@ -14,12 +15,27 @@ export enum LocationType {
   Station = "station",
 }
 
+// https://developers.google.com/transit/gtfs/reference#routestxt
+export enum RouteType {
+  LightRail = 0,
+  Subway = 1,
+  Rail = 2,
+  Bus = 3,
+  Ferry = 4,
+  CableTram = 5,
+  AerialLift = 6,
+  Funicular = 7,
+  TrolleyBus = 11,
+  Monorail = 12,
+}
+
 export const StopData = type({
   id: string(),
   name: string(),
   lat: number(),
   lon: number(),
   location_type: enums(["station", "stop"]),
+  vehicle_type: optional(nullable(enums([0, 1, 2, 3, 4, 5, 6, 7, 11, 12]))),
   routes: optional(
     array(
       type({
@@ -42,5 +58,6 @@ export const stopsFromData = (stopsData: StopData[]): Stop[] =>
       stopData.location_type === "station"
         ? LocationType.Station
         : LocationType.Stop,
+    vehicleType: stopData.vehicle_type || null,
     routes: stopData.routes,
   }))

--- a/assets/src/models/stopData.ts
+++ b/assets/src/models/stopData.ts
@@ -1,9 +1,17 @@
-import { Infer, number, type, string, enums } from "superstruct"
+import {
+  Infer,
+  number,
+  type,
+  string,
+  enums,
+  optional,
+  array,
+} from "superstruct"
 import { Stop } from "../schedule"
 
 export enum LocationType {
-  Stop,
-  Station,
+  Stop = "stop",
+  Station = "station",
 }
 
 export const StopData = type({
@@ -12,6 +20,15 @@ export const StopData = type({
   lat: number(),
   lon: number(),
   location_type: enums(["station", "stop"]),
+  routes: optional(
+    array(
+      type({
+        type: number(),
+        id: string(),
+        name: string(),
+      })
+    )
+  ),
 })
 export type StopData = Infer<typeof StopData>
 
@@ -25,4 +42,5 @@ export const stopsFromData = (stopsData: StopData[]): Stop[] =>
       stopData.location_type === "station"
         ? LocationType.Station
         : LocationType.Stop,
+    routes: stopData.routes,
   }))

--- a/assets/src/schedule.d.ts
+++ b/assets/src/schedule.d.ts
@@ -98,4 +98,3 @@ export type TimepointsByRouteId = ByRouteId<LoadableTimepoints>
 export type TripId = string
 
 export type ViaVariant = string
-export { RouteType }

--- a/assets/src/schedule.d.ts
+++ b/assets/src/schedule.d.ts
@@ -1,4 +1,4 @@
-import { LocationType } from "./models/stopData"
+import { LocationType, RouteType } from "./models/stopData"
 import { RunId } from "./realtime"
 
 export type BlockId = string
@@ -15,7 +15,8 @@ export interface Stop {
   lat: number
   lon: number
   routes?: { type: number; id: RouteId; name: string }[]
-  locationType?: LocationType
+  locationType: LocationType | null
+  vehicleType: RouteType | null
 }
 
 export type RouteId = string
@@ -97,3 +98,4 @@ export type TimepointsByRouteId = ByRouteId<LoadableTimepoints>
 export type TripId = string
 
 export type ViaVariant = string
+export { RouteType }

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -26,6 +26,7 @@ import {
   fetchLocationSearchResults,
   fetchLocationSearchResultById,
   fetchLocationSearchSuggestions,
+  fetchAllStops,
 } from "../src/api"
 import routeFactory from "./factories/route"
 import routeTabFactory from "./factories/routeTab"
@@ -527,6 +528,54 @@ describe("fetchStations", () => {
 
     fetchStations().then((stations) => {
       expect(stations).toEqual([station1, station2])
+      done()
+    })
+  })
+
+  test("returns empty list on error", (done) => {
+    mockFetch(500, {
+      data: null,
+    })
+
+    fetchStations().then((stations) => {
+      expect(stations).toEqual([])
+      done()
+    })
+  })
+})
+
+describe("fetchAllStops", () => {
+  test("fetches a list of stops", (done) => {
+    const route1 = routeFactory.build()
+    const [station1, stop1] = [
+      stopFactory.build({ locationType: LocationType.Station }),
+      stopFactory.build({
+        locationType: LocationType.Stop,
+        routes: [{ id: route1.id, name: route1.name, type: 3 }],
+      }),
+    ]
+    mockFetch(200, {
+      data: [
+        {
+          id: station1.id,
+          name: station1.name,
+          location_type: "station",
+          lat: station1.lat,
+          lon: station1.lon,
+        },
+        {
+          id: stop1.id,
+          name: stop1.name,
+          location_type: "stop",
+          lat: stop1.lat,
+          lon: stop1.lon,
+          routes: [{ id: route1.id, name: route1.name, type: 3 }],
+        },
+      ],
+    })
+
+    fetchAllStops().then((stops) => {
+      expect(stops).toEqual([station1, stop1])
       done()
     })
   })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -33,7 +33,7 @@ import routeTabFactory from "./factories/routeTab"
 import stopFactory from "./factories/stop"
 import * as browser from "../src/models/browser"
 import { string, unknown } from "superstruct"
-import { LocationType } from "../src/models/stopData"
+import { LocationType, RouteType } from "../src/models/stopData"
 import * as Sentry from "@sentry/react"
 import locationSearchResultDataFactory from "./factories/locationSearchResultData"
 import locationSearchResultFactory from "./factories/locationSearchResult"
@@ -506,6 +506,7 @@ describe("fetchStations", () => {
   test("fetches a list stations", (done) => {
     const [station1, station2] = stopFactory.buildList(2, {
       locationType: LocationType.Station,
+      vehicleType: null,
     })
     mockFetch(200, {
       data: [
@@ -513,6 +514,7 @@ describe("fetchStations", () => {
           id: station1.id,
           name: station1.name,
           location_type: "station",
+          vehicle_type: null,
           lat: station1.lat,
           lon: station1.lon,
         },
@@ -520,6 +522,7 @@ describe("fetchStations", () => {
           id: station2.id,
           name: station2.name,
           location_type: "station",
+          vehicle_type: null,
           lat: station2.lat,
           lon: station2.lon,
         },
@@ -548,10 +551,20 @@ describe("fetchAllStops", () => {
   test("fetches a list of stops", (done) => {
     const route1 = routeFactory.build()
     const [station1, stop1] = [
-      stopFactory.build({ locationType: LocationType.Station }),
+      stopFactory.build({
+        locationType: LocationType.Station,
+        vehicleType: null,
+      }),
       stopFactory.build({
         locationType: LocationType.Stop,
-        routes: [{ id: route1.id, name: route1.name, type: 3 }],
+        vehicleType: RouteType.Bus,
+        routes: [
+          {
+            id: route1.id,
+            name: route1.name,
+            type: 3,
+          },
+        ],
       }),
     ]
     mockFetch(200, {
@@ -560,6 +573,7 @@ describe("fetchAllStops", () => {
           id: station1.id,
           name: station1.name,
           location_type: "station",
+          vehicle_type: null,
           lat: station1.lat,
           lon: station1.lon,
         },
@@ -567,6 +581,7 @@ describe("fetchAllStops", () => {
           id: stop1.id,
           name: stop1.name,
           location_type: "stop",
+          vehicle_type: 3,
           lat: stop1.lat,
           lon: stop1.lon,
           routes: [{ id: route1.id, name: route1.name, type: 3 }],

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -34,22 +34,23 @@ import { setHtmlDefaultWidthHeight } from "../testHelpers/leafletMapWidth"
 import { mockFullStoryEvent, mockTileUrls } from "../testHelpers/mockHelpers"
 import { streetViewModeSwitch } from "../testHelpers/selectors/components/mapPage/map"
 import { streetViewUrl } from "../../src/util/streetViewUrl"
+import shapeFactory from "../factories/shape"
 
-const shape = {
+const shape = shapeFactory.build({
   id: "shape",
   points: [
     { lat: 0, lon: 0 },
     { lat: 0, lon: 0 },
   ],
   stops: [
-    {
+    stopFactory.build({
       id: "stop",
       name: "stop",
       lat: 0,
       lon: 0,
-    },
+    }),
   ],
-}
+})
 
 const station = stopFactory.build({ locationType: LocationType.Station })
 

--- a/assets/tests/factories/shape_data.ts
+++ b/assets/tests/factories/shape_data.ts
@@ -1,9 +1,9 @@
 import { Factory } from "fishery"
 import { ShapeData } from "../../src/models/shapeData"
-import stopFactory from "./stop"
+import stopDataFactory from "./stopData"
 
 export default Factory.define<ShapeData>(({ sequence }) => ({
   id: `shape${sequence}`,
   points: [{ shape_id: `shape${sequence}`, sequence: 1, lat: 0, lon: 0 }],
-  stops: [stopFactory.build({ id: `stop${sequence}` })],
+  stops: [stopDataFactory.build({ id: `stop${sequence}` })],
 }))

--- a/assets/tests/factories/stop.ts
+++ b/assets/tests/factories/stop.ts
@@ -6,6 +6,7 @@ const stopFactory = Factory.define<Stop>(({ sequence }) => ({
   id: `stop${sequence}`,
   name: `Some Stop - ${sequence}`,
   locationType: LocationType.Stop,
+  vehicleType: 3,
   lat: 0,
   lon: 0,
   routes: undefined,

--- a/assets/tests/factories/stop.ts
+++ b/assets/tests/factories/stop.ts
@@ -8,6 +8,7 @@ const stopFactory = Factory.define<Stop>(({ sequence }) => ({
   locationType: LocationType.Stop,
   lat: 0,
   lon: 0,
+  routes: undefined,
 }))
 
 export default stopFactory

--- a/assets/tests/factories/stopData.ts
+++ b/assets/tests/factories/stopData.ts
@@ -1,0 +1,13 @@
+import { Factory } from "fishery"
+import { StopData } from "../../src/models/stopData"
+
+const stopDataFactory = Factory.define<StopData>(({ sequence }) => ({
+  id: `stop${sequence}`,
+  name: `Some Stop - ${sequence}`,
+  location_type: "stop",
+  lat: 0,
+  lon: 0,
+  routes: [],
+}))
+
+export default stopDataFactory

--- a/assets/tests/hooks/useAllStops.test.ts
+++ b/assets/tests/hooks/useAllStops.test.ts
@@ -1,0 +1,39 @@
+import { jest, describe, test, expect } from "@jest/globals"
+import { renderHook } from "@testing-library/react"
+import { fetchAllStops } from "../../src/api"
+import { LocationType } from "../../src/models/stopData"
+import { Stop } from "../../src/schedule"
+import { instantPromise } from "../testHelpers/mockHelpers"
+import { useAllStops } from "../../src/hooks/useAllStops"
+import stopFactory from "../factories/stop"
+
+jest.mock("../../src/api", () => ({
+  __esModule: true,
+
+  fetchAllStops: jest.fn(() => new Promise<Stop[]>(() => [])),
+}))
+
+describe("useAllStops", () => {
+  test("returns stops and stations", () => {
+    const stops = [
+      stopFactory.build({ locationType: LocationType.Stop }),
+      stopFactory.build({ locationType: LocationType.Station }),
+    ]
+    ;(fetchAllStops as jest.Mock).mockReturnValueOnce(instantPromise(stops))
+
+    const { result } = renderHook(() => {
+      return useAllStops()
+    })
+
+    expect(fetchAllStops).toHaveBeenCalledTimes(1)
+    expect(result.current).toEqual(stops)
+  })
+
+  test("returns null when data not fetched", () => {
+    const { result } = renderHook(() => {
+      return useAllStops()
+    })
+
+    expect(result.current).toEqual(null)
+  })
+})

--- a/assets/tests/models/shapeData.test.ts
+++ b/assets/tests/models/shapeData.test.ts
@@ -6,7 +6,8 @@ import {
 } from "../../src/models/shapeData"
 import shapeDataFactory from "../factories/shape_data"
 import shapeFactory from "../factories/shape"
-import stopFactory from "../factories/stop"
+import stopDataFactory from "../factories/stopData"
+import { stopsFromData } from "../../src/models/stopData"
 
 describe("shapeFromData", () => {
   test("handles data", () => {
@@ -17,7 +18,7 @@ describe("shapeFromData", () => {
 
     const expectedResult = shapeFactory.build({
       id: shapeId,
-      stops: data.stops,
+      stops: stopsFromData(data.stops!),
     })
 
     expect(shapeFromData(data)).toEqual(expectedResult)
@@ -28,7 +29,7 @@ describe("shapeFromData", () => {
     const data: ShapeData = shapeDataFactory.build({
       id: shapeId,
       stops: [
-        stopFactory.build({
+        stopDataFactory.build({
           id: "1",
           routes: [{ type: 3, id: "747", name: "CT2" }],
         }),
@@ -37,7 +38,7 @@ describe("shapeFromData", () => {
 
     const expectedResult = shapeFactory.build({
       id: shapeId,
-      stops: data.stops,
+      stops: stopsFromData(data.stops!),
     })
 
     expect(shapeFromData(data)).toEqual(expectedResult)
@@ -53,22 +54,22 @@ describe("shapesFromData", () => {
     const [shape1, shape2]: ShapeData[] = [
       shapeDataFactory.build({
         id: shapeId1,
-        stops: [stopFactory.build({ id: stopId1 })],
+        stops: [stopDataFactory.build({ id: stopId1 })],
       }),
       shapeDataFactory.build({
         id: shapeId2,
-        stops: [stopFactory.build({ id: stopId2 })],
+        stops: [stopDataFactory.build({ id: stopId2 })],
       }),
     ]
 
     const expectedResult = [
       shapeFactory.build({
         id: shapeId1,
-        stops: shape1.stops,
+        stops: stopsFromData(shape1.stops!),
       }),
       shapeFactory.build({
         id: shapeId2,
-        stops: shape2.stops,
+        stops: stopsFromData(shape2.stops!),
       }),
     ]
 

--- a/assets/tests/models/stopData.test.ts
+++ b/assets/tests/models/stopData.test.ts
@@ -4,6 +4,7 @@ import {
   StopData,
   stopsFromData,
 } from "../../src/models/stopData"
+import stopDataFactory from "../factories/stopData"
 
 describe("stopsFromData", () => {
   test("transforms list of stopData to stops", () => {
@@ -31,6 +32,7 @@ describe("stopsFromData", () => {
         locationType: LocationType.Station,
         lat: 42.1,
         lon: -71.1,
+        routes: undefined,
       },
       {
         id: "stop-2",
@@ -38,6 +40,24 @@ describe("stopsFromData", () => {
         locationType: LocationType.Stop,
         lat: 42.2,
         lon: -71.2,
+        routes: undefined,
+      },
+    ])
+  })
+
+  test("when stopData includes routes, then includes routes", () => {
+    const stop = stopDataFactory.build({
+      routes: [{ id: "route_1", name: "Route 1", type: 3 }],
+    })
+
+    expect(stopsFromData([stop])).toEqual([
+      {
+        id: stop.id,
+        name: stop.name,
+        locationType: stop.location_type,
+        lat: stop.lat,
+        lon: stop.lon,
+        routes: stop.routes,
       },
     ])
   })

--- a/assets/tests/models/stopData.test.ts
+++ b/assets/tests/models/stopData.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals"
 import {
   LocationType,
+  RouteType,
   StopData,
   stopsFromData,
 } from "../../src/models/stopData"
@@ -20,6 +21,7 @@ describe("stopsFromData", () => {
         id: "stop-2",
         name: "Stop 2",
         location_type: "stop",
+        vehicle_type: 3,
         lat: 42.2,
         lon: -71.2,
       },
@@ -30,6 +32,7 @@ describe("stopsFromData", () => {
         id: "station-1",
         name: "Station 1",
         locationType: LocationType.Station,
+        vehicleType: null,
         lat: 42.1,
         lon: -71.1,
         routes: undefined,
@@ -38,6 +41,7 @@ describe("stopsFromData", () => {
         id: "stop-2",
         name: "Stop 2",
         locationType: LocationType.Stop,
+        vehicleType: RouteType.Bus,
         lat: 42.2,
         lon: -71.2,
         routes: undefined,
@@ -55,6 +59,7 @@ describe("stopsFromData", () => {
         id: stop.id,
         name: stop.name,
         locationType: stop.location_type,
+        vehicleType: null,
         lat: stop.lat,
         lon: stop.lon,
         routes: stop.routes,

--- a/assets/tests/testHelpers/selectors/components/mapPage/map.ts
+++ b/assets/tests/testHelpers/selectors/components/mapPage/map.ts
@@ -1,2 +1,14 @@
 import { byRole } from "testing-library-selector"
 export const streetViewModeSwitch = byRole("switch", { name: /Street View/ })
+
+export const getAllStationIcons = (
+  container: HTMLElement
+): NodeListOf<Element> => {
+  return container.querySelectorAll(".c-station-icon")
+}
+
+export const getAllStopIcons = (
+  container: HTMLElement
+): NodeListOf<Element> => {
+  return container.querySelectorAll(".c-vehicle-map__stop")
+}

--- a/lib/schedule/gtfs/stop.ex
+++ b/lib/schedule/gtfs/stop.ex
@@ -12,6 +12,7 @@ defmodule Schedule.Gtfs.Stop do
           parent_station_id: id() | nil,
           latitude: float() | nil,
           longitude: float() | nil,
+          vehicle_type: integer() | nil,
           routes: [Route.t()],
           location_type: location_type()
         }
@@ -28,6 +29,7 @@ defmodule Schedule.Gtfs.Stop do
     :parent_station_id,
     :latitude,
     :longitude,
+    :vehicle_type,
     routes: [],
     location_type: :stop
   ]
@@ -68,13 +70,19 @@ defmodule Schedule.Gtfs.Stop do
   def from_csv_row(row) do
     parent_station_id = if row["parent_station"] == "", do: nil, else: row["parent_station"]
 
+    vehicle_type =
+      if row["vehicle_type"] == "" || is_nil(row["vehicle_type"]),
+        do: nil,
+        else: String.to_integer(row["vehicle_type"])
+
     %__MODULE__{
       id: row["stop_id"],
       name: row["stop_name"],
       parent_station_id: parent_station_id,
       latitude: parse_lat_lon(row["stop_lat"]),
       longitude: parse_lat_lon(row["stop_lon"]),
-      location_type: Map.fetch!(@location_type_map, row["location_type"])
+      location_type: Map.fetch!(@location_type_map, row["location_type"]),
+      vehicle_type: vehicle_type
     }
   end
 

--- a/test/schedule/gtfs/stop_test.exs
+++ b/test/schedule/gtfs/stop_test.exs
@@ -26,14 +26,14 @@ defmodule Schedule.Gtfs.StopTest do
       file =
         Enum.join(
           [
-            "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type",
-            "stop-1,No Location Type,1.0,1.5,,",
-            "stop-2,Stop,2.0,2.5,,0",
-            "stop-3,Platform,2.0,2.5,stop-4,0",
-            "stop-4,Station,2.0,2.5,,1",
-            "stop-5,Enterance,2.0,2.5,,2",
-            "stop-6,Generic Node,2.0,2.5,,3",
-            "stop-7,Boarding Area,2.0,2.5,,4"
+            "stop_id,stop_name,stop_lat,stop_lon,parent_station,location_type,vehicle_type",
+            "stop-1,No Location Type,1.0,1.5,,,3",
+            "stop-2,Stop,2.0,2.5,,0,3",
+            "stop-3,Platform,2.0,2.5,stop-4,0,3",
+            "stop-4,Station,2.0,2.5,,1,",
+            "stop-5,Enterance,2.0,2.5,,2,",
+            "stop-6,Generic Node,2.0,2.5,,3,",
+            "stop-7,Boarding Area,2.0,2.5,,4,"
           ],
           "\n"
         )
@@ -43,20 +43,23 @@ defmodule Schedule.Gtfs.StopTest do
                  id: "stop-1",
                  name: "No Location Type",
                  location_type: :stop,
-                 parent_station_id: nil
+                 parent_station_id: nil,
+                 vehicle_type: 3
                },
                %Stop{id: "stop-2", name: "Stop", location_type: :stop, parent_station_id: nil},
                %Stop{
                  id: "stop-3",
                  name: "Platform",
                  location_type: :stop,
-                 parent_station_id: "stop-4"
+                 parent_station_id: "stop-4",
+                 vehicle_type: 3
                },
                %Stop{
                  id: "stop-4",
                  name: "Station",
                  location_type: :station,
-                 parent_station_id: nil
+                 parent_station_id: nil,
+                 vehicle_type: nil
                }
              ] = Stop.parse(file)
     end

--- a/test/skate_web/controllers/shape_controller_test.exs
+++ b/test/skate_web/controllers/shape_controller_test.exs
@@ -44,6 +44,7 @@ defmodule SkateWeb.ShapeControllerTest do
       %Stop{
         id: "stop_1",
         name: "One",
+        vehicle_type: 3,
         latitude: 42.01,
         longitude: -71.01,
         routes: [
@@ -55,7 +56,14 @@ defmodule SkateWeb.ShapeControllerTest do
           }
         ]
       },
-      %Stop{id: "stop_2", name: "Two", latitude: 42.02, longitude: -71.02, routes: []}
+      %Stop{
+        id: "stop_2",
+        name: "Two",
+        vehicle_type: 3,
+        latitude: 42.02,
+        longitude: -71.02,
+        routes: []
+      }
     ]
   }
 
@@ -76,6 +84,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "lat" => 42.01,
         "lon" => -71.01,
         "location_type" => "stop",
+        "vehicle_type" => 3,
         "routes" => [
           %{
             "id" => "route_1",
@@ -93,6 +102,7 @@ defmodule SkateWeb.ShapeControllerTest do
         "lat" => 42.02,
         "lon" => -71.02,
         "location_type" => "stop",
+        "vehicle_type" => 3,
         "routes" => []
       }
     ]

--- a/test/skate_web/controllers/stop_controller_test.exs
+++ b/test/skate_web/controllers/stop_controller_test.exs
@@ -42,6 +42,7 @@ defmodule SkateWeb.StopControllerTest do
                    "id" => "stop1",
                    "lat" => 42.01,
                    "location_type" => "station",
+                   "vehicle_type" => nil,
                    "lon" => -71.01,
                    "name" => "Stop 1"
                  },
@@ -50,6 +51,7 @@ defmodule SkateWeb.StopControllerTest do
                    "id" => "stop2",
                    "lat" => 42.01,
                    "location_type" => "station",
+                   "vehicle_type" => nil,
                    "lon" => -71.01,
                    "name" => "Stop 2"
                  }
@@ -66,7 +68,8 @@ defmodule SkateWeb.StopControllerTest do
           build(:gtfs_stop, %{
             id: "stop2",
             name: "Stop 2",
-            location_type: :stop
+            location_type: :stop,
+            vehicle_type: 3
           })
         ]
       end)
@@ -90,6 +93,7 @@ defmodule SkateWeb.StopControllerTest do
                    "id" => "stop1",
                    "lat" => 42.01,
                    "location_type" => "station",
+                   "vehicle_type" => nil,
                    "lon" => -71.01,
                    "name" => "Stop 1",
                    "routes" => [
@@ -109,6 +113,7 @@ defmodule SkateWeb.StopControllerTest do
                  %{
                    "id" => "stop2",
                    "lat" => 42.01,
+                   "vehicle_type" => 3,
                    "location_type" => "stop",
                    "lon" => -71.01,
                    "name" => "Stop 2",
@@ -148,6 +153,7 @@ defmodule SkateWeb.StopControllerTest do
                    "id" => "stop1",
                    "lat" => 42.01,
                    "location_type" => "station",
+                   "vehicle_type" => nil,
                    "lon" => -71.01,
                    "name" => "Stop 1",
                    "routes" => [
@@ -168,6 +174,7 @@ defmodule SkateWeb.StopControllerTest do
                    "id" => "stop2",
                    "lat" => 42.01,
                    "location_type" => "stop",
+                   "vehicle_type" => 3,
                    "lon" => -71.01,
                    "name" => "Stop 2",
                    "routes" => []


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1204906972532767/f

Adding the nearby stop markers is done as part of https://github.com/mbta/skate/pull/2201, but these hook + typing changes were starting to feel substantial enough to separate out for an isolated review.

This also adds the `vehicle_type` field to `stop`,[ which is null for stations and populated for stops](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#stopstxt)