### PR TITLE
fix(ts/components/vehicleIcon): rename `Ghost` to `GhostIcon`

### DIFF
--- a/assets/src/components/vehicleIcon.tsx
+++ b/assets/src/components/vehicleIcon.tsx
@@ -278,7 +278,7 @@ export const VehicleIconSvgNode = React.memo(
           <Label size={size} orientation={orientation} label={label} />
         ) : null}
         {status === "ghost" ? (
-          <Ghost size={size} variant={variant} />
+          <GhostIcon size={size} variant={variant} />
         ) : (
           <Triangle size={size} orientation={orientation} />
         )}
@@ -320,7 +320,7 @@ const Triangle = React.memo(
   }
 )
 
-const Ghost = React.memo(
+const GhostIcon = React.memo(
   ({ size, variant }: { size: Size; variant?: string }) => {
     // No orientation argument, because the ghost icon is always right side up.
     const scale = scaleForSize(size)


### PR DESCRIPTION
Fixes occasional errors in Storybook due to name collision with `Ghost` from "../realtime.d" on line 9 (https://github.com/mbta/skate/blob/main/assets/src/components/vehicleIcon.tsx#L9)