### PR TITLE
fix(ts/layers_control): make radio button circular and expand option tap targets

### DIFF
--- a/assets/css/map/controls/_layers_control.scss
+++ b/assets/css/map/controls/_layers_control.scss
@@ -57,10 +57,8 @@
       padding-bottom: 0;
 
       div {
-        * {
-          padding-top: 0.5rem;
-          padding-bottom: 0.5rem;
-        }
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
 
         h2 {
           margin: 0;

--- a/assets/src/components/map/controls/layersControl.tsx
+++ b/assets/src/components/map/controls/layersControl.tsx
@@ -125,7 +125,7 @@ const TileLayerControl = ({
 }): JSX.Element => (
   <div className="c-layers-control__tile_layer_control">
     <h2 id={sectionLabelId}>Base Map</h2>
-    <div className="form-check">
+    <div className="form-check position-relative">
       <input
         className="form-check-input"
         type="radio"
@@ -135,11 +135,11 @@ const TileLayerControl = ({
         checked={tileType === "base"}
         onChange={() => setTileType("base")}
       />
-      <label className="form-check-label" htmlFor="base">
+      <label className="form-check-label stretched-link" htmlFor="base">
         Map (default)
       </label>
     </div>
-    <div className="form-check">
+    <div className="form-check position-relative">
       <input
         className="form-check-input"
         type="radio"
@@ -149,7 +149,7 @@ const TileLayerControl = ({
         checked={tileType === "satellite"}
         onChange={() => setTileType("satellite")}
       />
-      <label className="form-check-label" htmlFor="satellite">
+      <label className="form-check-label stretched-link" htmlFor="satellite">
         Satellite
       </label>
     </div>
@@ -170,7 +170,7 @@ const VehicleLayersControl = ({
   return (
     <div className="c-layers-control__vehicle_layers_control">
       <h2 id={sectionLabelId}>Vehicles</h2>
-      <div className="form-check form-switch">
+      <div className="form-check form-switch position-relative">
         <input
           className="form-check-input"
           type="checkbox"
@@ -184,7 +184,7 @@ const VehicleLayersControl = ({
             }
           }}
         />
-        <label className="form-check-label" htmlFor={inputId}>
+        <label className="form-check-label stretched-link" htmlFor={inputId}>
           Show pull-backs
         </label>
       </div>


### PR DESCRIPTION
Asana Ticket: [⚙️ 🐛 Fix radio buttons in map layers menu to no longer look "stretched"](https://app.asana.com/0/1148853526253420/1205524997955955/f)