### PR TITLE
fix(dependabot): ignore JS path based dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   versioning-strategy: increase
+  ignore:
+    - dependency-name: "phoenix"
+    - dependency-name: "phoenix_html"


### PR DESCRIPTION
# Summary

Dependabot stopped updating our JS dependencies without notification. Upon looking into dependabot jobs, the error message tells us that our path based dependencies are the issue. This commit ignores dependencies that are managed by `mix` like `phoenix` and `phoenix_html`.

## Error message
> **Update check skipped**
> Dependabot updates have stopped for your repository due to repeated errors. To see logs, click "Check for Updates" and Dependabot will try again.
> The last error message was:
>
> **Dependabot couldn't fetch all your path-based dependencies**
> The affected dependencies were `phoenix`.
>
> To use path-based dependencies with Dependabot the paths must be relative, resolve to a directory in this project's source code, and contain a valid JavaScript project.
> [Troubleshoot Dependabot errors](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors)