### PR TITLE
feat(gh/actions/chromatic): require label for automatic chromatic runs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,9 @@
 name: "Chromatic"
 
-on: push
+on:
+  workflow_dispatch:
+  push:
+
 
 jobs:
   chromatic:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,12 +2,14 @@ name: "Chromatic"
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
 
 
 jobs:
   chromatic:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'chromatic') }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
[Failing Dependabot PR](https://github.com/mbta/skate/pull/2324)'s are due to the `chromatic` job having issues with secrets permissions. This forces chromatic to only run if the `chromatic` label is present on a PR, essentially opting in to running chromatic.

Additionally, to support building arbitrary commits without a PR, this enables `workflow_dispatch` so that chromatic can be triggered manually.