### PR TITLE
feat: log on application startup

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -4,9 +4,12 @@ defmodule Skate.Application do
   @moduledoc false
 
   use Application
+  require Logger
 
   @impl true
   def start(_type, _args) do
+    Logger.info("Skate application starting")
+
     load_runtime_config()
 
     start_data_processes? = Application.get_env(:skate, :start_data_processes)


### PR DESCRIPTION
Asana ticket: [⚙️ Log unique message when Skate starts](https://app.asana.com/0/1148853526253420/1205805997139898/f)

I figure that once we do [⚙️ Use :mfa to log module information](https://app.asana.com/0/1148853526253420/1205805997139906/f) this will additionally specify that the logging is coming from `Skate.Application`, so I'm not explicitly including the module here like we do in some other log messages. I did also consider writing a test for this but it doesn't appear that there's a way to start a copy of the application under a different name for testing purposes, and there's no real logic to the logging so it doesn't make sense to factor out into a helper function and test that.