### PR TITLE
refactor: Improve error handling if TestGroup.update/1 is given a bad override value

### DIFF
--- a/test/skate/settings/test_group_test.exs
+++ b/test/skate/settings/test_group_test.exs
@@ -133,6 +133,15 @@ defmodule Skate.Settings.TestGroupTest do
 
       assert test_group.override == :none
     end
+
+    @tag :skip
+    test "cannot update override to an invalid value" do
+      {:ok, test_group} = TestGroup.create("group name")
+
+      new_test_group = TestGroup.update(%{test_group | override: :wrong})
+
+      assert new_test_group.override == :none
+    end
   end
 
   describe "delete/1" do


### PR DESCRIPTION
Just leaving this here for now to flag that the contract of `TestGroup.update/1` could use some improvement.

It's not a big deal. I don't think there's any way from the UI to get "bad" behavior out of `TestGroup.update/1` right now, but it sort of offends my sensibilities, and it's a (very minor) source of risk in the future to have a context that exposes methods with no graceful error handling.