### PR TITLE
feat: get the Postgres estimate of rows in notifications table

### DIFF
--- a/lib/report.ex
+++ b/lib/report.ex
@@ -4,7 +4,12 @@ defmodule Report do
   """
   @type t :: module()
 
-  @report_modules [Report.UserSettings, Report.UserNamesAndUuids, Report.UserConfigurations]
+  @report_modules [
+    Report.UserSettings,
+    Report.UserNamesAndUuids,
+    Report.UserConfigurations,
+    Report.NotificationsCountEstimate
+  ]
 
   @callback run() :: {:ok, [map()]} | :error
   @callback short_name() :: String.t()

--- a/lib/report/notifications_count_estimate.ex
+++ b/lib/report/notifications_count_estimate.ex
@@ -1,0 +1,24 @@
+defmodule Report.NotificationsCountEstimate do
+  @moduledoc """
+  Returns the Postgres estimated count of entries in the notifications table,
+  for evaluating options to delete old entries
+  """
+  import Ecto.Query
+
+  @behaviour Report
+
+  @impl Report
+  def run() do
+    [count] =
+      from(p in "pg_class", where: p.relname == "notifications", select: p.reltuples)
+      |> Skate.Repo.all()
+
+    {:ok, [%{count: count}]}
+  end
+
+  @impl Report
+  def short_name(), do: "notifications_count_estimate"
+
+  @impl Report
+  def description(), do: "Estimated count of notifications"
+end

--- a/test/report/notifications_count_estimate_test.exs
+++ b/test/report/notifications_count_estimate_test.exs
@@ -1,0 +1,25 @@
+defmodule Report.NotificationsCountEstimateTest do
+  use Skate.DataCase
+
+  describe "run/0" do
+    test "returns a single-row numeric value" do
+      {:ok, result} = Report.NotificationsCountEstimate.run()
+
+      assert [%{count: count}] = result
+
+      assert is_number(count)
+    end
+  end
+
+  describe "short_name/0" do
+    test "returns short name" do
+      assert Report.NotificationsCountEstimate.short_name() == "notifications_count_estimate"
+    end
+  end
+
+  describe "description/0" do
+    test "returns description" do
+      assert Report.NotificationsCountEstimate.description() == "Estimated count of notifications"
+    end
+  end
+end

--- a/test/report_test.exs
+++ b/test/report_test.exs
@@ -54,7 +54,8 @@ defmodule ReportTest do
       assert Report.all_reports() == %{
                "user_configurations" => Report.UserConfigurations,
                "user_settings" => Report.UserSettings,
-               "user_names_and_uuids" => Report.UserNamesAndUuids
+               "user_names_and_uuids" => Report.UserNamesAndUuids,
+               "notifications_count_estimate" => Report.NotificationsCountEstimate
              }
     end
   end


### PR DESCRIPTION
Asana ticket: part of [⚙️ Bulk delete old notifications_users records](https://app.asana.com/0/1148853526253420/1204432817126652/f)

We don't want to `SELECT count(*)` because that can actually be slow with Postgres' MVCC model, so I followed [these instructions](https://wiki.postgresql.org/wiki/Count_estimate) to get Postgres' internal estimate for the size of the table. This should be sufficient as I only need a rough order of magnitude of how many records we're going to have to delete. When I tried it out on dev-blue, the GET request to `/reports/notifications_count_estimate` took only around 9 ms total.