### PR TITLE
feat: change application supervision strategy

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -119,7 +119,8 @@ config :skate, Skate.Repo,
 config :skate, Skate.WarmUp,
   minimum_percent_queries_to_succeed: 0.6,
   max_attempts: 20,
-  seconds_between_attempts: 1
+  seconds_between_attempts: 5,
+  backoff_min: 5_000
 
 config :skate, Oban,
   repo: Skate.Repo,

--- a/config/config.exs
+++ b/config/config.exs
@@ -114,13 +114,13 @@ config :skate, Skate.Repo,
   password: System.get_env("POSTGRES_PASSWORD", ""),
   hostname: System.get_env("POSTGRES_HOSTNAME", "localhost"),
   port: System.get_env("POSTGRES_PORT", "5432") |> String.to_integer(),
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  backoff_min: 5_000
 
 config :skate, Skate.WarmUp,
   minimum_percent_queries_to_succeed: 0.6,
   max_attempts: 20,
-  seconds_between_attempts: 5,
-  backoff_min: 5_000
+  seconds_between_attempts: 5
 
 config :skate, Oban,
   repo: Skate.Repo,

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -9,12 +9,21 @@ defmodule Skate.Application do
   def start(_type, _args) do
     load_runtime_config()
 
+    start_data_processes? = Application.get_env(:skate, :start_data_processes)
+
     # List all child processes to be supervised
     children =
-      [{Skate.Repo, []}, Skate.WarmUp] ++
-        if Application.get_env(:skate, :start_data_processes) do
+      [{Skate.Repo, []}] ++
+        if start_data_processes? do
           [
-            Schedule.Supervisor,
+            Schedule.Supervisor
+          ]
+        else
+          []
+        end ++
+        [Skate.WarmUp] ++
+        if start_data_processes? do
+          [
             TrainVehicles.Supervisor,
             Notifications.Supervisor,
             Realtime.Supervisor

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -29,7 +29,7 @@ defmodule Skate.Application do
           {Oban, Application.fetch_env!(:skate, Oban)}
         ]
 
-    Supervisor.start_link(children, strategy: :one_for_all, name: Skate.Supervisor)
+    Supervisor.start_link(children, strategy: :rest_for_one, name: Skate.Supervisor)
   end
 
   # Tell Phoenix to update the endpoint configuration


### PR DESCRIPTION
Asana ticket: [⚙️ Application can survive minor crashes](https://app.asana.com/0/1148853526253420/1205805990143476/f)

Go from :one_for_all to :rest_for_one to hopefully reduce the impact of processes like Oban crashing

My purpose in bundling the changes to the DB parameters is that I want to avoid the chance that deploying this causes further downtime by causing the Oban process on the existing containers to thrash.