### PR TITLE
fix(ts/math): fix and test `closestPosition`

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -92,18 +92,14 @@ const RouteShapeWithDetour = ({
         eventHandlers={{
           click: (e) => {
             if (startPoint === null) {
-              const { position } = closestPosition(
-                routeShapePositions,
-                e.latlng
-              ) ?? {}
+              const { position } =
+                closestPosition(routeShapePositions, e.latlng) ?? {}
 
               position && onSetStartPoint(position)
               position && onAddDetourPosition(position)
             } else if (endPoint === null) {
-              const { position } = closestPosition(
-                routeShapePositions,
-                e.latlng
-              ) ?? {}
+              const { position } =
+                closestPosition(routeShapePositions, e.latlng) ?? {}
 
               position && onSetEndPoint(position)
               position && onAddDetourPosition(position)

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -95,15 +95,17 @@ const RouteShapeWithDetour = ({
               const { position } = closestPosition(
                 routeShapePositions,
                 e.latlng
-              )
-              onSetStartPoint(position)
+              ) ?? {}
+
+              position && onSetStartPoint(position)
               position && onAddDetourPosition(position)
             } else if (endPoint === null) {
               const { position } = closestPosition(
                 routeShapePositions,
                 e.latlng
-              )
-              onSetEndPoint(position)
+              ) ?? {}
+
+              position && onSetEndPoint(position)
               position && onAddDetourPosition(position)
             }
           },

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react"
 import { Shape } from "../../schedule"
 import { LatLngExpression } from "leaflet"
-import { Polyline, useMap, useMapEvent } from "react-leaflet"
-import Leaflet, { Map as LeafletMap } from "leaflet"
+import { Polyline, useMapEvent } from "react-leaflet"
+import Leaflet from "leaflet"
 import Map from "../map"
 import { CustomControl } from "../map/controls/customControl"
 import { Button } from "react-bootstrap"
 import { ReactMarker } from "../map/utilities/reactMarker"
+import { closestPosition } from "../../util/math"
 
 export const DetourMap = ({ shape }: { shape: Shape }) => {
   const [startPoint, setStartPoint] = useState<LatLngExpression | null>(null)
@@ -69,8 +70,6 @@ const RouteShapeWithDetour = ({
     (point) => [point.lat, point.lon]
   )
 
-  const map = useMap()
-
   useMapEvent("click", (e) => {
     if (startPoint !== null && endPoint === null) {
       onAddDetourPosition(e.latlng)
@@ -93,18 +92,16 @@ const RouteShapeWithDetour = ({
         eventHandlers={{
           click: (e) => {
             if (startPoint === null) {
-              const position = closestPosition(
+              const { position } = closestPosition(
                 routeShapePositions,
-                e.latlng,
-                map
+                e.latlng
               )
               onSetStartPoint(position)
               position && onAddDetourPosition(position)
             } else if (endPoint === null) {
-              const position = closestPosition(
+              const { position } = closestPosition(
                 routeShapePositions,
-                e.latlng,
-                map
+                e.latlng
               )
               onSetEndPoint(position)
               position && onAddDetourPosition(position)
@@ -180,25 +177,3 @@ const DetourPointMarker = ({ position }: { position: LatLngExpression }) => (
     }
   />
 )
-
-const closestPosition = (
-  positions: LatLngExpression[],
-  position: LatLngExpression,
-  map: LeafletMap
-): LatLngExpression | null => {
-  const [closestPosition] = positions.reduce<
-    [LatLngExpression | null, number | null]
-  >(
-    ([closestPosition, closestDistance], currentPosition) => {
-      const distance = map.distance(position, currentPosition)
-      if (closestDistance === null || distance < closestDistance) {
-        return [position, distance]
-      } else {
-        return [closestPosition, closestDistance]
-      }
-    },
-    [null, null]
-  )
-
-  return closestPosition
-}

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -1,3 +1,5 @@
+import { LatLng, LatLngExpression } from "leaflet"
+
 /**
  * A helper function to help clarify code when clamping a value between a range.
  * (Remove when tc39 implements `Math.clamp`)
@@ -7,3 +9,26 @@
  */
 export const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(min, value), max)
+
+/**
+ * Finds the element in {@link positions} that is closest to {@link point}
+ * @param positions List of coordinates to search
+ * @param point Point of reference to check distance to
+ * @returns The closest point in {@link positions} to {@link point}
+ */
+export const closestPosition = (
+  positions: LatLngExpression[],
+  point: LatLng
+) => {
+  const positionsByDistance = positions
+    .map((currentPosition, index) => ({
+      distance: point.distanceTo(currentPosition),
+      position: currentPosition,
+      index,
+    }))
+    .sort((lhs, rhs) => lhs.distance - rhs.distance)
+
+  return positionsByDistance[0] ?? undefined
+
+  // Interpolate here
+}

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -10,16 +10,29 @@ import { LatLng, LatLngExpression } from "leaflet"
 export const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(min, value), max)
 
+
+interface ClosestPosition {
+  position: LatLngExpression,
+  index: number
+  distance: number
+}
+
 /**
  * Finds the element in {@link positions} that is closest to {@link point}
  * @param positions List of coordinates to search
  * @param point Point of reference to check distance to
- * @returns The closest point in {@link positions} to {@link point}
+ * @returns
+ * if {@link positions} is empty, returns `undefined`
+ *
+ * Otherwise, returns a {@link ClosestPosition} object containing
+ * - the closest element in {@link positions} to {@link point}
+ * - the index of the element in {@link positions}
+ * - the distance to {@link point}
  */
 export const closestPosition = (
   positions: LatLngExpression[],
   point: LatLng
-) => {
+): ClosestPosition | undefined => {
   const positionsByDistance = positions
     .map((currentPosition, index) => ({
       distance: point.distanceTo(currentPosition),

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -10,9 +10,8 @@ import { LatLng, LatLngExpression } from "leaflet"
 export const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(min, value), max)
 
-
 interface ClosestPosition {
-  position: LatLngExpression,
+  position: LatLngExpression
   index: number
   distance: number
 }

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -25,9 +25,9 @@ interface ClosestPosition {
  * if {@link positions} is empty, returns `undefined`
  *
  * Otherwise, returns a {@link ClosestPosition} object containing
- * - the closest element in {@link positions} to {@link point}
- * - the index of the element in {@link positions}
- * - the distance to {@link point}
+ * - {@link ClosestPosition.position}: the closest element in {@link positions} to {@link point}
+ * - {@link ClosestPosition.index}: the index of the element in {@link positions}
+ * - {@link ClosestPosition.distance}: the distance to {@link point}
  */
 export const closestPosition = (
   positions: LatLngExpression[],

--- a/assets/src/util/math.ts
+++ b/assets/src/util/math.ts
@@ -42,5 +42,13 @@ export const closestPosition = (
 
   return positionsByDistance[0] ?? undefined
 
-  // Interpolate here
+  /**
+   * In the future, we may want to be able to snap to the line _line_ formed
+   * by {@link positions}.
+   * (in the case of, e.g., a low resolution line formed by {@link positions}).
+   *
+   * Now that we have the sorted {@link positionsByDistance}, we can interpolate
+   * the two closest points with respect to {@link point} to find the closest
+   * point on the line.
+   */
 }

--- a/assets/tests/util/math.test.ts
+++ b/assets/tests/util/math.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect } from "@jest/globals"
-import { clamp } from "../../src/util/math"
+import { describe, test, expect, it } from "@jest/globals"
+import { clamp, closestPosition } from "../../src/util/math"
+import { LatLngExpression, latLng } from "leaflet"
 
 describe("clamp", () => {
   test("when value is below minimum, returns minimum value", () => {
@@ -12,5 +13,34 @@ describe("clamp", () => {
 
   test("when value is between minimum and maximum, returns value", () => {
     expect(clamp(5, 0, 10)).toBe(5)
+  })
+})
+
+describe("closestPosition", () => {
+  it("returns `undefined` if provided a empty list", () => {
+    expect(closestPosition([], latLng(0, 0))).toBeUndefined()
+  })
+
+  it("returns the closest point from the provided list", () => {
+    const point = latLng(0, 0)
+
+    const closestPoint: LatLngExpression = {
+      lat: point.lat + 1,
+      lng: 0,
+    }
+    const index = 3
+
+    // Generate range and offset so all are farther than `position`
+    const positions: LatLngExpression[] = Array(5).map((_, idx) => [
+      point.lat + closestPoint.lat + idx,
+      0,
+    ])
+
+    positions[index] = closestPoint
+
+    expect(closestPosition(positions, point)).toMatchObject({
+      index,
+      position: closestPoint,
+    })
   })
 })

--- a/assets/tests/util/math.test.ts
+++ b/assets/tests/util/math.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, it } from "@jest/globals"
+import { describe, test, expect } from "@jest/globals"
 import { clamp, closestPosition } from "../../src/util/math"
 import { LatLngExpression, latLng } from "leaflet"
 
@@ -17,11 +17,11 @@ describe("clamp", () => {
 })
 
 describe("closestPosition", () => {
-  it("returns `undefined` if provided a empty list", () => {
+  test("returns `undefined` if provided a empty list", () => {
     expect(closestPosition([], latLng(0, 0))).toBeUndefined()
   })
 
-  it("returns the closest point from the provided list", () => {
+  test("returns the closest point from the provided list", () => {
     const point = latLng(0, 0)
 
     const closestPoint: LatLngExpression = {

--- a/assets/tests/util/math.test.ts
+++ b/assets/tests/util/math.test.ts
@@ -30,7 +30,7 @@ describe("closestPosition", () => {
     }
     const index = 3
 
-    // Generate range and offset so all are farther than `position`
+    // Generate range and offset so all are farther than `closestPoint`
     const positions: LatLngExpression[] = Array(5).map((_, idx) => [
       point.lat + closestPoint.lat + idx,
       0,


### PR DESCRIPTION
The old implementation was not tested and returned the input `position` instead of the closest point within `positions`.