### PR TITLE
feat: add index for created_at on notifications

### DIFF
--- a/priv/repo/async_migrations/20230914153345_add_notifications_created_at_index.exs
+++ b/priv/repo/async_migrations/20230914153345_add_notifications_created_at_index.exs
@@ -1,0 +1,7 @@
+defmodule Skate.Repo.Migrations.AddNotificationsCreatedAtIndex do
+  use Ecto.Migration
+
+  def change do
+    create index("notifications", [:created_at])
+  end
+end


### PR DESCRIPTION
Asana ticket: followup on [⚙️ Add index to notification_users table](https://app.asana.com/0/1148853526253420/1204432817126661/f)

I was sort of on the fence about keeping this column at all versus using `inserted_at`, but even if it's not the case now I can imagine a future state where the time that a notification was created doesn't necessarily match when it was reflected in our system. Along with `user_id` on `users_notifications`, this column is the main one used to filter the notifications to serve to a user in [`unexpired_notifications_for_user/2`](https://github.com/mbta/skate/blob/62ee67108692175660edbc882d21fd23823a29bc/lib/notifications/notification.ex#L177). At the current size of the tables I don't think it will make a measurable impact on performance, but if we decide to start saving old notifications again this will become very important.