### PR TITLE
Initial fixes to tab order

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -73,7 +73,7 @@ export const DetourMap = ({
   undoDisabled,
   onUndoLastWaypoint,
 }: DetourMapProps) => (
-  <Map vehicles={[]}>
+  <Map vehicles={[]} allowStreetView>
     <CustomControl position="topleft" className="leaflet-bar">
       <Button
         variant="primary"

--- a/assets/src/components/ladderPage.tsx
+++ b/assets/src/components/ladderPage.tsx
@@ -79,7 +79,8 @@ const LadderTab = ({
         }
       }}
       role="tab"
-      tabIndex={tab.isCurrentTab ? 0 : -1}
+      tabIndex={tab.isCurrentTab ? -1 : 0}
+      aria-selected={tab.isCurrentTab}
     >
       <div className="c-ladder-page__tab-contents">
         <div

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -56,6 +56,7 @@ export const StreetViewControl = ({
           "c-street-view-switch",
           "position-absolute",
         ])}
+        insertFirst
       >
         <StreetViewSwitch
           streetViewEnabled={streetViewEnabled}

--- a/assets/src/components/map/controls/StreetViewSwitch.tsx
+++ b/assets/src/components/map/controls/StreetViewSwitch.tsx
@@ -1,13 +1,13 @@
-import Leaflet, { ControlOptions } from "leaflet"
-import React, { useEffect, useId, useState } from "react"
-import ReactDOM from "react-dom"
-import { useMap, useMapEvents } from "react-leaflet"
-import { joinClasses } from "../../../helpers/dom"
+import { ControlOptions } from "leaflet"
+import React, { useId } from "react"
+import { useMapEvents } from "react-leaflet"
 import { WalkingIcon } from "../../../helpers/icon"
 import { streetViewUrl } from "../../../util/streetViewUrl"
 import { CutoutOverlay } from "../../cutoutOverlay"
 import { fullStoryEvent } from "../../../helpers/fullStory"
 import { Form } from "react-bootstrap"
