### PR TITLE
cleanup: Remove unused CSS classes for settings page

### DIFF
--- a/assets/css/_settings_page.scss
+++ b/assets/css/_settings_page.scss
@@ -18,18 +18,6 @@
   padding: 0rem 0rem 0.5rem 0rem;
 }
 
-.c-settings-page__icon {
-  align-self: normal;
-  flex: 0 1 auto;
-  margin: 0.2rem 0.5rem 0 0;
-}
-
-.c-settings-page__icon-path {
-  display: block;
-  fill: $color-primary-legacy;
-  width: 13px;
-}
-
 .c-settings-page__setting-label {
   font-size: 1rem;
   flex: 1 1 6rem;


### PR DESCRIPTION
This is a follow-up to https://github.com/mbta/skate/pull/2270. The previous PR removed a few elements. This one removes the CSS classes that styled those elements, since those CSS classes aren't used anywhere else.