### PR TITLE
chore(devtools): add typescript-language-server as a dev dependency

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -88,6 +88,7 @@
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.4",
         "typescript": "^5.1.6",
+        "typescript-language-server": "^4.1.3",
         "webpack": "^5.76.2",
         "webpack-cli": "^5.0.1"
       }
@@ -22449,6 +22450,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.1.3.tgz",
+      "integrity": "sha512-miJcwsS5ZGuYlix9mbGZDF96ynzgxAZbCeQO2MpgaVahmnRjoZ3dI6hnnsvBbdTrpHAAEqdigOnVezoOzcXSag==",
+      "dev": true,
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/uglify-js": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -107,6 +107,7 @@
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.4",
     "typescript": "^5.1.6",
+    "typescript-language-server": "^4.1.3",
     "webpack": "^5.76.2",
     "webpack-cli": "^5.0.1"
   },


### PR DESCRIPTION
No Asana ticket, just a quick quality of life improvement for those of us who use a project-local installation of the language server so that it's pulled in by default.