### PR TITLE
feat(Skate.Migrate): Support running a subset of migrations async

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 /assets/node_modules
 /priv
 !/priv/repo/migrations
+!/priv/repo/async_migrations

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -5,8 +5,6 @@ defmodule Skate.Application do
 
   use Application
 
-  alias Skate.Migrate
-
   @impl true
   def start(_type, _args) do
     load_runtime_config()
@@ -26,17 +24,11 @@ defmodule Skate.Application do
         end ++
         [
           {Phoenix.PubSub, name: Skate.PubSub},
-          SkateWeb.Endpoint
+          SkateWeb.Endpoint,
+          Skate.Migrate
         ]
 
-    case Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor) do
-      {:ok, _pid} = link ->
-        Migrate.up()
-        link
-
-      error ->
-        error
-    end
+    Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/lib/skate/migrate.ex
+++ b/lib/skate/migrate.ex
@@ -1,5 +1,53 @@
 defmodule Skate.Migrate do
-  def up() do
-    Ecto.Migrator.run(Skate.Repo, :up, all: true)
+  @moduledoc """
+  GenServer which runs on startup to run Ecto migrations. All migrations stored in the "migrations" directory are run during init. Migrations stored in the "async_migrations" directory will be run after the regular migrations complete and will only log a warning on failure.
+  """
+  use GenServer, restart: :transient
+  require Logger
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    Logger.info("#{__MODULE__} synchronous migrations starting")
+    Keyword.get(opts, :run_sync_migrations, default_migrator_fn("migrations")).()
+
+    Logger.info("#{__MODULE__} synchronous migrations finished")
+    {:ok, opts, {:continue, :async_migrations}}
+  end
+
+  @impl GenServer
+  def handle_continue(:async_migrations, opts) do
+    Logger.info("#{__MODULE__} async migrations starting")
+
+    try do
+      Keyword.get(
+        opts,
+        :run_async_migrations,
+        default_migrator_fn("async_migrations")
+      ).()
+
+      Logger.info("#{__MODULE__} async migrations finished")
+    rescue
+      e ->
+        Logger.warn("#{__MODULE__} async migrations failed. error=#{inspect(e)}")
+        :ok
+    end
+
+    {:stop, :normal, opts}
+  end
+
+  @spec default_migrator_fn(String.t()) :: function()
+  defp default_migrator_fn(migration_directory) do
+    fn ->
+      Ecto.Migrator.run(
+        Skate.Repo,
+        Ecto.Migrator.migrations_path(Skate.Repo, migration_directory),
+        :up,
+        all: true
+      )
+    end
   end
 end

--- a/lib/skate/migrate.ex
+++ b/lib/skate/migrate.ex
@@ -15,7 +15,7 @@ defmodule Skate.Migrate do
   @impl GenServer
   def init(opts) do
     Logger.info("#{__MODULE__} synchronous migrations starting")
-    Keyword.get(opts, :run_sync_migrations, default_migrator_fn("migrations")).()
+    Keyword.get(opts, :sync_migrate_fn, &default_migrate_fn/1).("migrations")
 
     Logger.info("#{__MODULE__} synchronous migrations finished")
     {:ok, opts, {:continue, :async_migrations}}
@@ -28,9 +28,9 @@ defmodule Skate.Migrate do
     try do
       Keyword.get(
         opts,
-        :run_async_migrations,
-        default_migrator_fn("async_migrations")
-      ).()
+        :async_migrate_fn,
+        &default_migrate_fn/1
+      ).("async_migrations")
 
       Logger.info("#{__MODULE__} async migrations finished")
     rescue
@@ -42,8 +42,8 @@ defmodule Skate.Migrate do
     {:stop, :normal, opts}
   end
 
