### PR TITLE
Layer to show pull-backs on search map

### DIFF
--- a/assets/css/map/controls/_layers_control.scss
+++ b/assets/css/map/controls/_layers_control.scss
@@ -34,7 +34,7 @@
   text-align: center;
   color: $white;
   font-size: 11px;
-  line-height: 11px;
+  line-height: 1;
   font-weight: var(--font-weight-semi);
   user-select: none;
 }

--- a/assets/css/map/controls/_layers_control.scss
+++ b/assets/css/map/controls/_layers_control.scss
@@ -71,9 +71,3 @@
     }
   }
 }
-
-// .c-layers-control__tile_layer_control {
-//     display: flex;
-//     flex-direction: column;
-//     gap: 0.5rem;
-// }

--- a/assets/css/map/controls/_layers_control.scss
+++ b/assets/css/map/controls/_layers_control.scss
@@ -21,19 +21,41 @@
   }
 }
 
-.c-layers-control__layers_list {
+.c-layers-control__content {
   position: fixed;
   right: 55px;
   border-radius: 8px;
-  .list-group {
-    margin: 0rem;
-    .list-group-item {
-      display: flex;
-      gap: 0.5rem;
-    }
-  }
+
+  background-color: $white;
+
   font-family: $font-family;
   font-size: var(--font-size-m);
 
-  background-color: $white;
+  .list-group {
+    margin: 0;
+
+    .list-group-item {
+      padding-top: 0;
+      padding-bottom: 0;
+
+      div {
+        * {
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+        }
+
+        h2 {
+          margin: 0;
+          font-size: var(--font-size-m);
+          font-weight: var(--font-weight-bold);
+        }
+      }
+    }
+  }
 }
+
+// .c-layers-control__tile_layer_control {
+//     display: flex;
+//     flex-direction: column;
+//     gap: 0.5rem;
+// }

--- a/assets/css/map/controls/_layers_control.scss
+++ b/assets/css/map/controls/_layers_control.scss
@@ -21,6 +21,24 @@
   }
 }
 
