### PR TITLE
Minor Sentry cleanup

### DIFF
--- a/assets/src/skate.d.ts
+++ b/assets/src/skate.d.ts
@@ -25,9 +25,6 @@ declare global {
       }
       orgSlug: string
     }
-    sentry?: {
-      dsn: string
-    }
   }
 }
 

--- a/lib/skate_web/templates/layout/_sentry.html.eex
+++ b/lib/skate_web/templates/layout/_sentry.html.eex
@@ -1,9 +1,4 @@
 <script>
-  window.sentry = {
-    dsn: "<%= Application.get_env(:skate, :sentry_frontend_dsn) %>",
-    environment: "<%= Application.get_env(:skate, :sentry_environment) %>",
-    release: "<%= Application.get_env(:sentry, :release) %>"
-  };
   window.sentryInitialization = {
     initArgs: {
       dsn: "<%= Application.get_env(:skate, :sentry_frontend_dsn) %>",
@@ -11,5 +6,5 @@
       release: "<%= Application.get_env(:sentry, :release) %>"
     },
     orgSlug: "<%= Application.get_env(:skate, :sentry_org_slug) %>"
-  };
+  }
 </script>


### PR DESCRIPTION
Asana ticket: last bit of [⚙️ Integrate Fullstory and Sentry](https://app.asana.com/0/1148853526253420/1205560495149255/f)

Now that we're using `window.sentryInitialization`, we can get rid of the old `window.sentry` and any references to it.