### PR TITLE
chore: reduce frequency of notifications cleanup to every 15 minutes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -128,7 +128,7 @@ config :skate, Oban,
     {
       Oban.Plugins.Cron,
       crontab: [
-        {"* * * * *", Skate.Oban.CleanUpNotifications,
+        {"*/15 * * * *", Skate.Oban.CleanUpNotifications,
          args: %{"cutoff_days" => 10, "limit" => 1000}}
       ]
     }


### PR DESCRIPTION
Asana ticket: followup from [⚙️ Bulk delete old notifications_users records](https://app.asana.com/0/1148853526253420/1204432817126652/f)

Every 15 minutes is admittedly arbitrary but to me it feels like it's a good compromise between not hitting the database constantly while also not running too infrequently.