### PR TITLE
cleanup(webpack): remove `svg-inline-loader`

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -79,7 +79,6 @@
         "sass-loader": "^13.3.2",
         "screenfull": "^6.0.2",
         "storybook": "^7.4.2",
-        "svg-inline-loader": "^0.8.2",
         "svgo": "^3.0.2",
         "svgo-loader": "^3.0.0",
         "terser-webpack-plugin": "^5.3.1",
@@ -21055,12 +21054,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-html-tokenizer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
-      "integrity": "sha512-Mc/gH3RvlKvB/gkp9XwgDKEWrSYyefIJPGG8Jk1suZms/rISdUuVEMx5O1WBnTWaScvxXDvGJrZQWblUmQHjkQ==",
-      "dev": true
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -21692,43 +21685,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svg-inline-loader": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/svg-inline-loader/-/svg-inline-loader-0.8.2.tgz",
-      "integrity": "sha512-kbrcEh5n5JkypaSC152eGfGcnT4lkR0eSfvefaUJkLqgGjRQJyKDvvEE/CCv5aTSdfXuc+N98w16iAojhShI3g==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "object-assign": "^4.0.1",
-        "simple-html-tokenizer": "^0.1.1"
-      }
-    },
-    "node_modules/svg-inline-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/svg-inline-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/svgo": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -97,7 +97,6 @@
     "sass-loader": "^13.3.2",
     "screenfull": "^6.0.2",
     "storybook": "^7.4.2",
-    "svg-inline-loader": "^0.8.2",
     "svgo": "^3.0.2",
     "svgo-loader": "^3.0.0",
     "terser-webpack-plugin": "^5.3.1",

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -54,8 +54,8 @@ module.exports = (env, options) => {
         },
         {
           test: /\.svg$/,
+          type: "asset/source",
           use: [
-            { loader: "svg-inline-loader" },
             {
               loader: "svgo-loader",
               options: {


### PR DESCRIPTION
- [x] Tested Locally
- [x] Tested on someone else's dev machine
- [x] Tested in Dev Environment

---

Asana Ticket: [⚙️ Switch to using Asset modules to load SVG's](https://app.asana.com/0/1148853526253420/1205512287746848)