### PR TITLE
fix(sb/map/layersControl): add `pullbackLayerEnabled` parameter as `undefined`

### DIFF
--- a/assets/stories/skate-components/map/controls/layersControl.stories.tsx
+++ b/assets/stories/skate-components/map/controls/layersControl.stories.tsx
@@ -68,6 +68,7 @@ export const WithoutPullbackControls: Story = {
     onTogglePullbackLayer: { table: { disable: true } },
   },
   args: {
+    pullbackLayerEnabled: undefined,
     onTogglePullbackLayer: undefined,
   },
 }


### PR DESCRIPTION
Fixes the layers control stories to do what they say.
Found this when looking for references about how to use this control.

No Ticket. 