### PR TITLE
feat(storybook): Add story for location marker icon

### DIFF
--- a/assets/stories/skate-components/map/markers/locationMarker.stories.tsx
+++ b/assets/stories/skate-components/map/markers/locationMarker.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import React from "react"
+import { LocationMarker } from "../../../../src/components/mapMarkers"
+import { LocationDotIcon } from "../../../../src/helpers/icon"
+import { inMapDecorator } from "../../../../.storybook/inMapDecorator"
+import locationSearchResultFactory from "../../../../tests/factories/locationSearchResult"
+
+const location = locationSearchResultFactory.build({
+  latitude: 42.360082,
+  longitude: -71.05888,
+})
+
+const meta = {
+  args: { location },
+  argTypes: {
+    location: { table: { disable: true } },
+  },
+  render: ({ selected }) => {
+    return (
+      <LocationDotIcon
+        className={
+          "c-location-dot-icon" +
+          (selected ? " c-location-dot-icon--selected" : "")
+        }
+      />
+    )
+  },
+  component: LocationMarker,
+  parameters: {
+    layout: "centered",
+    stretch: false,
+  },
+} satisfies Meta<typeof LocationMarker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Unselected: Story = {
+  args: {
+    selected: false,
+  },
+}
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+}
+
+const InMap: Story = {
+  decorators: [inMapDecorator],
+  render: LocationMarker,
+  parameters: {
+    layout: "fullscreen",
+    stretch: true,
+  },
+}
+
+export const UnselectedInMap: Story = {
+  ...Unselected,
+  ...InMap,
+}
+
+export const SelectedInMap: Story = {
+  ...Selected,
+  ...InMap,
+}


### PR DESCRIPTION
This is a follow-up to [this PR](https://github.com/mbta/skate/pull/2271) to add a storybook story for the affected icon.

Question: I wasn't able to get the icon to load without being in the map context. It _feels_ like we should have a non-map version of the icon, but I sort of timeboxed the effort to add it. What do you all think?