### PR TITLE
feat: report for estimated count of notifications_users records

### DIFF
--- a/lib/report.ex
+++ b/lib/report.ex
@@ -8,7 +8,8 @@ defmodule Report do
     Report.UserSettings,
     Report.UserNamesAndUuids,
     Report.UserConfigurations,
-    Report.NotificationsCountEstimate
+    Report.NotificationsCountEstimate,
+    Report.NotificationsUsersCountEstimate
   ]
 
   @callback run() :: {:ok, [map()]} | :error

--- a/lib/report/notifications_users_count_estimate.ex
+++ b/lib/report/notifications_users_count_estimate.ex
@@ -1,0 +1,24 @@
+defmodule Report.NotificationsUsersCountEstimate do
+  @moduledoc """
+  Returns the Postgres estimated count of entries in the notifications table,
+  for evaluating options to delete old entries
+  """
+  import Ecto.Query
+
+  @behaviour Report
+
+  @impl Report
+  def run() do
+    [count] =
+      from(p in "pg_class", where: p.relname == "notifications_users", select: p.reltuples)
+      |> Skate.Repo.all()
+
+    {:ok, [%{count: count}]}
+  end
+
+  @impl Report
+  def short_name(), do: "notifications_users_count_estimate"
+
+  @impl Report
+  def description(), do: "Estimated count of notifications_users"
+end

--- a/test/report/notifications_users_count_estimate_test.exs
+++ b/test/report/notifications_users_count_estimate_test.exs
@@ -1,0 +1,27 @@
+defmodule Report.NotificationsUsersCountEstimateTest do
+  use Skate.DataCase
+
+  describe "run/0" do
+    test "returns a single-row numeric value" do
+      {:ok, result} = Report.NotificationsUsersCountEstimate.run()
+
+      assert [%{count: count}] = result
+
+      assert is_number(count)
+    end
+  end
+
+  describe "short_name/0" do
+    test "returns short name" do
+      assert Report.NotificationsUsersCountEstimate.short_name() ==
+               "notifications_users_count_estimate"
+    end
+  end
+
+  describe "description/0" do
+    test "returns description" do
+      assert Report.NotificationsUsersCountEstimate.description() ==
+               "Estimated count of notifications_users"
+    end
+  end
+end

--- a/test/report_test.exs
+++ b/test/report_test.exs
@@ -55,7 +55,8 @@ defmodule ReportTest do
                "user_configurations" => Report.UserConfigurations,
                "user_settings" => Report.UserSettings,
                "user_names_and_uuids" => Report.UserNamesAndUuids,
-               "notifications_count_estimate" => Report.NotificationsCountEstimate
+               "notifications_count_estimate" => Report.NotificationsCountEstimate,
+               "notifications_users_count_estimate" => Report.NotificationsUsersCountEstimate
              }
     end
   end


### PR DESCRIPTION
Asana ticket: prep for [⚙️ Add index to notification_users table](https://app.asana.com/0/1148853526253420/1204432817126661/f)

This is basically just a rehash of #2209 but for the `notifications_users` table, since that's the one we're actually adding an index to.