### PR TITLE
chore: bump node to version 20.7.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 elixir 1.13.3-otp-24
 erlang 24.3.2
-nodejs 20.5.1
+nodejs 20.7.0
 adr-tools 3.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix local.hex --force && \
   mix local.rebar --force && \
   mix do deps.get --only prod
 
-FROM node:20.5.1-alpine3.17 as assets-builder
+FROM node:20.7.0-alpine3.17 as assets-builder
 
 WORKDIR /root
 ADD . .


### PR DESCRIPTION
Node 20.8 is out but it's only about a day old at this point and there isn't an image for it on Docker Hub yet, so I'm going with 20.7.