### PR TITLE
fix: reload page when channel join fails due to authentication

### DIFF
--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -47,10 +47,15 @@ export const useChannel = <T>({
             channel = undefined
           }
         })
-        .receive("error", ({ reason }) =>
-          // eslint-disable-next-line no-console
-          console.error(`joining topic ${topic} failed`, reason)
-        )
+
+        .receive("error", ({ reason }) => {
+          if (reason === "not_authenticated") {
+            reload()
+          } else {
+            // eslint-disable-next-line no-console
+            console.error(`joining topic ${topic} failed`, reason)
+          }
+        })
         .receive("timeout", reload)
     }
 
@@ -166,10 +171,14 @@ export const useCheckedTwoWayChannel = <T, U, V>({
             channel = undefined
           }
         })
-        .receive("error", ({ reason }) =>
-          // eslint-disable-next-line no-console
-          console.error(`joining topic ${topic} failed`, reason)
-        )
+        .receive("error", ({ reason }) => {
+          if (reason === "not_authenticated") {
+            reload()
+          } else {
+            // eslint-disable-next-line no-console
+            console.error(`joining topic ${topic} failed`, reason)
+          }
+        })
         .receive("timeout", reload)
     }
 

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -283,6 +283,29 @@ describe("useChannel", () => {
     spyConsoleError.mockRestore()
   })
 
+  test("reloads on join error due to not being authenticated", async () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("error", {
+      reason: "not_authenticated",
+    })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+
+    renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
+  })
+
   test("reloads the window on channel timeout", async () => {
     const reloadSpy = jest.spyOn(browser, "reload")
     reloadSpy.mockImplementationOnce(() => ({}))
@@ -664,6 +687,31 @@ describe("useCheckedChannel", () => {
 
     expect(spyConsoleError).toHaveBeenCalled()
     spyConsoleError.mockRestore()
+  })
+
+  test("reloads on join error due to not being authenticated", async () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("error", {
+      reason: "not_authenticated",
+    })
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    const dataStruct = unknown()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
   })
 
   test("reloads the window on channel timeout", async () => {

--- a/assets/tests/testHelpers/socketHelpers.ts
+++ b/assets/tests/testHelpers/socketHelpers.ts
@@ -30,17 +30,24 @@ export const makeMockChannel = (
       switch (message) {
         case "ok":
           if (expectedReceiveData !== undefined) {
-            if (typeof expectedReceiveData === "function") {
-              const expectedReceived = expectedReceiveData()
-              handler(expectedReceived)
-            } else {
-              handler(expectedReceiveData)
-            }
+            handler(
+              typeof expectedReceiveData === "function"
+                ? expectedReceiveData()
+                : expectedReceiveData
+            )
           }
           return result
 
         case "error":
-          handler({ reason: "ERROR_REASON" })
+          if (expectedReceiveData !== undefined) {
+            handler(
+              typeof expectedReceiveData === "function"
+                ? expectedReceiveData()
+                : expectedReceiveData
+            )
+          } else {
+            handler({ reason: "ERROR_REASON" })
+          }
           break
 
         case "timeout":


### PR DESCRIPTION
Asana ticket: [⚙️ Gracefully handle sessions where authentication expires](https://app.asana.com/0/1148853526253420/1205451125311872/f)

I've been testing this out locally by adjusting `Skate.Ueberauth.Strategy.Fake` to give a token that's only valid for 10 seconds and finding that it works better than before.

On the search page without an active search, the user won't be making any API requests or subscribed to any channels that would notice that the auth is expired (notably, the data status channel sends an `auth_expired` message from the backend but the frontend doesn't do anything with it - something else to look into). In the old state, this meant that when a user goes and tries to perform a search it would silently fail to join the channel.