### PR TITLE
fix:test(ts/factories/route): fix route name generation

### DIFF
--- a/assets/tests/factories/route.ts
+++ b/assets/tests/factories/route.ts
@@ -2,12 +2,12 @@ import { Factory } from "fishery"
 import { Route } from "../../src/schedule"
 
 const routeFactory = Factory.define<Route>(({ sequence }) => ({
-  id: sequence.toString(),
+  id: `route${sequence}`,
   directionNames: {
     0: "Outbound",
     1: "Inbound",
   },
-  name: `Route ${sequence}`,
+  name: sequence.toString(),
   garages: ["Garage A"],
 }))
 


### PR DESCRIPTION
Seems that when addressing this [feedback on storybook page addition PR](https://github.com/mbta/skate/pull/2354#discussion_r1445104632), I didn't actually check that the change did what I was expecting. So I've fixed it this time and double checked that the names are rendering correctly.