### PR TITLE
fix(ts/components/mapMarkers): rename import to avoid duplicate name collision

### DIFF
--- a/assets/src/components/mapMarkers.tsx
+++ b/assets/src/components/mapMarkers.tsx
@@ -12,7 +12,7 @@ import { TrainVehicle, Vehicle } from "../realtime"
 import { Shape, Stop } from "../schedule"
 import { UserSettings } from "../userSettings"
 
-import garages, { Garage } from "../data/garages"
+import garages, { Garage as GarageData } from "../data/garages"
 import useDeviceSupportsHover from "../hooks/useDeviceSupportsHover"
 import { LocationType } from "../models/stopData"
 
@@ -411,7 +411,7 @@ const Garage = ({
   garage,
   zoomLevel,
 }: {
-  garage: Garage
+  garage: GarageData
   zoomLevel: number
 }) => {
   const showLabel = zoomLevel >= 16


### PR DESCRIPTION
This fixes a build issue encountered with Storybook & Babel.

When working with Storybook, babel fails to build with the following:
```
Module build failed (from ./node_modules/babel-loader/lib/index.js):
TypeError: Duplicate declaration "Garage"
  408 | })
  409 |
> 410 | const Garage = ({
      |       ^^^^^^
  411 |   garage,
  412 |   zoomLevel,
  413 | }: {
```

---

Sortof related to the following ticket
Asana Ticket: [⚙️ Add StorybookJS to Skate](https://app.asana.com/0/1148853526253420/1205339217615967/f)