### PR TITLE
fix(ex/api/stream_test): fix intermitently failing tests

### DIFF
--- a/test/api/stream_test.exs
+++ b/test/api/stream_test.exs
@@ -2,6 +2,7 @@ defmodule Api.StreamTest do
   use ExUnit.Case, async: false
   import Test.Support.Helpers
   alias Plug.Conn
+  alias ServerSentEventStage, as: SSES
 
   describe "build_options" do
     setup do
@@ -17,38 +18,22 @@ defmodule Api.StreamTest do
   end
 
   describe "start_link" do
-    setup do
-      bypass = Bypass.open()
+    @data %{
+      "attributes" => [],
+      "type" => "vehicle",
+      "id" => "vehicle"
+    }
 
-      {:ok, %{bypass: bypass}}
-    end
-
-    test "starts a genserver that sends events", %{bypass: bypass} do
-      Bypass.expect(bypass, fn conn ->
-        conn = Conn.send_chunked(conn, 200)
-
-        data = %{
-          "attributes" => [],
-          "type" => "vehicle",
-          "id" => "vehicle"
-        }
-
-        Conn.chunk(conn, "event: reset\ndata: #{Jason.encode!([data])}\n\n")
-        conn
-      end)
+    test "starts a genserver that sends events" do
+      data = @data
 
       assert {:ok, sses} =
-               [
-                 name: :start_link_test,
-                 base_url: "http://localhost:#{bypass.port}",
-                 path: "/vehicles",
-                 params: [
-                   "fields[vehicle]": "direction_id,current_status,longitude,latitude,bearing",
-                   include: "stop,trip"
-                 ]
-               ]
-               |> Api.Stream.build_options()
-               |> ServerSentEventStage.start_link()
+               GenStage.from_enumerable([
+                 %SSES.Event{
+                   event: "reset",
+                   data: Jason.encode!(data)
+                 }
+               ])
 
       assert {:ok, pid} = Api.Stream.start_link(name: __MODULE__, subscribe_to: sses)
 
@@ -58,46 +43,29 @@ defmodule Api.StreamTest do
                |> Enum.take(1)
     end
 
-    # We're seeing occasional failures in this test due to an underlying issue
-    # with the `Bypass` library. There is an
-    # [open issue on Bypass's github](https://github.com/PSPDFKit-labs/bypass/issues/120).
-    test "handles api events", %{bypass: bypass} do
-      Bypass.expect(bypass, fn conn ->
-        conn = Conn.send_chunked(conn, 200)
-
-        data = %{
-          "attributes" => [],
-          "type" => "vehicle",
-          "id" => "vehicle"
-        }
-
-        {:ok, conn} = Conn.chunk(conn, "event: ignores unexpected events\n\n")
-        {:ok, conn} = Conn.chunk(conn, "ignored garbled data\n\n")
-        {:ok, conn} = Conn.chunk(conn, "event: reset\ndata: #{Jason.encode!([data])}\n\n")
-        {:ok, conn} = Conn.chunk(conn, "event: add\ndata: #{Jason.encode!(data)}\n\n")
-        {:ok, conn} = Conn.chunk(conn, "event: update\ndata: #{Jason.encode!(data)}\n\n")
-        {:ok, conn} = Conn.chunk(conn, "event: remove\ndata: #{Jason.encode!(data)}\n\n")
-        conn
-      end)
+    test "handles api events" do
+      data = @data
 
       assert {:ok, sses} =
-               [
-                 base_url: "http://localhost:#{bypass.port}",
-                 path: "/vehicles"
-               ]
-               |> Api.Stream.build_options()
-               |> ServerSentEventStage.start_link()
+               GenStage.from_enumerable([
+                 %SSES.Event{event: "ignores unexpected events"},
+                 # garbled data contains no data and the `event` is `message`
+                 %SSES.Event{event: "message"},
+                 %SSES.Event{event: "reset", data: Jason.encode!([data])},
+                 %SSES.Event{event: "add", data: Jason.encode!(data)},
+                 %SSES.Event{event: "update", data: Jason.encode!(data)},
+                 %SSES.Event{event: "remove", data: Jason.encode!(data)}
+               ])
 
       assert {:ok, pid} = Api.Stream.start_link(name: __MODULE__, subscribe_to: sses)
 
-      stream = GenStage.stream([pid])
-
-      assert [
-               %Api.Stream.Event{event: :reset},
-               %Api.Stream.Event{event: :add},
-               %Api.Stream.Event{event: :update},
-               %Api.Stream.Event{event: :remove}
-             ] = Enum.take(stream, 4)
+      stream =
+        assert [
+                 %Api.Stream.Event{event: :reset},
+                 %Api.Stream.Event{event: :add},
+                 %Api.Stream.Event{event: :update},
+                 %Api.Stream.Event{event: :remove}
+               ] = [pid] |> GenStage.stream() |> Enum.take(4)
     end
   end
 end


### PR DESCRIPTION
I tried fixing this by addressing the [Bypass issue](https://github.com/PSPDFKit-labs/bypass/issues/120), but that didn't actually help. So instead I've decided to cut out the `ServerSentEventsStage` and replace it with the parse results that `Api.Stream` received from the tests before this change.

---

Asana Ticket: [⚙️ Fix false positive test failure in `stream_test.ex`](https://app.asana.com/0/1148853526253420/1206096617521840/f)

<details>
<summary><h3>CI Runs Information</h3></summary>
<dl>
<dt>Number of <code>stream_test</code> Failures in <a href="https://github.com/mbta/skate/pull/2303">#2303</a> so far</dt>
<dd>0</dd>

<dt>Total <a href="https://github.com/mbta/skate/pull/2303">#2303</a> Pipeline Runs</dt>
<dt>Total <a href="https://github.com/mbta/skate/pull/2303">#2303</a> Pushed Commits</dt>
<dd>11</dd>

<dt>Total <a href="https://github.com/mbta/skate/pull/2303">#2303</a> CI Jobs</dt>
<dd>14</dd>

<dt>Successful <a href="https://github.com/mbta/skate/pull/2303">#2303</a> Jobs</dt>
<dd>
<details>
<summary>14 Successful Jobs</summary>
<ol>
<li><a href="https://github.com/mbta/skate/actions/runs/7121431005/job/19390649117?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (pull_request) Successful in 3m
</a></li>

<li><a href="https://github.com/mbta/skate/actions/runs/7121429590/job/19390645956?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7121431689/job/19390652591?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7121431751/job/19390656652?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7121431809/job/19390653789?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 4m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7121432166/job/19390659167?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7121432303/job/19390659224?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (pull_request) Successful in 3m
</a></li>

<li><a href="https://github.com/mbta/skate/actions/runs/7122528954/job/19393706407?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

----


<li><a href="https://github.com/mbta/skate/actions/runs/7122528954/job/19393706407?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7122529062/job/19393708398?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 4m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7122529123/job/19393714000?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7122529336/job/19393709050?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

---

<li><a href="https://github.com/mbta/skate/actions/runs/7122529411/job/19393708835?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (push) Successful in 3m
</a></li>

<li><a href="https://github.com/mbta/skate/actions/runs/7122529541/job/19393705670?pr=2303">
Elixir and TypeScript CI / Build and test Elixir (pull_request) Successful in 3m
</a></li>

</ol>
</details>
<dl>