### PR TITLE
feat: green dot cursor for existing route shape

### DIFF
--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -3,7 +3,7 @@
 }
 
 .c-detour_map--original-route-shape__unstarted {
-  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 22 22' fill='none'%3E%3Cg filter='url(%23a)'%3E%3Ccircle cx='11' cy='11' r='8' fill='%2303A900'/%3E%3Ccircle cx='11' cy='11' r='7' stroke='%23fff' stroke-width='2'/%3E%3C/g%3E%3Cdefs%3E%3Cfilter id='a' width='22' height='22' x='0' y='0' color-interpolation-filters='sRGB' filterUnits='userSpaceOnUse'%3E%3CfeFlood flood-opacity='0' result='BackgroundImageFix'/%3E%3CfeColorMatrix in='SourceAlpha' result='hardAlpha' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0'/%3E%3CfeMorphology in='SourceAlpha' operator='dilate' radius='2' result='effect1_dropShadow_363_1789'/%3E%3CfeOffset/%3E%3CfeGaussianBlur stdDeviation='.5'/%3E%3CfeComposite in2='hardAlpha' operator='out'/%3E%3CfeColorMatrix values='0 0 0 0 0.0135731 0 0 0 0 0.663314 0 0 0 0 0.000313088 0 0 0 0.5 0'/%3E%3CfeBlend in2='BackgroundImageFix' result='effect1_dropShadow_363_1789'/%3E%3CfeBlend in='SourceGraphic' in2='effect1_dropShadow_363_1789' result='shape'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E")
+  cursor: url("data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E .color %7B fill: %2303A900; %7D %3C/style%3E%3Ccircle cx='11' cy='11' r='10' class='color' style='filter: opacity(0.5) blur(0.5px)'/%3E%3Ccircle cx='11' cy='11' r='7' class='color' stroke='white' stroke-width='2'/%3E%3C/svg%3E")
       11 11,
     pointer;
 }

--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -2,6 +2,12 @@
   stroke: $color-kiwi-500;
 }
 
+.c-detour_map--original-route-shape__unstarted {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 22 22' fill='none'%3E%3Cg filter='url(%23a)'%3E%3Ccircle cx='11' cy='11' r='8' fill='%2303A900'/%3E%3Ccircle cx='11' cy='11' r='7' stroke='%23fff' stroke-width='2'/%3E%3C/g%3E%3Cdefs%3E%3Cfilter id='a' width='22' height='22' x='0' y='0' color-interpolation-filters='sRGB' filterUnits='userSpaceOnUse'%3E%3CfeFlood flood-opacity='0' result='BackgroundImageFix'/%3E%3CfeColorMatrix in='SourceAlpha' result='hardAlpha' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0'/%3E%3CfeMorphology in='SourceAlpha' operator='dilate' radius='2' result='effect1_dropShadow_363_1789'/%3E%3CfeOffset/%3E%3CfeGaussianBlur stdDeviation='.5'/%3E%3CfeComposite in2='hardAlpha' operator='out'/%3E%3CfeColorMatrix values='0 0 0 0 0.0135731 0 0 0 0 0.663314 0 0 0 0 0.000313088 0 0 0 0.5 0'/%3E%3CfeBlend in2='BackgroundImageFix' result='effect1_dropShadow_363_1789'/%3E%3CfeBlend in='SourceGraphic' in2='effect1_dropShadow_363_1789' result='shape'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E")
+      11 11,
+    pointer;
+}
+
 .c-detour_map--detour-route-shape {
   stroke: $color-lemon-500;
 }

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useId } from "react"
 import { LatLngLiteral } from "leaflet"
 import { Polyline, useMapEvents } from "react-leaflet"
 import Leaflet from "leaflet"
@@ -13,6 +13,7 @@ import {
   shapePointToLatLngLiteral,
 } from "../../util/pointLiterals"
 import { MapTooltip } from "../map/tooltip"
+import { joinClasses } from "../../helpers/dom"
 
 interface DetourMapProps {
   /**
@@ -111,7 +112,14 @@ export const DetourMap = ({
 
     <Polyline
       positions={originalShape.map(shapePointToLatLngLiteral)}
-      className="c-detour_map--original-route-shape"
+      className={joinClasses([
+        "c-detour_map--original-route-shape",
+        startPoint === undefined &&
+          "c-detour_map--original-route-shape__unstarted",
+      ])}
+      key={`detour-map-original-route-shape-${useId()}-${
+        startPoint === undefined
+      }`}
       bubblingMouseEvents={false}
       eventHandlers={{
         click: (e) => {

--- a/assets/tests/components/detours/detourMap.test.tsx
+++ b/assets/tests/components/detours/detourMap.test.tsx
@@ -44,6 +44,41 @@ describe("DetourMap", () => {
     expect(onClickOriginalShape).toHaveBeenNthCalledWith(1, shapePoint)
   })
 
+  test("`originalShape` has unstarted class before being clicked", async () => {
+    const onClickOriginalShape = jest.fn()
+    const shapePoint = { lat: 0, lon: 0 }
+    const { container } = render(
+      <DetourMapWithDefaults
+        originalShape={[shapePoint]}
+        onClickOriginalShape={onClickOriginalShape}
+      />
+    )
+
+    expect(
+      container.querySelector(
+        ".c-detour_map--original-route-shape.c-detour_map--original-route-shape__unstarted"
+      )!
+    ).toBeInTheDocument()
+  })
+
+  test("`originalShape` no longer has unstarted class after detour is started", async () => {
+    const onClickOriginalShape = jest.fn()
+    const shapePoint = { lat: 0, lon: 0 }
+    const { container } = render(
+      <DetourMapWithDefaults
+        originalShape={[shapePoint]}
+        startPoint={shapePoint}
+        onClickOriginalShape={onClickOriginalShape}
+      />
+    )
+
+    expect(
+      container.querySelector(
+        ".c-detour_map--original-route-shape.c-detour_map--original-route-shape__unstarted"
+      )
+    ).toBeNull()
+  })
+
   test("when map is clicked, fires `onClickMap`", async () => {
     const onClickMap = jest.fn()
     const { container } = render(


### PR DESCRIPTION
Asana ticket: [⚙️🚧 Have a green dot appear on hover](https://app.asana.com/0/1148853526253420/1206260856814698/f)

I haven't quite figured out getting the cursor to appear 1rem on either side of the route shape, but I at least have the cursor itself working.