### PR TITLE
fix(ts/fullStory): use `mockFullStoryEvent` to address new babel rules issues

### DIFF
--- a/assets/tests/helpers/fullStory.test.ts
+++ b/assets/tests/helpers/fullStory.test.ts
@@ -1,29 +1,23 @@
-import { jest, describe, test, expect, afterEach } from "@jest/globals"
+import { describe, test, expect } from "@jest/globals"
 import { fullStoryIdentify } from "../../src/helpers/fullStory"
-
-const originalFS = window.FS
-
-afterEach(() => {
-  window.FS = originalFS
-})
+import { mockFullStoryEvent } from "../testHelpers/mockHelpers"
 
 describe("fullStoryIdentify", () => {
   test("calls identify if username is given", () => {
-    const mockIdentify = jest.fn()
-    window.FS = { identify: mockIdentify, event: jest.fn() }
+    mockFullStoryEvent()
 
     fullStoryIdentify("username")
 
-    expect(mockIdentify).toHaveBeenCalledWith("username", {
+    expect(window.FS.identify).toHaveBeenCalledWith("username", {
       displayName: "username",
     })
   })
 
   test("does not call identify if username is undefined", () => {
-    const mockIdentify = jest.fn()
-    window.FS = { identify: mockIdentify, event: jest.fn() }
+    mockFullStoryEvent()
 
     fullStoryIdentify(undefined)
-    expect(mockIdentify).not.toHaveBeenCalled()
+
+    expect(window.FS.identify).not.toHaveBeenCalled()
   })
 })

--- a/assets/tests/helpers/fullStory.test.ts
+++ b/assets/tests/helpers/fullStory.test.ts
@@ -8,7 +8,7 @@ describe("fullStoryIdentify", () => {
 
     fullStoryIdentify("username")
 
-    expect(window.FS.identify).toHaveBeenCalledWith("username", {
+    expect(window.FS!.identify).toHaveBeenCalledWith("username", {
       displayName: "username",
     })
   })
@@ -18,6 +18,6 @@ describe("fullStoryIdentify", () => {
 
     fullStoryIdentify(undefined)
 
-    expect(window.FS.identify).not.toHaveBeenCalled()
+    expect(window.FS!.identify).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
When working on https://github.com/mbta/skate/pull/2220, I needed to add [new babel rules to make typescript work in storybookjs](https://github.com/mbta/skate/blob/kf/asn/storybook/assets/babel.config.js#L4). This seems to have made babel more strict and due to these rules, CI started to throw the following error:
```
tests/helpers/fullStory.test.ts(13,5): error TS2322: Type '{ identify: Mock<UnknownFunction>; event: Mock<UnknownFunction>; }' is not assignable to type '{ identify(uid: string, opts: { displayName?: string | undefined; email?: string | undefined; }): void; event(event: string, properties?: object | undefined): void; } & typeof FS'.
  Type '{ identify: Mock<UnknownFunction>; event: Mock<UnknownFunction>; }' is missing the following properties from type 'typeof FS': lookupPath, getPath, isFile, isDir, and 51 more.
tests/helpers/fullStory.test.ts(24,5): error TS2322: Type '{ identify: Mock<UnknownFunction>; event: Mock<UnknownFunction>; }' is not assignable to type '{ identify(uid: string, opts: { displayName?: string | undefined; email?: string | undefined; }): void; event(event: string, properties?: object | undefined): void; } & typeof FS'.
  Type '{ identify: Mock<UnknownFunction>; event: Mock<UnknownFunction>; }' is missing the following properties from type 'typeof FS': lookupPath, getPath, isFile, isDir, and 51 more.
```

We don't seem to get these rules applied to our `mockFullStoryEvent` helper so I've decided to convert this test over to using that helper. I'm not sure this is the best way to address this, so I'm open to any other ideas.

---

Asana Ticket: [⚙️ Add StorybookJS to Skate](https://app.asana.com/0/1148853526253420/1205339217615967/f)