### PR TITLE
fix: don't use HASTUS start / end place for through-routed trips

### DIFF
--- a/assets/src/models/minischeduleData.ts
+++ b/assets/src/models/minischeduleData.ts
@@ -57,8 +57,8 @@ interface TripData {
   run_id: RunId | null
   start_time: Time
   end_time: Time
-  start_place: string
-  end_place: string
+  start_place: string | null
+  end_place: string | null
 }
 
 const isBreakData = (
@@ -117,8 +117,8 @@ const tripFromData = (tripData: TripData): Trip => ({
   runId: tripData.run_id,
   startTime: tripData.start_time,
   endTime: tripData.end_time,
-  startPlace: tripData.start_place,
-  endPlace: tripData.end_place,
+  startPlace: tripData.start_place || "",
+  endPlace: tripData.end_place || "",
 })
 
 const asDirectedFromData = (asDirectedData: AsDirectedData): AsDirected => ({

--- a/lib/schedule/hastus/trip.ex
+++ b/lib/schedule/hastus/trip.ex
@@ -11,8 +11,8 @@ defmodule Schedule.Hastus.Trip do
           block_id: Block.id(),
           start_time: Util.Time.time_of_day(),
           end_time: Util.Time.time_of_day(),
-          start_place: Place.id(),
-          end_place: Place.id(),
+          start_place: Place.id() | nil,
+          end_place: Place.id() | nil,
           # nil means nonrevenue
           route_id: Route.id() | nil,
           trip_id: Trip.id()
@@ -121,7 +121,10 @@ defmodule Schedule.Hastus.Trip do
             _ -> 0
           end
         end)
-        |> Enum.map(&%__MODULE__{trip | trip_id: &1})
+        # Since these trips are split up in GTFS, start and end place from HASTUS are not
+        # necessarily accurate. Origin and destination should be derived from stop times
+        # instead. See Schedule.Trip.merge/3
+        |> Enum.map(&%__MODULE__{trip | trip_id: &1, start_place: nil, end_place: nil})
       else
         [trip]
       end

--- a/test/schedule/hastus/trip_test.exs
+++ b/test/schedule/hastus/trip_test.exs
@@ -107,8 +107,13 @@ defmodule Schedule.Hastus.TripTest do
 
       assert result == [
                hastus_trip1,
-               %Trip{hastus_trip2 | trip_id: "through_routed_1"},
-               %Trip{hastus_trip2 | trip_id: "through_routed_2"}
+               %Trip{
+                 hastus_trip2
+                 | trip_id: "through_routed_1",
+                   start_place: nil,
+                   end_place: nil
+               },
+               %Trip{hastus_trip2 | trip_id: "through_routed_2", start_place: nil, end_place: nil}
              ]
     end
   end


### PR DESCRIPTION
Asana ticket: continuing work from [⚙️ Fix negative duration layovers in minischedules](https://app.asana.com/0/1148853526253420/1205367064394203/f)

The comment I left in `Schedule.Hastus.Trip` explains the rationale behind this change. I have checked the current GTFS and verified that all of the through-routed trips start and end with `stop_times` that have a timepoint ID associated with them, meaning that they will get an origin filled in. That said, I've also updated the front-end code to not crash if it does get a blank start / end place for a trip.