### PR TITLE
feat: handle new tm_trip_id field

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -108,7 +108,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     [
       TripUpdate.new(
         overload_offset: Map.get(trip, "overload_offset"),
-        trip_id: Map.get(trip, "trip_id"),
+        trip_id: Map.get(trip, "tm_trip_id") || Map.get(trip, "trip_id"),
         route_id: Map.get(trip, "route_id"),
         direction_id: Map.get(trip, "direction_id"),
         start_date: date(Map.get(trip, "start_date")),

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -90,48 +90,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
     end
 
     test "decodes a VehiclePosition JSON map" do
-      input = %{
-        "block_id" => "Q238-135",
-        "capacity" => 18,
-        "congestion_level" => nil,
-        "current_status" => "STOPPED_AT",
-        "current_stop_sequence" => 670,
-        "load" => 12,
-        "location_source" => "samsara",
-        "occupancy_percentage" => 0.67,
-        "occupancy_status" => "FEW_SEATS_AVAILABLE",
-        "operator" => %{
-          "id" => build(:operator_id),
-          "logon_time" => 1_534_340_301,
-          "first_name" => build(:first_name),
-          "last_name" => "EVANS"
-        },
-        "position" => %{
-          "bearing" => 135,
-          "latitude" => 42.32951,
-          "longitude" => -71.11109,
-          "odometer" => 5.1,
-          "speed" => 2.9796
-        },
-        "run_id" => "128-1007",
-        "stop_id" => "70257",
-        "timestamp" => 1_534_340_406,
-        "trip" => %{
-          "direction_id" => 0,
-          "overload_offset" => -6,
-          "route_id" => "Green-E",
-          "schedule_relationship" => "SCHEDULED",
-          "start_date" => "20180815",
-          "start_time" => nil,
-          "tm_trip_id" => "37165437-X"
-        },
-        "vehicle" => %{
-          "id" => "G-10098",
-          "label" => "3823-3605",
-          "license_plate" => nil
-        },
-        "revenue" => false
-      }
+      input = build(:gtfs_realtime_enhanced_vehicle_position)
 
       assert [tu, vp] = GTFSRealtimeEnhanced.decode_vehicle(input)
 
@@ -180,48 +139,13 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
     end
 
     test "decodes a VehiclePosition JSON map, falling back on trip_id if tm_trip_id is absent" do
-      input = %{
-        "block_id" => "Q238-135",
-        "capacity" => 18,
-        "congestion_level" => nil,
-        "current_status" => "STOPPED_AT",
-        "current_stop_sequence" => 670,
-        "load" => 12,
-        "location_source" => "samsara",
-        "occupancy_percentage" => 0.67,
-        "occupancy_status" => "FEW_SEATS_AVAILABLE",
-        "operator" => %{
-          "id" => build(:operator_id),
-          "logon_time" => 1_534_340_301,
-          "first_name" => build(:first_name),
-          "last_name" => "EVANS"
-        },
-        "position" => %{
-          "bearing" => 135,
-          "latitude" => 42.32951,
-          "longitude" => -71.11109,
-          "odometer" => 5.1,
-          "speed" => 2.9796
-        },
-        "run_id" => "128-1007",
-        "stop_id" => "70257",
-        "timestamp" => 1_534_340_406,
-        "trip" => %{
-          "direction_id" => 0,
-          "overload_offset" => -6,
-          "route_id" => "Green-E",
-          "schedule_relationship" => "SCHEDULED",
-          "start_date" => "20180815",
-          "start_time" => nil,
-          "trip_id" => "37165437-X"
-        },
-        "vehicle" => %{
-          "id" => "G-10098",
-          "label" => "3823-3605",
-          "license_plate" => nil
-        },
-        "revenue" => false
-      }
+      input =
+        build(:gtfs_realtime_enhanced_vehicle_position, %{
+          trip:
+            :gtfs_realtime_enhanced_trip_descriptor
+            |> build(%{"trip_id" => "37165437-X"})
+            |> Map.drop(["tm_trip_id"])
+        })
 
       assert [tu, vp] = GTFSRealtimeEnhanced.decode_vehicle(input)
 

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -123,7 +123,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
           "schedule_relationship" => "SCHEDULED",
           "start_date" => "20180815",
           "start_time" => nil,
-          "trip_id" => "37165437-X"
+          "tm_trip_id" => "37165437-X"
         },
         "vehicle" => %{
           "id" => "G-10098",
@@ -177,6 +177,57 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  },
                  revenue: false
                )
