### PR TITLE
feat: Switch name of Keycloak test group to recover from Keycloak rollout issues

### DIFF
--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -4,7 +4,7 @@ export enum TestGroups {
   DemoMode = "demo-mode",
   DetoursPilot = "detours-pilot",
   DummyDetourPage = "dummy-detour-page",
-  KeycloakSso = "keycloak-sso",
+  KeycloakSso = "keycloak-sso-2",
   LateView = "late-view",
 }
 

--- a/lib/skate_web/auth_manager/error_handler.ex
+++ b/lib/skate_web/auth_manager/error_handler.ex
@@ -8,7 +8,7 @@ defmodule SkateWeb.AuthManager.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
   def auth_error(conn, {_type, _reason}, _opts) do
     keycloak_enabled? =
-      "keycloak-sso" in Enum.map(Skate.Settings.TestGroup.get_override_enabled(), & &1.name)
+      "keycloak-sso-2" in Enum.map(Skate.Settings.TestGroup.get_override_enabled(), & &1.name)
 
     if keycloak_enabled? do
       Phoenix.Controller.redirect(conn, to: ~p"/auth/keycloak")

--- a/test/skate_web/auth_manager/error_handler_test.exs
+++ b/test/skate_web/auth_manager/error_handler_test.exs
@@ -3,7 +3,7 @@ defmodule SkateWeb.AuthManager.ErrorHandlerTest do
 
   describe "auth_error/3" do
     test "redirects to Keycloak login", %{conn: conn} do
-      {:ok, test_group} = Skate.Settings.TestGroup.create("keycloak-sso")
+      {:ok, test_group} = Skate.Settings.TestGroup.create("keycloak-sso-2")
 
       Skate.Settings.TestGroup.update(%{test_group | override: :enabled})
 


### PR DESCRIPTION
This exists as an escape hatch in case the Keycloak rollout runs into issues that cause us to not be able to access `/admin` in order to roll it back.

If we do run into that kind of issue, then we merge this PR and immediately deploy it to production.