### PR TITLE
 feat(ts/hooks/usePanelState): add `setTabMode` API 

### DIFF
--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -37,7 +37,7 @@ export const AppRoutes = () => {
 
   const {
     setPath,
-    currentView: { openView, selectedVehicleOrGhost },
+    currentView: { openView, selectedVehicleOrGhost, vppTabMode },
   } = usePanelStateFromStateDispatchContext()
 
   // Keep panel in sync with current path
@@ -75,6 +75,7 @@ export const AppRoutes = () => {
                     <Outlet />
                     <RightPanel
                       selectedVehicleOrGhost={selectedVehicleOrGhost}
+                      initialTab={vppTabMode}
                     />
                     {openView === OpenView.Late ? <LateView /> : null}
                   </>

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -18,7 +18,6 @@ import LadderPage from "./ladderPage"
 import Modal from "./modal"
 import SettingsPage from "./settingsPage"
 import ShuttleMapPage from "./shuttleMapPage"
-import LateView from "./lateView"
 import { allOpenRouteIds } from "../models/routeTab"
 import Nav from "./nav"
 import RightPanel from "./rightPanel"
@@ -77,7 +76,6 @@ export const AppRoutes = () => {
                       selectedVehicleOrGhost={selectedVehicleOrGhost}
                       initialTab={vppTabMode}
                     />
-                    {openView === OpenView.Late ? <LateView /> : null}
                   </>
                 }
               >

--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -27,6 +27,8 @@ import MapPage from "./mapPage"
 import SearchPage from "./searchPage"
 import { OpenView, isPagePath } from "../state/pagePanelState"
 import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
+import PropertiesPanel from "./propertiesPanel"
+import { isGhost, isVehicle } from "../models/vehicle"
 
 export const AppRoutes = () => {
   useAppcues()
@@ -36,6 +38,8 @@ export const AppRoutes = () => {
 
   const {
     setPath,
+    setTabMode,
+    closeView,
     currentView: { openView, selectedVehicleOrGhost, vppTabMode },
   } = usePanelStateFromStateDispatchContext()
 
@@ -73,8 +77,19 @@ export const AppRoutes = () => {
                   <>
                     <Outlet />
                     <RightPanel
-                      selectedVehicleOrGhost={selectedVehicleOrGhost}
-                      initialTab={vppTabMode}
+                      openView={openView}
+                      propertiesPanel={
+                        selectedVehicleOrGhost &&
+                        (isVehicle(selectedVehicleOrGhost) ||
+                          isGhost(selectedVehicleOrGhost)) ? (
+                          <PropertiesPanel
+                            selectedVehicleOrGhost={selectedVehicleOrGhost}
+                            tabMode={vppTabMode ?? "status"}
+                            onChangeTabMode={setTabMode}
+                            onClosePanel={closeView}
+                          />
+                        ) : undefined
+                      }
                     />
                   </>
                 }

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -12,11 +12,17 @@ interface Props extends IndividualPropertiesPanelProps {
   selectedVehicleOrGhost: Vehicle | Ghost
 }
 
-export type IndividualPropertiesPanelProps = {
+export type TabModeProps = {
   tabMode: TabMode
   onChangeTabMode: (tabMode: TabMode) => void
   onClosePanel: () => void
 }
+
+export type ClosePanelProps = {
+  onClosePanel: () => void
+}
+
+export type IndividualPropertiesPanelProps = TabModeProps & ClosePanelProps
 
 export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
   const noTooltipOpen =

--- a/assets/src/components/propertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel.tsx
@@ -8,15 +8,13 @@ import StaleDataPropertiesPanel from "./propertiesPanel/staleDataPropertiesPanel
 import VehiclePropertiesPanel from "./propertiesPanel/vehiclePropertiesPanel"
 import { TabMode } from "./propertiesPanel/tabPanels"
 
-interface Props {
+interface Props extends IndividualPropertiesPanelProps {
   selectedVehicleOrGhost: Vehicle | Ghost
-  initialTab?: TabMode
-  onClosePanel: () => void
 }
 
 export type IndividualPropertiesPanelProps = {
   tabMode: TabMode
-  onChangeTabMode: React.Dispatch<React.SetStateAction<TabMode>>
+  onChangeTabMode: (tabMode: TabMode) => void
   onClosePanel: () => void
 }
 
@@ -31,7 +29,8 @@ export const hideMeIfNoCrowdingTooltip = (hideMe: () => void) => {
 
 const PropertiesPanel = ({
   selectedVehicleOrGhost,
-  initialTab = "status",
+  tabMode,
+  onChangeTabMode,
   onClosePanel,
 }: Props) => {
   const { socket } = useSocket()
@@ -39,7 +38,6 @@ const PropertiesPanel = ({
   const [mostRecentVehicle, setMostRecentVehicle] = useState<Vehicle | Ghost>(
     liveVehicle || selectedVehicleOrGhost
   )
-  const [tabMode, setTabMode] = useState<TabMode>(initialTab)
 
   useEffect(() => {
     if (liveVehicle) {
@@ -55,21 +53,21 @@ const PropertiesPanel = ({
           <StaleDataPropertiesPanel
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
-            onChangeTabMode={setTabMode}
+            onChangeTabMode={onChangeTabMode}
             onClosePanel={onClosePanel}
           />
         ) : isVehicle(mostRecentVehicle) ? (
           <VehiclePropertiesPanel
             selectedVehicle={mostRecentVehicle}
             tabMode={tabMode}
-            onChangeTabMode={setTabMode}
+            onChangeTabMode={onChangeTabMode}
             onClosePanel={onClosePanel}
           />
         ) : (
           <GhostPropertiesPanel
             selectedGhost={mostRecentVehicle}
             tabMode={tabMode}
-            onChangeTabMode={setTabMode}
+            onChangeTabMode={onChangeTabMode}
             onClosePanel={onClosePanel}
           />
         )}
@@ -85,5 +83,26 @@ const PropertiesPanel = ({
     </>
   )
 }
+
+interface PropertiesPanelWithTabsStateProps extends Props {
+  initialTab?: TabMode
+}
+
+const PropertiesPanelWithTabState = ({
+  initialTab = "status",
+  ...props
+}: Omit<PropertiesPanelWithTabsStateProps, "tabMode" | "onChangeTabMode">) => {
+  const [tabMode, setTabMode] = useState<TabMode>(initialTab)
+
+  return (
+    <PropertiesPanel
+      {...props}
+      tabMode={tabMode}
+      onChangeTabMode={setTabMode}
+    />
+  )
+}
+
+PropertiesPanel.WithTabState = PropertiesPanelWithTabState
 
 export default PropertiesPanel

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -23,9 +23,9 @@ import TabList from "./tabList"
 import { currentRouteTab } from "../../models/routeTab"
 import ViewHeader from "../viewHeader"
 import { usePanelStateFromStateDispatchContext } from "../../hooks/usePanelState"
-import { IndividualPropertiesPanelProps } from "../propertiesPanel"
+import { ClosePanelProps, TabModeProps } from "../propertiesPanel"
 
-interface Props extends IndividualPropertiesPanelProps {
+interface Props extends TabModeProps, ClosePanelProps {
   vehicle: Vehicle | Ghost
 }
 

--- a/assets/src/components/propertiesPanel/header.tsx
+++ b/assets/src/components/propertiesPanel/header.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useContext } from "react"
+import React, { useContext } from "react"
 import { useRoute } from "../../contexts/routesContext"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
 import { joinClasses } from "../../helpers/dom"
@@ -20,16 +20,13 @@ import { Ghost, Vehicle, VehicleInScheduledService } from "../../realtime"
 import { RouteVariantName } from "../routeVariantName"
 import VehicleIcon, { Size, vehicleOrientation } from "../vehicleIcon"
 import TabList from "./tabList"
-import { TabMode } from "./tabPanels"
 import { currentRouteTab } from "../../models/routeTab"
 import ViewHeader from "../viewHeader"
 import { usePanelStateFromStateDispatchContext } from "../../hooks/usePanelState"
+import { IndividualPropertiesPanelProps } from "../propertiesPanel"
 
-interface Props {
+interface Props extends IndividualPropertiesPanelProps {
   vehicle: Vehicle | Ghost
-  tabMode: TabMode
-  onChangeTabMode: Dispatch<SetStateAction<TabMode>>
-  onClosePanel: () => void
 }
 
 const ScheduleAdherenceStatusIcon = () => (

--- a/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
+++ b/assets/src/components/propertiesPanel/staleDataPropertiesPanel.tsx
@@ -1,8 +1,8 @@
-import React, { Dispatch, SetStateAction, useContext } from "react"
+import React, { useContext } from "react"
 import { hasBlockWaiver } from "../../models/blockWaiver"
 import { Vehicle } from "../../realtime"
 import BlockWaiverList from "./blockWaiverList"
-import TabPanels, { TabMode } from "./tabPanels"
+import TabPanels from "./tabPanels"
 import { Card, CardBody } from "../card"
 import VehicleIcon, { Orientation, Size } from "../vehicleIcon"
 import { StateDispatchContext } from "../../contexts/stateDispatchContext"
@@ -28,8 +28,8 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
       <StaleDataHeader
         vehicle={selectedVehicle}
         tabMode={tabMode}
-        setTabMode={onChangeTabMode}
-        closePanel={onClosePanel}
+        onChangeTabMode={onChangeTabMode}
+        onClosePanel={onClosePanel}
       />
       {isVehicleInScheduledService(selectedVehicle) ? (
         <TabPanels
@@ -44,12 +44,11 @@ const StaleDataPropertiesPanel: React.FC<Props> = ({
   )
 }
 
-const StaleDataHeader: React.FC<{
-  vehicle: Vehicle
-  tabMode: TabMode
-  setTabMode: Dispatch<SetStateAction<TabMode>>
-  closePanel: () => void
-}> = ({ vehicle, tabMode, setTabMode, closePanel }) => {
+const StaleDataHeader: React.FC<
+  {
+    vehicle: Vehicle
+  } & IndividualPropertiesPanelProps
+> = ({ vehicle, tabMode, onChangeTabMode, onClosePanel }) => {
   const [{ userSettings }] = useContext(StateDispatchContext)
   const {
     currentView: { previousView },
@@ -60,7 +59,7 @@ const StaleDataHeader: React.FC<{
     <div className="c-properties-panel__header-wrapper">
       <ViewHeader
         title="Vehicles"
-        closeView={closePanel}
+        closeView={onClosePanel}
         backlinkToView={previousView}
         followBacklink={openPreviousView}
       />
@@ -81,7 +80,7 @@ const StaleDataHeader: React.FC<{
         </div>
       </div>
       {vehicle.isShuttle || (
-        <TabList activeTab={tabMode} setActiveTab={setTabMode} />
+        <TabList activeTab={tabMode} setActiveTab={onChangeTabMode} />
       )}
     </div>
   )

--- a/assets/src/components/propertiesPanel/tabList.tsx
+++ b/assets/src/components/propertiesPanel/tabList.tsx
@@ -1,10 +1,10 @@
-import React, { Dispatch, SetStateAction } from "react"
+import React from "react"
 
 import { TabMode } from "./tabPanels"
 
 interface Props {
   activeTab: TabMode
-  setActiveTab: Dispatch<SetStateAction<TabMode>>
+  setActiveTab: (tabMode: TabMode) => void
 }
 
 const TabStatusIcon = () => (
@@ -31,7 +31,7 @@ const Tab = ({
 }: {
   tabName: TabMode
   activeTab: TabMode
-  setActiveTab: Dispatch<SetStateAction<TabMode>>
+  setActiveTab: (tabMode: TabMode) => void
 }) => {
   const classes =
     tabName === activeTab ? "c-tabs__tab c-tabs__tab--selected" : "c-tabs__tab"

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -1,42 +1,29 @@
-import React, { ReactElement } from "react"
-import { Ghost, Vehicle } from "../realtime.d"
+import React, { ReactElement, ReactNode } from "react"
 import NotificationDrawer from "./notificationDrawer"
-import PropertiesPanel from "./propertiesPanel"
 import SwingsView from "./swingsView"
 import { OpenView } from "../state/pagePanelState"
-import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
-import { TabMode } from "./propertiesPanel/tabPanels"
 import LateView from "./lateView"
 
-const RightPanel = ({
-  selectedVehicleOrGhost,
-  initialTab,
-}: {
-  selectedVehicleOrGhost?: Vehicle | Ghost | null
-  initialTab?: TabMode
-}): ReactElement<HTMLElement> | null => {
-  const {
-    currentView: { openView },
-    closeView,
-  } = usePanelStateFromStateDispatchContext()
+type RightPanelProps = {
+  openView: OpenView
+  propertiesPanel?: ReactNode
+}
 
-  if (selectedVehicleOrGhost) {
-    return (
-      <PropertiesPanel.WithTabState
-        selectedVehicleOrGhost={selectedVehicleOrGhost}
-        onClosePanel={closeView}
-        initialTab={initialTab}
-      />
-    )
+const RightPanel = ({
+  openView,
+  propertiesPanel,
+}: RightPanelProps): ReactElement | null => {
+  if (propertiesPanel !== undefined) {
+    return <>{propertiesPanel}</>
   } else if (openView === OpenView.Swings) {
     return <SwingsView />
   } else if (openView === OpenView.Late) {
     return <LateView />
   } else if (openView === OpenView.NotificationDrawer) {
     return <NotificationDrawer />
-  } else {
-    return null
   }
+
+  return null
 }
 
 export default RightPanel

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -22,7 +22,7 @@ const RightPanel = ({
 
   if (selectedVehicleOrGhost) {
     return (
-      <PropertiesPanel
+      <PropertiesPanel.WithTabState
         selectedVehicleOrGhost={selectedVehicleOrGhost}
         onClosePanel={closeView}
         initialTab={initialTab}

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -6,6 +6,7 @@ import SwingsView from "./swingsView"
 import { OpenView } from "../state/pagePanelState"
 import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
 import { TabMode } from "./propertiesPanel/tabPanels"
+import LateView from "./lateView"
 
 const RightPanel = ({
   selectedVehicleOrGhost,
@@ -29,6 +30,8 @@ const RightPanel = ({
     )
   } else if (openView === OpenView.Swings) {
     return <SwingsView />
+  } else if (openView === OpenView.Late) {
+    return <LateView />
   } else if (openView === OpenView.NotificationDrawer) {
     return <NotificationDrawer />
   } else {

--- a/assets/src/components/rightPanel.tsx
+++ b/assets/src/components/rightPanel.tsx
@@ -5,11 +5,14 @@ import PropertiesPanel from "./propertiesPanel"
 import SwingsView from "./swingsView"
 import { OpenView } from "../state/pagePanelState"
 import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
+import { TabMode } from "./propertiesPanel/tabPanels"
 
 const RightPanel = ({
   selectedVehicleOrGhost,
+  initialTab,
 }: {
   selectedVehicleOrGhost?: Vehicle | Ghost | null
+  initialTab?: TabMode
 }): ReactElement<HTMLElement> | null => {
   const {
     currentView: { openView },
@@ -21,6 +24,7 @@ const RightPanel = ({
       <PropertiesPanel
         selectedVehicleOrGhost={selectedVehicleOrGhost}
         onClosePanel={closeView}
+        initialTab={initialTab}
       />
     )
   } else if (openView === OpenView.Swings) {

--- a/assets/src/hooks/usePanelState.ts
+++ b/assets/src/hooks/usePanelState.ts
@@ -13,6 +13,7 @@ import {
   openSwingsView,
   selectVehicle,
   setPath,
+  setTabMode,
 } from "../state/pagePanelState"
 
 /**
@@ -43,10 +44,9 @@ export const usePanelStateForViewState = (
         dispatch(setPath(path))
       }
     },
-    openVehiclePropertiesPanel: (
-      vehicle: VehicleType,
-      initialView?: TabMode
-    ) => dispatch(selectVehicle(vehicle, initialView ?? "status")),
+    setTabMode: (tabMode: TabMode) => dispatch(setTabMode(tabMode)),
+    openVehiclePropertiesPanel: (vehicle: VehicleType, initialView?: TabMode) =>
+      dispatch(selectVehicle(vehicle, initialView ?? "status")),
     openLateView: () => dispatch(openLateView()),
     openSwingsView: () => dispatch(openSwingsView()),
     openNotificationDrawer: () => dispatch(openNotificaitonDrawer()),

--- a/assets/src/hooks/usePanelState.ts
+++ b/assets/src/hooks/usePanelState.ts
@@ -45,8 +45,8 @@ export const usePanelStateForViewState = (
     },
     openVehiclePropertiesPanel: (
       vehicle: VehicleType,
-      _initialView?: TabMode
-    ) => dispatch(selectVehicle(vehicle)),
+      initialView?: TabMode
+    ) => dispatch(selectVehicle(vehicle, initialView ?? "status")),
     openLateView: () => dispatch(openLateView()),
     openSwingsView: () => dispatch(openSwingsView()),
     openNotificationDrawer: () => dispatch(openNotificaitonDrawer()),

--- a/assets/src/state/pagePanelState.ts
+++ b/assets/src/state/pagePanelState.ts
@@ -101,6 +101,14 @@ const openViewPanelReducer = (
         vppTabMode,
       }
     }
+    case "SET_TAB_MODE": {
+      return state.selectedVehicleOrGhost
+        ? {
+            ...state,
+            vppTabMode: action.payload.tabMode,
+          }
+        : state
+    }
     case "OPEN_NOTIFICATION_DRAWER":
       return openView === OpenView.NotificationDrawer
         ? state
@@ -176,6 +184,13 @@ export const selectVehicle = (vehicle: VehicleType, tabMode: TabMode): SelectVeh
   }
 }
 
+export const setTabMode = (tabMode: TabMode): SetVppTabMode => {
+  return {
+    type: "SET_TAB_MODE",
+    payload: { tabMode },
+  }
+}
+
 export const setPath = (path: PagePath): SetCurrentPath => {
   return {
     type: "SET_CURRENT_PATH",
@@ -228,6 +243,7 @@ export type PanelViewAction =
   // Vehicles
   | SelectVehicleAction
   | SelectVehicleFromNotificationAction
+  | SetVppTabMode
   // Views
   | OpenNotificationDrawerAction
   | OpenSwingsViewAction
@@ -238,6 +254,11 @@ export type PanelViewAction =
 interface SetCurrentPath {
   type: "SET_CURRENT_PATH"
   payload: { path: PagePath }
+}
+
+interface SetVppTabMode {
+  type: "SET_TAB_MODE"
+  payload: { tabMode: TabMode }
 }
 
 interface SelectVehicleAction {

--- a/assets/src/state/pagePanelState.ts
+++ b/assets/src/state/pagePanelState.ts
@@ -1,3 +1,4 @@
+import { TabMode } from "../components/propertiesPanel/tabPanels"
 import { Vehicle, Ghost } from "../realtime"
 import { Action } from "../state"
 
@@ -41,12 +42,14 @@ export type PageViewState = {
   openView: OpenView
   previousView: OpenView
   selectedVehicleOrGhost: VehicleType
+  vppTabMode: TabMode | undefined
 }
 
 export const initialPageState = {
   openView: OpenView.None,
   previousView: OpenView.None,
   selectedVehicleOrGhost: undefined,
+  vppTabMode: undefined,
 }
 
 export const initialPageViewState: ViewState = {
@@ -88,13 +91,14 @@ const openViewPanelReducer = (
   state: PageViewState,
   action: Action
 ): PageViewState => {
-  const { openView, previousView, selectedVehicleOrGhost } = state
+  const { openView, previousView, selectedVehicleOrGhost, vppTabMode } = state
   switch (action.type) {
     case "SET_CURRENT_PATH": {
       return {
         openView: OpenView.None,
         previousView: OpenView.None,
         selectedVehicleOrGhost,
+        vppTabMode,
       }
     }
     case "OPEN_NOTIFICATION_DRAWER":
@@ -104,6 +108,7 @@ const openViewPanelReducer = (
             openView: OpenView.NotificationDrawer,
             previousView: openView,
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
           }
     case "OPEN_SWINGS_VIEW":
       return openView === OpenView.Swings
@@ -112,6 +117,7 @@ const openViewPanelReducer = (
             openView: OpenView.Swings,
             previousView: openView,
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
           }
     case "OPEN_LATE_VIEW":
       return openView === OpenView.Late
@@ -120,6 +126,7 @@ const openViewPanelReducer = (
             openView: OpenView.Late,
             previousView: openView,
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
           }
     case "CLOSE_VIEW":
       return openView !== null
@@ -127,6 +134,7 @@ const openViewPanelReducer = (
             openView: OpenView.None,
             previousView: OpenView.None,
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
           }
         : state
     case "SELECT_VEHICLE":
@@ -135,12 +143,15 @@ const openViewPanelReducer = (
         openView: OpenView.None,
         previousView: openView === OpenView.None ? previousView : openView,
         selectedVehicleOrGhost: action.payload.vehicle,
+        vppTabMode:
+          action.type === "SELECT_VEHICLE" ? action.payload.tabMode : undefined,
       }
     case "SET_NOTIFICATION":
       return {
         openView,
         previousView: previousView,
         selectedVehicleOrGhost: undefined,
+        vppTabMode: undefined,
       }
     case "RETURN_TO_PREVIOUS_VIEW":
       return previousView !== OpenView.None
@@ -148,6 +159,7 @@ const openViewPanelReducer = (
             openView: previousView,
             previousView: OpenView.None,
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
           }
         : state
     default:
@@ -157,10 +169,10 @@ const openViewPanelReducer = (
 //#endregion Reducers
 
 //#region Action Constructors
-export const selectVehicle = (vehicle: VehicleType): SelectVehicleAction => {
+export const selectVehicle = (vehicle: VehicleType, tabMode: TabMode): SelectVehicleAction => {
   return {
     type: "SELECT_VEHICLE",
-    payload: { vehicle },
+    payload: { vehicle, tabMode },
   }
 }
 
@@ -232,6 +244,7 @@ interface SelectVehicleAction {
   type: "SELECT_VEHICLE"
   payload: {
     vehicle: VehicleType
+    tabMode: TabMode
   }
 }
 

--- a/assets/src/state/pagePanelState.ts
+++ b/assets/src/state/pagePanelState.ts
@@ -177,7 +177,10 @@ const openViewPanelReducer = (
 //#endregion Reducers
 
 //#region Action Constructors
-export const selectVehicle = (vehicle: VehicleType, tabMode: TabMode): SelectVehicleAction => {
+export const selectVehicle = (
+  vehicle: VehicleType,
+  tabMode: TabMode
+): SelectVehicleAction => {
   return {
     type: "SELECT_VEHICLE",
     payload: { vehicle, tabMode },

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -125,6 +125,7 @@ describe("App", () => {
         mockUsePanelState({
           currentView: {
             selectedVehicleOrGhost: vehicle,
+            vppTabMode: "status",
             openView: OpenView.None,
             previousView: OpenView.None,
           },
@@ -155,6 +156,7 @@ describe("App", () => {
         mockUsePanelState({
           currentView: {
             selectedVehicleOrGhost: undefined,
+            vppTabMode: undefined,
             openView,
             previousView: OpenView.None,
           },

--- a/assets/tests/components/propertiesPanel.test.tsx
+++ b/assets/tests/components/propertiesPanel.test.tsx
@@ -138,7 +138,7 @@ const PropertiesPanelWrapper: React.FC<{
 
   return (
     <RoutesProvider routes={routes}>
-      <PropertiesPanel
+      <PropertiesPanel.WithTabState
         selectedVehicleOrGhost={vehicleOrGhost}
         onClosePanel={closePanel || jest.fn()}
         initialTab={initialTab}

--- a/assets/tests/components/rightPanel.test.tsx
+++ b/assets/tests/components/rightPanel.test.tsx
@@ -5,19 +5,14 @@ import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom/jest-globals"
 import renderer from "react-test-renderer"
 import RightPanel from "../../src/components/rightPanel"
-import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
-import { State } from "../../src/state"
 import * as dateTime from "../../src/util/dateTime"
 
 import ghostFactory from "../factories/ghost"
 import vehicleFactory from "../factories/vehicle"
-import stateFactory from "../factories/applicationState"
 import { RunFactory } from "../factories/run"
 import { OpenView } from "../../src/state/pagePanelState"
-import { viewFactory } from "../factories/pagePanelStateFactory"
 
 const ghost = ghostFactory.build({ runId: "ghostrun-1" })
-const vehicle = vehicleFactory.build()
 
 jest
   .spyOn(dateTime, "now")
@@ -30,7 +25,7 @@ describe("rightPanel", () => {
     const tree = renderer
       .create(
         <BrowserRouter>
-          <RightPanel />
+          <RightPanel openView={OpenView.None} />
         </BrowserRouter>
       )
       .toJSON()
@@ -40,112 +35,48 @@ describe("rightPanel", () => {
   test("shows a selected vehicle", () => {
     const { id: runId } = RunFactory.build()
     const vehicle = vehicleFactory.build({ runId })
-    const state = stateFactory.build({
-      view: viewFactory
-        .currentState({ selectedVehicleOrGhost: vehicle })
-        .build(),
-    })
 
     const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel selectedVehicleOrGhost={vehicle} />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <RightPanel
+        openView={OpenView.None}
+        propertiesPanel={<button>{vehicle.runId!}</button>}
+      />
     )
 
     expect(result.queryByRole("button", { name: vehicle.runId! })).toBeVisible()
   })
 
   test("shows a selected ghost", () => {
-    const state: State = stateFactory.build({
-      view: viewFactory
-        .currentState({
-          selectedVehicleOrGhost: ghost,
-        })
-        .build(),
-    })
     const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel selectedVehicleOrGhost={ghost} />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <RightPanel openView={OpenView.None} propertiesPanel={ghost.runId!} />
     )
     expect(result.queryByText(ghost.runId!)).toBeVisible()
   })
 
   test("shows notification drawer", () => {
-    const state: State = stateFactory.build({
-      view: viewFactory
-        .currentState({
-          openView: OpenView.NotificationDrawer,
-        })
-        .build(),
-    })
-    const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel />
-        </BrowserRouter>
-      </StateDispatchProvider>
-    )
+    const result = render(<RightPanel openView={OpenView.NotificationDrawer} />)
     expect(result.getByText("Notifications")).toBeVisible()
   })
 
   test("prefers VPP to notification drawer", () => {
-    const state: State = stateFactory.build({
-      view: viewFactory
-        .withVehicle()
-        .currentState({
-          openView: OpenView.NotificationDrawer,
-        })
-        .build(),
-    })
     const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel selectedVehicleOrGhost={vehicle} />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <RightPanel
+        openView={OpenView.NotificationDrawer}
+        propertiesPanel="Vehicles"
+      />
     )
     expect(result.queryByText("Vehicles")).toBeVisible()
     expect(result.queryByText("Notifications")).toBeNull()
   })
 
   test("shows swings view", () => {
-    const state: State = stateFactory.build({
-      view: viewFactory
-        .currentState({
-          openView: OpenView.Swings,
-        })
-        .build(),
-    })
-    const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel />
-        </BrowserRouter>
-      </StateDispatchProvider>
-    )
+    const result = render(<RightPanel openView={OpenView.Swings} />)
     expect(result.queryByText("Swings")).toBeVisible()
   })
 
   test("prefers VPP to swings view", () => {
-    const state: State = stateFactory.build({
-      view: viewFactory
-        .currentState({
-          selectedVehicleOrGhost: vehicle,
-          openView: OpenView.Swings,
-        })
-        .build(),
-    })
     const result = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
-        <BrowserRouter>
-          <RightPanel selectedVehicleOrGhost={vehicle} />
-        </BrowserRouter>
-      </StateDispatchProvider>
+      <RightPanel openView={OpenView.Swings} propertiesPanel="Vehicles" />
     )
     expect(result.queryByText("Vehicles")).toBeVisible()
     expect(result.queryByText("Swings")).toBeNull()

--- a/assets/tests/hooks/usePanelState.test.tsx
+++ b/assets/tests/hooks/usePanelState.test.tsx
@@ -25,15 +25,29 @@ import React from "react"
 import stateFactory from "../factories/applicationState"
 
 describe("usePanelStateForViewState", () => {
-  test("openVehiclePropertiesPanel", () => {
-    const mock = jest.fn()
-    const vehicle = vehicleFactory.build()
+  describe("openVehiclePropertiesPanel", () => {
+    test("sends vehicle", () => {
+      const mock = jest.fn()
+      const vehicle = vehicleFactory.build()
 
-    const cb = usePanelStateForViewState(viewFactory.build(), mock)
+      const cb = usePanelStateForViewState(viewFactory.build(), mock)
 
-    cb.openVehiclePropertiesPanel(vehicle)
+      cb.openVehiclePropertiesPanel(vehicle)
 
-    expect(mock).toHaveBeenCalledWith(selectVehicle(vehicle))
+      expect(mock).toHaveBeenCalledWith(selectVehicle(vehicle, "status"))
+    })
+
+    test("sends TabMode", () => {
+      const mock = jest.fn()
+      const vehicle = vehicleFactory.build()
+
+      const cb = usePanelStateForViewState(viewFactory.build(), mock)
+
+      const tabMode = "block"
+      cb.openVehiclePropertiesPanel(vehicle, tabMode)
+
+      expect(mock).toHaveBeenCalledWith(selectVehicle(vehicle, tabMode))
+    })
   })
 
   test("setPath", () => {

--- a/assets/tests/hooks/usePanelState.test.tsx
+++ b/assets/tests/hooks/usePanelState.test.tsx
@@ -14,6 +14,7 @@ import {
   openSwingsView,
   selectVehicle,
   setPath,
+  setTabMode,
 } from "../../src/state/pagePanelState"
 import {
   pageViewFactory,
@@ -39,14 +40,13 @@ describe("usePanelStateForViewState", () => {
 
     test("sends TabMode", () => {
       const mock = jest.fn()
-      const vehicle = vehicleFactory.build()
+      const tabMode = "block"
 
       const cb = usePanelStateForViewState(viewFactory.build(), mock)
 
-      const tabMode = "block"
-      cb.openVehiclePropertiesPanel(vehicle, tabMode)
+      cb.setTabMode(tabMode)
 
-      expect(mock).toHaveBeenCalledWith(selectVehicle(vehicle, tabMode))
+      expect(mock).toHaveBeenCalledWith(setTabMode(tabMode))
     })
   })
 

--- a/assets/tests/state/pagePanelState.test.ts
+++ b/assets/tests/state/pagePanelState.test.ts
@@ -13,6 +13,7 @@ import {
   setPath,
 } from "../../src/state/pagePanelState"
 import { viewFactory } from "../factories/pagePanelStateFactory"
+import { TabMode } from "../../src/components/propertiesPanel/tabPanels"
 
 describe("openVehiclePropertiesPanel", () => {
   test("selects vehicle", () => {
@@ -24,7 +25,7 @@ describe("openVehiclePropertiesPanel", () => {
           selectedVehicleOrGhost: undefined,
         })
         .build(),
-      selectVehicle(vehicle)
+      selectVehicle(vehicle, "status")
     )
 
     expect(state.state[state.currentPath].selectedVehicleOrGhost).toBe(vehicle)
@@ -44,12 +45,32 @@ describe("openVehiclePropertiesPanel", () => {
           previousView: OpenView.None,
         })
         .build(),
-      selectVehicle(vehicle)
+      selectVehicle(vehicle, "status")
     )
 
     expect(state.state[state.currentPath].openView).toBe(OpenView.None)
     expect(state.state[state.currentPath].previousView).toBe(openView)
     expect(state.state[state.currentPath].selectedVehicleOrGhost).toBe(vehicle)
+  })
+
+
+  test.each<{ tab: TabMode }>([
+    { tab: "status" },
+    { tab: "block" },
+    { tab: "run" },
+  ])("when vehicle is selected, can select a specific tab: $tab", ({ tab }) => {
+    const vehicle = vehicleFactory.build()
+
+    const state = openViewReducer(
+      viewFactory
+        .currentState({
+          selectedVehicleOrGhost: undefined,
+        })
+        .build(),
+      selectVehicle(vehicle, tab)
+    )
+
+    expect(state.state[state.currentPath].vppTabMode).toBe(tab)
   })
 })
 
@@ -115,10 +136,10 @@ describe("setPath", () => {
 
     const state = [
       setPath(slot1),
-      selectVehicle(vehicle1),
+      selectVehicle(vehicle1, "status"),
 
       setPath(slot2),
-      selectVehicle(vehicle2),
+      selectVehicle(vehicle2, "status"),
     ].reduce(openViewReducer, viewFactory.build())
 
     expect(state.state[slot1].selectedVehicleOrGhost).toBe(vehicle1)

--- a/assets/tests/state/pagePanelState.test.ts
+++ b/assets/tests/state/pagePanelState.test.ts
@@ -11,6 +11,7 @@ import {
   openViewReducer,
   selectVehicle,
   setPath,
+  setTabMode,
 } from "../../src/state/pagePanelState"
 import { viewFactory } from "../factories/pagePanelStateFactory"
 import { TabMode } from "../../src/components/propertiesPanel/tabPanels"
@@ -53,24 +54,35 @@ describe("openVehiclePropertiesPanel", () => {
     expect(state.state[state.currentPath].selectedVehicleOrGhost).toBe(vehicle)
   })
 
-
-  test.each<{ tab: TabMode }>([
+  describe.each<{ tab: TabMode }>([
     { tab: "status" },
     { tab: "block" },
     { tab: "run" },
-  ])("when vehicle is selected, can select a specific tab: $tab", ({ tab }) => {
-    const vehicle = vehicleFactory.build()
-
-    const state = openViewReducer(
-      viewFactory
+  ])("can select tab: $tab", ({ tab }) => {
+    test("when vehicle is selected", () => {
+      const vehicle = vehicleFactory.build()
+      const state = openViewReducer(
+        viewFactory
         .currentState({
-          selectedVehicleOrGhost: undefined,
+          selectedVehicleOrGhost: undefined
         })
-        .build(),
-      selectVehicle(vehicle, tab)
-    )
+          .build(),
+        selectVehicle(vehicle, tab)
+      )
 
-    expect(state.state[state.currentPath].vppTabMode).toBe(tab)
+      expect(state.state[state.currentPath].vppTabMode).toBe(tab)
+    })
+
+    test("after vehicle is selected", () => {
+      const state = openViewReducer(
+        viewFactory
+          .withVehicle()
+          .build(),
+        setTabMode(tab)
+      )
+
+      expect(state.state[state.currentPath].vppTabMode).toBe(tab)
+    })
   })
 })
 

--- a/assets/tests/state/pagePanelState.test.ts
+++ b/assets/tests/state/pagePanelState.test.ts
@@ -63,9 +63,9 @@ describe("openVehiclePropertiesPanel", () => {
       const vehicle = vehicleFactory.build()
       const state = openViewReducer(
         viewFactory
-        .currentState({
-          selectedVehicleOrGhost: undefined
-        })
+          .currentState({
+            selectedVehicleOrGhost: undefined,
+          })
           .build(),
         selectVehicle(vehicle, tab)
       )
@@ -75,9 +75,7 @@ describe("openVehiclePropertiesPanel", () => {
 
     test("after vehicle is selected", () => {
       const state = openViewReducer(
-        viewFactory
-          .withVehicle()
-          .build(),
+        viewFactory.withVehicle().build(),
         setTabMode(tab)
       )
 

--- a/assets/tests/testHelpers/usePanelStateMocks.tsx
+++ b/assets/tests/testHelpers/usePanelStateMocks.tsx
@@ -14,6 +14,7 @@ export function mockUsePanelState(
     openNotificationDrawer: jest.fn(),
     openLateView: jest.fn(),
     openSwingsView: jest.fn(),
+    setTabMode: jest.fn(),
 
     ...(values || {}),
   })


### PR DESCRIPTION
When working on #2273, I ended up breaking the MapPage feature which allowed opening the VPP to a specific page. I considered adding the first part of this PR in #2273, but I figured it was getting large enough it'd be easier to digest as a separate PR.

This "stores" the state of the active VPP Tab in the `usePanelState*` hooks because the `initialTab` prop was insufficient because switching pages wouldn't reset the state of `tabMode`, therefore `initialState` was only respected once. By pulling the state out into the panel state, the tab can now be remembered across pages, and each page has it's own tab mode.

---

Depends On: #2273 
Asana Ticket: https://app.asana.com/0/1148853526253420/1205762199809559/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205877298615016