### PR TITLE
fix(ts/hooks/useDetour): clear directions and coordinates when undoing points

### DIFF
--- a/assets/src/hooks/useDetour.tsx
+++ b/assets/src/hooks/useDetour.tsx
@@ -13,6 +13,10 @@ const useDetourDirections = (shapePoints: ShapePoint[]) => {
     let shouldUpdate = true
 
     if (shapePoints.length < 2) {
+      // We expect not to have any directions or shape if we don't have at
+      // least two points to route between
+      setDetourShape([])
+      setDirections(undefined)
       return
     }
 

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -5,6 +5,7 @@ import { useDetour } from "../../src/hooks/useDetour"
 import { act } from "react-dom/test-utils"
 import { detourShapeFactory } from "../factories/detourShapeFactory"
 import { ShapePoint } from "../../src/schedule"
+import { shapePointFactory } from "../factories/shapePointFactory"
 
 jest.mock("../../src/api")
 
@@ -132,6 +133,30 @@ describe("useDetour", () => {
       start,
       mid,
     ])
+  })
+
+  test("when `undoLastWaypoint` removes the last waypoint, `detourShape` and `directions` should be empty", async () => {
+    jest
+      .mocked(fetchDetourDirections)
+      .mockResolvedValue(detourShapeFactory.build())
+
+    const { result } = renderHook(useDetour)
+
+    act(() => result.current.addConnectionPoint(shapePointFactory.build()))
+    act(() => result.current.addWaypoint(shapePointFactory.build()))
+    act(() => result.current.addWaypoint(shapePointFactory.build()))
+
+    await waitFor(() => {
+      expect(result.current.directions).not.toBeUndefined()
+      expect(result.current.detourShape).not.toHaveLength(0)
+    })
+
+    act(() => result.current.undoLastWaypoint())
+    act(() => result.current.undoLastWaypoint())
+
+    expect(result.current.waypoints).toHaveLength(0)
+    expect(result.current.directions).toBeUndefined()
+    expect(result.current.detourShape).toHaveLength(0)
   })
 
   test("when `waypoints` is empty, `canUndo` is `false`", async () => {


### PR DESCRIPTION
I found that the directions persisted even after pressing undo to the very beginning. So this makes sure we clear it if we stop making API calls to update the state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206470407069009