### PR TITLE
fix: Fix icon size for location search result marker

### DIFF
--- a/assets/css/map/markers/_location_dot_icon.scss
+++ b/assets/css/map/markers/_location_dot_icon.scss
@@ -1,5 +1,7 @@
 .c-location-dot-icon {
   svg {
+    height: 24px;
+
     overflow: visible;
 
     path {


### PR DESCRIPTION
# Before
<img width="480" alt="Screenshot 2023-11-06 at 4 56 41 PM" src="https://github.com/mbta/skate/assets/912020/fc36a763-ca55-4dd1-a6d0-329a50b221bc">

# After
<img width="481" alt="Screenshot 2023-11-06 at 4 56 23 PM" src="https://github.com/mbta/skate/assets/912020/02526d56-ee2d-4a67-8f38-e806fc35fac1">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205658795320766