### PR TITLE
fix: sort through-routed trips numerically

### DIFF
--- a/test/schedule/hastus/trip_test.exs
+++ b/test/schedule/hastus/trip_test.exs
@@ -99,7 +99,7 @@ defmodule Schedule.Hastus.TripTest do
     test "replaces a single consolidated through_routed trip with multiple differentiated trips" do
       hastus_trip1 = build(:hastus_trip, trip_id: "nonthrough_routed")
       hastus_trip2 = build(:hastus_trip, trip_id: "through_routed")
-      gtfs_trip_ids = ["nonthrough_routed", "through_routed_1", "through_routed_2"]
+      gtfs_trip_ids = ["nonthrough_routed", "through_routed_2", "through_routed_1"]
 
       result =
         [hastus_trip1, hastus_trip2]


### PR DESCRIPTION
Asana ticket: [⚙️ Fix negative duration layovers in minischedules](https://app.asana.com/0/1148853526253420/1205367064394203/f)

It turned out that the issue was that the trips were in reverse order in the GTFS `trips.txt` (which is fine, that file isn't guaranteed to be in any particular order). This adds logic to explicitly sort the trips by their numeric suffix.

I'm sort of of two minds on the `try` / `rescue` part of the code. On the one hand either the pattern matching on the return value of `Regex.scan/3` or the call to `String.to_integer/1` could in theory raise an error, but because of the way `original_id_to_through_routed_trip_ids` is built this case should never happen. That said, if it somehow _did_ happen it could be very bad and would cause the application to fail to fully start up, so it felt better to cover it. One disadvantage of including this logic is that, since it's unreachable, we can't write a test for it.

Note that the trip start and end place still come from HASTUS, and since HASTUS thinks of these through-routed trips as a single trip, that means both of the expanded trips will have the same departure point listed in the schedule. I'm thinking through how we might address that, if at all, but it will be a separate PR.