### PR TITLE
feat(ts/components/DiversionPage): create diversion page stub

### DIFF
--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -1,0 +1,56 @@
+.l-diversion-page {
+  display: grid;
+  // Default layout is linear
+  grid-template:
+    "heading" min-content
+    "panel" auto
+    "map" 80vh
+    / 1fr;
+
+  &__header {
+    grid-area: heading;
+  }
+
+  &__panel {
+    grid-area: panel;
+  }
+
+  &__map {
+    grid-area: map;
+  }
+
+  @include media-breakpoint-up(md) {
+    // For larger breakpoints, layout into grid
+    grid-template:
+      "heading heading" min-content
+      "panel map" auto
+      / fit-content(28ch) auto;
+
+    // Overlay the panel and make the panel header match
+    // the size of the page header if subgrid is supported
+    @supports (grid-template-rows: subgrid) {
+      grid-template:
+        [panel-start] "heading heading" min-content
+        "panel map" auto
+        / fit-content(28ch) auto;
+
+      .c-diversion-panel,
+      .l-diversion-page__panel {
+        display: grid;
+
+        grid-template-rows: subgrid;
+        grid-template-columns: 1fr;
+
+        grid-area: panel;
+
+        .c-diversion-panel__header {
+          grid-row: heading;
+        }
+
+        .c-diversion-panel__body {
+          grid-row: 2/-1;
+        }
+      }
+    }
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -49,6 +49,7 @@ $z-properties-panel-context: (
 @import "data_status_banner";
 @import "directions_button";
 @import "disconnected_modal";
+@import "diversion_page";
 @import "drawer_tab";
 @import "filter_accordion";
 @import "garage_filter";

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { DiversionPanel, DiversionPanelProps } from "./diversionPanel"
+import MapDisplay from "../mapPage/mapDisplay"
+
+export const DiversionPage = ({
+  directions,
+  missedStops,
+  routeName,
+  routeDescription,
+  routeDirection,
+  routeOrigin,
+}: DiversionPanelProps) => (
+  <article className="l-diversion-page h-100 border-box">
+    <header className="l-diversion-page__header text-bg-light border-bottom">
+      <h1 className="h3 text-center">Create Detour</h1>
+    </header>
+    <div className="l-diversion-page__panel bg-light">
+      <DiversionPanel
+        directions={directions}
+        missedStops={missedStops}
+        routeName={routeName}
+        routeDescription={routeDescription}
+        routeOrigin={routeOrigin}
+        routeDirection={routeDirection}
+      />
+    </div>
+    <div className="l-diversion-page__map">
+      <MapDisplay
+        selectedEntity={null}
+        setSelection={() => {}}
+        fetchedSelectedLocation={null}
+      />
+    </div>
+  </article>
+)

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -27,10 +27,13 @@ export const DiversionPanel = ({
       <section className="py-3 border-bottom">
         <h3 className="h4">Affected route</h3>
 
-        <div className="d-flex gap-2">
-          <RoutePill routeName={routeName} />
+        <div>
+          <RoutePill
+            className="d-inline-block me-2 align-top"
+            routeName={routeName}
+          />
 
-          <div>
+          <div className="d-inline-block">
             <p className="my-0">{routeDescription}</p>
             <p className="my-0">{routeOrigin}</p>
             <p className="my-0">{routeDirection}</p>

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode } from "react"
+import { RoutePill } from "../routePill"
+
+export interface DiversionPanelProps {
+  directions?: ReactNode
+  missedStops?: ReactNode
+  routeName: string
+  routeDescription: string
+  routeOrigin: string
+  routeDirection: string
+}
+
+export const DiversionPanel = ({
+  directions,
+  missedStops,
+  routeName,
+  routeDescription,
+  routeOrigin,
+  routeDirection,
+}: DiversionPanelProps) => (
+  <article className="c-diversion-panel h-100 bg-light border-end">
+    <header className="c-diversion-panel__header align-items-center border-bottom d-flex justify-content-around px-3">
+      <h2 className="h6 m-0">Detour Details</h2>
+    </header>
+
+    <div className="c-diversion-panel__body overflow-auto px-3">
+      <section className="py-3 border-bottom">
+        <h3 className="h4">Affected route</h3>
+
+        <div className="d-flex gap-2">
+          <RoutePill routeName={routeName} />
+
+          <div>
+            <p className="my-0">{routeDescription}</p>
+            <p className="my-0">{routeOrigin}</p>
+            <p className="my-0">{routeDirection}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-3">
+        <h3 className="h4">Detour Directions</h3>
+        {directions || <DirectionsHelpText />}
+      </section>
+
+      {missedStops && (
+        <section className="py-3">
+          <h3 className="h4">Missed Stops</h3>
+          {missedStops}
+        </section>
+      )}
+    </div>
+  </article>
+)
+
+const DirectionsHelpText = () => (
+  <p>
+    <i>
+      Click a point on the regular route to start drawing your detour. As you
+      continue to select points on the map, turn-by-turn directions will appear
+      in this drawer.
+    </i>
+  </p>
+)

--- a/assets/src/components/routePill.tsx
+++ b/assets/src/components/routePill.tsx
@@ -3,10 +3,12 @@ import { joinClasses } from "../helpers/dom"
 
 export const RoutePill = ({
   routeName,
+  className,
 }: {
   routeName: string
+  className?: string
 }): JSX.Element => {
-  const classes = joinClasses(["c-route-pill", modeClass(routeName)])
+  const classes = joinClasses(["c-route-pill", modeClass(routeName), className])
 
   return <div className={classes}>{routeNameTransform(routeName)}</div>
 }

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { DiversionPage } from "../../../src/components/detours/diversionPage"
+import DiversionPanelMeta, {
+  WithDirections as DiversionPanelWithDirections,
+  WithStops as DiversionPanelWithStops,
+} from "./diversionPanel.stories"
+
+const meta = {
+  component: DiversionPage,
+  parameters: {
+    layout: "fullscreen",
+    stretch: true,
+  },
+  args: {
+    // Provide default route settings
+    ...DiversionPanelMeta.args,
+  },
+  argTypes: {
+    ...DiversionPanelMeta.argTypes,
+  },
+} satisfies Meta<typeof DiversionPage>
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithoutDirections: Story = {}
+
+export const WithDirections: Story = {
+  args: {
+    ...DiversionPanelWithDirections.args,
+  },
+}
+
+export const WithStops: Story = {
+  args: {
+    ...DiversionPanelWithStops.args,
+  },
+}

--- a/assets/stories/skate-components/detours/diversionPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPanel.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { DiversionPanel } from "../../../src/components/detours/diversionPanel"
+import React from "react"
+import { ListGroup } from "react-bootstrap"
+
+const meta = {
+  component: DiversionPanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    routeName: "66",
+    routeDescription: "Harvard via Allston",
+    routeOrigin: "from Andrew Station",
+    routeDirection: "Outbound",
+  },
+  argTypes: {
+    // Since there's not a good way to expose JSX to the Storybook frontend yet:
+    // Disable `ReactNode` args to reduce UI noise and prevent invalid parameters.
+    directions: { table: { disable: true } },
+    missedStops: { table: { disable: true } },
+  },
+} satisfies Meta<typeof DiversionPanel>
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithoutDirections: Story = {}
+
+export const WithDirections: Story = {
+  args: {
+    directions: (
+      <>
+        <ListGroup variant="flush" as="ol">
+          <ListGroup.Item as="li">Start at Centre St & John St</ListGroup.Item>
+          <ListGroup.Item as="li">Right on John St</ListGroup.Item>
+          <ListGroup.Item as="li">Left on Abbotsford Rd</ListGroup.Item>
+          <ListGroup.Item as="li">Right on Boston St</ListGroup.Item>
+          <ListGroup.Item as="li">
+            <strong>Regular Route</strong>
+          </ListGroup.Item>
+        </ListGroup>
+      </>
+    ),
+  },
+}
+
+export const WithStops: Story = {
+  args: {
+    ...WithDirections.args,
+    missedStops: (
+      <>
+        <ListGroup variant="flush" as="ol">
+          <ListGroup.Item as="li">Stop 1</ListGroup.Item>
+          <ListGroup.Item as="li">Stop 2</ListGroup.Item>
+          <ListGroup.Item as="li">Stop 3</ListGroup.Item>
+          <ListGroup.Item as="li">Stop 4</ListGroup.Item>
+        </ListGroup>
+      </>
+    ),
+  },
+}


### PR DESCRIPTION
This is only available & visible via Storybook at this moment.
I've styled this using bootstrap classes which some of we currently do not import. Given this is "lightly styled" I focused on CSS layout functionality and getting a few bootstrap classes right.

---

Asana Ticket: [⚙️🚧 Create lightly styled stub screen to display directions/missed stops](https://app.asana.com/0/1148853526253420/1206038957525484/f)