+.c-layers-control__pill {
+  position: absolute;
+  top: -6px;
+  left: -6px;
+  width: 22px;
+  height: 13px;
+  border-radius: 16px;
+
+  background-color: $color-strawberry-500;
+
+  text-align: center;
+  color: $white;
+  font-size: 11px;
+  line-height: 11px;
+  font-weight: var(--font-weight-semi);
+  user-select: none;
+}
+
 .c-layers-control__content {
   position: fixed;
   right: 55px;

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -46,41 +46,51 @@ export const LayersControl = ({
         <MapLayersIcon />
       </button>
       {showLayersList && (
-        <div className="c-layers-control__layers_list">
-          <ul className="list-group">
-            <li className="list-group-item">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="tileType"
-                value=""
-                id="base"
-                checked={tileType === "base"}
-                onChange={() => setTileType("base")}
-              />
-              <label className="form-check-label" htmlFor="base">
-                Map (default)
-              </label>
-            </li>
-            <li className="list-group-item">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="tileType"
-                value=""
-                id="satellite"
-                checked={tileType === "satellite"}
-                onChange={() => setTileType("satellite")}
-              />
-              <label className="form-check-label" htmlFor="satellite">
-                Satellite
-              </label>
-            </li>
-          </ul>
-        </div>
+        <TileLayerControl tileType={tileType} setTileType={setTileType} />
       )}
     </CustomControl>
   )
 }
+
+const TileLayerControl = ({
+  tileType,
+  setTileType,
+}: {
+  tileType: TileType
+  setTileType: (tileType: TileType) => void
+}): JSX.Element => (
+  <div className="c-layers-control__layers_list">
+    <ul className="list-group">
+      <li className="list-group-item">
+        <input
+          className="form-check-input"
+          type="radio"
+          name="tileType"
+          value=""
+          id="base"
+          checked={tileType === "base"}
+          onChange={() => setTileType("base")}
+        />
+        <label className="form-check-label" htmlFor="base">
+          Map (default)
+        </label>
+      </li>
+      <li className="list-group-item">
+        <input
+          className="form-check-input"
+          type="radio"
+          name="tileType"
+          value=""
+          id="satellite"
+          checked={tileType === "satellite"}
+          onChange={() => setTileType("satellite")}
+        />
+        <label className="form-check-label" htmlFor="satellite">
+          Satellite
+        </label>
+      </li>
+    </ul>
+  </div>
+)
 
 LayersControl.WithTileContext = LayersControlWithTileContext

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -5,6 +5,7 @@ import { TileType } from "../../../tilesetUrls"
 import { MapLayersIcon } from "../../../helpers/icon"
 import { CustomControl } from "./customControl"
 import { TileTypeContext } from "../../../contexts/tileTypeContext"
+import inTestGroup, { TestGroups } from "../../../userInTestGroup"
 
 const LayersControlWithTileContext = (props: {
   setTileType: (tileType: TileType) => void
@@ -60,6 +61,7 @@ const LayersControlContent = ({
   setTileType: (tileType: TileType) => void
 }): JSX.Element => {
   const tileLayerControlLabelId = "tile-layer-control-label-" + useId()
+  const vehicleLayersControlLabelId = "vehicle-layers-control-label-" + useId()
 
   return (
     <div className="c-layers-control__content">
@@ -71,9 +73,19 @@ const LayersControlContent = ({
           <TileLayerControl
             tileType={tileType}
             setTileType={setTileType}
-            labelId={tileLayerControlLabelId}
+            sectionLabelId={tileLayerControlLabelId}
           />
         </li>
+        {inTestGroup(TestGroups.PullBackMapLayer) && (
+          <li
+            className="list-group-item"
+            aria-labelledby={vehicleLayersControlLabelId}
+          >
+            <VehicleLayersControl
+              sectionLabelId={vehicleLayersControlLabelId}
+            />
+          </li>
+        )}
       </ul>
     </div>
   )
@@ -82,41 +94,64 @@ const LayersControlContent = ({
 const TileLayerControl = ({
   tileType,
   setTileType,
-  labelId,
+  sectionLabelId,
 }: {
   tileType: TileType
   setTileType: (tileType: TileType) => void
-  labelId?: string
+  sectionLabelId?: string
+}): JSX.Element => (
+  <div className="c-layers-control__tile_layer_control">
+    <h2 id={sectionLabelId}>Base Map</h2>
+    <div className="form-check">
+      <input
+        className="form-check-input"
+        type="radio"
+        name="tileType"
+        value=""
+        id="base"
+        checked={tileType === "base"}
+        onChange={() => setTileType("base")}
+      />
+      <label className="form-check-label" htmlFor="base">
+        Map (default)
+      </label>
+    </div>
+    <div className="form-check">
+      <input
+        className="form-check-input"
+        type="radio"
+        name="tileType"
+        value=""
+        id="satellite"
+        checked={tileType === "satellite"}
+        onChange={() => setTileType("satellite")}
+      />
+      <label className="form-check-label" htmlFor="satellite">
+        Satellite
+      </label>
+    </div>
+  </div>
+)
+
+const VehicleLayersControl = ({
+  sectionLabelId,
+}: {
+  sectionLabelId?: string
 }): JSX.Element => {
+  const inputId = "pull-back-layer-switch-" + useId()
+
   return (
-    <div className="c-layers-control__tile_layer_control">
-      <h2 id={labelId}>Base Map</h2>
-      <div className="form-check">
+    <div className="c-layers-control__vehicle_layers_control">
+      <h2 id={sectionLabelId}>Vehicles</h2>
+      <div className="form-check form-switch">
         <input
           className="form-check-input"
-          type="radio"
-          name="tileType"
-          value=""
-          id="base"
-          checked={tileType === "base"}
-          onChange={() => setTileType("base")}
+          type="checkbox"
+          role="switch"
+          id={inputId}
         />
-        <label className="form-check-label" htmlFor="base">
-          Map (default)
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="tileType"
-          value=""
-          id="satellite"
-          checked={tileType === "satellite"}
-          onChange={() => setTileType("satellite")}
-        />
-        <label className="form-check-label" htmlFor="satellite">
-          Satellite
+        <label className="form-check-label" htmlFor={inputId}>
+          Show pull-backs
         </label>
       </div>
     </div>

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -52,6 +52,12 @@ export const LayersControl = ({
       >
         <MapLayersIcon />
       </button>
+
+      {/* For now there's only one vehicle layer, in the future this might need to be an actual count */}
+      {pullbackLayerEnabled ? (
+        <div className="c-layers-control__pill">1</div>
+      ) : null}
+
       {showLayersList && (
         <LayersControlContent
           tileType={tileType}

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -9,6 +9,8 @@ import inTestGroup, { TestGroups } from "../../../userInTestGroup"
 
 const LayersControlWithTileContext = (props: {
   setTileType: (tileType: TileType) => void
+  pullbackLayerEnabled?: boolean
+  togglePullbackLayerEnabled?: () => void
 }): JSX.Element | null => {
   const tileType = useContext(TileTypeContext)
   return <LayersControl tileType={tileType} {...props} />
@@ -17,9 +19,13 @@ const LayersControlWithTileContext = (props: {
 export const LayersControl = ({
   tileType,
   setTileType,
+  pullbackLayerEnabled,
+  togglePullbackLayerEnabled,
 }: {
   tileType: TileType
   setTileType: (tileType: TileType) => void
+  pullbackLayerEnabled?: boolean
+  togglePullbackLayerEnabled?: () => void
 }): JSX.Element | null => {
   const [showLayersList, setShowLayersList] = useState(false)
 
@@ -47,7 +53,12 @@ export const LayersControl = ({
         <MapLayersIcon />
       </button>
       {showLayersList && (
-        <LayersControlContent tileType={tileType} setTileType={setTileType} />
+        <LayersControlContent
+          tileType={tileType}
+          setTileType={setTileType}
+          pullbackLayerEnabled={pullbackLayerEnabled}
+          togglePullbackLayerEnabled={togglePullbackLayerEnabled}
+        />
       )}
     </CustomControl>
   )
@@ -56,9 +67,13 @@ export const LayersControl = ({
 const LayersControlContent = ({
   tileType,
   setTileType,
+  pullbackLayerEnabled,
+  togglePullbackLayerEnabled,
 }: {
   tileType: TileType
   setTileType: (tileType: TileType) => void
+  pullbackLayerEnabled?: boolean
+  togglePullbackLayerEnabled?: () => void
 }): JSX.Element => {
   const tileLayerControlLabelId = "tile-layer-control-label-" + useId()
   const vehicleLayersControlLabelId = "vehicle-layers-control-label-" + useId()
@@ -76,16 +91,20 @@ const LayersControlContent = ({
             sectionLabelId={tileLayerControlLabelId}
           />
         </li>
-        {inTestGroup(TestGroups.PullBackMapLayer) && (
-          <li
-            className="list-group-item"
-            aria-labelledby={vehicleLayersControlLabelId}
-          >
-            <VehicleLayersControl
-              sectionLabelId={vehicleLayersControlLabelId}
-            />
-          </li>
-        )}
+        {pullbackLayerEnabled !== undefined &&
+          togglePullbackLayerEnabled !== undefined &&
+          inTestGroup(TestGroups.PullBackMapLayer) && (
+            <li
+              className="list-group-item"
+              aria-labelledby={vehicleLayersControlLabelId}
+            >
+              <VehicleLayersControl
+                sectionLabelId={vehicleLayersControlLabelId}
+                pullbackLayerEnabled={pullbackLayerEnabled}
+                togglePullbackLayerEnabled={togglePullbackLayerEnabled}
+              />
+            </li>
+          )}
       </ul>
     </div>
   )
@@ -135,8 +154,12 @@ const TileLayerControl = ({
 
 const VehicleLayersControl = ({
   sectionLabelId,
+  pullbackLayerEnabled,
+  togglePullbackLayerEnabled,
 }: {
   sectionLabelId?: string
+  pullbackLayerEnabled: boolean
+  togglePullbackLayerEnabled?: () => void
 }): JSX.Element => {
   const inputId = "pull-back-layer-switch-" + useId()
 
@@ -149,6 +172,8 @@ const VehicleLayersControl = ({
           type="checkbox"
           role="switch"
           id={inputId}
+          checked={pullbackLayerEnabled}
+          onChange={togglePullbackLayerEnabled}
         />
         <label className="form-check-label" htmlFor={inputId}>
           Show pull-backs

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -180,6 +180,11 @@ const VehicleLayersControl = ({
           id={inputId}
           checked={pullbackLayerEnabled}
           onChange={togglePullbackLayerEnabled}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && togglePullbackLayerEnabled) {
+              togglePullbackLayerEnabled()
+            }
+          }}
         />
         <label className="form-check-label" htmlFor={inputId}>
           Show pull-backs

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react"
+import React, { useContext, useId, useState } from "react"
 import { useMapEvents } from "react-leaflet"
 import { joinClasses } from "../../../helpers/dom"
 import { TileType } from "../../../tilesetUrls"
@@ -46,22 +46,52 @@ export const LayersControl = ({
         <MapLayersIcon />
       </button>
       {showLayersList && (
-        <TileLayerControl tileType={tileType} setTileType={setTileType} />
+        <LayersControlContent tileType={tileType} setTileType={setTileType} />
       )}
     </CustomControl>
+  )
+}
+
+const LayersControlContent = ({
+  tileType,
+  setTileType,
+}: {
+  tileType: TileType
+  setTileType: (tileType: TileType) => void
+}): JSX.Element => {
+  const tileLayerControlLabelId = "tile-layer-control-label-" + useId()
+
+  return (
+    <div className="c-layers-control__content">
+      <ul className="list-group">
+        <li
+          className="list-group-item"
+          aria-labelledby={tileLayerControlLabelId}
+        >
+          <TileLayerControl
+            tileType={tileType}
+            setTileType={setTileType}
+            labelId={tileLayerControlLabelId}
+          />
+        </li>
+      </ul>
+    </div>
   )
 }
 
 const TileLayerControl = ({
   tileType,
   setTileType,
+  labelId,
 }: {
   tileType: TileType
   setTileType: (tileType: TileType) => void
-}): JSX.Element => (
-  <div className="c-layers-control__layers_list">
-    <ul className="list-group">
-      <li className="list-group-item">
+  labelId?: string
+}): JSX.Element => {
+  return (
+    <div className="c-layers-control__tile_layer_control">
+      <h2 id={labelId}>Base Map</h2>
+      <div className="form-check">
         <input
           className="form-check-input"
           type="radio"
@@ -74,8 +104,8 @@ const TileLayerControl = ({
         <label className="form-check-label" htmlFor="base">
           Map (default)
         </label>
-      </li>
-      <li className="list-group-item">
+      </div>
+      <div className="form-check">
         <input
           className="form-check-input"
           type="radio"
@@ -88,9 +118,9 @@ const TileLayerControl = ({
         <label className="form-check-label" htmlFor="satellite">
           Satellite
         </label>
-      </li>
-    </ul>
-  </div>
-)
+      </div>
+    </div>
+  )
+}
 
 LayersControl.WithTileContext = LayersControlWithTileContext

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -512,25 +512,37 @@ const NearbyStops = ({ stops }: { stops: Stop[] }) => {
 const PullbackVehiclesLayer = ({
   pullbackLayerEnabled,
   selectVehicle,
+  selectedEntity,
 }: {
   pullbackLayerEnabled: boolean
   selectVehicle: (vehicleOrGhost: Vehicle | Ghost) => void
+  selectedEntity: SelectedEntity | null
 }): JSX.Element => {
   const { socket } = useContext(SocketContext)
 
   const pullbackVehicles = usePullbackVehicles(socket, pullbackLayerEnabled)
 
+  const selectedVehicleId =
+    selectedEntity?.type === SelectedEntityType.Vehicle
+      ? selectedEntity.vehicleId
+      : null
+
   return (
     <>
-      {(pullbackVehicles || []).map((vehicle) => (
-        <VehicleMarker
-          key={vehicle.id}
-          vehicle={vehicle}
-          isPrimary={false}
-          isSelected={false}
-          onSelect={selectVehicle}
-        />
-      ))}
+      {(pullbackVehicles || [])
+        .filter(
+          (vehicle) =>
+            selectedVehicleId === null || vehicle.id !== selectedVehicleId
+        )
+        .map((vehicle) => (
+          <VehicleMarker
+            key={vehicle.id}
+            vehicle={vehicle}
+            isPrimary={false}
+            isSelected={false}
+            onSelect={selectVehicle}
+          />
+        ))}
     </>
   )
 }
@@ -592,6 +604,7 @@ const DataLayers = ({
       <PullbackVehiclesLayer
         pullbackLayerEnabled={pullbackLayerEnabled}
         selectVehicle={selectVehicle}
+        selectedEntity={selectedEntity}
       />
     </>
   )

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -41,7 +41,7 @@ import ZoomLevelWrapper from "../ZoomLevelWrapper"
 import StreetViewModeEnabledContext from "../../contexts/streetViewModeEnabledContext"
 import { streetViewUrl } from "../../util/streetViewUrl"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
-import { setTileType } from "../../state/mapLayersState"
+import { setTileType, togglePullbackLayer } from "../../state/mapLayersState"
 import { TileType } from "../../tilesetUrls"
 import { LayersControl } from "../map/controls/layersControl"
 import { LocationSearchResult } from "../../models/locationSearchResult"
@@ -545,10 +545,14 @@ const MapDisplay = ({
   const [stateClasses, setStateClasses] = useState<string | undefined>(
     undefined
   )
+
   const [
     {
       mapLayers: {
-        searchMap: { tileType: tileType },
+        searchMap: {
+          tileType: tileType,
+          pullbackLayerEnabled: pullbackLayerEnabled,
+        },
       },
     },
     dispatch,
@@ -579,6 +583,10 @@ const MapDisplay = ({
         <LayersControl.WithTileContext
           setTileType={(tileType: TileType) =>
             dispatch(setTileType("searchMap", tileType))
+          }
+          pullbackLayerEnabled={pullbackLayerEnabled}
+          togglePullbackLayerEnabled={() =>
+            dispatch(togglePullbackLayer("searchMap"))
           }
         />
       </MapSafeAreaContext.Provider>

--- a/assets/src/hooks/usePullbackVehicles.ts
+++ b/assets/src/hooks/usePullbackVehicles.ts
@@ -1,0 +1,25 @@
+import { Socket } from "phoenix"
+import { array } from "superstruct"
+import { VehicleData, vehicleFromData } from "../models/vehicleData"
+import { Vehicle } from "../realtime"
+import { useCheckedChannel } from "./useChannel"
+
+const parser = (data: VehicleData[]): Vehicle[] => data.map(vehicleFromData)
+
+const dataStruct = array(VehicleData)
+
+const usePullbackVehicles = (
+  socket: Socket | undefined,
+  subscribe: boolean = true
+): Vehicle[] | null => {
+  return useCheckedChannel<VehicleData[], Vehicle[] | null>({
+    socket: subscribe ? socket : undefined,
+    topic: "vehicles:pull_backs:all",
+    event: "pull_backs",
+    dataStruct,
+    parser,
+    loadingState: null,
+  })
+}
+
+export default usePullbackVehicles

--- a/assets/src/state/mapLayersState.ts
+++ b/assets/src/state/mapLayersState.ts
@@ -5,6 +5,7 @@ import { TileType } from "../tilesetUrls"
 export interface MapLayersState {
   searchMap: {
     tileType: TileType
+    pullbackLayerEnabled: boolean
   }
   shuttleMap: {
     tileType: TileType
@@ -14,11 +15,12 @@ export interface MapLayersState {
   }
 }
 
-type MapKey = keyof MapLayersState
+export type MapKey = keyof MapLayersState
 
 export const initialMapLayersState: MapLayersState = {
   searchMap: {
     tileType: "base",
+    pullbackLayerEnabled: false,
   },
   shuttleMap: {
     tileType: "base",
@@ -39,11 +41,23 @@ export const setTileType = (
   tileType: TileType
 ): SetTileTypeAction => ({
   type: "SET_TILE_TYPE",
-  key: key,
+  key,
   payload: tileType,
 })
 
-export type MapLayersAction = SetTileTypeAction
+interface TogglePullbackLayerAction {
+  type: "TOGGLE_PULLBACK_LAYER"
+  key: MapKey
+}
+
+export const togglePullbackLayer = (
+  key: MapKey
+): TogglePullbackLayerAction => ({
+  type: "TOGGLE_PULLBACK_LAYER",
+  key,
+})
+
+export type MapLayersAction = SetTileTypeAction | TogglePullbackLayerAction
 
 export type Dispatch = ReactDispatch<Action>
 
@@ -57,6 +71,16 @@ export const reducer = (
         ...state,
         [action.key]: { ...state[action.key], tileType: action.payload },
       }
+    case "TOGGLE_PULLBACK_LAYER":
+      return action.key === "searchMap"
+        ? {
+            ...state,
+            [action.key]: {
+              ...state[action.key],
+              pullbackLayerEnabled: !state[action.key].pullbackLayerEnabled,
+            },
+          }
+        : state
   }
 
   return state

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -5,6 +5,7 @@ export enum TestGroups {
   LocationSearch = "location-search",
   MapBeta = "map-beta",
   SearchLoggedOutVehicles = "search-logged-out-vehicles",
+  PullBackMapLayer = "pull-back-map-layer",
 }
 
 const inTestGroup = (key: TestGroups): boolean => {

--- a/assets/tests/components/map/controls/layersControl.test.tsx
+++ b/assets/tests/components/map/controls/layersControl.test.tsx
@@ -86,9 +86,17 @@ describe("LayersControl", () => {
   test("pull-back layer control is shown when user is in test group", async () => {
     ;(getTestGroups as jest.Mock).mockReturnValue(["pull-back-map-layer"])
 
-    render(<LayersControl tileType="base" setTileType={jest.fn()} />, {
-      wrapper: mapWrapper,
-    })
+    render(
+      <LayersControl
+        tileType="base"
+        setTileType={jest.fn()}
+        pullbackLayerEnabled={false}
+        togglePullbackLayerEnabled={jest.fn()}
+      />,
+      {
+        wrapper: mapWrapper,
+      }
+    )
     await userEvent.click(layersControlButton.get())
 
     expect(screen.getByLabelText("Show pull-backs")).toBeInTheDocument()

--- a/assets/tests/components/map/controls/layersControl.test.tsx
+++ b/assets/tests/components/map/controls/layersControl.test.tsx
@@ -101,4 +101,22 @@ describe("LayersControl", () => {
 
     expect(screen.getByLabelText("Show pull-backs")).toBeInTheDocument()
   })
+
+  test("when pull-back layer is enabled, shows pill", async () => {
+    ;(getTestGroups as jest.Mock).mockReturnValue(["pull-back-map-layer"])
+
+    render(
+      <LayersControl
+        tileType="base"
+        setTileType={jest.fn()}
+        pullbackLayerEnabled={true}
+        togglePullbackLayerEnabled={jest.fn()}
+      />,
+      {
+        wrapper: mapWrapper,
+      }
+    )
+
+    expect(screen.getByText("1")).toBeInTheDocument()
+  })
 })

--- a/assets/tests/components/map/controls/layersControl.test.tsx
+++ b/assets/tests/components/map/controls/layersControl.test.tsx
@@ -167,4 +167,22 @@ describe("LayersControl", () => {
 
     expect(screen.getByText("1")).toBeInTheDocument()
   })
+
+  test("when pull-back layer is disabled, doesn't show pill", async () => {
+    ;(getTestGroups as jest.Mock).mockReturnValue(["pull-back-map-layer"])
+
+    render(
+      <LayersControl
+        tileType="base"
+        setTileType={jest.fn()}
+        pullbackLayerEnabled={false}
+        togglePullbackLayerEnabled={jest.fn()}
+      />,
+      {
+        wrapper: mapWrapper,
+      }
+    )
+
+    expect(screen.queryByText("1")).not.toBeInTheDocument()
+  })
 })

--- a/assets/tests/components/map/controls/layersControl.test.tsx
+++ b/assets/tests/components/map/controls/layersControl.test.tsx
@@ -80,7 +80,9 @@ describe("LayersControl", () => {
     })
     await userEvent.click(layersControlButton.get())
 
-    expect(screen.queryByLabelText("Show pull-backs")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("switch", { name: "Show pull-backs" })
+    ).not.toBeInTheDocument()
   })
 
   test("pull-back layer control is shown when user is in test group", async () => {
@@ -99,7 +101,56 @@ describe("LayersControl", () => {
     )
     await userEvent.click(layersControlButton.get())
 
-    expect(screen.getByLabelText("Show pull-backs")).toBeInTheDocument()
+    expect(
+      screen.getByRole("switch", { name: "Show pull-backs" })
+    ).toBeInTheDocument()
+  })
+
+  test("clicking pull-back layer control toggles pull-back layer", async () => {
+    ;(getTestGroups as jest.Mock).mockReturnValue(["pull-back-map-layer"])
+
+    const mockToggle = jest.fn()
+
+    render(
+      <LayersControl
+        tileType="base"
+        setTileType={jest.fn()}
+        pullbackLayerEnabled={false}
+        togglePullbackLayerEnabled={mockToggle}
+      />,
+      {
+        wrapper: mapWrapper,
+      }
+    )
+    await userEvent.click(layersControlButton.get())
+    await userEvent.click(
+      screen.getByRole("switch", { name: "Show pull-backs" })
+    )
+
+    expect(mockToggle).toHaveBeenCalledTimes(1)
+  })
+
+  test("enter key toggles pull-back layer", async () => {
+    ;(getTestGroups as jest.Mock).mockReturnValue(["pull-back-map-layer"])
+
+    const mockToggle = jest.fn()
+
+    render(
+      <LayersControl
+        tileType="base"
+        setTileType={jest.fn()}
+        pullbackLayerEnabled={false}
+        togglePullbackLayerEnabled={mockToggle}
+      />,
+      {
+        wrapper: mapWrapper,
+      }
+    )
+    await userEvent.click(layersControlButton.get())
+    screen.getByRole("switch", { name: "Show pull-backs" }).focus()
+    await userEvent.keyboard("{Enter}")
+
+    expect(mockToggle).toHaveBeenCalledTimes(1)
   })
 
   test("when pull-back layer is enabled, shows pill", async () => {

--- a/assets/tests/components/map/controls/layersControl.test.tsx
+++ b/assets/tests/components/map/controls/layersControl.test.tsx
@@ -5,7 +5,10 @@ import React, { ReactNode } from "react"
 import { MapContainer } from "react-leaflet"
 import { LayersControl } from "../../../../src/components/map/controls/layersControl"
 import userEvent from "@testing-library/user-event"
-import { layersControlButton } from "../../../testHelpers/selectors/components/map"
+import {
+  layersControlButton,
+  pullbacksSwitch,
+} from "../../../testHelpers/selectors/components/map"
 import getTestGroups from "../../../../src/userTestGroups"
 
 jest.mock("userTestGroups", () => ({
@@ -80,9 +83,7 @@ describe("LayersControl", () => {
     })
     await userEvent.click(layersControlButton.get())
 
-    expect(
-      screen.queryByRole("switch", { name: "Show pull-backs" })
-    ).not.toBeInTheDocument()
+    expect(pullbacksSwitch.query()).not.toBeInTheDocument()
   })
 
   test("pull-back layer control is shown when user is in test group", async () => {
@@ -101,9 +102,7 @@ describe("LayersControl", () => {
     )
     await userEvent.click(layersControlButton.get())
 
-    expect(
-      screen.getByRole("switch", { name: "Show pull-backs" })
-    ).toBeInTheDocument()
+    expect(pullbacksSwitch.get()).toBeInTheDocument()
   })
 
   test("clicking pull-back layer control toggles pull-back layer", async () => {
@@ -123,9 +122,7 @@ describe("LayersControl", () => {
       }
     )
     await userEvent.click(layersControlButton.get())
-    await userEvent.click(
-      screen.getByRole("switch", { name: "Show pull-backs" })
-    )
+    await userEvent.click(pullbacksSwitch.get())
 
     expect(mockToggle).toHaveBeenCalledTimes(1)
   })
@@ -147,7 +144,7 @@ describe("LayersControl", () => {
       }
     )
     await userEvent.click(layersControlButton.get())
-    screen.getByRole("switch", { name: "Show pull-backs" }).focus()
+    pullbacksSwitch.get().focus()
     await userEvent.keyboard("{Enter}")
 
     expect(mockToggle).toHaveBeenCalledTimes(1)

--- a/assets/tests/components/mapPage/mapDisplay.test.tsx
+++ b/assets/tests/components/mapPage/mapDisplay.test.tsx
@@ -11,15 +11,18 @@ import usePatternsByIdForRoute from "../../../src/hooks/usePatternsByIdForRoute"
 import { useRouteShapes } from "../../../src/hooks/useShapes"
 import useVehicleForId from "../../../src/hooks/useVehicleForId"
 import useVehiclesForRoute from "../../../src/hooks/useVehiclesForRoute"
+import usePullbackVehicles from "../../../src/hooks/usePullbackVehicles"
 import { LocationType, RouteType } from "../../../src/models/stopData"
 import {
   Ghost,
+  Vehicle,
   VehicleId,
   VehicleInScheduledService,
 } from "../../../src/realtime"
 import { RouteId } from "../../../src/schedule"
 import { SelectedEntityType } from "../../../src/state/searchPageState"
 import { streetViewUrl } from "../../../src/util/streetViewUrl"
+import getTestGroups from "../../../src/userTestGroups"
 
 import ghostFactory from "../../factories/ghost"
 import routeFactory from "../../factories/route"
@@ -49,6 +52,11 @@ import {
   getAllStopIcons,
 } from "../../testHelpers/selectors/components/mapPage/map"
 
+jest.mock("userTestGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}))
+
 jest.mock("../../../src/hooks/usePatternsByIdForRoute", () => ({
   __esModule: true,
   default: jest.fn(() => null),
@@ -64,6 +72,11 @@ jest.mock("../../../src/hooks/useNearestIntersection", () => ({
 }))
 
 jest.mock("../../../src/hooks/useVehicleForId", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
+
+jest.mock("../../../src/hooks/usePullbackVehicles", () => ({
   __esModule: true,
   default: jest.fn(() => null),
 }))
@@ -111,6 +124,12 @@ function mockUseVehiclesForRouteMap(map: {
   ;(
     useVehiclesForRoute as jest.Mock<typeof useVehiclesForRoute>
   ).mockImplementation((_, routeId: RouteId | null) => map[routeId!] || null)
+}
+
+function mockUsePullbackVehicles(vehicles: Vehicle[]) {
+  ;(
+    usePullbackVehicles as jest.Mock<typeof usePullbackVehicles>
+  ).mockImplementation(() => vehicles)
 }
 
 describe("<MapDisplay />", () => {
@@ -608,6 +627,72 @@ describe("<MapDisplay />", () => {
           expect(
             container.querySelectorAll(".c-location-dot-icon")
           ).toHaveLength(1)
+        })
+      })
+    })
+
+    describe("pull-back data layer", () => {
+      test("renders vehicles", async () => {
+        ;(getTestGroups as jest.Mock<typeof getTestGroups>).mockReturnValue([
+          "pull-back-map-layer",
+        ])
+        setHtmlWidthHeightForLeafletMap()
+
+        const pullBackVehicle = vehicleFactory.build({
+          endOfTripType: "pull_back",
+        })
+
+        mockUsePullbackVehicles([pullBackVehicle])
+
+        render(
+          <MapDisplay
+            selectedEntity={null}
+            setSelection={jest.fn()}
+            fetchedSelectedLocation={null}
+          />
+        )
+
+        await userEvent.click(screen.getByRole("button", { name: "Layers" }))
+        await userEvent.click(
+          screen.getByRole("switch", { name: "Show pull-backs" })
+        )
+
+        expect(screen.getAllByRole("button", { name: "PULL-B" })).toHaveLength(
+          1
+        )
+      })
+
+      test("can click to select a vehicle", async () => {
+        const mockSetSelection = jest.fn()
+
+        ;(getTestGroups as jest.Mock<typeof getTestGroups>).mockReturnValue([
+          "pull-back-map-layer",
+        ])
+        setHtmlWidthHeightForLeafletMap()
+
+        const pullBackVehicle = vehicleFactory.build({
+          endOfTripType: "pull_back",
+        })
+
+        mockUsePullbackVehicles([pullBackVehicle])
+
+        render(
+          <MapDisplay
+            selectedEntity={null}
+            setSelection={mockSetSelection}
+            fetchedSelectedLocation={null}
+          />
+        )
+
+        await userEvent.click(screen.getByRole("button", { name: "Layers" }))
+        await userEvent.click(
+          screen.getByRole("switch", { name: "Show pull-backs" })
+        )
+        await userEvent.click(screen.getByRole("button", { name: "PULL-B" }))
+
+        expect(mockSetSelection).toHaveBeenCalledWith({
+          type: SelectedEntityType.Vehicle,
+          vehicleId: pullBackVehicle.id,
         })
       })
     })

--- a/assets/tests/components/mapPage/mapDisplay.test.tsx
+++ b/assets/tests/components/mapPage/mapDisplay.test.tsx
@@ -662,6 +662,49 @@ describe("<MapDisplay />", () => {
         )
       })
 
+      test("if a pulling back vehicle is selected, doesn't render it again in pull-backs layer", async () => {
+        ;(getTestGroups as jest.Mock<typeof getTestGroups>).mockReturnValue([
+          "pull-back-map-layer",
+        ])
+        setHtmlWidthHeightForLeafletMap()
+
+        const [pullBackVehicle1, pullBackVehicle2] = vehicleFactory.buildList(
+          2,
+          {
+            endOfTripType: "pull_back",
+          }
+        )
+
+        mockUsePullbackVehicles([pullBackVehicle1, pullBackVehicle2])
+        mockUseVehicleForId([pullBackVehicle1])
+        mockUseVehiclesForRouteMap({
+          [pullBackVehicle1.routeId]: [pullBackVehicle1],
+        })
+        mockUsePatternsByIdForVehicles([pullBackVehicle1], {
+          stopCount: 8,
+        })
+
+        render(
+          <MapDisplay
+            selectedEntity={{
+              type: SelectedEntityType.Vehicle,
+              vehicleId: pullBackVehicle1.id,
+            }}
+            setSelection={jest.fn()}
+            fetchedSelectedLocation={null}
+          />
+        )
+
+        await userEvent.click(screen.getByRole("button", { name: "Layers" }))
+        await userEvent.click(
+          screen.getByRole("switch", { name: "Show pull-backs" })
+        )
+
+        expect(screen.getAllByRole("button", { name: "PULL-B" })).toHaveLength(
+          2
+        )
+      })
+
       test("can click to select a vehicle", async () => {
         const mockSetSelection = jest.fn()
 

--- a/assets/tests/hooks/usePullbackVehicles.test.ts
+++ b/assets/tests/hooks/usePullbackVehicles.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "@jest/globals"
+import { renderHook } from "@testing-library/react"
+import usePullbackVehicles from "../../src/hooks/usePullbackVehicles"
+import { Vehicle } from "../../src/realtime.d"
+import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
+import vehicleDataFactory from "../factories/vehicle_data"
+import { vehicleFromData } from "../../src/models/vehicleData"
+
+const pullBackVehicle = vehicleDataFactory.build({
+  end_of_trip_type: "pull_back",
+})
+const pullBacksData = [pullBackVehicle]
+const pullBacks: Vehicle[] = [vehicleFromData(pullBackVehicle)]
+
+describe("usePullbacks", () => {
+  test("returns null while loading", () => {
+    const { result } = renderHook(() => usePullbackVehicles(undefined))
+    expect(result.current).toEqual(null)
+  })
+
+  test("initializing the hook subscribes to the pull-backs channel", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { rerender } = renderHook(() => usePullbackVehicles(mockSocket))
+
+    // Needs to be kicked to do the effects again after the socket initializes
+    rerender()
+
+    expect(mockSocket.channel).toHaveBeenCalledTimes(1)
+    expect(mockSocket.channel).toHaveBeenCalledWith("vehicles:pull_backs:all")
+    expect(mockChannel.join).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not subscribe to the pull-backs channel when the subscribe argument is flase", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok")
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { rerender } = renderHook(() =>
+      usePullbackVehicles(mockSocket, false)
+    )
+
+    // Needs to be kicked to do the effects again after the socket initializes
+    rerender()
+
+    expect(mockSocket.channel).not.toHaveBeenCalled()
+    expect(mockChannel.join).not.toHaveBeenCalled()
+  })
+
+  test("returns resulting vehicles", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: pullBacksData })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    const { result } = renderHook(() => usePullbackVehicles(mockSocket))
+
+    expect(result.current).toEqual(pullBacks)
+  })
+})

--- a/assets/tests/hooks/usePullbackVehicles.test.ts
+++ b/assets/tests/hooks/usePullbackVehicles.test.ts
@@ -33,7 +33,7 @@ describe("usePullbacks", () => {
     expect(mockChannel.join).toHaveBeenCalledTimes(1)
   })
 
-  test("does not subscribe to the pull-backs channel when the subscribe argument is flase", () => {
+  test("does not subscribe to the pull-backs channel when the subscribe argument is false", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok")
     mockSocket.channel.mockImplementationOnce(() => mockChannel)

--- a/assets/tests/state/mapLayerState.test.ts
+++ b/assets/tests/state/mapLayerState.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "@jest/globals"
+import {
+  initialMapLayersState,
+  MapKey,
+  reducer,
+  togglePullbackLayer,
+} from "../../src/state/mapLayersState"
+
+describe("initialMapLayersState", () => {
+  test.each<MapKey>(["searchMap", "shuttleMap", "legacySearchMap"])(
+    "sets default tile type for %s",
+    (mapKey) => {
+      expect(initialMapLayersState[mapKey].tileType).toBe("base")
+    }
+  )
+
+  test("searchMap starts with pull-back layer disabled", () => {
+    expect(initialMapLayersState.searchMap.pullbackLayerEnabled).toBeFalsy()
+  })
+})
+
+describe("reducer", () => {
+  test("togglePullbackLayer toggles from false to true", () => {
+    const result = reducer(
+      initialMapLayersState,
+      togglePullbackLayer("searchMap")
+    )
+
+    expect(result.searchMap.pullbackLayerEnabled).toBeTruthy()
+  })
+
+  test("togglePullbackLayer toggles from true to false", () => {
+    const result = reducer(
+      {
+        ...initialMapLayersState,
+        searchMap: {
+          ...initialMapLayersState.searchMap,
+          pullbackLayerEnabled: true,
+        },
+      },
+      togglePullbackLayer("searchMap")
+    )
+
+    expect(result.searchMap.pullbackLayerEnabled).toBeFalsy()
+  })
+
+  test("togglePullbackLayer for maps other than search map does nothing", () => {
+    const result = reducer(
+      initialMapLayersState,
+      togglePullbackLayer("shuttleMap")
+    )
+
+    expect(result).toEqual(initialMapLayersState)
+  })
+})

--- a/assets/tests/testHelpers/selectors/components/map.ts
+++ b/assets/tests/testHelpers/selectors/components/map.ts
@@ -5,3 +5,5 @@ export const zoomInButton = byRole("button", { name: "Zoom in" })
 export const zoomOutButton = byRole("button", { name: "Zoom out" })
 
 export const layersControlButton = byRole("button", { name: "Layers" })
+
+export const pullbacksSwitch = byRole("switch", { name: "Show pull-backs" })

--- a/lib/concentrate/consumer/vehicle_positions.ex
+++ b/lib/concentrate/consumer/vehicle_positions.ex
@@ -32,12 +32,12 @@ defmodule Concentrate.Consumer.VehiclePositions do
   def handle_events(events, _from, state) do
     groups = List.last(events)
 
+    timepoint_names_by_id = Schedule.timepoint_names_by_id()
+
     all_vehicles =
       groups
       |> vehicle_positions_from_groups()
-      |> Enum.map(&Vehicle.from_vehicle_position/1)
-
-    timepoint_names_by_id = Schedule.timepoint_names_by_id()
+      |> Enum.map(fn vp -> Vehicle.from_vehicle_position(vp, timepoint_names_by_id) end)
 
     by_route = Vehicles.group_by_route(all_vehicles, timepoint_names_by_id)
     shuttles = Enum.filter(all_vehicles, & &1.is_shuttle)

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -41,6 +41,7 @@ defmodule Realtime.Vehicle do
           is_overload: boolean(),
           is_off_course: boolean(),
           is_revenue: boolean(),
+          is_pullback: boolean(),
           layover_departure_time: Util.Time.timestamp() | nil,
           block_is_active: boolean(),
           sources: MapSet.t(String.t()),
@@ -123,7 +124,8 @@ defmodule Realtime.Vehicle do
     :end_of_trip_type,
     :crowding,
     block_waivers: [],
-    data_discrepancies: []
+    data_discrepancies: [],
+    is_pullback: false
   ]
 
   @spec from_vehicle_position(map()) :: t()
@@ -330,8 +332,8 @@ defmodule Realtime.Vehicle do
           Run.id() | nil,
           Stop.id() | nil
         ) :: end_of_trip_type()
-  def end_of_trip_type(block, trip, run_id, stop_id)
-      when block == nil or trip == nil or stop_id == nil or run_id == nil do
+  def end_of_trip_type(block, trip, run_id, _stop_id)
+      when block == nil or trip == nil or run_id == nil do
     :another_trip
   end
 

--- a/lib/realtime/vehicle.ex
+++ b/lib/realtime/vehicle.ex
@@ -1,4 +1,5 @@
 defmodule Realtime.Vehicle do
+  alias Schedule.Gtfs.Timepoint
   alias Concentrate.{DataDiscrepancy, VehiclePosition}
   alias Schedule.{Block, Route, Trip}
   alias Schedule.Gtfs.{Direction, RoutePattern, Stop}
@@ -41,9 +42,9 @@ defmodule Realtime.Vehicle do
           is_overload: boolean(),
           is_off_course: boolean(),
           is_revenue: boolean(),
-          is_pullback: boolean(),
           layover_departure_time: Util.Time.timestamp() | nil,
           block_is_active: boolean(),
+          pull_back_place_name: String.t() | nil,
           sources: MapSet.t(String.t()),
           data_discrepancies: [DataDiscrepancy.t()],
           stop_status: stop_status(),
@@ -116,6 +117,7 @@ defmodule Realtime.Vehicle do
     :is_revenue,
     :layover_departure_time,
     :block_is_active,
+    :pull_back_place_name,
     :sources,
     :stop_status,
     :timepoint_status,
@@ -124,12 +126,11 @@ defmodule Realtime.Vehicle do
     :end_of_trip_type,
     :crowding,
     block_waivers: [],
-    data_discrepancies: [],
-    is_pullback: false
+    data_discrepancies: []
   ]
 
-  @spec from_vehicle_position(map()) :: t()
-  def from_vehicle_position(vehicle_position) do
+  @spec from_vehicle_position(map(), Timepoint.timepoint_names_by_id()) :: t()
+  def from_vehicle_position(vehicle_position, timepoint_names_by_id) do
     trip_fn = Application.get_env(:realtime, :trip_fn, &Schedule.trip/1)
     block_fn = Application.get_env(:realtime, :block_fn, &Schedule.block/2)
     now_fn = Application.get_env(:realtime, :now_fn, &Util.Time.now/0)
@@ -156,6 +157,11 @@ defmodule Realtime.Vehicle do
     via_variant = trip && trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id)
     stop_times_on_trip = (trip && trip.stop_times) || []
     stop_name = stop_name(vehicle_position, stop_id)
+
+    pull_back_place_name =
+      block
+      |> Block.pull_back_place_id()
+      |> (fn id -> Timepoint.pretty_name_for_id(timepoint_names_by_id, id) end).()
 
     timepoint_status =
       TimepointStatus.timepoint_status(
@@ -214,6 +220,7 @@ defmodule Realtime.Vehicle do
       is_revenue: VehiclePosition.revenue(vehicle_position),
       layover_departure_time: VehiclePosition.layover_departure_time(vehicle_position),
       block_is_active: active_block?(is_off_course, block, now_fn.()),
+      pull_back_place_name: pull_back_place_name,
       sources: VehiclePosition.sources(vehicle_position),
       data_discrepancies: data_discrepancies,
       stop_status: %{

--- a/lib/schedule/block.ex
+++ b/lib/schedule/block.ex
@@ -145,6 +145,20 @@ defmodule Schedule.Block do
     end
   end
 
+  @spec pull_back_place_id(t() | nil) :: String.t() | nil
+  def pull_back_place_id(block) do
+    with true <- !is_nil(block),
+         last_piece <- List.last(block.pieces),
+         true <- !is_nil(last_piece),
+         piece_trips <- last_piece.trips,
+         last_piece_trip <- List.last(piece_trips),
+         true <- !is_nil(last_piece_trip) do
+      last_piece_trip.end_place
+    else
+      _ -> nil
+    end
+  end
+
   @spec overload?(id()) :: boolean
   def overload?(block_id), do: String.match?(block_id, overload_id_regex())
 

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -12,6 +12,11 @@ defmodule SkateWeb.VehiclesChannel do
     {:ok, %{data: shuttles}, socket}
   end
 
+  def join_authenticated("vehicles:pull_backs:all", _message, socket) do
+    pull_backs = Duration.log_duration(Server, :subscribe_to_all_pull_backs, [])
+    {:ok, %{data: pull_backs}, socket}
+  end
+
   def join_authenticated("vehicles:route:" <> route_id, _message, socket) do
     vehicles_and_ghosts = Duration.log_duration(Server, :subscribe_to_route, [route_id])
     {:ok, %{data: vehicles_and_ghosts}, socket}
@@ -95,6 +100,7 @@ defmodule SkateWeb.VehiclesChannel do
 
   @spec event_name(Server.lookup_key()) :: String.t()
   defp event_name({_ets, :all_shuttles}), do: "shuttles"
+  defp event_name({_ets, :all_pull_backs}), do: "pull_backs"
   defp event_name({_ets, {:search, _}}), do: "search"
   defp event_name({_ets, _}), do: "vehicles"
 end

--- a/test/realtime/server_test.exs
+++ b/test/realtime/server_test.exs
@@ -605,7 +605,7 @@ defmodule Realtime.ServerTest do
     end
 
     test "returns empty data when the route is not found", %{ets: ets} do
-      assert Server.lookup({ets, {:route_id, "3"}}) == []
+      assert Server.lookup({ets, {:route_id, "non-existent-1 "}}) == []
     end
 
     test "fetches all vehicles, on routes and shuttles", %{ets: ets} do

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -579,6 +579,14 @@ defmodule Realtime.VehicleTest do
       assert Vehicle.end_of_trip_type(block, last_trip_of_block, "run2", "middle") == :pull_back
     end
 
+    test "when finished with the last trip of the block but still logged in, returns :pull_back",
+         %{
+           last_trip_of_block: last_trip_of_block,
+           block: block
+         } do
+      assert Vehicle.end_of_trip_type(block, last_trip_of_block, "run2", nil) == :pull_back
+    end
+
     test "defaults to :another_trip if we're missing data", %{
       last_trip_of_block: last_trip_of_block,
       block: block
@@ -586,7 +594,6 @@ defmodule Realtime.VehicleTest do
       assert Vehicle.end_of_trip_type(nil, last_trip_of_block, "run2", "middle") == :another_trip
       assert Vehicle.end_of_trip_type(block, nil, "run2", "middle") == :another_trip
       assert Vehicle.end_of_trip_type(block, last_trip_of_block, nil, "middle") == :another_trip
-      assert Vehicle.end_of_trip_type(block, last_trip_of_block, "run2", nil) == :another_trip
     end
 
     test "doesn't consider it a swing off if the next trip's run is nil", %{

--- a/test/realtime/vehicle_test.exs
+++ b/test/realtime/vehicle_test.exs
@@ -68,7 +68,8 @@ defmodule Realtime.VehicleTest do
             build(:gtfs_stoptime, stop_id: "18513", time: 2, timepoint_id: "tp2")
           ],
           start_time: 0,
-          end_time: 2
+          end_time: 2,
+          end_place: "place"
         )
 
   describe "from_vehicle_position" do
@@ -121,7 +122,7 @@ defmodule Realtime.VehicleTest do
         operator_last_name: operator_last_name
       } = vehicle_position = @vehicle_position
 
-      result = Vehicle.from_vehicle_position(vehicle_position)
+      result = Vehicle.from_vehicle_position(vehicle_position, %{})
 
       assert %Vehicle{
                id: "y1261",
@@ -151,6 +152,7 @@ defmodule Realtime.VehicleTest do
                is_revenue: true,
                layover_departure_time: nil,
                block_is_active: true,
+               pull_back_place_name: "place",
                sources: %MapSet{},
                data_discrepancies: [
                  %DataDiscrepancy{
@@ -198,7 +200,7 @@ defmodule Realtime.VehicleTest do
 
     test "handles unknown trips" do
       reassign_env(:realtime, :trip_fn, fn _ -> nil end)
-      result = Vehicle.from_vehicle_position(@vehicle_position)
+      result = Vehicle.from_vehicle_position(@vehicle_position, %{})
       assert %Vehicle{} = result
     end
 
@@ -214,7 +216,7 @@ defmodule Realtime.VehicleTest do
       trip_id = @trip.id
 
       assert %Vehicle{id: ^vehicle_id, trip_id: ^trip_id, route_pattern_id: nil} =
-               Vehicle.from_vehicle_position(@vehicle_position)
+               Vehicle.from_vehicle_position(@vehicle_position, %{})
     end
   end
 

--- a/test/schedule/block_test.exs
+++ b/test/schedule/block_test.exs
@@ -13,7 +13,8 @@ defmodule Schedule.BlockTest do
     schedule_id: "schedule",
     route_id: nil,
     start_time: 1,
-    end_time: 3
+    end_time: 3,
+    start_place: "garage"
   }
 
   @trip1 %Trip{
@@ -59,7 +60,8 @@ defmodule Schedule.BlockTest do
     schedule_id: "schedule",
     route_id: nil,
     start_time: 17,
-    end_time: 19
+    end_time: 19,
+    end_place: "garage"
   }
 
   @piece build(:piece,
@@ -183,6 +185,24 @@ defmodule Schedule.BlockTest do
 
     test "returns the last trip if pulling back" do
       assert %Trip{id: "t2"} = Block.trip_at_time(@block, 18)
+    end
+  end
+
+  describe "pull_back_place_id/1" do
+    test "handles nil" do
+      assert nil |> Block.pull_back_place_id() |> is_nil()
+    end
+
+    test "returns end place of last trip" do
+      assert Block.pull_back_place_id(@block) == "garage"
+    end
+
+    test "handles empty pieces list" do
+      assert %{@block | pieces: []} |> Block.pull_back_place_id() |> is_nil()
+    end
+
+    test "handles piece without trips" do
+      assert %{@block | pieces: [%{@piece | trips: []}]} |> Block.pull_back_place_id() |> is_nil()
     end
   end
 


### PR DESCRIPTION
Asana ticket: [⚙️ Better Maps | Show pull-backs](https://app.asana.com/0/1200180014510248/1204946801340572/f)

This PR covers everything except for changes to the VPC for pull-backs to show their destination garage. I'm going to put that into a separate PR and release so that I don't have to start out with the new field being `optional` in Superstruct and then later change it to only `nullable`.

It's a minor thing but I don't think I've been entirely consistent with how I've written variables that involve "pull back" in their names. With snake_case I find that `pull_back` looks natural whereas for whatever reason I find `pullback` without capitalizing the "B" looks better in camelCase, but feel free to push back on that.