### PR TITLE
AuthenticatedChannel improvements

### DIFF
--- a/assets/src/hooks/useChannel.ts
+++ b/assets/src/hooks/useChannel.ts
@@ -36,6 +36,7 @@ export const useChannel = <T>({
       channel.on(event, ({ data: data }) => {
         setState(parser(data))
       })
+      channel.on("auth_expired", reload)
 
       channel
         .join()
@@ -159,6 +160,7 @@ export const useCheckedTwoWayChannel = <T, U, V>({
       channel.on(event, (data: { data: unknown }) => {
         onOk(data)
       })
+      channel.on("auth_expired", reload)
 
       channel
         .join()

--- a/assets/tests/hooks/useChannel.test.ts
+++ b/assets/tests/hooks/useChannel.test.ts
@@ -131,6 +131,33 @@ describe("useChannel", () => {
     expect(result.current).toEqual("parsed")
   })
 
+  test("reloads on auth_expired event", () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "auth_expired") {
+        handler()
+      }
+      return 1
+    })
+
+    renderHook(() =>
+      useChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
+  })
+
   test("leaves the channel on unmount", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel()
@@ -523,6 +550,35 @@ describe("useCheckedChannel", () => {
     )
 
     expect(Sentry.captureException).toHaveBeenCalled()
+  })
+
+  test("reloads on auth_expired event", () => {
+    const reloadSpy = jest.spyOn(browser, "reload")
+    reloadSpy.mockImplementationOnce(() => ({}))
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel()
+    mockSocket.channel.mockImplementationOnce(() => mockChannel)
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "auth_expired") {
+        handler()
+      }
+      return 1
+    })
+    const dataStruct = unknown()
+
+    renderHook(() =>
+      useCheckedChannel({
+        socket: mockSocket,
+        topic: "topic",
+        event: "event",
+        dataStruct,
+        parser: jest.fn(),
+        loadingState: "loading",
+      })
+    )
+
+    expect(reloadSpy).toHaveBeenCalled()
+    reloadSpy.mockRestore()
   })
 
   test("leaves the channel on unmount", () => {

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -92,10 +92,12 @@ describe("useNotifications", () => {
   test("parses initial notification message", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel()
-    mockChannel.on.mockImplementation((_event, handler) => {
-      handler({
-        data: notification1Data,
-      })
+    mockChannel.on.mockImplementation((event, handler) => {
+      if (event === "notification") {
+        handler({
+          data: notification1Data,
+        })
+      }
       return 1
     })
     mockSocket.channel.mockImplementationOnce(() => mockChannel)

--- a/assets/tests/hooks/useNotificationsReducer.test.tsx
+++ b/assets/tests/hooks/useNotificationsReducer.test.tsx
@@ -242,10 +242,12 @@ describe("useNotificationsReducer", () => {
     const mockChannel = makeMockChannel()
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
 
-    mockChannel.on.mockImplementation((_event, dataHandler) => {
-      dataHandler({
-        data: notification1Data,
-      })
+    mockChannel.on.mockImplementation((event, dataHandler) => {
+      if (event === "notification") {
+        dataHandler({
+          data: notification1Data,
+        })
+      }
       return 1
     })
 

--- a/lib/skate_web/authenticated_channel.ex
+++ b/lib/skate_web/authenticated_channel.ex
@@ -2,13 +2,16 @@ defmodule SkateWeb.AuthenticatedChannel do
   @moduledoc """
   A `use` macro and `@behaviour` which implements `c:Phoenix.Channel.join/3` and
   calls `c:SkateWeb.AuthenticatedChannel.join_authenticated/3` when socket is
-  authenticated. In addition, implements `c:Phoenix.Channel.handle_info/2` and
-  calls `c:SkateWeb.AuthenticatedChannel.handle_info/2` with the provided message
-  after checking the socket's current validity.
+  authenticated.
 
   This ensures that the token associated with the `socket` passed to
   `c:Phoenix.Channel.join/3` is valid before forwarding the call to
   `c:SkateWeb.AuthenticatedChannel.join_authenticated/3`.
+
+  In addition, implements `c:Phoenix.Channel.handle_info/2` and
+  calls `c:SkateWeb.AuthenticatedChannel.handle_info/2` with the provided message
+  after checking the socket's current validity, as well as a similar
+  `c:SkateWeb.AuthenticatedChannel.handle_in/3` callback.
 
   ## Examples
   Simple usage of `SkateWeb.AuthenticatedChannel`
@@ -81,7 +84,8 @@ defmodule SkateWeb.AuthenticatedChannel do
   Macro which imports the `SkateWeb.AuthenticatedChannel` behaviour. Implements
   `c:Phoenix.Channel.join/3` for `c:SkateWeb.AuthenticatedChannel.join_authenticated/3`
   as well as `c:Phoenix.Channel.handle_info/2` for
-  `c:SkateWeb.AuthenticatedChannel.handle_info_authenticated/2`.
+  `c:SkateWeb.AuthenticatedChannel.handle_info_authenticated/2` and `c:Phoenix.Channel.handle_in/3`
+  for `c:SkateWeb.AuthenticatedChannel.handle_in_authenticated/3`
   """
   defmacro __using__(_) do
     quote do

--- a/lib/skate_web/channels/alerts_channel.ex
+++ b/lib/skate_web/channels/alerts_channel.ex
@@ -11,15 +11,10 @@ defmodule SkateWeb.AlertsChannel do
     {:ok, %{data: alerts}, socket}
   end
 
-  @impl Phoenix.Channel
-  def handle_info({:new_realtime_data, lookup_args}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      data = Server.lookup(lookup_args)
-      :ok = push(socket, "alerts", %{data: data})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_realtime_data, lookup_args}, socket) do
+    data = Server.lookup(lookup_args)
+    :ok = push(socket, "alerts", %{data: data})
+    {:noreply, socket}
   end
 end

--- a/lib/skate_web/channels/data_status_channel.ex
+++ b/lib/skate_web/channels/data_status_channel.ex
@@ -14,14 +14,9 @@ defmodule SkateWeb.DataStatusChannel do
     {:error, %{message: "no such topic \"#{topic}\""}}
   end
 
-  @impl Phoenix.Channel
-  def handle_info({:new_data_status, data_status}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      :ok = push(socket, "data_status", %{data: data_status})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_data_status, data_status}, socket) do
+    :ok = push(socket, "data_status", %{data: data_status})
+    {:noreply, socket}
   end
 end

--- a/lib/skate_web/channels/notifications_channel.ex
+++ b/lib/skate_web/channels/notifications_channel.ex
@@ -2,15 +2,10 @@ defmodule SkateWeb.NotificationsChannel do
   use SkateWeb, :channel
   use SkateWeb.AuthenticatedChannel
 
-  @impl Phoenix.Channel
-  def handle_info({:notification, notification}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      :ok = push(socket, "notification", %{data: notification})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:notification, notification}, socket) do
+    :ok = push(socket, "notification", %{data: notification})
+    {:noreply, socket}
   end
 
   @impl SkateWeb.AuthenticatedChannel

--- a/lib/skate_web/channels/train_vehicles_channel.ex
+++ b/lib/skate_web/channels/train_vehicles_channel.ex
@@ -18,14 +18,9 @@ defmodule SkateWeb.TrainVehiclesChannel do
     {:ok, %{data: train_vehicles}, socket}
   end
 
-  @impl Phoenix.Channel
-  def handle_info({:new_train_vehicles, train_vehicles}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      :ok = push(socket, "train_vehicles", %{data: train_vehicles})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_train_vehicles, train_vehicles}, socket) do
+    :ok = push(socket, "train_vehicles", %{data: train_vehicles})
+    {:noreply, socket}
   end
 end

--- a/lib/skate_web/channels/vehicle_channel.ex
+++ b/lib/skate_web/channels/vehicle_channel.ex
@@ -4,8 +4,8 @@ defmodule SkateWeb.VehicleChannel do
 
   alias Realtime.Server
 
-  @impl true
-  def handle_info({:new_realtime_data, lookup_params}, socket) do
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_realtime_data, lookup_params}, socket) do
     vehicle_or_ghost = Realtime.Server.lookup(lookup_params)
     :ok = push(socket, "vehicle", %{data: List.first(vehicle_or_ghost)})
 

--- a/lib/skate_web/channels/vehicles_channel.ex
+++ b/lib/skate_web/channels/vehicles_channel.ex
@@ -85,17 +85,12 @@ defmodule SkateWeb.VehiclesChannel do
     {:error, %{message: "no such topic \"#{topic}\""}}
   end
 
-  @impl Phoenix.Channel
-  def handle_info({:new_realtime_data, lookup_args}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      event_name = event_name(lookup_args)
-      data = Server.lookup(lookup_args)
-      :ok = push(socket, event_name, %{data: data})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_realtime_data, lookup_args}, socket) do
+    event_name = event_name(lookup_args)
+    data = Server.lookup(lookup_args)
+    :ok = push(socket, event_name, %{data: data})
+    {:noreply, socket}
   end
 
   @spec event_name(Server.lookup_key()) :: String.t()

--- a/lib/skate_web/channels/vehicles_search_channel.ex
+++ b/lib/skate_web/channels/vehicles_search_channel.ex
@@ -89,17 +89,12 @@ defmodule SkateWeb.VehiclesSearchChannel do
     %{property: String.to_existing_atom(property), text: text}
   end
 
-  @impl Phoenix.Channel
-  def handle_info({:new_realtime_data, lookup_args}, socket) do
-    if SkateWeb.ChannelAuth.valid_token?(socket) do
-      event_name = event_name(lookup_args)
-      data = Server.lookup(lookup_args)
-      :ok = push(socket, event_name, %{data: data})
-      {:noreply, socket}
-    else
-      :ok = push(socket, "auth_expired", %{})
-      {:stop, :normal, socket}
-    end
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_info_authenticated({:new_realtime_data, lookup_args}, socket) do
+    event_name = event_name(lookup_args)
+    data = Server.lookup(lookup_args)
+    :ok = push(socket, event_name, %{data: data})
+    {:noreply, socket}
   end
 
   @spec event_name(Server.lookup_key()) :: String.t()

--- a/lib/skate_web/channels/vehicles_search_channel.ex
+++ b/lib/skate_web/channels/vehicles_search_channel.ex
@@ -47,8 +47,8 @@ defmodule SkateWeb.VehiclesSearchChannel do
     {:ok, %{data: result}, socket}
   end
 
-  @impl Phoenix.Channel
-  def handle_in(
+  @impl SkateWeb.AuthenticatedChannel
+  def handle_in_authenticated(
         "update_search_query",
         %{"limit" => limit},
         socket

--- a/test/skate_web/channels/vehicles_search_channel_test.exs
+++ b/test/skate_web/channels/vehicles_search_channel_test.exs
@@ -139,5 +139,24 @@ defmodule SkateWeb.VehiclesSearchChannelTest do
         data: %{matching_vehicles: [^new_match, ^match_1, ^match_2], has_more_matches: false}
       })
     end
+
+    test "handles updated search query with invalid token", %{
+      socket: socket
+    } do
+      {:ok, %{data: _data}, socket} =
+        subscribe_and_join(
+          socket,
+          VehiclesSearchChannel,
+          "vehicles_search:limited:vehicle:000"
+        )
+
+      reassign_env(:skate, :valid_token_fn, fn _socket -> false end)
+
+      Phoenix.ChannelTest.push(socket, "update_search_query", %{
+        "limit" => 3
+      })
+
+      assert_push "auth_expired", %{}
+    end
   end
 end


### PR DESCRIPTION
Asana ticket: [⚙️ Gracefully handle sessions where authentication expires](https://app.asana.com/0/1148853526253420/1205451125311872/f)

This extends the `AuthenticatedChannel` behaviour so that `handle_info` and `handle_in` also check the token status before further processing. There are some other callbacks we could implement like `handle_out` but since we don't currently use them I haven't implemented them yet.

I also updated the `useChannel` and related hooks so that any channels using them will auto-reload on `auth_expired` messages.