-  @spec default_migrator_fn(String.t()) :: function()
-  defp default_migrator_fn(migration_directory) do
+  @spec default_migrate_fn(String.t()) :: function()
+  defp default_migrate_fn(migration_directory) do
     fn ->
       Ecto.Migrator.run(
         Skate.Repo,

--- a/lib/skate/migrate.ex
+++ b/lib/skate/migrate.ex
@@ -42,15 +42,12 @@ defmodule Skate.Migrate do
     {:stop, :normal, opts}
   end
 
-  @spec default_migrate_fn(String.t()) :: function()
   defp default_migrate_fn(migration_directory) do
-    fn ->
-      Ecto.Migrator.run(
-        Skate.Repo,
-        Ecto.Migrator.migrations_path(Skate.Repo, migration_directory),
-        :up,
-        all: true
-      )
-    end
+    Ecto.Migrator.run(
+      Skate.Repo,
+      Ecto.Migrator.migrations_path(Skate.Repo, migration_directory),
+      :up,
+      all: true
+    )
   end
 end

--- a/lib/skate/migrate.ex
+++ b/lib/skate/migrate.ex
@@ -1,6 +1,9 @@
 defmodule Skate.Migrate do
   @moduledoc """
-  GenServer which runs on startup to run Ecto migrations. All migrations stored in the "migrations" directory are run during init. Migrations stored in the "async_migrations" directory will be run after the regular migrations complete and will only log a warning on failure.
+  GenServer which runs on startup to run Ecto migrations. All migrations
+  stored in the "migrations" directory are run during init. Migrations stored
+  in the "async_migrations" directory will be run after the regular migrations
+  complete and will only log a warning on failure.
   """
   use GenServer, restart: :transient
   require Logger

--- a/mix.exs
+++ b/mix.exs
@@ -97,11 +97,14 @@ defmodule Skate.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup", "assets.setup"],
-      "ecto.setup": ["ecto.create", "ecto.migrate"],
+      "ecto.migrate_all": [
+        "ecto.migrate --quiet --migrations-path=priv/repo/migrations --migrations-path=priv/repo/async_migrations"
+      ],
+      "ecto.setup": ["ecto.create", "ecto.migrate_all"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "assets.setup": ["cmd npm --prefix=assets install"],
       "assets.reset": ["cmd npm --prefix=assets ci"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate_all", "test"]
     ]
   end
 end

--- a/priv/repo/async_migrations/20230830202227_first_async_migration.exs
+++ b/priv/repo/async_migrations/20230830202227_first_async_migration.exs
@@ -1,0 +1,9 @@
+defmodule Skate.Repo.AsyncMigrations.FirstAsyncMigration do
+  use Ecto.Migration
+  require Logger
+
+  def change do
+    Logger.info("first async migration")
+
+  end
+end

--- a/test/skate/migrate_test.exs
+++ b/test/skate/migrate_test.exs
@@ -1,0 +1,119 @@
+defmodule Skate.MigrateTest do
+  use ExUnit.Case
+  import Test.Support.Helpers
+  import ExUnit.CaptureLog
+
+  describe "start_link/1" do
+    test "when all migrations run successfully, starts & exits successfully" do
+      test_pid = self()
+
+      pid =
+        start_supervised!(
+          {Skate.Migrate,
+           run_sync_migrations: fn ->
+             send(test_pid, :sync_migrations_ran)
+             :ok
+           end,
+           run_async_migrations: fn ->
+             send(test_pid, :async_migrations_ran)
+             :ok
+           end}
+        )
+
+      assert :ok = await_stopped(pid)
+
+      assert_receive :sync_migrations_ran
+      assert_receive :async_migrations_ran
+    end
+
+    test "when sync migrations fail, raises an error and async migrations are not run" do
+      test_pid = self()
+
+      assert_raise RuntimeError, ~r/migration error/, fn ->
+        start_supervised!(
+          {Skate.Migrate,
+           run_sync_migrations: fn ->
+             raise RuntimeError, "migration error"
+           end,
+           run_async_migrations: fn ->
+             send(test_pid, :async_migrations_ran)
+             :ok
+           end}
+        )
+      end
+
+      refute_receive :async_migrations_ran
+    end
+
+    test "when sync migrations succeed but async migrations fail, still starts successfully then shuts down normally." do
+      test_pid = self()
+
+      pid =
+        start_supervised!(
+          {Skate.Migrate,
+           run_sync_migrations: fn ->
+             send(test_pid, :sync_migrations_ran)
+           end,
+           run_async_migrations: fn ->
+             raise RuntimeError, "migration error"
+           end}
+        )
+
+      assert :ok = await_stopped(pid)
+
+      assert_receive :sync_migrations_ran
+      refute_receive :async_migrations_ran
+    end
+  end
+
+  describe "handle_continue/1" do
+    test "when async migrations ran successfully, logs & returns normal stop" do
+      set_log_level(:info)
+
+      {result, log} =
+        with_log(fn ->
+          Skate.Migrate.handle_continue(:async_migrations,
+            run_async_migrations: fn -> :ok end
+          )
+        end)
+
+      assert {:stop, :normal, _opts} = result
+      assert log =~ "Elixir.Skate.Migrate async migrations starting"
+      assert log =~ "Elixir.Skate.Migrate async migrations finished"
+    end
+
+    test "when async migrations raises an exception, logs & returns normal stop" do
+      set_log_level(:info)
+
+      {result, log} =
+        with_log(fn ->
+          Skate.Migrate.handle_continue(:async_migrations,
+            run_async_migrations: fn -> raise RuntimeError, "migration error" end
+          )
+        end)
+
+      assert {:stop, :normal, _opts} = result
+
+      assert log =~ "Elixir.Skate.Migrate async migrations starting"
+
+      assert log =~
+               "Elixir.Skate.Migrate async migrations failed. error=%RuntimeError{message: \"migration error\"}"
+    end
+  end
+
+  defp await_stopped(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, good_exit} when good_exit in [:normal, :noproc] ->
+        refute Process.alive?(pid)
+        :ok
+
+      {:DOWN, ^ref, :process, ^pid, exit} ->
+        {:error, exit}
+    after
+      5_000 ->
+        {:error, :timeout}
+    end
+  end
+end

--- a/test/skate/migrate_test.exs
+++ b/test/skate/migrate_test.exs
@@ -10,11 +10,11 @@ defmodule Skate.MigrateTest do
       pid =
         start_supervised!(
           {Skate.Migrate,
-           run_sync_migrations: fn ->
+           sync_migrate_fn: fn _dir ->
              send(test_pid, :sync_migrations_ran)
              :ok
            end,
-           run_async_migrations: fn ->
+           async_migrate_fn: fn _dir ->
              send(test_pid, :async_migrations_ran)
              :ok
            end}
@@ -32,10 +32,10 @@ defmodule Skate.MigrateTest do
       assert_raise RuntimeError, ~r/migration error/, fn ->
         start_supervised!(
           {Skate.Migrate,
-           run_sync_migrations: fn ->
+           sync_migrate_fn: fn _dir ->
              raise RuntimeError, "migration error"
            end,
-           run_async_migrations: fn ->
+           async_migrate_fn: fn _dir ->
              send(test_pid, :async_migrations_ran)
              :ok
            end}
@@ -51,10 +51,10 @@ defmodule Skate.MigrateTest do
       pid =
         start_supervised!(
           {Skate.Migrate,
-           run_sync_migrations: fn ->
+           sync_migrate_fn: fn _dir ->
              send(test_pid, :sync_migrations_ran)
            end,
-           run_async_migrations: fn ->
+           async_migrate_fn: fn _dir ->
              raise RuntimeError, "migration error"
            end}
         )
@@ -73,7 +73,7 @@ defmodule Skate.MigrateTest do
       {result, log} =
         with_log(fn ->
           Skate.Migrate.handle_continue(:async_migrations,
-            run_async_migrations: fn -> :ok end
+            async_migrate_fn: fn _dir -> :ok end
           )
         end)
 
@@ -88,7 +88,7 @@ defmodule Skate.MigrateTest do
       {result, log} =
         with_log(fn ->
           Skate.Migrate.handle_continue(:async_migrations,
-            run_async_migrations: fn -> raise RuntimeError, "migration error" end
+            async_migrate_fn: fn _dir -> raise RuntimeError, "migration error" end
           )
         end)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
 Application.ensure_all_started(:stream_data)
-Skate.Migrate.up()
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
ticket: https://app.asana.com/0/1200180014510248/1205378257072522/f

References: 
* [Approach for splitting migrations into two directories](https://dashbit.co/blog/automatic-and-manual-ecto-migrations)
* [Approach for running migrations async on application startup (Arrow)
](https://github.com/mbta/arrow/blob/master/lib/arrow/repo/migrator.ex)


Note: Originally I was considering exposing admin UI to run migrations, but in looking at the approach taken in the Arrow repo, I liked the ability to still trigger the migration automatically on deploy but in a way that doesn't block application start. This still seemed fitting with the spirit of the original [infra thread](https://mbta.slack.com/archives/G01E809HUF2/p1682622136324209) that explored alternative approaches to running all queries in a way that blocks application start, and with the suggestion in that thread to consider GenServer migrations. 