+    end
+
+    test "decodes a VehiclePosition JSON map, falling back on trip_id if tm_trip_id is absent" do
+      input = %{
+        "block_id" => "Q238-135",
+        "capacity" => 18,
+        "congestion_level" => nil,
+        "current_status" => "STOPPED_AT",
+        "current_stop_sequence" => 670,
+        "load" => 12,
+        "location_source" => "samsara",
+        "occupancy_percentage" => 0.67,
+        "occupancy_status" => "FEW_SEATS_AVAILABLE",
+        "operator" => %{
+          "id" => build(:operator_id),
+          "logon_time" => 1_534_340_301,
+          "first_name" => build(:first_name),
+          "last_name" => "EVANS"
+        },
+        "position" => %{
+          "bearing" => 135,
+          "latitude" => 42.32951,
+          "longitude" => -71.11109,
+          "odometer" => 5.1,
+          "speed" => 2.9796
+        },
+        "run_id" => "128-1007",
+        "stop_id" => "70257",
+        "timestamp" => 1_534_340_406,
+        "trip" => %{
+          "direction_id" => 0,
+          "overload_offset" => -6,
+          "route_id" => "Green-E",
+          "schedule_relationship" => "SCHEDULED",
+          "start_date" => "20180815",
+          "start_time" => nil,
+          "trip_id" => "37165437-X"
+        },
+        "vehicle" => %{
+          "id" => "G-10098",
+          "label" => "3823-3605",
+          "license_plate" => nil
+        },
+        "revenue" => false
+      }
+
+      assert [tu, vp] = GTFSRealtimeEnhanced.decode_vehicle(input)
+
+      assert %TripUpdate{trip_id: "37165437-X"} = tu
+
+      assert %VehiclePosition{trip_id: "37165437-X"} = vp
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -67,6 +67,55 @@ defmodule Skate.Factory do
     }
   end
 
+  def gtfs_realtime_enhanced_trip_descriptor_factory do
+    %{
+      "direction_id" => 0,
+      "overload_offset" => -6,
+      "route_id" => "Green-E",
+      "schedule_relationship" => "SCHEDULED",
+      "start_date" => "20180815",
+      "start_time" => nil,
+      "tm_trip_id" => "37165437-X"
+    }
+  end
+
+  def gtfs_realtime_enhanced_vehicle_position_factory do
+    %{
+      "block_id" => "Q238-135",
+      "capacity" => 18,
+      "congestion_level" => nil,
+      "current_status" => "STOPPED_AT",
+      "current_stop_sequence" => 670,
+      "load" => 12,
+      "location_source" => "samsara",
+      "occupancy_percentage" => 0.67,
+      "occupancy_status" => "FEW_SEATS_AVAILABLE",
+      "operator" => %{
+        "id" => build(:operator_id),
+        "logon_time" => 1_534_340_301,
+        "first_name" => build(:first_name),
+        "last_name" => "EVANS"
+      },
+      "position" => %{
+        "bearing" => 135,
+        "latitude" => 42.32951,
+        "longitude" => -71.11109,
+        "odometer" => 5.1,
+        "speed" => 2.9796
+      },
+      "run_id" => "128-1007",
+      "stop_id" => "70257",
+      "timestamp" => 1_534_340_406,
+      "trip" => build(:gtfs_realtime_enhanced_trip_descriptor),
+      "vehicle" => %{
+        "id" => "G-10098",
+        "label" => "3823-3605",
+        "license_plate" => nil
+      },
+      "revenue" => false
+    }
+  end
+
   def piece_factory do
     %Schedule.Piece{
       schedule_id: "schedule",


### PR DESCRIPTION
Asana ticket: background work related to [⚙️ Better Maps | Show pull-backs](https://app.asana.com/0/1200180014510248/1204946801340572/f)

Transit Data is going to no longer using these trip IDs from Busloc in the Concentrate feed, but we still want them. For now we'll check for the new field but fall back to the old one if present, so that we don't need to do deploys simultaneously.