### PR TITLE
Link VPC run number to VPP

### DIFF
--- a/assets/css/_skate_ui.scss
+++ b/assets/css/_skate_ui.scss
@@ -94,6 +94,16 @@ $font-weights: (
   color: var(--font-color-on-light-700);
 }
 
+.kv-value--clickable {
+  color: var(--font-color-text-clickable);
+  font-weight: var(--font-weight-semi);
+  text-decoration: underline;
+
+  &:hover {
+    color: $color-eggplant-500;
+  }
+}
+
 .headsign {
   font-weight: var(--font-weight-semi);
   font-size: var(--font-size-m);

--- a/assets/css/_skate_ui.scss
+++ b/assets/css/_skate_ui.scss
@@ -102,6 +102,12 @@ $font-weights: (
   &:hover {
     color: $color-eggplant-500;
   }
+
+  &:focus {
+    color: $color-eggplant-500;
+    border: 1px solid $color-eggplant-700;
+    border-radius: 3px;
+  }
 }
 
 .headsign {

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -26,6 +26,8 @@ import Nav from "./nav"
 import RightPanel from "./rightPanel"
 import { mapModeForUser } from "../util/mapMode"
 import { Ghost, VehicleInScheduledService } from "../realtime"
+import MapPage from "./mapPage"
+import SearchPage from "./searchPage"
 
 export const AppRoutes = () => {
   useAppcues()
@@ -47,6 +49,8 @@ export const AppRoutes = () => {
     )
 
   const mapMode = mapModeForUser()
+
+  const mapElement = mapMode.path === "/map" ? <MapPage /> : <SearchPage />
 
   return (
     <div className="l-app">
@@ -79,12 +83,12 @@ export const AppRoutes = () => {
                 />
                 <BrowserRoute path="/settings" element={<SettingsPage />} />
                 {mapMode.supportsRightPanel ? (
-                  <BrowserRoute path={mapMode.path} element={mapMode.element} />
+                  <BrowserRoute path={mapMode.path} element={mapElement} />
                 ) : null}
               </Route>
               <Route>
                 {!mapMode.supportsRightPanel ? (
-                  <BrowserRoute path={mapMode.path} element={mapMode.element} />
+                  <BrowserRoute path={mapMode.path} element={mapElement} />
                 ) : null}
               </Route>
             </Routes>

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -286,61 +286,60 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   }
 
   return (
-    <div
-      className="c-map-page inherit-box border-box"
-      aria-label="Search Map Page"
-    >
+    <>
       <div
-        className={joinClasses([
-          "c-map-page__input-and-results",
-          searchOpen
-            ? "c-map-page__input-and-results--visible"
-            : "c-map-page__input-and-results--hidden",
-        ])}
-        aria-label="Map Search Panel"
+        className="c-map-page inherit-box border-box"
+        aria-label="Search Map Page"
       >
-        <DrawerTab
-          isVisible={searchOpen}
-          toggleVisibility={toggleSearchDrawer}
-        />
-        {selectedEntity ? (
-          <Selection
+        <div
+          className={joinClasses([
+            "c-map-page__input-and-results",
+            searchOpen
+              ? "c-map-page__input-and-results--visible"
+              : "c-map-page__input-and-results--hidden",
+          ])}
+          aria-label="Map Search Panel"
+        >
+          <DrawerTab
+            isVisible={searchOpen}
+            toggleVisibility={toggleSearchDrawer}
+          />
+          {selectedEntity ? (
+            <Selection
+              selectedEntity={selectedEntity}
+              setSelection={setVehicleSelection}
+              fetchedSelectedLocation={fetchedSelectedLocation}
+            />
+          ) : (
+            <SearchMode
+              onSelectVehicleResult={(...args) => {
+                setFollowerShouldSetZoomLevel(true)
+                selectVehicleResult(...args)
+              }}
+              onSelectLocationResult={selectLocationResult}
+            />
+          )}
+        </div>
+        <div className="c-map-page__map">
+          <MapDisplay
             selectedEntity={selectedEntity}
             setSelection={(...args) => {
               setFollowerShouldSetZoomLevel(false)
               setVehicleSelection(...args)
             }}
             fetchedSelectedLocation={fetchedSelectedLocation}
+            initializeRouteFollowerEnabled={followerShouldSetZoomLevel === true}
+            vehicleUseCurrentZoom={followerShouldSetZoomLevel === false}
+            onInterruptVehicleFollower={
+              (followerShouldSetZoomLevel === false || undefined) &&
+              (() => {
+                setFollowerShouldSetZoomLevel(false)
+              })
+            }
           />
-        ) : (
-          <SearchMode
-            onSelectVehicleResult={(...args) => {
-              setFollowerShouldSetZoomLevel(true)
-              selectVehicleResult(...args)
-            }}
-            onSelectLocationResult={selectLocationResult}
-          />
-        )}
+        </div>
       </div>
-      <div className="c-map-page__map">
-        <MapDisplay
-          selectedEntity={selectedEntity}
-          setSelection={(...args) => {
-            setFollowerShouldSetZoomLevel(false)
-            setVehicleSelection(...args)
-          }}
-          fetchedSelectedLocation={fetchedSelectedLocation}
-          initializeRouteFollowerEnabled={followerShouldSetZoomLevel === true}
-          vehicleUseCurrentZoom={followerShouldSetZoomLevel === false}
-          onInterruptVehicleFollower={
-            (followerShouldSetZoomLevel === false || undefined) &&
-            (() => {
-              setFollowerShouldSetZoomLevel(false)
-            })
-          }
-        />
-      </div>
-    </div>
+    </>
   )
 }
 

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -219,9 +219,10 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
   const [{ searchPageState, openView }, dispatch] =
       useContext(StateDispatchContext),
     { selectedEntity = null } = searchPageState
-  const [selectedVehicleOrGhost, setSelectedVehicleOrGhost] = useState<
-    Vehicle | Ghost | null
-  >(null)
+  const [
+    selectedRightPanelVehicleOrGhost,
+    setSelectedRightPanelVehicleOrGhost,
+  ] = useState<Vehicle | Ghost | null>(null)
 
   useEffect(() => {
     // don't dispatch closeView if the VPP is open
@@ -326,7 +327,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
               onVehicleRunClicked={
                 inTestGroup(TestGroups.SearchMapsOnMobile)
                   ? (vehicleOrGhost: Vehicle | Ghost) =>
-                      setSelectedVehicleOrGhost(vehicleOrGhost)
+                      setSelectedRightPanelVehicleOrGhost(vehicleOrGhost)
                   : undefined
               }
             />
@@ -359,10 +360,10 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
           />
         </div>
       </div>
-      {selectedVehicleOrGhost && (
+      {selectedRightPanelVehicleOrGhost && (
         <PropertiesPanel
-          selectedVehicleOrGhost={selectedVehicleOrGhost}
-          closePanel={() => setSelectedVehicleOrGhost(null)}
+          selectedVehicleOrGhost={selectedRightPanelVehicleOrGhost}
+          closePanel={() => setSelectedRightPanelVehicleOrGhost(null)}
           initialTab="run"
         />
       )}

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -110,7 +110,7 @@ const SelectedVehicle = ({
       vehicleOrGhost={selectedVehicleOrGhost}
       key={selectedVehicleOrGhost.id}
       onRouteVariantNameClicked={onRouteClicked || undefined}
-      onRunClicked={onRunClicked}
+      onRunClick={onRunClicked}
     />
   )
 }

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -363,7 +363,7 @@ const MapPage = (): ReactElement<HTMLDivElement> => {
       {selectedRightPanelVehicleOrGhost && (
         <PropertiesPanel
           selectedVehicleOrGhost={selectedRightPanelVehicleOrGhost}
-          closePanel={() => setSelectedRightPanelVehicleOrGhost(null)}
+          onClosePanel={() => setSelectedRightPanelVehicleOrGhost(null)}
           initialTab="run"
         />
       )}

--- a/assets/src/components/mapPage/vehiclePropertiesCard.tsx
+++ b/assets/src/components/mapPage/vehiclePropertiesCard.tsx
@@ -73,7 +73,7 @@ interface TrNameValueProps {
   children: ReactNode
   idPrefix?: string
   sensitivity?: HideSensitiveInfo
-  onValueClicked?: () => void
+  onValueClick?: () => void
 }
 
 const maskClass = "fs-mask"
@@ -85,7 +85,7 @@ const TrNameValue = ({
   children: value,
   idPrefix,
   sensitivity: sensitive = HideSensitiveInfo.None,
-  onValueClicked,
+  onValueClick,
 }: TrNameValueProps): React.ReactElement => {
   const id = (idPrefix ?? name) + useId()
   return (
@@ -104,8 +104,8 @@ const TrNameValue = ({
         ])}
         aria-labelledby={id}
       >
-        {onValueClicked ? (
-          <button className="kv-value--clickable" onClick={onValueClicked}>
+        {onValueClick ? (
+          <button className="kv-value--clickable" onClick={onValueClick}>
             {value}
           </button>
         ) : (
@@ -117,14 +117,14 @@ const TrNameValue = ({
 }
 
 type VehicleWorkInfoEventProps = {
-  onRunClicked?: (vehicleOrGhost: Vehicle | Ghost) => void
+  onRunClick?: (vehicleOrGhost: Vehicle | Ghost) => void
 }
 
 type VehicleWorkInfoProps = VehicleOrGhostProp & VehicleWorkInfoEventProps
 
 const VehicleWorkInfo = ({
   vehicleOrGhost,
-  onRunClicked,
+  onRunClick,
 }: VehicleWorkInfoProps): React.ReactElement => {
   const isLoggedOutVehicle =
     isVehicle(vehicleOrGhost) && isLoggedOut(vehicleOrGhost)
@@ -137,9 +137,7 @@ const VehicleWorkInfo = ({
         <tbody className="c-vehicle-work-info__items">
           <TrNameValue
             name="run"
-            onValueClicked={
-              onRunClicked && (() => onRunClicked(vehicleOrGhost))
-            }
+            onValueClick={onRunClick && (() => onRunClick(vehicleOrGhost))}
           >
             {vehicleOrGhost.runId || noRunText}
           </TrNameValue>
@@ -219,7 +217,7 @@ export type VehiclePropertiesCardProps = VehicleOrGhostProp &
 const VehiclePropertiesCard = ({
   vehicleOrGhost,
   onRouteVariantNameClicked,
-  onRunClicked,
+  onRunClick,
 }: VehiclePropertiesCardProps): React.ReactElement => {
   return (
     <div
@@ -248,7 +246,7 @@ const VehiclePropertiesCard = ({
         <div className="c-vehicle-properties-card__properties c-vehicle-properties-card__info-section">
           <VehicleWorkInfo
             vehicleOrGhost={vehicleOrGhost}
-            onRunClicked={onRunClicked}
+            onRunClick={onRunClick}
           />
         </div>
 

--- a/assets/src/components/mapPage/vehiclePropertiesCard.tsx
+++ b/assets/src/components/mapPage/vehiclePropertiesCard.tsx
@@ -73,6 +73,7 @@ interface TrNameValueProps {
   children: ReactNode
   idPrefix?: string
   sensitivity?: HideSensitiveInfo
+  onValueClicked?: () => void
 }
 
 const maskClass = "fs-mask"
@@ -84,6 +85,7 @@ const TrNameValue = ({
   children: value,
   idPrefix,
   sensitivity: sensitive = HideSensitiveInfo.None,
+  onValueClicked,
 }: TrNameValueProps): React.ReactElement => {
   const id = (idPrefix ?? name) + useId()
   return (
@@ -102,15 +104,28 @@ const TrNameValue = ({
         ])}
         aria-labelledby={id}
       >
-        {value}
+        {onValueClicked ? (
+          <button className="kv-value--clickable" onClick={onValueClicked}>
+            {value}
+          </button>
+        ) : (
+          <>{value}</>
+        )}
       </td>
     </tr>
   )
 }
 
+type VehicleWorkInfoEventProps = {
+  onRunClicked?: (vehicleOrGhost: Vehicle | Ghost) => void
+}
+
+type VehicleWorkInfoProps = VehicleOrGhostProp & VehicleWorkInfoEventProps
+
 const VehicleWorkInfo = ({
   vehicleOrGhost,
-}: VehicleOrGhostProp): React.ReactElement => {
+  onRunClicked,
+}: VehicleWorkInfoProps): React.ReactElement => {
   const isLoggedOutVehicle =
     isVehicle(vehicleOrGhost) && isLoggedOut(vehicleOrGhost)
   const noRunText = isLoggedOutVehicle ? "No run logged in" : "N/A"
@@ -120,7 +135,12 @@ const VehicleWorkInfo = ({
     <>
       <table className="c-vehicle-work-info">
         <tbody className="c-vehicle-work-info__items">
-          <TrNameValue name="run">
+          <TrNameValue
+            name="run"
+            onValueClicked={
+              onRunClicked && (() => onRunClicked(vehicleOrGhost))
+            }
+          >
             {vehicleOrGhost.runId || noRunText}
           </TrNameValue>
           <TrNameValue name="vehicle">
@@ -193,11 +213,13 @@ const VehicleLocationStreetViewButton = ({ vehicle }: { vehicle: Vehicle }) => (
 
 // #region Vehicle Properties Card
 export type VehiclePropertiesCardProps = VehicleOrGhostProp &
-  VehicleRouteSummaryEventProps
+  VehicleRouteSummaryEventProps &
+  VehicleWorkInfoEventProps
 
 const VehiclePropertiesCard = ({
   vehicleOrGhost,
   onRouteVariantNameClicked,
+  onRunClicked,
 }: VehiclePropertiesCardProps): React.ReactElement => {
   return (
     <div
@@ -224,7 +246,10 @@ const VehiclePropertiesCard = ({
 
       <div className="c-vehicle-properties-card__body">
         <div className="c-vehicle-properties-card__properties c-vehicle-properties-card__info-section">
-          <VehicleWorkInfo vehicleOrGhost={vehicleOrGhost} />
+          <VehicleWorkInfo
+            vehicleOrGhost={vehicleOrGhost}
+            onRunClicked={onRunClicked}
+          />
         </div>
 
         <div

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export type IndividualPropertiesPanelProps = {
   tabMode: TabMode
-  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  onChangeTabMode: React.Dispatch<React.SetStateAction<TabMode>>
   closePanel: () => void
 }
 
@@ -55,21 +55,21 @@ const PropertiesPanel = ({
           <StaleDataPropertiesPanel
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
-            setTabMode={setTabMode}
+            onChangeTabMode={setTabMode}
             closePanel={closePanel}
           />
         ) : isVehicle(mostRecentVehicle) ? (
           <VehiclePropertiesPanel
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
-            setTabMode={setTabMode}
+            onChangeTabMode={setTabMode}
             closePanel={closePanel}
           />
         ) : (
           <GhostPropertiesPanel
             selectedGhost={mostRecentVehicle}
             tabMode={tabMode}
-            setTabMode={setTabMode}
+            onChangeTabMode={setTabMode}
             closePanel={closePanel}
           />
         )}

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -11,13 +11,13 @@ import { TabMode } from "./propertiesPanel/tabPanels"
 interface Props {
   selectedVehicleOrGhost: Vehicle | Ghost
   initialTab?: TabMode
-  closePanel: () => void
+  onClosePanel: () => void
 }
 
 export type IndividualPropertiesPanelProps = {
   tabMode: TabMode
   onChangeTabMode: React.Dispatch<React.SetStateAction<TabMode>>
-  closePanel: () => void
+  onClosePanel: () => void
 }
 
 export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
@@ -32,7 +32,7 @@ export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
 const PropertiesPanel = ({
   selectedVehicleOrGhost,
   initialTab = "status",
-  closePanel,
+  onClosePanel,
 }: Props) => {
   const { socket } = useSocket()
   const liveVehicle = useVehicleForId(socket, selectedVehicleOrGhost.id)
@@ -56,21 +56,21 @@ const PropertiesPanel = ({
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
             onChangeTabMode={setTabMode}
-            closePanel={closePanel}
+            onClosePanel={onClosePanel}
           />
         ) : isVehicle(mostRecentVehicle) ? (
           <VehiclePropertiesPanel
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
             onChangeTabMode={setTabMode}
-            closePanel={closePanel}
+            onClosePanel={onClosePanel}
           />
         ) : (
           <GhostPropertiesPanel
             selectedGhost={mostRecentVehicle}
             tabMode={tabMode}
             onChangeTabMode={setTabMode}
-            closePanel={closePanel}
+            onClosePanel={onClosePanel}
           />
         )}
       </div>
@@ -78,7 +78,7 @@ const PropertiesPanel = ({
         className="c-properties-panel-backdrop"
         onClick={
           /* istanbul ignore next */
-          () => hideMeIfNoCrowdingTooltip(closePanel)
+          () => hideMeIfNoCrowdingTooltip(onClosePanel)
         }
         aria-hidden={true}
       />

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -64,7 +64,11 @@ const PropertiesPanel = ({
             setTabMode={setTabMode}
           />
         ) : (
-          <GhostPropertiesPanel selectedGhost={vehicleToDisplay} />
+          <GhostPropertiesPanel
+            selectedGhost={vehicleToDisplay}
+            tabMode={tabMode}
+            setTabMode={setTabMode}
+          />
         )}
       </div>
       <div

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -14,6 +14,12 @@ interface Props {
   closePanel: () => void
 }
 
+export type IndividualPropertiesPanelProps = {
+  tabMode: TabMode
+  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  closePanel: () => void
+}
+
 export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
   const noTooltipOpen =
     document.getElementsByClassName("c-crowding-diagram__crowding-tooltip")

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -8,9 +8,11 @@ import { closeView } from "../state"
 import GhostPropertiesPanel from "./propertiesPanel/ghostPropertiesPanel"
 import StaleDataPropertiesPanel from "./propertiesPanel/staleDataPropertiesPanel"
 import VehiclePropertiesPanel from "./propertiesPanel/vehiclePropertiesPanel"
+import { TabMode } from "./propertiesPanel/tabPanels"
 
 interface Props {
   selectedVehicleOrGhost: Vehicle | Ghost
+  initialTab?: TabMode
 }
 
 export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
@@ -22,7 +24,10 @@ export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
   }
 }
 
-const PropertiesPanel = ({ selectedVehicleOrGhost }: Props) => {
+const PropertiesPanel = ({
+  selectedVehicleOrGhost,
+  initialTab = "status",
+}: Props) => {
   const [, dispatch] = useContext(StateDispatchContext)
   const { socket } = useSocket()
   const liveVehicle = useVehicleForId(socket, selectedVehicleOrGhost.id)
@@ -30,6 +35,7 @@ const PropertiesPanel = ({ selectedVehicleOrGhost }: Props) => {
     liveVehicle || selectedVehicleOrGhost
   )
   const [dataIsStale, setDataIsStale] = useState<boolean>(false)
+  const [tabMode, setTabMode] = useState<TabMode>(initialTab)
 
   useEffect(() => {
     if (liveVehicle) {
@@ -52,7 +58,11 @@ const PropertiesPanel = ({ selectedVehicleOrGhost }: Props) => {
         (dataIsStale || isLoggedOut(vehicleToDisplay)) ? (
           <StaleDataPropertiesPanel selectedVehicle={vehicleToDisplay} />
         ) : isVehicle(vehicleToDisplay) ? (
-          <VehiclePropertiesPanel selectedVehicle={vehicleToDisplay} />
+          <VehiclePropertiesPanel
+            selectedVehicle={vehicleToDisplay}
+            tabMode={tabMode}
+            setTabMode={setTabMode}
+          />
         ) : (
           <GhostPropertiesPanel selectedGhost={vehicleToDisplay} />
         )}

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -1,10 +1,8 @@
-import React, { useContext, useEffect, useState } from "react"
-import { StateDispatchContext } from "../contexts/stateDispatchContext"
+import React, { useEffect, useState } from "react"
 import useSocket from "../hooks/useSocket"
 import useVehicleForId from "../hooks/useVehicleForId"
 import { isLoggedOut, isVehicle } from "../models/vehicle"
 import { Ghost, Vehicle } from "../realtime.d"
-import { closeView } from "../state"
 import GhostPropertiesPanel from "./propertiesPanel/ghostPropertiesPanel"
 import StaleDataPropertiesPanel from "./propertiesPanel/staleDataPropertiesPanel"
 import VehiclePropertiesPanel from "./propertiesPanel/vehiclePropertiesPanel"
@@ -13,6 +11,7 @@ import { TabMode } from "./propertiesPanel/tabPanels"
 interface Props {
   selectedVehicleOrGhost: Vehicle | Ghost
   initialTab?: TabMode
+  closePanel: () => void
 }
 
 export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
@@ -27,8 +26,8 @@ export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
 const PropertiesPanel = ({
   selectedVehicleOrGhost,
   initialTab = "status",
+  closePanel,
 }: Props) => {
-  const [, dispatch] = useContext(StateDispatchContext)
   const { socket } = useSocket()
   const liveVehicle = useVehicleForId(socket, selectedVehicleOrGhost.id)
   const [vehicleToDisplay, setVehicleToDisplay] = useState<Vehicle | Ghost>(
@@ -49,8 +48,6 @@ const PropertiesPanel = ({
     }
   }, [liveVehicle])
 
-  const hideMe = () => dispatch(closeView())
-
   return (
     <>
       <div id="c-properties-panel" className="c-properties-panel">
@@ -60,18 +57,21 @@ const PropertiesPanel = ({
             selectedVehicle={vehicleToDisplay}
             tabMode={tabMode}
             setTabMode={setTabMode}
+            closePanel={closePanel}
           />
         ) : isVehicle(vehicleToDisplay) ? (
           <VehiclePropertiesPanel
             selectedVehicle={vehicleToDisplay}
             tabMode={tabMode}
             setTabMode={setTabMode}
+            closePanel={closePanel}
           />
         ) : (
           <GhostPropertiesPanel
             selectedGhost={vehicleToDisplay}
             tabMode={tabMode}
             setTabMode={setTabMode}
+            closePanel={closePanel}
           />
         )}
       </div>
@@ -79,7 +79,7 @@ const PropertiesPanel = ({
         className="c-properties-panel-backdrop"
         onClick={
           /* istanbul ignore next */
-          () => hideMeIfNoCrowdingTooltip(hideMe)
+          () => hideMeIfNoCrowdingTooltip(closePanel)
         }
         aria-hidden={true}
       />

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -56,7 +56,11 @@ const PropertiesPanel = ({
       <div id="c-properties-panel" className="c-properties-panel">
         {isVehicle(vehicleToDisplay) &&
         (dataIsStale || isLoggedOut(vehicleToDisplay)) ? (
-          <StaleDataPropertiesPanel selectedVehicle={vehicleToDisplay} />
+          <StaleDataPropertiesPanel
+            selectedVehicle={vehicleToDisplay}
+            tabMode={tabMode}
+            setTabMode={setTabMode}
+          />
         ) : isVehicle(vehicleToDisplay) ? (
           <VehiclePropertiesPanel
             selectedVehicle={vehicleToDisplay}

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -30,45 +30,38 @@ const PropertiesPanel = ({
 }: Props) => {
   const { socket } = useSocket()
   const liveVehicle = useVehicleForId(socket, selectedVehicleOrGhost.id)
-  const [vehicleToDisplay, setVehicleToDisplay] = useState<Vehicle | Ghost>(
+  const [mostRecentVehicle, setMostRecentVehicle] = useState<Vehicle | Ghost>(
     liveVehicle || selectedVehicleOrGhost
   )
-  const [dataIsStale, setDataIsStale] = useState<boolean>(false)
   const [tabMode, setTabMode] = useState<TabMode>(initialTab)
 
   useEffect(() => {
     if (liveVehicle) {
-      setVehicleToDisplay(liveVehicle)
-    }
-
-    if (liveVehicle === null) {
-      setDataIsStale(true)
-    } else {
-      setDataIsStale(false)
+      setMostRecentVehicle(liveVehicle)
     }
   }, [liveVehicle])
 
   return (
     <>
       <div id="c-properties-panel" className="c-properties-panel">
-        {isVehicle(vehicleToDisplay) &&
-        (dataIsStale || isLoggedOut(vehicleToDisplay)) ? (
+        {isVehicle(mostRecentVehicle) &&
+        (liveVehicle === null || isLoggedOut(mostRecentVehicle)) ? (
           <StaleDataPropertiesPanel
-            selectedVehicle={vehicleToDisplay}
+            selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
             setTabMode={setTabMode}
             closePanel={closePanel}
           />
-        ) : isVehicle(vehicleToDisplay) ? (
+        ) : isVehicle(mostRecentVehicle) ? (
           <VehiclePropertiesPanel
-            selectedVehicle={vehicleToDisplay}
+            selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
             setTabMode={setTabMode}
             closePanel={closePanel}
           />
         ) : (
           <GhostPropertiesPanel
-            selectedGhost={vehicleToDisplay}
+            selectedGhost={mostRecentVehicle}
             tabMode={tabMode}
             setTabMode={setTabMode}
             closePanel={closePanel}

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -36,8 +36,8 @@ const GhostPropertiesPanel = ({
       <Header
         vehicle={selectedGhost}
         tabMode={tabMode}
-        setTabMode={onChangeTabMode}
-        closePanel={onClosePanel}
+        onChangeTabMode={onChangeTabMode}
+        onClosePanel={onClosePanel}
       />
 
       <TabPanels

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -29,7 +29,7 @@ const GhostPropertiesPanel = ({
   selectedGhost,
   tabMode,
   onChangeTabMode,
-  closePanel,
+  onClosePanel,
 }: Props) => {
   return (
     <div className="c-ghost-properties-panel">
@@ -37,7 +37,7 @@ const GhostPropertiesPanel = ({
         vehicle={selectedGhost}
         tabMode={tabMode}
         setTabMode={onChangeTabMode}
-        closePanel={closePanel}
+        closePanel={onClosePanel}
       />
 
       <TabPanels

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 import { hasBlockWaiver } from "../../models/blockWaiver"
 import { Ghost } from "../../realtime"
 import PropertiesList, { ghostProperties } from "../propertiesList"
@@ -9,6 +9,8 @@ import TabPanels, { TabMode } from "./tabPanels"
 
 interface Props {
   selectedGhost: Ghost
+  tabMode: TabMode
+  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
 }
 
 const StatusContent = ({ ghost }: { ghost: Ghost }) => (
@@ -24,9 +26,11 @@ const StatusContent = ({ ghost }: { ghost: Ghost }) => (
   </>
 )
 
-const GhostPropertiesPanel = ({ selectedGhost }: Props) => {
-  const [tabMode, setTabMode] = useState<TabMode>("status")
-
+const GhostPropertiesPanel = ({
+  selectedGhost,
+  tabMode,
+  setTabMode,
+}: Props) => {
   return (
     <div className="c-ghost-properties-panel">
       <Header

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -5,14 +5,12 @@ import PropertiesList, { ghostProperties } from "../propertiesList"
 import { NoWaiverBanner } from "./blockWaiverBanner"
 import BlockWaiverList from "./blockWaiverList"
 import Header from "./header"
-import TabPanels, { TabMode } from "./tabPanels"
+import TabPanels from "./tabPanels"
+import { IndividualPropertiesPanelProps } from "../propertiesPanel"
 
-interface Props {
+type Props = {
   selectedGhost: Ghost
-  tabMode: TabMode
-  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
-  closePanel: () => void
-}
+} & IndividualPropertiesPanelProps
 
 const StatusContent = ({ ghost }: { ghost: Ghost }) => (
   <>

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -28,7 +28,7 @@ const StatusContent = ({ ghost }: { ghost: Ghost }) => (
 const GhostPropertiesPanel = ({
   selectedGhost,
   tabMode,
-  setTabMode,
+  onChangeTabMode,
   closePanel,
 }: Props) => {
   return (
@@ -36,7 +36,7 @@ const GhostPropertiesPanel = ({
       <Header
         vehicle={selectedGhost}
         tabMode={tabMode}
-        setTabMode={setTabMode}
+        setTabMode={onChangeTabMode}
         closePanel={closePanel}
       />
 

--- a/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/ghostPropertiesPanel.tsx
@@ -11,6 +11,7 @@ interface Props {
   selectedGhost: Ghost
   tabMode: TabMode
   setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  closePanel: () => void
 }
 
 const StatusContent = ({ ghost }: { ghost: Ghost }) => (
@@ -30,6 +31,7 @@ const GhostPropertiesPanel = ({
   selectedGhost,
   tabMode,
   setTabMode,
+  closePanel,
 }: Props) => {
   return (
     <div className="c-ghost-properties-panel">
@@ -37,6 +39,7 @@ const GhostPropertiesPanel = ({
         vehicle={selectedGhost}
         tabMode={tabMode}
         setTabMode={setTabMode}
+        closePanel={closePanel}
       />
 
       <TabPanels

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -17,7 +17,7 @@ import {
   statusClasses,
 } from "../../models/vehicleStatus"
 import { Ghost, Vehicle, VehicleInScheduledService } from "../../realtime"
-import { closeView, returnToPreviousView } from "../../state"
+import { returnToPreviousView } from "../../state"
 import { RouteVariantName } from "../routeVariantName"
 import VehicleIcon, { Size, vehicleOrientation } from "../vehicleIcon"
 import TabList from "./tabList"
@@ -29,6 +29,7 @@ interface Props {
   vehicle: Vehicle | Ghost
   tabMode: TabMode
   setTabMode: Dispatch<SetStateAction<TabMode>>
+  closePanel: () => void
 }
 
 const ScheduleAdherenceStatusIcon = () => (
@@ -91,13 +92,11 @@ const ScheduleAdherence = ({
   )
 }
 
-const Header = ({ vehicle, tabMode, setTabMode }: Props) => {
+const Header = ({ vehicle, tabMode, setTabMode, closePanel }: Props) => {
   const [{ routeTabs, userSettings, previousView }, dispatch] =
     useContext(StateDispatchContext)
   const epochNowInSeconds = useCurrentTimeSeconds()
   const route = useRoute(vehicle.routeId)
-
-  const hideMe = () => dispatch(closeView())
 
   const vehicleIsShuttle = isVehicle(vehicle) && vehicle.isShuttle
 
@@ -110,7 +109,7 @@ const Header = ({ vehicle, tabMode, setTabMode }: Props) => {
     <div className="c-properties-panel__header-wrapper">
       <ViewHeader
         title="Vehicles"
-        closeView={hideMe}
+        closeView={closePanel}
         backlinkToView={previousView}
         followBacklink={() => dispatch(returnToPreviousView())}
       />

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -28,8 +28,8 @@ import ViewHeader from "../viewHeader"
 interface Props {
   vehicle: Vehicle | Ghost
   tabMode: TabMode
-  setTabMode: Dispatch<SetStateAction<TabMode>>
-  closePanel: () => void
+  onChangeTabMode: Dispatch<SetStateAction<TabMode>>
+  onClosePanel: () => void
 }
 
 const ScheduleAdherenceStatusIcon = () => (
@@ -92,7 +92,7 @@ const ScheduleAdherence = ({
   )
 }
 
-const Header = ({ vehicle, tabMode, setTabMode, closePanel }: Props) => {
+const Header = ({ vehicle, tabMode, onChangeTabMode, onClosePanel }: Props) => {
   const [{ routeTabs, userSettings, previousView }, dispatch] =
     useContext(StateDispatchContext)
   const epochNowInSeconds = useCurrentTimeSeconds()
@@ -109,7 +109,7 @@ const Header = ({ vehicle, tabMode, setTabMode, closePanel }: Props) => {
     <div className="c-properties-panel__header-wrapper">
       <ViewHeader
         title="Vehicles"
-        closeView={closePanel}
+        closeView={onClosePanel}
         backlinkToView={previousView}
         followBacklink={() => dispatch(returnToPreviousView())}
       />
@@ -144,7 +144,7 @@ const Header = ({ vehicle, tabMode, setTabMode, closePanel }: Props) => {
         </div>
       </div>
       {vehicleIsShuttle || (
-        <TabList activeTab={tabMode} setActiveTab={setTabMode} />
+        <TabList activeTab={tabMode} setActiveTab={onChangeTabMode} />
       )}
     </div>
   )

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useContext, useState } from "react"
+import React, { Dispatch, SetStateAction, useContext } from "react"
 import { hasBlockWaiver } from "../../models/blockWaiver"
 import { Vehicle } from "../../realtime"
 import BlockWaiverList from "./blockWaiverList"
@@ -14,11 +14,15 @@ import { isVehicleInScheduledService } from "../../models/vehicle"
 
 interface Props {
   selectedVehicle: Vehicle
+  tabMode: TabMode
+  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
 }
 
-const StaleDataPropertiesPanel: React.FC<Props> = ({ selectedVehicle }) => {
-  const [tabMode, setTabMode] = useState<TabMode>("status")
-
+const StaleDataPropertiesPanel: React.FC<Props> = ({
+  selectedVehicle,
+  tabMode,
+  setTabMode,
+}) => {
   return (
     <div className="c-stale-data-properties-panel">
       <StaleDataHeader

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -6,7 +6,7 @@ import TabPanels, { TabMode } from "./tabPanels"
 import { Card, CardBody } from "../card"
 import VehicleIcon, { Orientation, Size } from "../vehicleIcon"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
-import { closeView, returnToPreviousView } from "../../state"
+import { returnToPreviousView } from "../../state"
 import { runOrBusNumberLabel } from "../../helpers/vehicleLabel"
 import TabList from "./tabList"
 import ViewHeader from "../viewHeader"
@@ -16,12 +16,14 @@ interface Props {
   selectedVehicle: Vehicle
   tabMode: TabMode
   setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  closePanel: () => void
 }
 
 const StaleDataPropertiesPanel: React.FC<Props> = ({
   selectedVehicle,
   tabMode,
   setTabMode,
+  closePanel,
 }) => {
   return (
     <div className="c-stale-data-properties-panel">
@@ -29,6 +31,7 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
         vehicle={selectedVehicle}
         tabMode={tabMode}
         setTabMode={setTabMode}
+        closePanel={closePanel}
       />
       {isVehicleInScheduledService(selectedVehicle) ? (
         <TabPanels
@@ -47,17 +50,16 @@ const StaleDataHeader: React.FC<{
   vehicle: Vehicle
   tabMode: TabMode
   setTabMode: Dispatch<SetStateAction<TabMode>>
-}> = ({ vehicle, tabMode, setTabMode }) => {
+  closePanel: () => void
+}> = ({ vehicle, tabMode, setTabMode, closePanel }) => {
   const [{ userSettings, previousView }, dispatch] =
     useContext(StateDispatchContext)
-
-  const hideMe = () => dispatch(closeView())
 
   return (
     <div className="c-properties-panel__header-wrapper">
       <ViewHeader
         title="Vehicles"
-        closeView={hideMe}
+        closeView={closePanel}
         backlinkToView={previousView}
         followBacklink={() => dispatch(returnToPreviousView())}
       />

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -21,7 +21,7 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
   selectedVehicle,
   tabMode,
   onChangeTabMode,
-  closePanel,
+  onClosePanel,
 }) => {
   return (
     <div className="c-stale-data-properties-panel">
@@ -29,7 +29,7 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
         vehicle={selectedVehicle}
         tabMode={tabMode}
         setTabMode={onChangeTabMode}
-        closePanel={closePanel}
+        closePanel={onClosePanel}
       />
       {isVehicleInScheduledService(selectedVehicle) ? (
         <TabPanels

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -20,7 +20,7 @@ type Props = {
 const StaleDataPropertiesPanel: React.FC<Props> = ({
   selectedVehicle,
   tabMode,
-  setTabMode,
+  onChangeTabMode,
   closePanel,
 }) => {
   return (
@@ -28,7 +28,7 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
       <StaleDataHeader
         vehicle={selectedVehicle}
         tabMode={tabMode}
-        setTabMode={setTabMode}
+        setTabMode={onChangeTabMode}
         closePanel={closePanel}
       />
       {isVehicleInScheduledService(selectedVehicle) ? (

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -11,13 +11,11 @@ import { runOrBusNumberLabel } from "../../helpers/vehicleLabel"
 import TabList from "./tabList"
 import ViewHeader from "../viewHeader"
 import { isVehicleInScheduledService } from "../../models/vehicle"
+import { IndividualPropertiesPanelProps } from "../propertiesPanel"
 
-interface Props {
+type Props = {
   selectedVehicle: Vehicle
-  tabMode: TabMode
-  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
-  closePanel: () => void
-}
+} & IndividualPropertiesPanelProps
 
 const StaleDataPropertiesPanel: React.FC<Props> = ({
   selectedVehicle,

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -29,6 +29,7 @@ interface Props {
   selectedVehicle: Vehicle
   tabMode: TabMode
   setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  closePanel: () => void
 }
 
 const InvalidBanner = () => (
@@ -205,6 +206,7 @@ const VehiclePropertiesPanel = ({
   selectedVehicle,
   tabMode,
   setTabMode,
+  closePanel,
 }: Props) => {
   return (
     <div className="c-vehicle-properties-panel">
@@ -219,6 +221,7 @@ const VehiclePropertiesPanel = ({
           }
           setTabMode(newTabMode)
         }}
+        closePanel={closePanel}
       />
 
       {isVehicleInScheduledService(selectedVehicle) ? (

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -21,16 +21,14 @@ import BlockWaiverList from "./blockWaiverList"
 import CrowdingDiagram from "./crowdingDiagram"
 import Header from "./header"
 import MiniMap from "./miniMap"
-import TabPanels, { TabMode } from "./tabPanels"
+import TabPanels from "./tabPanels"
 import { DiamondTurnRightIcon } from "../../helpers/icon"
 import { fullStoryEvent } from "../../helpers/fullStory"
+import { IndividualPropertiesPanelProps } from "../propertiesPanel"
 
-interface Props {
+type Props = {
   selectedVehicle: Vehicle
-  tabMode: TabMode
-  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
-  closePanel: () => void
-}
+} & IndividualPropertiesPanelProps
 
 const InvalidBanner = () => (
   <Card

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -211,7 +211,7 @@ const VehiclePropertiesPanel = ({
       <Header
         vehicle={selectedVehicle}
         tabMode={tabMode}
-        setTabMode={(newTabMode) => {
+        onChangeTabMode={(newTabMode) => {
           if (newTabMode !== tabMode) {
             fullStoryEvent("Switched tab in Vehicle Properties Panel", {
               tab_str: newTabMode,
@@ -219,7 +219,7 @@ const VehiclePropertiesPanel = ({
           }
           onChangeTabMode(newTabMode)
         }}
-        closePanel={onClosePanel}
+        onClosePanel={onClosePanel}
       />
 
       {isVehicleInScheduledService(selectedVehicle) ? (

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -203,7 +203,7 @@ const StatusContent = ({ selectedVehicle }: { selectedVehicle: Vehicle }) => (
 const VehiclePropertiesPanel = ({
   selectedVehicle,
   tabMode,
-  setTabMode,
+  onChangeTabMode,
   closePanel,
 }: Props) => {
   return (
@@ -217,7 +217,7 @@ const VehiclePropertiesPanel = ({
               tab_str: newTabMode,
             })
           }
-          setTabMode(newTabMode)
+          onChangeTabMode(newTabMode)
         }}
         closePanel={closePanel}
       />

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -204,7 +204,7 @@ const VehiclePropertiesPanel = ({
   selectedVehicle,
   tabMode,
   onChangeTabMode,
-  closePanel,
+  onClosePanel,
 }: Props) => {
   return (
     <div className="c-vehicle-properties-panel">
@@ -219,7 +219,7 @@ const VehiclePropertiesPanel = ({
           }
           onChangeTabMode(newTabMode)
         }}
-        closePanel={closePanel}
+        closePanel={onClosePanel}
       />
 
       {isVehicleInScheduledService(selectedVehicle) ? (

--- a/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/vehiclePropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react"
+import React, { useContext } from "react"
 import { SocketContext } from "../../contexts/socketContext"
 import { VehiclesByRouteIdContext } from "../../contexts/vehiclesByRouteIdContext"
 import { useNearestIntersection } from "../../hooks/useNearestIntersection"
@@ -27,7 +27,8 @@ import { fullStoryEvent } from "../../helpers/fullStory"
 
 interface Props {
   selectedVehicle: Vehicle
-  initialTab?: TabMode
+  tabMode: TabMode
+  setTabMode: React.Dispatch<React.SetStateAction<TabMode>>
 }
 
 const InvalidBanner = () => (
@@ -202,10 +203,9 @@ const StatusContent = ({ selectedVehicle }: { selectedVehicle: Vehicle }) => (
 
 const VehiclePropertiesPanel = ({
   selectedVehicle,
-  initialTab = "status",
+  tabMode,
+  setTabMode,
 }: Props) => {
-  const [tabMode, setTabMode] = useState<TabMode>(initialTab)
-
   return (
     <div className="c-vehicle-properties-panel">
       <Header

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -17,7 +17,7 @@ const RightPanel = ({
     return (
       <PropertiesPanel
         selectedVehicleOrGhost={selectedVehicleOrGhost}
-        closePanel={() => dispatch(closeView())}
+        onClosePanel={() => dispatch(closeView())}
       />
     )
   } else if (state.openView === OpenView.Swings) {

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useContext } from "react"
 import { StateDispatchContext } from "../contexts/stateDispatchContext"
 import { Ghost, Vehicle } from "../realtime.d"
-import { OpenView } from "../state"
+import { OpenView, closeView } from "../state"
 import NotificationDrawer from "./notificationDrawer"
 import PropertiesPanel from "./propertiesPanel"
 import SwingsView from "./swingsView"
@@ -11,10 +11,15 @@ const RightPanel = ({
 }: {
   selectedVehicleOrGhost?: Vehicle | Ghost | null
 }): ReactElement<HTMLElement> | null => {
-  const [state] = useContext(StateDispatchContext)
+  const [state, dispatch] = useContext(StateDispatchContext)
 
   if (selectedVehicleOrGhost) {
-    return <PropertiesPanel selectedVehicleOrGhost={selectedVehicleOrGhost} />
+    return (
+      <PropertiesPanel
+        selectedVehicleOrGhost={selectedVehicleOrGhost}
+        closePanel={() => dispatch(closeView())}
+      />
+    )
   } else if (state.openView === OpenView.Swings) {
     return <SwingsView />
   } else if (state.openView === OpenView.NotificationDrawer) {

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -4,6 +4,7 @@ export enum TestGroups {
   DemoMode = "demo-mode",
   MapBeta = "map-beta",
   LateView = "late-view",
+  SearchMapsOnMobile = "search-maps-on-mobile",
 }
 
 const inTestGroup = (key: TestGroups): boolean => {

--- a/assets/src/util/mapMode.ts
+++ b/assets/src/util/mapMode.ts
@@ -1,7 +1,3 @@
-import React from "react"
-import { ReactElement } from "react"
-import MapPage from "../components/mapPage"
-import SearchPage from "../components/searchPage"
 import { SearchIcon, SearchMapIcon } from "../helpers/icon"
 import inTestGroup, { TestGroups } from "../userInTestGroup"
 
@@ -10,7 +6,6 @@ type HTMLElementProps = React.PropsWithoutRef<React.HTMLAttributes<HTMLElement>>
 export interface NavMode {
   path: string
   title: string
-  element: ReactElement
   navIcon: React.JSXElementConstructor<HTMLElementProps>
   supportsRightPanel: boolean
   navEventText?: string
@@ -19,7 +14,6 @@ export interface NavMode {
 const legacyMapConfig = {
   path: "/search",
   title: "Search",
-  element: <SearchPage />,
   navIcon: SearchIcon,
   supportsRightPanel: true,
 }
@@ -27,7 +21,6 @@ const legacyMapConfig = {
 export const searchMapConfig = {
   path: "/map",
   title: "Search Map",
-  element: <MapPage />,
   navIcon: SearchMapIcon,
   supportsRightPanel: false,
   navEventText: "Search Map nav entry clicked",

--- a/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/propertiesPanel.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`PropertiesPanel renders a ghost 1`] = `
           <button
             aria-label="Close"
             className="c-close-button c-close-button--x-large c-close-button--light"
-            onClick={[Function]}
+            onClick={[MockFunction]}
           >
             <span
               aria-hidden={true}
@@ -342,7 +342,7 @@ exports[`PropertiesPanel renders a vehicle 1`] = `
           <button
             aria-label="Close"
             className="c-close-button c-close-button--x-large c-close-button--light"
-            onClick={[Function]}
+            onClick={[MockFunction]}
           >
             <span
               aria-hidden={true}

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -86,17 +86,14 @@ import { useMinischeduleRun } from "../../src/hooks/useMinischedule"
 import pieceFactory from "../factories/piece"
 
 jest.mock("../../src/hooks/useLocationSearchResults", () => ({
-  __esModule: true,
   useLocationSearchResults: jest.fn(() => null),
 }))
 
 jest.mock("../../src/hooks/useLocationSearchSuggestions", () => ({
-  __esModule: true,
   useLocationSearchSuggestions: jest.fn(() => null),
 }))
 
 jest.mock("../../src/hooks/useLocationSearchResultById", () => ({
-  __esModule: true,
   default: jest.fn(() => null),
   useLocationSearchResultById: jest.fn(() => null),
 }))
@@ -107,7 +104,6 @@ jest.mock("../../src/hooks/usePatternsByIdForRoute", () => ({
 }))
 
 jest.mock("../../src/hooks/useNearestIntersection", () => ({
-  __esModule: true,
   useNearestIntersection: jest.fn(() => {
     return {
       is_loading: true,
@@ -126,23 +122,16 @@ jest.mock("../../src/hooks/useVehiclesForRoute", () => ({
 }))
 
 jest.mock("../../src/hooks/useAllStops", () => ({
-  __esModule: true,
   useAllStops: jest.fn(() => []),
 }))
 
 jest.mock("../../src/hooks/useStations", () => ({
-  __esModule: true,
   useStations: jest.fn(() => []),
 }))
 
-jest.mock("../../src/hooks/useMinischedule", () => ({
-  __esModule: true,
-  useMinischeduleRun: jest.fn(),
-  useMinischeduleBlock: jest.fn(),
-}))
+jest.mock("../../src/hooks/useMinischedule")
 
 jest.mock("../../src/tilesetUrls", () => ({
-  __esModule: true,
   tilesetUrlForType: jest.fn(() => null),
 }))
 

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -970,10 +970,9 @@ describe("<MapPage />", () => {
 
     expect(vehiclePropertiesPanelHeader.get()).toBeInTheDocument()
 
-    expect(screen.getByRole("tab", { name: "Run" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    )
+    expect(
+      screen.getByRole("tab", { name: "Run", selected: true })
+    ).toBeVisible()
   })
 
   describe("<VehiclePropertiesCard />", () => {

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -1,7 +1,8 @@
 import { jest, describe, test, expect, afterEach } from "@jest/globals"
 import React from "react"
 import renderer from "react-test-renderer"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom/jest-globals"
 import PropertiesPanel, {
   hideMeIfNoCrowdingTooltip,
 } from "../../src/components/propertiesPanel"
@@ -13,6 +14,9 @@ import vehicleFactory from "../factories/vehicle"
 import ghostFactory from "../factories/ghost"
 import routeFactory from "../factories/route"
 import useVehicleForId from "../../src/hooks/useVehicleForId"
+import { TabMode } from "../../src/components/propertiesPanel/tabPanels"
+import userEvent from "@testing-library/user-event"
+import { closeButton } from "../testHelpers/selectors/components/closeButton"
 
 jest
   .spyOn(dateTime, "now")
@@ -23,6 +27,36 @@ jest.spyOn(Date, "now").mockImplementation(() => 234000)
 jest.mock("../../src/hooks/useVehicleForId", () => ({
   __esModule: true,
   default: jest.fn(),
+}))
+
+jest.mock("../../src/hooks/useVehiclesForRoute", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock("../../src/hooks/useNearestIntersection", () => ({
+  __esModule: true,
+  useNearestIntersection: jest.fn(() => {
+    return {
+      is_loading: true,
+    }
+  }),
+}))
+
+jest.mock("../../src/hooks/useStations", () => ({
+  __esModule: true,
+  useStations: jest.fn(() => []),
+}))
+
+jest.mock("../../src/hooks/useShapes", () => ({
+  __esModule: true,
+  useTripShape: jest.fn(),
+}))
+
+jest.mock("../../src/hooks/useMinischedule", () => ({
+  __esModule: true,
+  useMinischeduleRun: jest.fn(),
+  useMinischeduleBlock: jest.fn(),
 }))
 
 const route: Route = routeFactory.build({
@@ -104,14 +138,17 @@ const ghost: Ghost = ghostFactory.build({
 
 const PropertiesPanelWrapper: React.FC<{
   vehicleOrGhost: Vehicle | Ghost
-}> = ({ vehicleOrGhost }) => {
+  initialTab?: TabMode
+  closePanel?: () => void
+}> = ({ vehicleOrGhost, initialTab, closePanel }) => {
   const routes = [route]
 
   return (
     <RoutesProvider routes={routes}>
       <PropertiesPanel
         selectedVehicleOrGhost={vehicleOrGhost}
-        closePanel={jest.fn()}
+        closePanel={closePanel || jest.fn()}
+        initialTab={initialTab}
       />
     </RoutesProvider>
   )
@@ -169,6 +206,32 @@ describe("PropertiesPanel", () => {
     )
 
     expect(result.queryByText(/Status data is not available/)).not.toBeNull()
+  })
+
+  test("respects initialTab prop", () => {
+    render(<PropertiesPanelWrapper vehicleOrGhost={vehicle} initialTab="run" />)
+
+    expect(screen.getByRole("tab", { name: "Run" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+  })
+
+  test("supplied closePanel prop is used", async () => {
+    const mockClosePanel = jest.fn()
+
+    jest.mocked(useVehicleForId).mockReturnValue(vehicle)
+
+    render(
+      <PropertiesPanelWrapper
+        vehicleOrGhost={vehicle}
+        closePanel={mockClosePanel}
+      />
+    )
+
+    await userEvent.click(closeButton.get())
+
+    expect(mockClosePanel).toHaveBeenCalled()
   })
 })
 

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -140,7 +140,7 @@ const PropertiesPanelWrapper: React.FC<{
     <RoutesProvider routes={routes}>
       <PropertiesPanel
         selectedVehicleOrGhost={vehicleOrGhost}
-        closePanel={closePanel || jest.fn()}
+        onClosePanel={closePanel || jest.fn()}
         initialTab={initialTab}
       />
     </RoutesProvider>

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -109,7 +109,10 @@ const PropertiesPanelWrapper: React.FC<{
 
   return (
     <RoutesProvider routes={routes}>
-      <PropertiesPanel selectedVehicleOrGhost={vehicleOrGhost} />
+      <PropertiesPanel
+        selectedVehicleOrGhost={vehicleOrGhost}
+        closePanel={jest.fn()}
+      />
     </RoutesProvider>
   )
 }

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -35,7 +35,6 @@ jest.mock("../../src/hooks/useVehiclesForRoute", () => ({
 }))
 
 jest.mock("../../src/hooks/useNearestIntersection", () => ({
-  __esModule: true,
   useNearestIntersection: jest.fn(() => {
     return {
       is_loading: true,
@@ -44,20 +43,14 @@ jest.mock("../../src/hooks/useNearestIntersection", () => ({
 }))
 
 jest.mock("../../src/hooks/useStations", () => ({
-  __esModule: true,
   useStations: jest.fn(() => []),
 }))
 
 jest.mock("../../src/hooks/useShapes", () => ({
-  __esModule: true,
   useTripShape: jest.fn(),
 }))
 
-jest.mock("../../src/hooks/useMinischedule", () => ({
-  __esModule: true,
-  useMinischeduleRun: jest.fn(),
-  useMinischeduleBlock: jest.fn(),
-}))
+jest.mock("../../src/hooks/useMinischedule")
 
 const route: Route = routeFactory.build({
   id: "39",

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -211,10 +211,9 @@ describe("PropertiesPanel", () => {
   test("respects initialTab prop", () => {
     render(<PropertiesPanelWrapper vehicleOrGhost={vehicle} initialTab="run" />)
 
-    expect(screen.getByRole("tab", { name: "Run" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    )
+    expect(
+      screen.getByRole("tab", { name: "Run", selected: true })
+    ).toBeVisible()
   })
 
   test("supplied closePanel prop is used", async () => {

--- a/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/ghostPropertiesPanel.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`GhostPropertiesPanel renders 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -325,7 +325,7 @@ exports[`GhostPropertiesPanel renders ghost with block waivers 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -678,7 +678,7 @@ exports[`GhostPropertiesPanel renders ghost with missing run 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}

--- a/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/header.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Header renders a header 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -262,7 +262,7 @@ exports[`Header renders for a ghost 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -483,7 +483,7 @@ exports[`Header renders for a late vehicle 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -730,7 +730,7 @@ exports[`Header renders for a shuttle 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -843,7 +843,7 @@ exports[`Header renders for an early vehicle 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -1090,7 +1090,7 @@ exports[`Header renders for an off-course vehicle 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}
@@ -1335,7 +1335,7 @@ exports[`Header renders with route data 1`] = `
     <button
       aria-label="Close"
       className="c-close-button c-close-button--x-large c-close-button--light"
-      onClick={[Function]}
+      onClick={[MockFunction]}
     >
       <span
         aria-hidden={true}

--- a/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
+++ b/assets/tests/components/propertiesPanel/__snapshots__/vehiclePropertiesPanel.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`VehiclePropertiesPanel renders a vehicle properties panel 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -395,7 +395,7 @@ exports[`VehiclePropertiesPanel renders for a late vehicle 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -772,7 +772,7 @@ exports[`VehiclePropertiesPanel renders for a shuttle 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -1015,7 +1015,7 @@ exports[`VehiclePropertiesPanel renders for a vehicle with block waivers 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -1489,7 +1489,7 @@ exports[`VehiclePropertiesPanel renders for an early vehicle 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -1866,7 +1866,7 @@ exports[`VehiclePropertiesPanel renders for an off-course vehicle 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}
@@ -2280,7 +2280,7 @@ exports[`VehiclePropertiesPanel renders with route data 1`] = `
       <button
         aria-label="Close"
         className="c-close-button c-close-button--x-large c-close-button--light"
-        onClick={[Function]}
+        onClick={[MockFunction]}
       >
         <span
           aria-hidden={true}

--- a/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
@@ -56,7 +56,7 @@ describe("GhostPropertiesPanel", () => {
           <GhostPropertiesPanel
             selectedGhost={ghost}
             tabMode="status"
-            setTabMode={jest.fn()}
+            onChangeTabMode={jest.fn()}
             closePanel={jest.fn()}
           />
         </RoutesProvider>
@@ -74,7 +74,7 @@ describe("GhostPropertiesPanel", () => {
           <GhostPropertiesPanel
             selectedGhost={ghostWithoutRun}
             tabMode="status"
-            setTabMode={jest.fn()}
+            onChangeTabMode={jest.fn()}
             closePanel={jest.fn()}
           />
         </RoutesProvider>
@@ -102,7 +102,7 @@ describe("GhostPropertiesPanel", () => {
         <GhostPropertiesPanel
           selectedGhost={ghostWithBlockWaivers}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -118,7 +118,7 @@ describe("GhostPropertiesPanel", () => {
       <GhostPropertiesPanel
         selectedGhost={ghost}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={mockClosePanel}
       />
     )
@@ -144,7 +144,7 @@ describe("GhostPropertiesPanel", () => {
         <GhostPropertiesPanel
           selectedGhost={ghostFactory.build()}
           tabMode={initialTab || "status"}
-          setTabMode={mockSetTabMode}
+          onChangeTabMode={mockSetTabMode}
           closePanel={jest.fn()}
         />
       )

--- a/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
@@ -42,7 +42,11 @@ describe("GhostPropertiesPanel", () => {
     const tree = renderer
       .create(
         <RoutesProvider routes={[route]}>
-          <GhostPropertiesPanel selectedGhost={ghost} />
+          <GhostPropertiesPanel
+            selectedGhost={ghost}
+            tabMode="status"
+            setTabMode={jest.fn()}
+          />
         </RoutesProvider>
       )
       .toJSON()
@@ -55,7 +59,11 @@ describe("GhostPropertiesPanel", () => {
     const tree = renderer
       .create(
         <RoutesProvider routes={[route]}>
-          <GhostPropertiesPanel selectedGhost={ghostWithoutRun} />
+          <GhostPropertiesPanel
+            selectedGhost={ghostWithoutRun}
+            tabMode="status"
+            setTabMode={jest.fn()}
+          />
         </RoutesProvider>
       )
       .toJSON()
@@ -77,7 +85,13 @@ describe("GhostPropertiesPanel", () => {
     }
 
     const tree = renderer
-      .create(<GhostPropertiesPanel selectedGhost={ghostWithBlockWaivers} />)
+      .create(
+        <GhostPropertiesPanel
+          selectedGhost={ghostWithBlockWaivers}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
@@ -46,6 +46,7 @@ describe("GhostPropertiesPanel", () => {
             selectedGhost={ghost}
             tabMode="status"
             setTabMode={jest.fn()}
+            closePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -63,6 +64,7 @@ describe("GhostPropertiesPanel", () => {
             selectedGhost={ghostWithoutRun}
             tabMode="status"
             setTabMode={jest.fn()}
+            closePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -90,6 +92,7 @@ describe("GhostPropertiesPanel", () => {
           selectedGhost={ghostWithBlockWaivers}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()

--- a/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
@@ -16,6 +16,7 @@ import {
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TabMode } from "../../../src/components/propertiesPanel/tabPanels"
+import { closeButton } from "../../testHelpers/selectors/components/closeButton"
 
 jest
   .spyOn(dateTime, "now")
@@ -108,6 +109,23 @@ describe("GhostPropertiesPanel", () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  test("calls closePanel callback on close", async () => {
+    const mockClosePanel = jest.fn()
+
+    render(
+      <GhostPropertiesPanel
+        selectedGhost={ghost}
+        tabMode="status"
+        setTabMode={jest.fn()}
+        closePanel={mockClosePanel}
+      />
+    )
+
+    await userEvent.click(closeButton.get())
+
+    expect(mockClosePanel).toHaveBeenCalled()
   })
 
   test.each<{ tab: TabMode; clickTarget: string; initialTab?: TabMode }>([

--- a/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/ghostPropertiesPanel.test.tsx
@@ -57,7 +57,7 @@ describe("GhostPropertiesPanel", () => {
             selectedGhost={ghost}
             tabMode="status"
             onChangeTabMode={jest.fn()}
-            closePanel={jest.fn()}
+            onClosePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -75,7 +75,7 @@ describe("GhostPropertiesPanel", () => {
             selectedGhost={ghostWithoutRun}
             tabMode="status"
             onChangeTabMode={jest.fn()}
-            closePanel={jest.fn()}
+            onClosePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -103,7 +103,7 @@ describe("GhostPropertiesPanel", () => {
           selectedGhost={ghostWithBlockWaivers}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -119,7 +119,7 @@ describe("GhostPropertiesPanel", () => {
         selectedGhost={ghost}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={mockClosePanel}
+        onClosePanel={mockClosePanel}
       />
     )
 
@@ -145,7 +145,7 @@ describe("GhostPropertiesPanel", () => {
           selectedGhost={ghostFactory.build()}
           tabMode={initialTab || "status"}
           onChangeTabMode={mockSetTabMode}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
 

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -17,7 +17,7 @@ import {
   VehicleInScheduledService,
 } from "../../../src/realtime"
 import { Route } from "../../../src/schedule"
-import { closeView, initialState } from "../../../src/state"
+import { initialState } from "../../../src/state"
 import vehicleFactory from "../../factories/vehicle"
 import ghostFactory from "../../factories/ghost"
 import routeFactory from "../../factories/route"
@@ -87,7 +87,12 @@ describe("Header", () => {
   test("renders a header", () => {
     const tree = renderer
       .create(
-        <Header vehicle={vehicle} tabMode={"status"} setTabMode={setTabMode} />
+        <Header
+          vehicle={vehicle}
+          tabMode={"status"}
+          setTabMode={setTabMode}
+          closePanel={jest.fn()}
+        />
       )
       .toJSON()
 
@@ -106,6 +111,7 @@ describe("Header", () => {
             vehicle={vehicle}
             tabMode={"status"}
             setTabMode={setTabMode}
+            closePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -125,6 +131,7 @@ describe("Header", () => {
           vehicle={earlyVehicle}
           tabMode={"status"}
           setTabMode={setTabMode}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -143,6 +150,7 @@ describe("Header", () => {
           vehicle={earlyVehicle}
           tabMode={"status"}
           setTabMode={setTabMode}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -162,6 +170,7 @@ describe("Header", () => {
           vehicle={offCourseVehicle}
           tabMode={"status"}
           setTabMode={setTabMode}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -181,6 +190,7 @@ describe("Header", () => {
           vehicle={shuttleVehicle}
           tabMode={"status"}
           setTabMode={setTabMode}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -210,7 +220,12 @@ describe("Header", () => {
 
     const tree = renderer
       .create(
-        <Header vehicle={ghost} tabMode={"status"} setTabMode={setTabMode} />
+        <Header
+          vehicle={ghost}
+          tabMode={"status"}
+          setTabMode={setTabMode}
+          closePanel={jest.fn()}
+        />
       )
       .toJSON()
 
@@ -223,6 +238,7 @@ describe("Header", () => {
         vehicle={{ ...vehicle, directionId: 0, routeStatus: "laying_over" }}
         tabMode={"status"}
         setTabMode={setTabMode}
+        closePanel={jest.fn()}
       />
     )
     expect(result.getByTestId("vehicle-triangle")).toHaveAttribute(
@@ -237,6 +253,7 @@ describe("Header", () => {
         vehicle={{ ...vehicle, directionId: 1, routeStatus: "laying_over" }}
         tabMode={"status"}
         setTabMode={setTabMode}
+        closePanel={jest.fn()}
       />
     )
 
@@ -262,7 +279,12 @@ describe("Header", () => {
         }}
         dispatch={jest.fn()}
       >
-        <Header vehicle={vehicle} tabMode={"status"} setTabMode={setTabMode} />
+        <Header
+          vehicle={vehicle}
+          tabMode={"status"}
+          setTabMode={setTabMode}
+          closePanel={jest.fn()}
+        />
       </StateDispatchProvider>
     )
 
@@ -284,6 +306,7 @@ describe("Header", () => {
         vehicle={shuttleVehicle}
         tabMode={"status"}
         setTabMode={setTabMode}
+        closePanel={jest.fn()}
       />
     )
 
@@ -294,17 +317,20 @@ describe("Header", () => {
   })
 
   test("clicking the X close button deselects the vehicle", async () => {
-    const mockDispatch = jest.fn()
+    const mockClosePanel = jest.fn()
 
     const user = userEvent.setup()
     const result = render(
-      <StateDispatchProvider state={initialState} dispatch={mockDispatch}>
-        <Header vehicle={vehicle} tabMode={"status"} setTabMode={setTabMode} />
-      </StateDispatchProvider>
+      <Header
+        vehicle={vehicle}
+        tabMode={"status"}
+        setTabMode={setTabMode}
+        closePanel={mockClosePanel}
+      />
     )
 
     await user.click(result.getByRole("button", { name: /close/i }))
 
-    expect(mockDispatch).toHaveBeenCalledWith(closeView())
+    expect(mockClosePanel).toHaveBeenCalled()
   })
 })

--- a/assets/tests/components/propertiesPanel/header.test.tsx
+++ b/assets/tests/components/propertiesPanel/header.test.tsx
@@ -90,8 +90,8 @@ describe("Header", () => {
         <Header
           vehicle={vehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -110,8 +110,8 @@ describe("Header", () => {
           <Header
             vehicle={vehicle}
             tabMode={"status"}
-            setTabMode={setTabMode}
-            closePanel={jest.fn()}
+            onChangeTabMode={setTabMode}
+            onClosePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -130,8 +130,8 @@ describe("Header", () => {
         <Header
           vehicle={earlyVehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -149,8 +149,8 @@ describe("Header", () => {
         <Header
           vehicle={earlyVehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -169,8 +169,8 @@ describe("Header", () => {
         <Header
           vehicle={offCourseVehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -189,8 +189,8 @@ describe("Header", () => {
         <Header
           vehicle={shuttleVehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -223,8 +223,8 @@ describe("Header", () => {
         <Header
           vehicle={ghost}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -237,8 +237,8 @@ describe("Header", () => {
       <Header
         vehicle={{ ...vehicle, directionId: 0, routeStatus: "laying_over" }}
         tabMode={"status"}
-        setTabMode={setTabMode}
-        closePanel={jest.fn()}
+        onChangeTabMode={setTabMode}
+        onClosePanel={jest.fn()}
       />
     )
     expect(result.getByTestId("vehicle-triangle")).toHaveAttribute(
@@ -252,8 +252,8 @@ describe("Header", () => {
       <Header
         vehicle={{ ...vehicle, directionId: 1, routeStatus: "laying_over" }}
         tabMode={"status"}
-        setTabMode={setTabMode}
-        closePanel={jest.fn()}
+        onChangeTabMode={setTabMode}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -282,8 +282,8 @@ describe("Header", () => {
         <Header
           vehicle={vehicle}
           tabMode={"status"}
-          setTabMode={setTabMode}
-          closePanel={jest.fn()}
+          onChangeTabMode={setTabMode}
+          onClosePanel={jest.fn()}
         />
       </StateDispatchProvider>
     )
@@ -305,8 +305,8 @@ describe("Header", () => {
       <Header
         vehicle={shuttleVehicle}
         tabMode={"status"}
-        setTabMode={setTabMode}
-        closePanel={jest.fn()}
+        onChangeTabMode={setTabMode}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -324,8 +324,8 @@ describe("Header", () => {
       <Header
         vehicle={vehicle}
         tabMode={"status"}
-        setTabMode={setTabMode}
-        closePanel={mockClosePanel}
+        onChangeTabMode={setTabMode}
+        onClosePanel={mockClosePanel}
       />
     )
 

--- a/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "@jest/globals"
+import { describe, test, expect, jest } from "@jest/globals"
 import React from "react"
 import { render } from "@testing-library/react"
 import StaleDataPropertiesPanel from "../../../src/components/propertiesPanel/staleDataPropertiesPanel"
@@ -10,7 +10,11 @@ describe("StaleDataPropertiesPanel", () => {
     const vehicle = vehicleFactory.build()
 
     const result = render(
-      <StaleDataPropertiesPanel selectedVehicle={vehicle} />
+      <StaleDataPropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
     )
 
     expect(result.queryByText(/Status data is not available/)).not.toBeNull()
@@ -23,7 +27,11 @@ describe("StaleDataPropertiesPanel", () => {
     })
 
     const result = render(
-      <StaleDataPropertiesPanel selectedVehicle={vehicle} />
+      <StaleDataPropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
     )
 
     expect(result.queryByText(/problem/)).not.toBeNull()
@@ -33,7 +41,11 @@ describe("StaleDataPropertiesPanel", () => {
     const vehicle = vehicleFactory.build({ isShuttle: true })
 
     const result = render(
-      <StaleDataPropertiesPanel selectedVehicle={vehicle} />
+      <StaleDataPropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
     )
 
     expect(result.queryByText(/Status data is not available/)).not.toBeNull()

--- a/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
@@ -23,7 +23,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -41,7 +41,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -56,7 +56,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -73,7 +73,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={mockClosePanel}
+        onClosePanel={mockClosePanel}
       />
     )
 
@@ -99,7 +99,7 @@ describe("StaleDataPropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
           onChangeTabMode={mockSetTabMode}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
 

--- a/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../src/hooks/useMinischedule"
 import userEvent from "@testing-library/user-event"
 import { TabMode } from "../../../src/components/propertiesPanel/tabPanels"
+import { closeButton } from "../../testHelpers/selectors/components/closeButton"
 
 jest.mock("../../../src/hooks/useMinischedule")
 
@@ -61,6 +62,24 @@ describe("StaleDataPropertiesPanel", () => {
 
     expect(result.queryByText(/Status data is not available/)).not.toBeNull()
     expect(result.queryByText(/Run/)).toBeNull()
+  })
+
+  test("calls closePanel callback on close", async () => {
+    const vehicle = vehicleFactory.build()
+    const mockClosePanel = jest.fn()
+
+    render(
+      <StaleDataPropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+        closePanel={mockClosePanel}
+      />
+    )
+
+    await userEvent.click(closeButton.get())
+
+    expect(mockClosePanel).toHaveBeenCalled()
   })
 
   test.each<{ tab: TabMode; clickTarget: string; initialTab?: TabMode }>([

--- a/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
@@ -22,7 +22,7 @@ describe("StaleDataPropertiesPanel", () => {
       <StaleDataPropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -40,7 +40,7 @@ describe("StaleDataPropertiesPanel", () => {
       <StaleDataPropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -55,7 +55,7 @@ describe("StaleDataPropertiesPanel", () => {
       <StaleDataPropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -72,7 +72,7 @@ describe("StaleDataPropertiesPanel", () => {
       <StaleDataPropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={mockClosePanel}
       />
     )
@@ -98,7 +98,7 @@ describe("StaleDataPropertiesPanel", () => {
         <StaleDataPropertiesPanel
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
-          setTabMode={mockSetTabMode}
+          onChangeTabMode={mockSetTabMode}
           closePanel={jest.fn()}
         />
       )

--- a/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/staleDataPropertiesPanel.test.tsx
@@ -14,6 +14,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 
@@ -31,6 +32,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 
@@ -45,6 +47,7 @@ describe("StaleDataPropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../../src/hooks/useMinischedule"
 import { useTripShape } from "../../../src/hooks/useShapes"
 import { fullStoryEvent } from "../../../src/helpers/fullStory"
+import { closeButton } from "../../testHelpers/selectors/components/closeButton"
 
 jest
   .spyOn(dateTime, "now")
@@ -404,6 +405,23 @@ describe("VehiclePropertiesPanel", () => {
     )
 
     expect(container.innerHTML).toContain("c-station-icon")
+  })
+
+  test("calls closePanel callback on close", async () => {
+    const mockClosePanel = jest.fn()
+
+    render(
+      <VehiclePropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+        closePanel={mockClosePanel}
+      />
+    )
+
+    await userEvent.click(closeButton.get())
+
+    expect(mockClosePanel).toHaveBeenCalled()
   })
 
   test.each<{ tab: TabMode; clickTarget: string; initialTab?: TabMode }>([

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -132,7 +132,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={vehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -152,7 +152,7 @@ describe("VehiclePropertiesPanel", () => {
           <VehiclePropertiesPanel
             selectedVehicle={vehicle}
             tabMode="status"
-            setTabMode={jest.fn()}
+            onChangeTabMode={jest.fn()}
             closePanel={jest.fn()}
           />
         </RoutesProvider>
@@ -172,7 +172,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={earlyVehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -186,7 +186,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={invalidVehicleFactory.build()}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -203,7 +203,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={earlyVehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -223,7 +223,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={offCourseVehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -245,7 +245,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={shuttleVehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -272,7 +272,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={vehicleWithBlockWaivers}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -289,7 +289,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -305,7 +305,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -322,7 +322,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -342,7 +342,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={thisVehicle}
           tabMode="status"
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       </VehiclesByRouteIdProvider>
@@ -370,7 +370,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={thisVehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -399,7 +399,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={jest.fn()}
       />
     )
@@ -414,7 +414,7 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclePropertiesPanel
         selectedVehicle={vehicle}
         tabMode="status"
-        setTabMode={jest.fn()}
+        onChangeTabMode={jest.fn()}
         closePanel={mockClosePanel}
       />
     )
@@ -441,7 +441,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
-          setTabMode={mockSetTabMode}
+          onChangeTabMode={mockSetTabMode}
           closePanel={jest.fn()}
         />
       )
@@ -469,7 +469,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )
@@ -500,7 +500,7 @@ describe("VehiclePropertiesPanel", () => {
         <VehiclePropertiesPanel
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab}
-          setTabMode={jest.fn()}
+          onChangeTabMode={jest.fn()}
           closePanel={jest.fn()}
         />
       )

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -127,7 +127,13 @@ const vehicle: VehicleInScheduledService = vehicleFactory.build({
 describe("VehiclePropertiesPanel", () => {
   test("renders a vehicle properties panel", () => {
     const tree = renderer
-      .create(<VehiclePropertiesPanel selectedVehicle={vehicle} />)
+      .create(
+        <VehiclePropertiesPanel
+          selectedVehicle={vehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -141,7 +147,11 @@ describe("VehiclePropertiesPanel", () => {
     const tree = renderer
       .create(
         <RoutesProvider routes={[route]}>
-          <VehiclePropertiesPanel selectedVehicle={vehicle} />
+          <VehiclePropertiesPanel
+            selectedVehicle={vehicle}
+            tabMode="status"
+            setTabMode={jest.fn()}
+          />
         </RoutesProvider>
       )
       .toJSON()
@@ -155,7 +165,13 @@ describe("VehiclePropertiesPanel", () => {
       scheduleAdherenceSecs: -61,
     }
     const tree = renderer
-      .create(<VehiclePropertiesPanel selectedVehicle={earlyVehicle} />)
+      .create(
+        <VehiclePropertiesPanel
+          selectedVehicle={earlyVehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -163,7 +179,11 @@ describe("VehiclePropertiesPanel", () => {
 
   test("Includes invalid bus banner when vehicle is off course", () => {
     render(
-      <VehiclePropertiesPanel selectedVehicle={invalidVehicleFactory.build()} />
+      <VehiclePropertiesPanel
+        selectedVehicle={invalidVehicleFactory.build()}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
     )
     expect(screen.getByRole("heading", { name: "Invalid Bus" })).toBeVisible()
   })
@@ -174,7 +194,13 @@ describe("VehiclePropertiesPanel", () => {
       scheduleAdherenceSecs: 361,
     }
     const tree = renderer
-      .create(<VehiclePropertiesPanel selectedVehicle={earlyVehicle} />)
+      .create(
+        <VehiclePropertiesPanel
+          selectedVehicle={earlyVehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -187,7 +213,13 @@ describe("VehiclePropertiesPanel", () => {
     }
 
     const tree = renderer
-      .create(<VehiclePropertiesPanel selectedVehicle={offCourseVehicle} />)
+      .create(
+        <VehiclePropertiesPanel
+          selectedVehicle={offCourseVehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -202,7 +234,13 @@ describe("VehiclePropertiesPanel", () => {
     }
 
     const tree = renderer
-      .create(<VehiclePropertiesPanel selectedVehicle={shuttleVehicle} />)
+      .create(
+        <VehiclePropertiesPanel
+          selectedVehicle={shuttleVehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
+      )
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -223,7 +261,11 @@ describe("VehiclePropertiesPanel", () => {
 
     const tree = renderer
       .create(
-        <VehiclePropertiesPanel selectedVehicle={vehicleWithBlockWaivers} />
+        <VehiclePropertiesPanel
+          selectedVehicle={vehicleWithBlockWaivers}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
       )
       .toJSON()
 
@@ -234,7 +276,13 @@ describe("VehiclePropertiesPanel", () => {
     ;(useNearestIntersection as jest.Mock).mockReturnValueOnce({
       ok: "Atlantic Ave & Summer St",
     })
-    const result = render(<VehiclePropertiesPanel selectedVehicle={vehicle} />)
+    const result = render(
+      <VehiclePropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
+    )
     expect(result.getByText("Atlantic Ave & Summer St")).toBeInTheDocument()
   })
 
@@ -243,7 +291,13 @@ describe("VehiclePropertiesPanel", () => {
       .spyOn(URLSearchParams.prototype, "get")
       .mockImplementation((_key) => "1")
 
-    const result = render(<VehiclePropertiesPanel selectedVehicle={vehicle} />)
+    const result = render(
+      <VehiclePropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
+    )
 
     expect(result.queryAllByTestId("data-discrepancy")).toHaveLength(2)
   })
@@ -253,7 +307,13 @@ describe("VehiclePropertiesPanel", () => {
       .spyOn(URLSearchParams.prototype, "get")
       .mockImplementation((_key) => null)
 
-    const result = render(<VehiclePropertiesPanel selectedVehicle={vehicle} />)
+    const result = render(
+      <VehiclePropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
+    )
 
     expect(result.queryAllByTestId("data-discrepancy")).toHaveLength(0)
   })
@@ -267,7 +327,11 @@ describe("VehiclePropertiesPanel", () => {
       <VehiclesByRouteIdProvider
         vehiclesByRouteId={{ "39": [thisVehicle, otherVehicle, ghost] }}
       >
-        <VehiclePropertiesPanel selectedVehicle={thisVehicle} />
+        <VehiclePropertiesPanel
+          selectedVehicle={thisVehicle}
+          tabMode="status"
+          setTabMode={jest.fn()}
+        />
       </VehiclesByRouteIdProvider>
     )
     expect(map.MapFollowingPrimaryVehicles).toHaveBeenCalledTimes(1)
@@ -289,7 +353,13 @@ describe("VehiclePropertiesPanel", () => {
       otherVehicle,
       ghost,
     ])
-    renderer.create(<VehiclePropertiesPanel selectedVehicle={thisVehicle} />)
+    renderer.create(
+      <VehiclePropertiesPanel
+        selectedVehicle={thisVehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
+    )
     expect(useVehiclesForRoute).toHaveBeenCalled()
     expect(map.MapFollowingPrimaryVehicles).toHaveBeenCalledTimes(1)
     const mapArgs: map.Props = (
@@ -312,7 +382,11 @@ describe("VehiclePropertiesPanel", () => {
     ])
 
     const { container } = render(
-      <VehiclePropertiesPanel selectedVehicle={vehicle} />
+      <VehiclePropertiesPanel
+        selectedVehicle={vehicle}
+        tabMode="status"
+        setTabMode={jest.fn()}
+      />
     )
 
     expect(container.innerHTML).toContain("c-station-icon")
@@ -334,7 +408,8 @@ describe("VehiclePropertiesPanel", () => {
       render(
         <VehiclePropertiesPanel
           selectedVehicle={vehicleFactory.build()}
-          initialTab={initialTab}
+          tabMode={initialTab || "status"}
+          setTabMode={jest.fn()}
         />
       )
 
@@ -347,7 +422,7 @@ describe("VehiclePropertiesPanel", () => {
     }
   )
 
-  test.each<{ clickTarget: string; initialTab?: TabMode }>([
+  test.each<{ clickTarget: string; initialTab: TabMode }>([
     { clickTarget: "Run", initialTab: "run" },
     { clickTarget: "Block", initialTab: "block" },
     { clickTarget: "Status", initialTab: "status" },
@@ -363,7 +438,8 @@ describe("VehiclePropertiesPanel", () => {
       render(
         <VehiclePropertiesPanel
           selectedVehicle={vehicleFactory.build()}
-          initialTab={initialTab}
+          tabMode={initialTab}
+          setTabMode={jest.fn()}
         />
       )
 

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -411,6 +411,34 @@ describe("VehiclePropertiesPanel", () => {
     { tab: "block", clickTarget: "Block" },
     { tab: "status", clickTarget: "Status", initialTab: "block" },
   ])(
+    "when active tab changes to '$tab', calls tab change callback",
+    async ({ tab, clickTarget, initialTab }) => {
+      jest.mocked(useTripShape).mockReturnValue([])
+      jest.mocked(useMinischeduleRun).mockReturnValue(undefined)
+      jest.mocked(useMinischeduleBlock).mockReturnValue(undefined)
+
+      const mockSetTabMode = jest.fn()
+
+      render(
+        <VehiclePropertiesPanel
+          selectedVehicle={vehicleFactory.build()}
+          tabMode={initialTab || "status"}
+          setTabMode={mockSetTabMode}
+          closePanel={jest.fn()}
+        />
+      )
+
+      await userEvent.click(screen.getByRole("tab", { name: clickTarget }))
+
+      expect(mockSetTabMode).toHaveBeenCalledWith(tab)
+    }
+  )
+
+  test.each<{ tab: TabMode; clickTarget: string; initialTab?: TabMode }>([
+    { tab: "run", clickTarget: "Run" },
+    { tab: "block", clickTarget: "Block" },
+    { tab: "status", clickTarget: "Status", initialTab: "block" },
+  ])(
     "when active tab changes to '$tab', fires fullstory event",
     async ({ tab, clickTarget, initialTab }) => {
       ;(useTripShape as jest.Mock).mockReturnValue([])

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -133,7 +133,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -153,7 +153,7 @@ describe("VehiclePropertiesPanel", () => {
             selectedVehicle={vehicle}
             tabMode="status"
             onChangeTabMode={jest.fn()}
-            closePanel={jest.fn()}
+            onClosePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -173,7 +173,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={earlyVehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -187,7 +187,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={invalidVehicleFactory.build()}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
     expect(screen.getByRole("heading", { name: "Invalid Bus" })).toBeVisible()
@@ -204,7 +204,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={earlyVehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -224,7 +224,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={offCourseVehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -246,7 +246,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={shuttleVehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -273,7 +273,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleWithBlockWaivers}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -290,7 +290,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
     expect(result.getByText("Atlantic Ave & Summer St")).toBeInTheDocument()
@@ -306,7 +306,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -323,7 +323,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -343,7 +343,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={thisVehicle}
           tabMode="status"
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       </VehiclesByRouteIdProvider>
     )
@@ -371,7 +371,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={thisVehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
     expect(useVehiclesForRoute).toHaveBeenCalled()
@@ -400,7 +400,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={jest.fn()}
+        onClosePanel={jest.fn()}
       />
     )
 
@@ -415,7 +415,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         onChangeTabMode={jest.fn()}
-        closePanel={mockClosePanel}
+        onClosePanel={mockClosePanel}
       />
     )
 
@@ -442,7 +442,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
           onChangeTabMode={mockSetTabMode}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
 
@@ -470,7 +470,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
 
@@ -501,7 +501,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab}
           onChangeTabMode={jest.fn()}
-          closePanel={jest.fn()}
+          onClosePanel={jest.fn()}
         />
       )
 

--- a/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel/vehiclePropertiesPanel.test.tsx
@@ -132,6 +132,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -151,6 +152,7 @@ describe("VehiclePropertiesPanel", () => {
             selectedVehicle={vehicle}
             tabMode="status"
             setTabMode={jest.fn()}
+            closePanel={jest.fn()}
           />
         </RoutesProvider>
       )
@@ -170,6 +172,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={earlyVehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -183,6 +186,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={invalidVehicleFactory.build()}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
     expect(screen.getByRole("heading", { name: "Invalid Bus" })).toBeVisible()
@@ -199,6 +203,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={earlyVehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -218,6 +223,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={offCourseVehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -239,6 +245,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={shuttleVehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -265,6 +272,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleWithBlockWaivers}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
       .toJSON()
@@ -281,6 +289,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
     expect(result.getByText("Atlantic Ave & Summer St")).toBeInTheDocument()
@@ -296,6 +305,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 
@@ -312,6 +322,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 
@@ -331,6 +342,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={thisVehicle}
           tabMode="status"
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       </VehiclesByRouteIdProvider>
     )
@@ -358,6 +370,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={thisVehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
     expect(useVehiclesForRoute).toHaveBeenCalled()
@@ -386,6 +399,7 @@ describe("VehiclePropertiesPanel", () => {
         selectedVehicle={vehicle}
         tabMode="status"
         setTabMode={jest.fn()}
+        closePanel={jest.fn()}
       />
     )
 
@@ -410,6 +424,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab || "status"}
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
 
@@ -440,6 +455,7 @@ describe("VehiclePropertiesPanel", () => {
           selectedVehicle={vehicleFactory.build()}
           tabMode={initialTab}
           setTabMode={jest.fn()}
+          closePanel={jest.fn()}
         />
       )
 

--- a/assets/tests/testHelpers/selectors/components/closeButton.ts
+++ b/assets/tests/testHelpers/selectors/components/closeButton.ts
@@ -1,0 +1,3 @@
+import { byRole } from "testing-library-selector"
+
+export const closeButton = byRole("button", { name: "Close" })

--- a/assets/tests/util/mapMode.test.ts
+++ b/assets/tests/util/mapMode.test.ts
@@ -1,18 +1,16 @@
 import { jest, describe, test, expect } from "@jest/globals"
 import { mapModeForUser } from "../../src/util/mapMode"
 import { SearchIcon, SearchMapIcon } from "../../src/helpers/icon"
-import { TestGroups } from "../../src/userInTestGroup"
-import getTestGroups from "../../src/userTestGroups"
-import { mapModeForUser } from "../../src/util/mapMode"
+import inTestGroup, { TestGroups } from "../../src/userInTestGroup"
 
-jest.mock("userTestGroups", () => ({
-  __esModule: true,
-  default: jest.fn(() => []),
-}))
+jest.mock("../../src/userInTestGroup")
 
 describe("mapModeForUser", () => {
   test("returns new map mode when a part of new map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([TestGroups.MapBeta])
+    jest
+      .mocked(inTestGroup)
+      .mockImplementation((key) => key === TestGroups.MapBeta)
+
     expect(mapModeForUser()).toEqual({
       path: "/map",
       title: "Search Map",
@@ -23,7 +21,7 @@ describe("mapModeForUser", () => {
   })
 
   test("returns old search mode when not a part of new map test group", () => {
-    ;(getTestGroups as jest.Mock).mockReturnValueOnce([])
+    jest.mocked(inTestGroup).mockReturnValue(false)
 
     expect(mapModeForUser()).toEqual({
       path: "/search",

--- a/assets/tests/util/mapMode.test.ts
+++ b/assets/tests/util/mapMode.test.ts
@@ -1,7 +1,5 @@
 import { jest, describe, test, expect } from "@jest/globals"
-import React from "react"
-import MapPage from "../../src/components/mapPage"
-import SearchPage from "../../src/components/searchPage"
+import { mapModeForUser } from "../../src/util/mapMode"
 import { SearchIcon, SearchMapIcon } from "../../src/helpers/icon"
 import { TestGroups } from "../../src/userInTestGroup"
 import getTestGroups from "../../src/userTestGroups"
@@ -18,7 +16,6 @@ describe("mapModeForUser", () => {
     expect(mapModeForUser()).toEqual({
       path: "/map",
       title: "Search Map",
-      element: <MapPage />,
       navIcon: SearchMapIcon,
       supportsRightPanel: false,
       navEventText: "Search Map nav entry clicked",
@@ -31,7 +28,6 @@ describe("mapModeForUser", () => {
     expect(mapModeForUser()).toEqual({
       path: "/search",
       title: "Search",
-      element: <SearchPage />,
       navIcon: SearchIcon,
       supportsRightPanel: true,
     })


### PR DESCRIPTION
Asana ticket: [⚙️ Link VPC Run # to VPP Run tab](https://app.asana.com/0/1148853526253420/1205703270277839/f)

Having the selection state for the VPP on the search maps page live in a `useState` hook in the component is probably not the long-term solution here, but I think it's an appropriate start for the purposes of this particular ticket.

One thing I'm not 100% sure on that I'd like feedback about is naming of callback function props and when those should or shouldn't start with `on`. My thinking was that clicking the run is a specific action / event handler so that should be `onRunClicked`, but closing the VPP can happen for a number of reasons and I opted to call it `closePanel`, but I'm open to changing that.