### PR TITLE
feat: Add logged-in-as element to desktop top nav

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -14,6 +14,7 @@ $z-page-layout-context: (
   "properties-panel": 1002,
   "view": 1100,
   "navbar": 1200,
+  "user-info-popover": 2000,
 );
 
 $z-properties-panel-context: (

--- a/assets/css/bootstrap.scss
+++ b/assets/css/bootstrap.scss
@@ -45,7 +45,7 @@
 // @import "../node_modules/bootstrap/scss/offcanvas";
 // @import "../node_modules/bootstrap/scss/pagination";
 // @import "../node_modules/bootstrap/scss/placeholders";
-// @import "../node_modules/bootstrap/scss/popover";
+@import "../node_modules/bootstrap/scss/popover";
 // @import "../node_modules/bootstrap/scss/progress";
 // @import "../node_modules/bootstrap/scss/spinners";
 // @import "../node_modules/bootstrap/scss/tables";

--- a/assets/css/nav/_top_nav.scss
+++ b/assets/css/nav/_top_nav.scss
@@ -30,6 +30,7 @@
 
 .c-top-nav__right-items {
   display: flex;
+  align-items: center;
 
   :not(:last-child) {
     padding-right: 1.5rem;
@@ -51,4 +52,8 @@
   &.c-top-nav__right-item--active {
     color: $color-eggplant-800;
   }
+}
+
+.c-top-nav__popover {
+  z-index: map-get($z-page-layout-context, "user-info-popover");
 }

--- a/assets/src/components/nav/topNav.tsx
+++ b/assets/src/components/nav/topNav.tsx
@@ -1,9 +1,18 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { LogoIcon, RefreshIcon } from "../../helpers/icon"
 import { reload } from "../../models/browser"
+import { Overlay, Popover } from "react-bootstrap"
+import { LoggedInAs } from "../loggedInAs"
+import getEmailAddress from "../../userEmailAddress"
+import { CircleButton } from "../circleButton"
+import { UserAvatar } from "../userAvatar"
 
 const TopNav = (): JSX.Element => {
+  const email = getEmailAddress()
+  const [showUserPopover, setShowUserPopover] = useState<boolean>(false)
+  const userButtonRef = useRef(null)
+
   return (
     <div className="c-top-nav">
       <Link className="c-top-nav__logo" to="/" title="Skate">
@@ -18,6 +27,30 @@ const TopNav = (): JSX.Element => {
           >
             <RefreshIcon className="c-top-nav__icon" />
           </button>
+        </li>
+        <li>
+          <div ref={userButtonRef}>
+            <CircleButton
+              isActive={showUserPopover}
+              onClick={() => {
+                setShowUserPopover(!showUserPopover)
+              }}
+              title="User Info"
+            >
+              <UserAvatar userName={email} />
+            </CircleButton>
+          </div>
+          <Overlay
+            target={userButtonRef.current}
+            show={showUserPopover}
+            placement="bottom"
+          >
+            <Popover className="c-top-nav__popover">
+              <Popover.Body>
+                <LoggedInAs email={email} />
+              </Popover.Body>
+            </Popover>
+          </Overlay>
         </li>
       </ul>
     </div>

--- a/assets/src/components/nav/topNav.tsx
+++ b/assets/src/components/nav/topNav.tsx
@@ -7,11 +7,13 @@ import { LoggedInAs } from "../loggedInAs"
 import getEmailAddress from "../../userEmailAddress"
 import { CircleButton } from "../circleButton"
 import { UserAvatar } from "../userAvatar"
+import inTestGroup, { TestGroups } from "../../userInTestGroup"
 
 const TopNav = (): JSX.Element => {
   const email = getEmailAddress()
   const [showUserPopover, setShowUserPopover] = useState<boolean>(false)
   const userButtonRef = useRef(null)
+  const showLoggedInUser = inTestGroup(TestGroups.KeycloakSso)
 
   return (
     <div className="c-top-nav">
@@ -28,30 +30,32 @@ const TopNav = (): JSX.Element => {
             <RefreshIcon className="c-top-nav__icon" />
           </button>
         </li>
-        <li>
-          <div ref={userButtonRef}>
-            <CircleButton
-              isActive={showUserPopover}
-              onClick={() => {
-                setShowUserPopover(!showUserPopover)
-              }}
-              title="User Info"
+        {showLoggedInUser && (
+          <li>
+            <div ref={userButtonRef}>
+              <CircleButton
+                isActive={showUserPopover}
+                onClick={() => {
+                  setShowUserPopover(!showUserPopover)
+                }}
+                title="User Info"
+              >
+                <UserAvatar userName={email} />
+              </CircleButton>
+            </div>
+            <Overlay
+              target={userButtonRef.current}
+              show={showUserPopover}
+              placement="bottom"
             >
-              <UserAvatar userName={email} />
-            </CircleButton>
-          </div>
-          <Overlay
-            target={userButtonRef.current}
-            show={showUserPopover}
-            placement="bottom"
-          >
-            <Popover className="c-top-nav__popover">
-              <Popover.Body>
-                <LoggedInAs email={email} />
-              </Popover.Body>
-            </Popover>
-          </Overlay>
-        </li>
+              <Popover className="c-top-nav__popover">
+                <Popover.Body>
+                  <LoggedInAs email={email} />
+                </Popover.Body>
+              </Popover>
+            </Overlay>
+          </li>
+        )}
       </ul>
     </div>
   )

--- a/assets/src/userEmailAddress.ts
+++ b/assets/src/userEmailAddress.ts
@@ -1,7 +1,7 @@
 import appData from "./appData"
 
-const getEmailAddress = () => {
-  return appData()?.emailAddress
+const getEmailAddress = (): string => {
+  return appData()?.emailAddress ?? ""
 }
 
 export default getEmailAddress

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -4,6 +4,7 @@ export enum TestGroups {
   DemoMode = "demo-mode",
   DetoursPilot = "detours-pilot",
   DummyDetourPage = "dummy-detour-page",
+  KeycloakSso = "keycloak-sso",
   LateView = "late-view",
 }
 

--- a/assets/tests/components/__snapshots__/app.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/app.test.tsx.snap
@@ -46,6 +46,36 @@ exports[`App renders 1`] = `
                   </span>
                 </button>
               </li>
+              <li>
+                <div>
+                  <button
+                    aria-pressed="false"
+                    class="c-circle-button"
+                    title="User Info"
+                  >
+                    <div
+                      class="c-circle-button__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="c-user-avatar"
+                        viewBox="0 0 32 32"
+                      >
+                        <circle
+                          class="c-user-avatar__circle"
+                          cx="16"
+                          cy="16"
+                          r="16"
+                        />
+                        <text
+                          x="16"
+                          y="23"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/appStateWrapper.test.tsx.snap
@@ -46,6 +46,36 @@ exports[`renders 1`] = `
                   </span>
                 </button>
               </li>
+              <li>
+                <div>
+                  <button
+                    aria-pressed="false"
+                    class="c-circle-button"
+                    title="User Info"
+                  >
+                    <div
+                      class="c-circle-button__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="c-user-avatar"
+                        viewBox="0 0 32 32"
+                      >
+                        <circle
+                          class="c-user-avatar__circle"
+                          cx="16"
+                          cy="16"
+                          r="16"
+                        />
+                        <text
+                          x="16"
+                          y="23"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -26,6 +26,8 @@ import { OpenView, PagePath } from "../../src/state/pagePanelState"
 import { viewFactory } from "../factories/pagePanelStateFactory"
 import userEvent from "@testing-library/user-event"
 import { mockUsePanelState } from "../testHelpers/usePanelStateMocks"
+import getTestGroups from "../../src/userTestGroups"
+import { TestGroups } from "../../src/userInTestGroup"
 
 jest.mock("../../src/hooks/useDataStatus", () => ({
   __esModule: true,
@@ -50,6 +52,7 @@ beforeEach(() => {
 
 describe("App", () => {
   test("renders", () => {
+    jest.mocked(getTestGroups).mockReturnValue([TestGroups.KeycloakSso])
     const result = render(<App />)
     expect(result.asFragment()).toMatchSnapshot()
   })

--- a/assets/tests/components/appStateWrapper.test.tsx
+++ b/assets/tests/components/appStateWrapper.test.tsx
@@ -1,9 +1,17 @@
-import { test, expect } from "@jest/globals"
+import { test, expect, jest } from "@jest/globals"
 import React from "react"
 import { render } from "@testing-library/react"
 import AppStateWrapper from "../../src/components/appStateWrapper"
+import getTestGroups from "../../src/userTestGroups"
+import { TestGroups } from "../../src/userInTestGroup"
+
+jest.mock("userTestGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}))
 
 test("renders", () => {
+  jest.mocked(getTestGroups).mockReturnValue([TestGroups.KeycloakSso])
   const result = render(<AppStateWrapper />)
   expect(result.asFragment()).toMatchSnapshot()
 })

--- a/assets/tests/components/nav/topNav.test.tsx
+++ b/assets/tests/components/nav/topNav.test.tsx
@@ -29,4 +29,56 @@ describe("TopNav", () => {
 
     expect(reloadSpy).toHaveBeenCalled()
   })
+
+  describe("User info", () => {
+    test("has a 'User Info' button", () => {
+      const dispatch = jest.fn()
+      const result = render(
+        <StateDispatchProvider state={initialState} dispatch={dispatch}>
+          <BrowserRouter>
+            <TopNav />
+          </BrowserRouter>
+        </StateDispatchProvider>
+      )
+
+      expect(
+        result.queryByRole("button", { name: "User Info" })
+      ).toBeInTheDocument()
+    })
+
+    test("brings up an element with 'logged in as' text when clicked", async () => {
+      const dispatch = jest.fn()
+      const user = userEvent.setup()
+      const result = render(
+        <StateDispatchProvider state={initialState} dispatch={dispatch}>
+          <BrowserRouter>
+            <TopNav />
+          </BrowserRouter>
+        </StateDispatchProvider>
+      )
+
+      expect(result.queryByText("Logged in as")).not.toBeInTheDocument()
+
+      await user.click(result.getByTitle("User Info"))
+
+      expect(result.queryByText("Logged in as")).toBeInTheDocument()
+    })
+
+    test("clicking the 'User Info' button again makes the 'Logged in as' popover disappear", async () => {
+      const dispatch = jest.fn()
+      const user = userEvent.setup()
+      const result = render(
+        <StateDispatchProvider state={initialState} dispatch={dispatch}>
+          <BrowserRouter>
+            <TopNav />
+          </BrowserRouter>
+        </StateDispatchProvider>
+      )
+
+      await user.click(result.getByTitle("User Info"))
+      await user.click(result.getByTitle("User Info"))
+
+      expect(result.queryByText("Logged in as")).not.toBeInTheDocument()
+    })
+  })
 })

--- a/assets/tests/components/nav/topNav.test.tsx
+++ b/assets/tests/components/nav/topNav.test.tsx
@@ -8,6 +8,13 @@ import { initialState } from "../../../src/state"
 import { BrowserRouter } from "react-router-dom"
 import "@testing-library/jest-dom/jest-globals"
 import * as browser from "../../../src/models/browser"
+import getTestGroups from "../../../src/userTestGroups"
+import { TestGroups } from "../../../src/userInTestGroup"
+
+jest.mock("userTestGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}))
 
 describe("TopNav", () => {
   test("refresh button reloads the page", async () => {
@@ -31,7 +38,26 @@ describe("TopNav", () => {
   })
 
   describe("User info", () => {
+    test("does not have a 'User Info' button if the user isn't in the right test group", () => {
+      jest.mocked(getTestGroups).mockReturnValue([])
+
+      const dispatch = jest.fn()
+      const result = render(
+        <StateDispatchProvider state={initialState} dispatch={dispatch}>
+          <BrowserRouter>
+            <TopNav />
+          </BrowserRouter>
+        </StateDispatchProvider>
+      )
+
+      expect(
+        result.queryByRole("button", { name: "User Info" })
+      ).not.toBeInTheDocument()
+    })
+
     test("has a 'User Info' button", () => {
+      jest.mocked(getTestGroups).mockReturnValue([TestGroups.KeycloakSso])
+
       const dispatch = jest.fn()
       const result = render(
         <StateDispatchProvider state={initialState} dispatch={dispatch}>
@@ -47,6 +73,8 @@ describe("TopNav", () => {
     })
 
     test("brings up an element with 'logged in as' text when clicked", async () => {
+      jest.mocked(getTestGroups).mockReturnValue([TestGroups.KeycloakSso])
+
       const dispatch = jest.fn()
       const user = userEvent.setup()
       const result = render(
@@ -65,6 +93,8 @@ describe("TopNav", () => {
     })
 
     test("clicking the 'User Info' button again makes the 'Logged in as' popover disappear", async () => {
+      jest.mocked(getTestGroups).mockReturnValue([TestGroups.KeycloakSso])
+
       const dispatch = jest.fn()
       const user = userEvent.setup()
       const result = render(


### PR DESCRIPTION
<img width="282" alt="Screenshot 2024-02-12 at 10 52 35 AM" src="https://github.com/mbta/skate/assets/912020/25d72e63-2753-4ace-b0ae-4a0e2c59edde">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206526459943491