### PR TITLE
feat(ex/mix): add `mix fmt` alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -104,7 +104,8 @@ defmodule Skate.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "assets.setup": ["cmd npm --prefix=assets install"],
       "assets.reset": ["cmd npm --prefix=assets ci"],
-      test: ["ecto.create --quiet", "ecto.migrate_all", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate_all", "test"],
+      fmt: ["format", "cmd npm --prefix=assets run format"]
     ]
   end
 end


### PR DESCRIPTION
Sometimes I get a little annoyed needing to run two commands to format the project, so this adds and alias which invokes all our formatters.

---

Asana Ticket: None