### PR TITLE
fix: off-by-one error when drawing detour point markers

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -83,7 +83,7 @@ const RouteShapeWithDetour = ({
       ? []
       : endPoint === null
       ? detourPositions.slice(1)
-      : detourPositions.slice(1, -2)
+      : detourPositions.slice(1, -1)
 
   return (
     <>

--- a/assets/tests/components/detours/detourMap.test.tsx
+++ b/assets/tests/components/detours/detourMap.test.tsx
@@ -36,7 +36,7 @@ describe("DetourMap", () => {
     expect(screen.getByTitle("Detour End")).not.toBeNull()
   })
 
-  test("clicking on map while drawing a detour adds a shape", async () => {
+  test("clicking on map while drawing a detour adds a point", async () => {
     const { container } = render(<DetourMap shape={shapeFactory.build()} />)
 
     await userEvent.click(

--- a/assets/tests/components/detours/detourMap.test.tsx
+++ b/assets/tests/components/detours/detourMap.test.tsx
@@ -50,6 +50,24 @@ describe("DetourMap", () => {
     ).toHaveLength(1)
   })
 
+  test("detour points are correctly rendered when detour is complete", async () => {
+    const { container } = render(<DetourMap shape={shapeFactory.build()} />)
+
+    await userEvent.click(
+      container.querySelector(".c-detour_map--original-route-shape")!
+    )
+
+    await userEvent.click(container.querySelector(".c-vehicle-map")!)
+
+    await userEvent.click(
+      container.querySelector(".c-detour_map--original-route-shape")!
+    )
+
+    expect(
+      container.querySelectorAll(".c-detour_map-circle-marker--detour-point")
+    ).toHaveLength(1)
+  })
+
   test("clicking on 'Clear Last Waypoint' removes last point from detour", async () => {
     const { container } = render(<DetourMap shape={shapeFactory.build()} />)
 


### PR DESCRIPTION
Asana ticket: slight follow-up on [⚙️🚧 Click on the map to draw, click on waypoints, and click on route to end](https://app.asana.com/0/1148853526253420/1206038957525487/f)