### PR TITLE
refactor(ts/components/follower): move `follower` and `recenterControl` out of `map.tsx`

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -1,24 +1,10 @@
-import Leaflet, {
-  Bounds,
-  Control,
-  ControlOptions,
-  DomUtil,
-  LatLng,
-  LatLngExpression,
-  LatLngLiteral,
-  Map as LeafletMap,
-  Point,
-} from "leaflet"
+import Leaflet, { LatLng, LatLngLiteral, Map as LeafletMap } from "leaflet"
 
 import "leaflet-defaulticon-compatibility" // see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-483402699
 import "leaflet.fullscreen"
 import React, {
-  Dispatch,
   MutableRefObject,
   ReactElement,
-  SetStateAction,
-  useCallback,
-  useContext,
   useEffect,
   useRef,
   useState,
@@ -28,17 +14,14 @@ import {
   MapContainer,
   Pane,
   TileLayer,
-  useMap,
   useMapEvents,
   ZoomControl,
 } from "react-leaflet"
 import { createControlComponent } from "@react-leaflet/core"
 
-import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { joinClasses } from "../helpers/dom"
 import { TrainVehicle, Vehicle, VehicleId } from "../realtime.d"
 import { Shape, Stop } from "../schedule"
-import { equalByElements } from "../helpers/array"
 import inTestGroup, { TestGroups } from "../userInTestGroup"
 import {
   GarageMarkers,
@@ -54,6 +37,11 @@ import StreetViewModeEnabledContext from "../contexts/streetViewModeEnabledConte
 import { TileType, tilesetUrlForType } from "../tilesetUrls"
 import { TileTypeContext } from "../contexts/tileTypeContext"
 import getMapLimits from "../mapLimits"
+import {
+  useInteractiveFollowerState,
+  InterruptibleFollower,
+  usePickerContainerFollowerFn,
+} from "./map/follower"
 
 export interface Props {
   reactLeafletRef?: MutableRefObject<LeafletMap | null>
@@ -81,58 +69,6 @@ export const defaultCenter: LatLngLiteral = {
   lng: -71.05891,
 }
 
-interface RecenterControlProps extends ControlOptions {
-  recenter: () => void
-}
-
-class LeafletRecenterControl extends Control {
-  private recenter: () => void
-  constructor(props: ControlOptions, recenter: () => void) {
-    super(props)
-    this.recenter = recenter
-  }
-
-  onAdd() {
-    const controlContainer = DomUtil.create(
-      "div",
-      "leaflet-control leaflet-bar c-vehicle-map__recenter-button"
-    )
-    controlContainer.onclick = (e) => {
-      e.stopPropagation()
-      e.preventDefault()
-
-      window.FS?.event("Recenter control clicked")
-
-      this.recenter()
-    }
-    controlContainer.innerHTML = `
-		<a
-		  href="#"
-		  title="Recenter Map"
-		  role="button"
-		  aria-label="Recenter Map"
-		    >
-		    <svg
-			height="26"
-			viewBox="-5 -5 32 32"
-			width="26"
-			xmlns="http://www.w3.org/2000/svg"
-			>
-			<path
-			     d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
-			     transform="rotate(60, 12, 12)"
-			/>
-		    </svg>
-		</a>`
-    return controlContainer
-  }
-}
-
-export const RecenterControl = createControlComponent(
-  ({ position: position, recenter: recenterFn }: RecenterControlProps) =>
-    new LeafletRecenterControl({ position: position }, recenterFn)
-)
-
 export const FullscreenControl = createControlComponent(
   Leaflet.control.fullscreen
 )
@@ -145,214 +81,6 @@ const EventAdder = (): ReactElement => {
   })
   return <></>
 }
-
-// #region Auto Center Functionality
-export type UpdateMapFromPointsFn = (map: LeafletMap, points: LatLng[]) => void
-
-export interface FollowerProps {
-  positions: LatLng[]
-  onUpdate: UpdateMapFromPointsFn
-}
-
-export const Follower = ({
-  positions,
-  onUpdate,
-  isAnimatingFollowUpdate,
-  shouldFollow = true,
-}: FollowerProps & InteractiveFollowState) => {
-  const map = useMap()
-  const [currentLatLngs, setCurrentLatLngs] = useState<LatLng[]>(positions)
-
-  if (
-    !equalByElements(positions, currentLatLngs, (lhs, rhs) => lhs.equals(rhs))
-  ) {
-    setCurrentLatLngs(positions)
-  }
-
-  useEffect(() => {
-    if (map !== null && shouldFollow) {
-      if (isAnimatingFollowUpdate !== undefined) {
-        isAnimatingFollowUpdate.current = true
-      }
-      onUpdate(map, currentLatLngs)
-    }
-  }, [map, shouldFollow, isAnimatingFollowUpdate, currentLatLngs, onUpdate])
-
-  return <></>
-}
-export interface InteractiveFollowState {
-  isAnimatingFollowUpdate: MutableRefObject<boolean>
-  shouldFollow: boolean
-  setShouldFollow: Dispatch<SetStateAction<boolean>>
-}
-
-// Gathers all state needed for the Follower to be able to display it's state
-// as well as support turning off when interrupted
-export const useInteractiveFollowerState = (): InteractiveFollowState => {
-  const [shouldFollow, setShouldFollow] = useState<boolean>(true)
-  const isAnimatingFollowUpdate: MutableRefObject<boolean> = useRef(false)
-
-  return {
-    shouldFollow,
-    setShouldFollow,
-    isAnimatingFollowUpdate,
-  }
-}
-
-// Sets up map events to get a callback when the user interacts with the map
-// which should override the follower on state
-function useStopFollowingOnInteraction(
-  isAnimatingFollowUpdate: React.MutableRefObject<boolean>,
-  setShouldFollow: React.Dispatch<React.SetStateAction<boolean>>
-) {
-  useMapEvents({
-    // If the user drags or zooms, they want manual control of the map.
-    // `zoomstart` is fired when the map changes zoom levels
-    // this can be because of animating the zoom change or user input
-    zoomstart: () => {
-      // But don't disable `shouldFollow` if the zoom was triggered by Follower.
-      if (!isAnimatingFollowUpdate.current) {
-        setShouldFollow(false)
-      }
-    },
-
-    // `dragstart` is fired when a user drags the map
-    // it is expected that this event is not fired for anything but user input
-    // by [handler/Map.Drag.js](https://github.com/Leaflet/Leaflet/blob/6b90c169d6cd11437bfbcc8ba261255e009afee3/src/map/handler/Map.Drag.js#L113-L115)
-    dragstart: () => {
-      setShouldFollow(false)
-    },
-
-    // `moveend` is called when the leaflet map has finished animating a pan
-    moveend: () => {
-      // Wait until the `Follower` `setView` animation is finished to resume listening for user interaction.
-      if (isAnimatingFollowUpdate.current) {
-        isAnimatingFollowUpdate.current = false
-      }
-    },
-
-    // `autopanstart` is invoked when opening a popup causes the map to pan to fit it
-    autopanstart: () => setShouldFollow(false),
-  })
-}
-
-export type InterruptibleFollowerProps = InteractiveFollowState & FollowerProps
-
-// Component which provides following capability and configures the map to stop
-// the follower component when a user interacts with the map
-export const InterruptibleFollower = ({
-  shouldFollow,
-  setShouldFollow,
-  isAnimatingFollowUpdate,
-  positions,
-  onUpdate,
-}: InterruptibleFollowerProps) => {
-  useStopFollowingOnInteraction(isAnimatingFollowUpdate, setShouldFollow)
-
-  return (
-    <>
-      <Follower
-        isAnimatingFollowUpdate={isAnimatingFollowUpdate}
-        shouldFollow={shouldFollow}
-        setShouldFollow={setShouldFollow}
-        positions={positions}
-        onUpdate={onUpdate}
-      />
-      <RecenterControl
-        position="topright"
-        recenter={() => setShouldFollow(true)}
-      />
-    </>
-  )
-}
-
-export const StatefulInteractiveFollower = (props: FollowerProps) => {
-  return InterruptibleFollower({
-    ...props,
-    ...useInteractiveFollowerState(),
-  })
-}
-
-// #region Previous Follower Logic
-export const autoCenter = (
-  map: LeafletMap,
-  latLngs: LatLngExpression[],
-  pickerContainerIsVisible: boolean
-): void => {
-  if (latLngs.length === 0) {
-    map.setView(defaultCenter, 13)
-  } else if (latLngs.length === 1) {
-    map.setView(latLngs[0], 16)
-  } else if (latLngs.length > 1) {
-    map.fitBounds(Leaflet.latLngBounds(latLngs), {
-      paddingBottomRight: [20, 50],
-      paddingTopLeft: [pickerContainerIsVisible ? 220 : 20, 20],
-    })
-  }
-}
-
-export const drawerOffsetAutoCenter: UpdateMapFromPointsFn = (map, points) => {
-  if (points.length === 0) {
-    // If there are no points, blink to default center
-    map.setView(defaultCenter, 13, { animate: false })
-    return
-  }
-
-  const { width, height } = map.getContainer().getBoundingClientRect()
-  const mapContainerBounds = new Bounds([0, 0], [width, height])
-
-  // ```
-  // vpcElement.getBoundingClientRect().right - mapElement.getBoundingClientRect().left
-  //  -> 445
-  // ```
-  // Create a new inner bounds from the map bounds + "padding" to shrink the
-  // inner bounds
-  // In this case, we get the top left of the inner bounds by padding the left
-  // with the distance from the right side of the VPC to the left side of the
-  // map container
-  const topLeft = new Point(445, 0)
-
-  if (points.length === 1) {
-    const targetZoom = 16
-    const innerBounds = new Bounds(topLeft, mapContainerBounds.getBottomRight())
-    // The "new center" is the offset between the two bounding boxes centers
-    const offset = innerBounds
-      .getCenter()
-      .subtract(mapContainerBounds.getCenter())
-
-    const targetPoint = map
-        // Project the target point into screenspace for the target zoom
-        .project(points[0], targetZoom)
-        // Offset the target point in screenspace to move the center of the map
-        // to apply the padding to the center
-        .subtract(offset),
-      // convert the target point to worldspace from screenspace
-      targetLatLng = map.unproject(targetPoint, targetZoom)
-
-    // Zoom/Pan center of map to offset location in worldspace
-    map.setView(targetLatLng, targetZoom)
-  } else {
-    const pointsBounds = Leaflet.latLngBounds(points)
-    map.fitBounds(pointsBounds, {
-      paddingBottomRight: [50, 20],
-      paddingTopLeft: topLeft,
-    })
-  }
-}
-
-export const usePickerContainerFollowerFn = () => {
-  const [{ pickerContainerIsVisible }] = useContext(StateDispatchContext)
-
-  const onUpdate = useCallback(
-    (map: Leaflet.Map, points: Leaflet.LatLng[]): void =>
-      autoCenter(map, points, pickerContainerIsVisible),
-    [pickerContainerIsVisible]
-  )
-
-  return onUpdate
-}
-// #endregion
-// #endregion
 
 const Map = (props: Props): ReactElement<HTMLDivElement> => {
   const mapRef: MutableRefObject<LeafletMap | null> =

--- a/assets/src/components/map/controls/recenterControl.tsx
+++ b/assets/src/components/map/controls/recenterControl.tsx
@@ -1,0 +1,53 @@
+import { Control, ControlOptions, DomUtil } from "leaflet"
+import { createControlComponent } from "@react-leaflet/core"
+
+interface RecenterControlProps extends ControlOptions {
+  recenter: () => void
+}
+class LeafletRecenterControl extends Control {
+  private recenter: () => void
+  constructor(props: ControlOptions, recenter: () => void) {
+    super(props)
+    this.recenter = recenter
+  }
+
+  onAdd() {
+    const controlContainer = DomUtil.create(
+      "div",
+      "leaflet-control leaflet-bar c-vehicle-map__recenter-button"
+    )
+    controlContainer.onclick = (e) => {
+      e.stopPropagation()
+      e.preventDefault()
+
+      window.FS?.event("Recenter control clicked")
+
+      this.recenter()
+    }
+    controlContainer.innerHTML = `
+		<a
+		  href="#"
+		  title="Recenter Map"
+		  role="button"
+		  aria-label="Recenter Map"
+		    >
+		    <svg
+			height="26"
+			viewBox="-5 -5 32 32"
+			width="26"
+			xmlns="http://www.w3.org/2000/svg"
+			>
+			<path
+			     d="m10 2.7-6.21 16.94a2.33 2.33 0 0 0 1.38 3 2.36 2.36 0 0 0 1.93-.14l4.9-2.67 4.89 2.71a2.34 2.34 0 0 0 3.34-2.8l-5.81-17a2.34 2.34 0 0 0 -4.4 0z"
+			     transform="rotate(60, 12, 12)"
+			/>
+		    </svg>
+		</a>`
+    return controlContainer
+  }
+}
+
+export const RecenterControl = createControlComponent(
+  ({ position: position, recenter: recenterFn }: RecenterControlProps) =>
+    new LeafletRecenterControl({ position: position }, recenterFn)
+)

--- a/assets/src/components/map/follower.tsx
+++ b/assets/src/components/map/follower.tsx
@@ -1,0 +1,227 @@
+import Leaflet, {
+  Bounds,
+  LatLng,
+  LatLngExpression,
+  Map as LeafletMap,
+  Point,
+} from "leaflet"
+import React, {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { useMap, useMapEvents } from "react-leaflet"
+import { StateDispatchContext } from "../../contexts/stateDispatchContext"
+import { equalByElements } from "../../helpers/array"
+import { RecenterControl } from "./controls/recenterControl"
+import { defaultCenter } from "../map"
+
+export type UpdateMapFromPointsFn = (map: LeafletMap, points: LatLng[]) => void
+
+export interface FollowerProps {
+  positions: LatLng[]
+  onUpdate: UpdateMapFromPointsFn
+}
+
+export const Follower = ({
+  positions,
+  onUpdate,
+  isAnimatingFollowUpdate,
+  shouldFollow = true,
+}: FollowerProps & InteractiveFollowState) => {
+  const map = useMap()
+  const [currentLatLngs, setCurrentLatLngs] = useState<LatLng[]>(positions)
+
+  if (
+    !equalByElements(positions, currentLatLngs, (lhs, rhs) => lhs.equals(rhs))
+  ) {
+    setCurrentLatLngs(positions)
+  }
+
+  useEffect(() => {
+    if (map !== null && shouldFollow) {
+      if (isAnimatingFollowUpdate !== undefined) {
+        isAnimatingFollowUpdate.current = true
+      }
+      onUpdate(map, currentLatLngs)
+    }
+  }, [map, shouldFollow, isAnimatingFollowUpdate, currentLatLngs, onUpdate])
+
+  return null
+}
+
+// #region Follower Helper Hooks
+export interface InteractiveFollowState {
+  isAnimatingFollowUpdate: MutableRefObject<boolean>
+  shouldFollow: boolean
+  setShouldFollow: Dispatch<SetStateAction<boolean>>
+}
+// Gathers all state needed for the Follower to be able to display it's state
+// as well as support turning off when interrupted
+
+export const useInteractiveFollowerState = (): InteractiveFollowState => {
+  const [shouldFollow, setShouldFollow] = useState<boolean>(true)
+  const isAnimatingFollowUpdate: MutableRefObject<boolean> = useRef(false)
+
+  return {
+    shouldFollow,
+    setShouldFollow,
+    isAnimatingFollowUpdate,
+  }
+}
+// Sets up map events to get a callback when the user interacts with the map
+// which should override the follower on state
+
+export const useStopFollowingOnInteraction = (
+  isAnimatingFollowUpdate: React.MutableRefObject<boolean>,
+  setShouldFollow: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  useMapEvents({
+    // If the user drags or zooms, they want manual control of the map.
+    // `zoomstart` is fired when the map changes zoom levels
+    // this can be because of animating the zoom change or user input
+    zoomstart: () => {
+      // But don't disable `shouldFollow` if the zoom was triggered by Follower.
+      if (!isAnimatingFollowUpdate.current) {
+        setShouldFollow(false)
+      }
+    },
+
+    // `dragstart` is fired when a user drags the map
+    // it is expected that this event is not fired for anything but user input
+    // by [handler/Map.Drag.js](https://github.com/Leaflet/Leaflet/blob/6b90c169d6cd11437bfbcc8ba261255e009afee3/src/map/handler/Map.Drag.js#L113-L115)
+    dragstart: () => {
+      setShouldFollow(false)
+    },
+
+    // `moveend` is called when the leaflet map has finished animating a pan
+    moveend: () => {
+      // Wait until the `Follower` `setView` animation is finished to resume listening for user interaction.
+      if (isAnimatingFollowUpdate.current) {
+        isAnimatingFollowUpdate.current = false
+      }
+    },
+
+    // `autopanstart` is invoked when opening a popup causes the map to pan to fit it
+    autopanstart: () => setShouldFollow(false),
+  })
+}
+// #endregion Follower Helper Hooks
+
+// #region Follower Variants
+// Component which provides following capability and configures the map to stop
+// the follower component when a user interacts with the map
+
+export type InterruptibleFollowerProps = InteractiveFollowState & FollowerProps
+
+export const InterruptibleFollower = (props: InterruptibleFollowerProps) => {
+  useStopFollowingOnInteraction(
+    props.isAnimatingFollowUpdate,
+    props.setShouldFollow
+  )
+
+  return (
+    <>
+      <Follower {...props} />
+      <RecenterControl
+        position="topright"
+        recenter={() => props.setShouldFollow(true)}
+      />
+    </>
+  )
+}
+
+export const StatefulInteractiveFollower = (props: FollowerProps) => {
+  return InterruptibleFollower({
+    ...props,
+    ...useInteractiveFollowerState(),
+  })
+}
+// #endregion Follower Variants
+
+// #region Follower Update Functions
+
+export const autoCenter = (
+  map: LeafletMap,
+  latLngs: LatLngExpression[],
+  pickerContainerIsVisible: boolean
+): void => {
+  if (latLngs.length === 0) {
+    map.setView(defaultCenter, 13)
+  } else if (latLngs.length === 1) {
+    map.setView(latLngs[0], 16)
+  } else if (latLngs.length > 1) {
+    map.fitBounds(Leaflet.latLngBounds(latLngs), {
+      paddingBottomRight: [20, 50],
+      paddingTopLeft: [pickerContainerIsVisible ? 220 : 20, 20],
+    })
+  }
+}
+
+export const usePickerContainerFollowerFn = () => {
+  const [{ pickerContainerIsVisible }] = useContext(StateDispatchContext)
+
+  const onUpdate = useCallback(
+    (map: Leaflet.Map, points: Leaflet.LatLng[]): void =>
+      autoCenter(map, points, pickerContainerIsVisible),
+    [pickerContainerIsVisible]
+  )
+
+  return onUpdate
+}
+
+export const drawerOffsetAutoCenter: UpdateMapFromPointsFn = (map, points) => {
+  if (points.length === 0) {
+    // If there are no points, blink to default center
+    map.setView(defaultCenter, 13, { animate: false })
+    return
+  }
+
+  const { width, height } = map.getContainer().getBoundingClientRect()
+  const mapContainerBounds = new Bounds([0, 0], [width, height])
+
+  // ```
+  // vpcElement.getBoundingClientRect().right - mapElement.getBoundingClientRect().left
+  //  -> 445
+  // ```
+  // Create a new inner bounds from the map bounds + "padding" to shrink the
+  // inner bounds
+  // In this case, we get the top left of the inner bounds by padding the left
+  // with the distance from the right side of the VPC to the left side of the
+  // map container
+  const topLeft = new Point(445, 0)
+
+  if (points.length === 1) {
+    const targetZoom = 16
+    const innerBounds = new Bounds(topLeft, mapContainerBounds.getBottomRight())
+    // The "new center" is the offset between the two bounding boxes centers
+    const offset = innerBounds
+      .getCenter()
+      .subtract(mapContainerBounds.getCenter())
+
+    const targetPoint = map
+        // Project the target point into screenspace for the target zoom
+        .project(points[0], targetZoom)
+        // Offset the target point in screenspace to move the center of the map
+        // to apply the padding to the center
+        .subtract(offset),
+      // convert the target point to worldspace from screenspace
+      targetLatLng = map.unproject(targetPoint, targetZoom)
+
+    // Zoom/Pan center of map to offset location in worldspace
+    map.setView(targetLatLng, targetZoom)
+  } else {
+    const pointsBounds = Leaflet.latLngBounds(points)
+    map.fitBounds(pointsBounds, {
+      paddingBottomRight: [50, 20],
+      paddingTopLeft: topLeft,
+    })
+  }
+}
+
+// #endregion Follower Update Functions

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -30,13 +30,12 @@ import {
   SelectedLocation,
   SelectedRoutePattern,
 } from "../../state/searchPageState"
-import Map, {
-  vehicleToLeafletLatLng,
-  FollowerStatusClasses,
+import Map, { vehicleToLeafletLatLng, FollowerStatusClasses } from "../map"
+import {
   InterruptibleFollower,
   useInteractiveFollowerState,
   drawerOffsetAutoCenter,
-} from "../map"
+} from "../map/follower"
 import {
   LocationMarker,
   RouteShape,

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -15,11 +15,11 @@ import React, { MutableRefObject } from "react"
 import { act } from "@testing-library/react"
 import { Map as LeafletMap } from "leaflet"
 import Map, {
-  autoCenter,
   defaultCenter,
   MapFollowingPrimaryVehicles,
   MapFollowingSelectionKey,
 } from "../../src/components/map"
+import { autoCenter } from "../../src/components/map/follower"
 import { TrainVehicle, VehicleInScheduledService } from "../../src/realtime"
 import vehicleFactory from "../factories/vehicle"
 import stopFactory from "../factories/stop"


### PR DESCRIPTION
I was getting a bit annoyed finding these when working on the user location button, so I've factored it out to make it a bit cleaner.


---

Asana Ticket: https://app.asana.com/0/1148853526253420/1205411312261324/f