+import { CustomControl } from "./customControl"
+import { joinClasses } from "../../../helpers/dom"
 
 export interface StreetViewControlProps extends ControlOptions {
   streetViewEnabled: boolean
@@ -18,31 +18,6 @@ export const StreetViewControl = ({
   streetViewEnabled,
   setStreetViewEnabled,
 }: StreetViewControlProps): JSX.Element | null => {
-  const map = useMap()
-  const portalParent = map
-    .getContainer()
-    .querySelector(".leaflet-control-container")
-  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
-
-  useEffect(() => {
-    if (!portalParent || !portalElement) {
-      setPortalElement(document.createElement("div"))
-    }
-
-    if (portalParent && portalElement) {
-      portalElement.className = joinClasses([
-        "leaflet-control",
-        "leaflet-bar",
-        "c-street-view-switch",
-        "position-absolute",
-      ])
-      portalParent.append(portalElement)
-      Leaflet.DomEvent.disableClickPropagation(portalElement)
-    }
-
-    return () => portalElement?.remove()
-  }, [portalElement, portalParent, setStreetViewEnabled])
-
   useMapEvents(
     streetViewEnabled
       ? {
@@ -75,14 +50,18 @@ export const StreetViewControl = ({
 
   return (
     <>
-      {portalElement &&
-        ReactDOM.createPortal(
-          <StreetViewSwitch
-            streetViewEnabled={streetViewEnabled}
-            setStreetViewEnabled={setStreetViewEnabled}
-          />,
-          portalElement
-        )}
+      <CustomControl
+        className={joinClasses([
+          "leaflet-bar",
+          "c-street-view-switch",
+          "position-absolute",
+        ])}
+      >
+        <StreetViewSwitch
+          streetViewEnabled={streetViewEnabled}
+          setStreetViewEnabled={setStreetViewEnabled}
+        />
+      </CustomControl>
       {streetViewEnabled && <CutoutOverlay.FollowMapMouseMove />}
     </>
   )

--- a/assets/src/components/map/controls/customControl.tsx
+++ b/assets/src/components/map/controls/customControl.tsx
@@ -39,9 +39,6 @@ export const CustomControl = ({
     )
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
 
-  console.debug(portalParent)
-  console.debug(position)
-
   useEffect(() => {
     if (!portalElement) {
       setPortalElement(document.createElement("div"))

--- a/assets/src/components/map/controls/customControl.tsx
+++ b/assets/src/components/map/controls/customControl.tsx
@@ -22,10 +22,12 @@ export const CustomControl = ({
   children,
   className,
   insertAfterSelector,
+  insertFirst,
 }: ControlOptions & {
   children: ReactNode
   className?: string
   insertAfterSelector?: string
+  insertFirst?: boolean
 }): JSX.Element | null => {
   const map = useMap()
   const portalParent = map
@@ -36,6 +38,9 @@ export const CustomControl = ({
       }`
     )
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
+
+  console.debug(portalParent)
+  console.debug(position)
 
   useEffect(() => {
     if (!portalElement) {
@@ -50,6 +55,8 @@ export const CustomControl = ({
         : null
       if (elementToInsertAfter) {
         elementToInsertAfter.after(portalElement)
+      } else if (insertFirst) {
+        portalParent.prepend(portalElement)
       } else {
         portalParent.append(portalElement)
       }
@@ -57,7 +64,7 @@ export const CustomControl = ({
     }
 
     return () => portalElement?.remove()
-  }, [portalElement, portalParent, className, insertAfterSelector])
+  }, [portalElement, portalParent, className, insertAfterSelector, insertFirst])
 
   return portalElement ? ReactDOM.createPortal(children, portalElement) : null
 }

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -22,14 +22,13 @@ const Nav: React.FC<Props> = ({ children }) => {
     case "mobile":
       return (
         <div className="l-nav--narrow">
-          <div className="l-nav__app-content">{children}</div>
           <MobilePortraitNav isViewOpen={isViewOpen} />
+          <div className="l-nav__app-content">{children}</div>
         </div>
       )
     case "mobile_landscape_tablet_portrait":
       return (
         <div className="l-nav--medium">
-          <div className="l-nav__app-content">{children}</div>
           <div
             className="l-nav__nav-bar l-nav__nav-bar--left"
             hidden={isViewOpen}
@@ -41,6 +40,7 @@ const Nav: React.FC<Props> = ({ children }) => {
               closePickerOnViewOpen={true}
             />
           </div>
+          <div className="l-nav__app-content">{children}</div>
         </div>
       )
     case "tablet":

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -59,15 +59,17 @@ const Nav: React.FC<Props> = ({ children }) => {
     default:
       return (
         <div className="l-nav--wide">
-          <div className="l-nav__nav-bar l-nav__nav-bar--top">
-            <TopNav />
-          </div>
-          <div className="l-nav__nav-bar l-nav__nav-bar--left">
-            <LeftNav
-              defaultToCollapsed={false}
-              dispatcherFlag={readDispatcherFlag()}
-            />
-          </div>
+          <>
+            <div className="l-nav__nav-bar l-nav__nav-bar--top">
+              <TopNav />
+            </div>
+            <div className="l-nav__nav-bar l-nav__nav-bar--left">
+              <LeftNav
+                defaultToCollapsed={false}
+                dispatcherFlag={readDispatcherFlag()}
+              />
+            </div>
+          </>
           <div className="l-nav__app-content">{children}</div>
         </div>
       )

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -46,7 +46,6 @@ const Nav: React.FC<Props> = ({ children }) => {
     case "tablet":
       return (
         <div className="l-nav--medium">
-          <div className="l-nav__app-content">{children}</div>
           <div className="l-nav__nav-bar l-nav__nav-bar--left">
             <LeftNav
               toggleMobileMenu={() => dispatch(toggleMobileMenu())}
@@ -54,6 +53,7 @@ const Nav: React.FC<Props> = ({ children }) => {
               dispatcherFlag={readDispatcherFlag()}
             />
           </div>
+          <div className="l-nav__app-content">{children}</div>
         </div>
       )
     default:

--- a/assets/src/components/nav.tsx
+++ b/assets/src/components/nav.tsx
@@ -59,7 +59,6 @@ const Nav: React.FC<Props> = ({ children }) => {
     default:
       return (
         <div className="l-nav--wide">
-          <div className="l-nav__app-content">{children}</div>
           <div className="l-nav__nav-bar l-nav__nav-bar--top">
             <TopNav />
           </div>
@@ -69,6 +68,7 @@ const Nav: React.FC<Props> = ({ children }) => {
               dispatcherFlag={readDispatcherFlag()}
             />
           </div>
+          <div className="l-nav__app-content">{children}</div>
         </div>
       )
   }

--- a/assets/src/components/routePicker.tsx
+++ b/assets/src/components/routePicker.tsx
@@ -105,6 +105,7 @@ const SelectedRouteButton = ({
       <button
         className="c-route-picker__selected-routes-button"
         onClick={() => deselectRoute(routeId)}
+        tabIndex={-1}
       >
         {routeNameOrId(routeId, routes)}
         <OldCloseIcon className="c-route-picker__selected-routes-button-icon" />
@@ -141,6 +142,7 @@ const RouteListButton = ({
     <button
       className="c-route-picker__route-list-button"
       onClick={() => selectRoute(route.id)}
+      tabIndex={-1}
     >
       {route.name}
     </button>

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -15,121 +15,6 @@ exports[`App renders 1`] = `
         class="l-nav--wide"
       >
         <div
-          class="l-nav__app-content"
-        >
-          <div
-            class="c-ladder-page c-ladder-page--picker-container-visible "
-          >
-            <div
-              class="c-notifications"
-            />
-            <div
-              class="c-picker-container c-picker-container--visible"
-              data-testid="picker-container"
-            >
-              <button
-                class="c-drawer-tab c-drawer-tab__tab-button"
-                title="Collapse"
-              >
-                <span>
-                  <svg />
-                </span>
-              </button>
-              <div
-                class="c-ladder-page__routes-presets-toggle u-hideable"
-              >
-                <button
-                  class="c-ladder-page__routes_picker_button--selected"
-                  id="c-ladder-page__routes_picker_button"
-                >
-                  Routes
-                </button>
-                <button
-                  class="c-ladder-page__routes_picker_button--unselected"
-                  id="c-ladder-page__presets_picker_button"
-                >
-                  Presets
-                </button>
-              </div>
-              <div
-                class="c-route-picker u-hideable"
-              >
-                <div
-                  class="c-route-filter"
-                >
-                  <div
-                    class="c-route-filter__text"
-                  >
-                    <input
-                      class="c-route-filter__input"
-                      placeholder="Search routes"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  class="c-garage-filter"
-                >
-                  <button
-                    class="c-garage-filter__show-hide-button"
-                    title="Toggle Garage Filter"
-                  >
-                    <div
-                      class="c-garage-filter__header"
-                    >
-                      Filter garages
-                    </div>
-                    <div
-                      class="c-garage-filter__show-hide-icon"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="c-route-picker__routes-container"
-                >
-                  loading...
-                  <p>
-                    Selected routes will show up here…
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="c-picker-container-backdrop"
-              data-testid="picker-container-backdrop"
-            />
-            <div
-              class="c-ladder-page__tab-bar-and-ladders"
-            >
-              <div
-                class="c-ladder-page__route-tab-bar"
-                role="tablist"
-              >
-                <button
-                  class="c-ladder-page__add-tab-button"
-                  title="Add Tab"
-                >
-                  <span
-                    class="c-ladder-page__add-tab-icon"
-                  >
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="c-route-ladders"
-                data-testid="route-ladders-div"
-              />
-            </div>
-          </div>
-        </div>
-        <div
           class="l-nav__nav-bar l-nav__nav-bar--top"
         >
           <div
@@ -306,6 +191,121 @@ exports[`App renders 1`] = `
                   </button>
                 </li>
               </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="l-nav__app-content"
+        >
+          <div
+            class="c-ladder-page c-ladder-page--picker-container-visible "
+          >
+            <div
+              class="c-notifications"
+            />
+            <div
+              class="c-picker-container c-picker-container--visible"
+              data-testid="picker-container"
+            >
+              <button
+                class="c-drawer-tab c-drawer-tab__tab-button"
+                title="Collapse"
+              >
+                <span>
+                  <svg />
+                </span>
+              </button>
+              <div
+                class="c-ladder-page__routes-presets-toggle u-hideable"
+              >
+                <button
+                  class="c-ladder-page__routes_picker_button--selected"
+                  id="c-ladder-page__routes_picker_button"
+                >
+                  Routes
+                </button>
+                <button
+                  class="c-ladder-page__routes_picker_button--unselected"
+                  id="c-ladder-page__presets_picker_button"
+                >
+                  Presets
+                </button>
+              </div>
+              <div
+                class="c-route-picker u-hideable"
+              >
+                <div
+                  class="c-route-filter"
+                >
+                  <div
+                    class="c-route-filter__text"
+                  >
+                    <input
+                      class="c-route-filter__input"
+                      placeholder="Search routes"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  class="c-garage-filter"
+                >
+                  <button
+                    class="c-garage-filter__show-hide-button"
+                    title="Toggle Garage Filter"
+                  >
+                    <div
+                      class="c-garage-filter__header"
+                    >
+                      Filter garages
+                    </div>
+                    <div
+                      class="c-garage-filter__show-hide-icon"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </div>
+                  </button>
+                </div>
+                <div
+                  class="c-route-picker__routes-container"
+                >
+                  loading...
+                  <p>
+                    Selected routes will show up here…
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="c-picker-container-backdrop"
+              data-testid="picker-container-backdrop"
+            />
+            <div
+              class="c-ladder-page__tab-bar-and-ladders"
+            >
+              <div
+                class="c-ladder-page__route-tab-bar"
+                role="tablist"
+              >
+                <button
+                  class="c-ladder-page__add-tab-button"
+                  title="Add Tab"
+                >
+                  <span
+                    class="c-ladder-page__add-tab-icon"
+                  >
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="c-route-ladders"
+                data-testid="route-ladders-div"
+              />
             </div>
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -292,9 +292,10 @@ exports[`renders 1`] = `
                 role="tablist"
               >
                 <div
+                  aria-selected="true"
                   class="c-ladder-page__tab c-ladder-page__tab-current"
                   role="tab"
-                  tabindex="0"
+                  tabindex="-1"
                 >
                   <div
                     class="c-ladder-page__tab-contents"

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -15,153 +15,6 @@ exports[`renders 1`] = `
         class="l-nav--wide"
       >
         <div
-          class="l-nav__app-content"
-        >
-          <div
-            class="c-ladder-page c-ladder-page--picker-container-visible "
-          >
-            <div
-              class="c-notifications"
-            />
-            <div
-              class="c-picker-container c-picker-container--visible"
-              data-testid="picker-container"
-            >
-              <button
-                class="c-drawer-tab c-drawer-tab__tab-button"
-                title="Collapse"
-              >
-                <span>
-                  <svg />
-                </span>
-              </button>
-              <div
-                class="c-ladder-page__routes-presets-toggle u-hideable"
-              >
-                <button
-                  class="c-ladder-page__routes_picker_button--selected"
-                  id="c-ladder-page__routes_picker_button"
-                >
-                  Routes
-                </button>
-                <button
-                  class="c-ladder-page__routes_picker_button--unselected"
-                  id="c-ladder-page__presets_picker_button"
-                >
-                  Presets
-                </button>
-              </div>
-              <div
-                class="c-route-picker u-hideable"
-              >
-                <div
-                  class="c-route-filter"
-                >
-                  <div
-                    class="c-route-filter__text"
-                  >
-                    <input
-                      class="c-route-filter__input"
-                      placeholder="Search routes"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <div
-                  class="c-garage-filter"
-                >
-                  <button
-                    class="c-garage-filter__show-hide-button"
-                    title="Toggle Garage Filter"
-                  >
-                    <div
-                      class="c-garage-filter__header"
-                    >
-                      Filter garages
-                    </div>
-                    <div
-                      class="c-garage-filter__show-hide-icon"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="c-route-picker__routes-container"
-                >
-                  loading...
-                  <p>
-                    Selected routes will show up here…
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="c-picker-container-backdrop"
-              data-testid="picker-container-backdrop"
-            />
-            <div
-              class="c-ladder-page__tab-bar-and-ladders"
-            >
-              <div
-                class="c-ladder-page__route-tab-bar"
-                role="tablist"
-              >
-                <div
-                  class="c-ladder-page__tab c-ladder-page__tab-current"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <div
-                    class="c-ladder-page__tab-contents"
-                  >
-                    <div
-                      class="c-ladder-page__tab-title"
-                    >
-                      Untitled
-                    </div>
-                    <button
-                      class="c-ladder-page__tab-save-button"
-                      title="Save"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </button>
-                    <button
-                      class="c-old-close-button"
-                      data-testid="close-button"
-                      title="Close"
-                    >
-                      <span>
-                        <svg />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <button
-                  class="c-ladder-page__add-tab-button"
-                  title="Add Tab"
-                >
-                  <span
-                    class="c-ladder-page__add-tab-icon"
-                  >
-                    <svg />
-                  </span>
-                </button>
-              </div>
-              <div
-                class="c-route-ladders"
-                data-testid="route-ladders-div"
-              />
-            </div>
-          </div>
-        </div>
-        <div
           class="l-nav__nav-bar l-nav__nav-bar--top"
         >
           <div
@@ -338,6 +191,153 @@ exports[`renders 1`] = `
                   </button>
                 </li>
               </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="l-nav__app-content"
+        >
+          <div
+            class="c-ladder-page c-ladder-page--picker-container-visible "
+          >
+            <div
+              class="c-notifications"
+            />
+            <div
+              class="c-picker-container c-picker-container--visible"
+              data-testid="picker-container"
+            >
+              <button
+                class="c-drawer-tab c-drawer-tab__tab-button"
+                title="Collapse"
+              >
+                <span>
+                  <svg />
+                </span>
+              </button>
+              <div
+                class="c-ladder-page__routes-presets-toggle u-hideable"
+              >
+                <button
+                  class="c-ladder-page__routes_picker_button--selected"
+                  id="c-ladder-page__routes_picker_button"
+                >
+                  Routes
+                </button>
+                <button
+                  class="c-ladder-page__routes_picker_button--unselected"
+                  id="c-ladder-page__presets_picker_button"
+                >
+                  Presets
+                </button>
+              </div>
+              <div
+                class="c-route-picker u-hideable"
+              >
+                <div
+                  class="c-route-filter"
+                >
+                  <div
+                    class="c-route-filter__text"
+                  >
+                    <input
+                      class="c-route-filter__input"
+                      placeholder="Search routes"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  class="c-garage-filter"
+                >
+                  <button
+                    class="c-garage-filter__show-hide-button"
+                    title="Toggle Garage Filter"
+                  >
+                    <div
+                      class="c-garage-filter__header"
+                    >
+                      Filter garages
+                    </div>
+                    <div
+                      class="c-garage-filter__show-hide-icon"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </div>
+                  </button>
+                </div>
+                <div
+                  class="c-route-picker__routes-container"
+                >
+                  loading...
+                  <p>
+                    Selected routes will show up here…
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              class="c-picker-container-backdrop"
+              data-testid="picker-container-backdrop"
+            />
+            <div
+              class="c-ladder-page__tab-bar-and-ladders"
+            >
+              <div
+                class="c-ladder-page__route-tab-bar"
+                role="tablist"
+              >
+                <div
+                  class="c-ladder-page__tab c-ladder-page__tab-current"
+                  role="tab"
+                  tabindex="0"
+                >
+                  <div
+                    class="c-ladder-page__tab-contents"
+                  >
+                    <div
+                      class="c-ladder-page__tab-title"
+                    >
+                      Untitled
+                    </div>
+                    <button
+                      class="c-ladder-page__tab-save-button"
+                      title="Save"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </button>
+                    <button
+                      class="c-old-close-button"
+                      data-testid="close-button"
+                      title="Close"
+                    >
+                      <span>
+                        <svg />
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  class="c-ladder-page__add-tab-button"
+                  title="Add Tab"
+                >
+                  <span
+                    class="c-ladder-page__add-tab-icon"
+                  >
+                    <svg />
+                  </span>
+                </button>
+              </div>
+              <div
+                class="c-route-ladders"
+                data-testid="route-ladders-div"
+              />
             </div>
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`LadderPage renders with route tabs 1`] = `
             <li>
               <button
                 class="c-route-picker__route-list-button"
+                tabindex="-1"
               >
                 28
               </button>
@@ -210,6 +211,7 @@ exports[`LadderPage renders with route tabs 1`] = `
             <li>
               <button
                 class="c-route-picker__selected-routes-button"
+                tabindex="-1"
               >
                 1
                 <span
@@ -440,6 +442,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
             <li>
               <button
                 class="c-route-picker__selected-routes-button"
+                tabindex="-1"
               >
                 28
                 <span
@@ -452,6 +455,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
             <li>
               <button
                 class="c-route-picker__selected-routes-button"
+                tabindex="-1"
               >
                 1
                 <span
@@ -697,6 +701,7 @@ exports[`LadderPage renders with timepoints 1`] = `
             <li>
               <button
                 class="c-route-picker__selected-routes-button"
+                tabindex="-1"
               >
                 28
                 <span
@@ -709,6 +714,7 @@ exports[`LadderPage renders with timepoints 1`] = `
             <li>
               <button
                 class="c-route-picker__selected-routes-button"
+                tabindex="-1"
               >
                 1
                 <span

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -236,9 +236,10 @@ exports[`LadderPage renders with route tabs 1`] = `
         role="tablist"
       >
         <div
+          aria-selected="true"
           class="c-ladder-page__tab c-ladder-page__tab-current"
           role="tab"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="c-ladder-page__tab-contents"
@@ -268,9 +269,10 @@ exports[`LadderPage renders with route tabs 1`] = `
           </div>
         </div>
         <div
+          aria-selected="false"
           class="c-ladder-page__tab"
           role="tab"
-          tabindex="-1"
+          tabindex="0"
         >
           <div
             class="c-ladder-page__tab-contents"
@@ -476,9 +478,10 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         role="tablist"
       >
         <div
+          aria-selected="true"
           class="c-ladder-page__tab c-ladder-page__tab-current"
           role="tab"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="c-ladder-page__tab-contents"
@@ -732,9 +735,10 @@ exports[`LadderPage renders with timepoints 1`] = `
         role="tablist"
       >
         <div
+          aria-selected="true"
           class="c-ladder-page__tab c-ladder-page__tab-current"
           role="tab"
-          tabindex="0"
+          tabindex="-1"
         >
           <div
             class="c-ladder-page__tab-contents"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -342,6 +342,39 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
           class="leaflet-control-container"
         >
           <div
+            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
+          >
+            <label
+              aria-hidden="true"
+              aria-label=""
+              class="c-street-view-switch__label"
+              for="street-view-toggle-:rh:"
+              role="presentation"
+            >
+              <span
+                class="c-street-view-switch__label-icon"
+              >
+                <svg />
+              </span>
+            </label>
+            <label
+              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
+              for="street-view-toggle-:rh:"
+            >
+              Street View
+            </label>
+            <div
+              class="c-street-view-switch__input form-switch"
+            >
+              <input
+                class="form-check-input"
+                id="street-view-toggle-:rh:"
+                role="switch"
+                type="checkbox"
+              />
+            </div>
+          </div>
+          <div
             class="leaflet-top leaflet-left"
           />
           <div
@@ -544,39 +577,6 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
                 OpenStreetMap
               </a>
                contributors
-            </div>
-          </div>
-          <div
-            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
-          >
-            <label
-              aria-hidden="true"
-              aria-label=""
-              class="c-street-view-switch__label"
-              for="street-view-toggle-:rh:"
-              role="presentation"
-            >
-              <span
-                class="c-street-view-switch__label-icon"
-              >
-                <svg />
-              </span>
-            </label>
-            <label
-              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
-              for="street-view-toggle-:rh:"
-            >
-              Street View
-            </label>
-            <div
-              class="c-street-view-switch__input form-switch"
-            >
-              <input
-                class="form-check-input"
-                id="street-view-toggle-:rh:"
-                role="switch"
-                type="checkbox"
-              />
             </div>
           </div>
         </div>
@@ -928,6 +928,39 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
           class="leaflet-control-container"
         >
           <div
+            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
+          >
+            <label
+              aria-hidden="true"
+              aria-label=""
+              class="c-street-view-switch__label"
+              for="street-view-toggle-:r3:"
+              role="presentation"
+            >
+              <span
+                class="c-street-view-switch__label-icon"
+              >
+                <svg />
+              </span>
+            </label>
+            <label
+              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
+              for="street-view-toggle-:r3:"
+            >
+              Street View
+            </label>
+            <div
+              class="c-street-view-switch__input form-switch"
+            >
+              <input
+                class="form-check-input"
+                id="street-view-toggle-:r3:"
+                role="switch"
+                type="checkbox"
+              />
+            </div>
+          </div>
+          <div
             class="leaflet-top leaflet-left"
           />
           <div
@@ -1130,39 +1163,6 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
                 OpenStreetMap
               </a>
                contributors
-            </div>
-          </div>
-          <div
-            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
-          >
-            <label
-              aria-hidden="true"
-              aria-label=""
-              class="c-street-view-switch__label"
-              for="street-view-toggle-:r3:"
-              role="presentation"
-            >
-              <span
-                class="c-street-view-switch__label-icon"
-              >
-                <svg />
-              </span>
-            </label>
-            <label
-              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
-              for="street-view-toggle-:r3:"
-            >
-              Street View
-            </label>
-            <div
-              class="c-street-view-switch__input form-switch"
-            >
-              <input
-                class="form-check-input"
-                id="street-view-toggle-:r3:"
-                role="switch"
-                type="checkbox"
-              />
             </div>
           </div>
         </div>
@@ -1906,6 +1906,39 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
           class="leaflet-control-container"
         >
           <div
+            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
+          >
+            <label
+              aria-hidden="true"
+              aria-label=""
+              class="c-street-view-switch__label"
+              for="street-view-toggle-:rp:"
+              role="presentation"
+            >
+              <span
+                class="c-street-view-switch__label-icon"
+              >
+                <svg />
+              </span>
+            </label>
+            <label
+              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
+              for="street-view-toggle-:rp:"
+            >
+              Street View
+            </label>
+            <div
+              class="c-street-view-switch__input form-switch"
+            >
+              <input
+                class="form-check-input"
+                id="street-view-toggle-:rp:"
+                role="switch"
+                type="checkbox"
+              />
+            </div>
+          </div>
+          <div
             class="leaflet-top leaflet-left"
           />
           <div
@@ -2108,39 +2141,6 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 OpenStreetMap
               </a>
                contributors
-            </div>
-          </div>
-          <div
-            class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
-          >
-            <label
-              aria-hidden="true"
-              aria-label=""
-              class="c-street-view-switch__label"
-              for="street-view-toggle-:rp:"
-              role="presentation"
-            >
-              <span
-                class="c-street-view-switch__label-icon"
-              >
-                <svg />
-              </span>
-            </label>
-            <label
-              class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
-              for="street-view-toggle-:rp:"
-            >
-              Street View
-            </label>
-            <div
-              class="c-street-view-switch__input form-switch"
-            >
-              <input
-                class="form-check-input"
-                id="street-view-toggle-:rp:"
-                role="switch"
-                type="checkbox"
-              />
             </div>
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routePicker.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__route-list-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           71
         </button>
@@ -64,6 +65,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__route-list-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           73
         </button>
@@ -72,6 +74,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__route-list-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           111
         </button>
@@ -80,6 +83,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__route-list-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           SL1
         </button>
@@ -92,6 +96,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__selected-routes-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           28
           <span
@@ -108,6 +113,7 @@ exports[`RoutePicker renders a list of routes and presets toggle 1`] = `
         <button
           className="c-route-picker__selected-routes-button"
           onClick={[Function]}
+          tabIndex={-1}
         >
           39
           <span

--- a/assets/tests/components/map/controls/customControl.test.tsx
+++ b/assets/tests/components/map/controls/customControl.test.tsx
@@ -62,6 +62,7 @@ describe("CustomControls", () => {
       container.querySelector(".leaflet-control-container")
     ).toMatchSnapshot()
   })
+
   test("when insertAfterSelector is specified and there is not a node matching that selector, then the control is added at the end of the leaflet-container", () => {
     const { container } = render(
       <>
@@ -84,5 +85,27 @@ describe("CustomControls", () => {
     expect(
       container.querySelector(".leaflet-control-container")
     ).toMatchSnapshot()
+  })
+
+  test("when insertFirst is specified, then the control is added at the beginning of the leaflet-container", () => {
+    const { container } = render(
+      <>
+        <ZoomControl position="topright" />
+
+        <FullscreenControl position="topright" />
+        <CustomControl className="test-control" position="topright" insertFirst>
+          {customControlContents()}
+        </CustomControl>
+      </>,
+      {
+        wrapper: mapWrapper,
+      }
+    )
+
+    expect(
+      container.querySelector(
+        ".leaflet-control-container .test-control:first-child"
+      )
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Asana ticket: [⚙️🚧 Investigate/implement tabbing order](https://app.asana.com/0/1148853526253420/1206260856814692/f)

This provides some very basic fixes to the high-level navigation of Skate by tabbing, in particular on the route ladders page. For the most part this is accomplished through improvement to the layout of the DOM rather than explicitly setting `tabindex`. This uncovers a lot of additional issues like missing focus state, but it's at least a start.