### PR TITLE
chore/fix: Upgrade node to 20.11.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 elixir 1.15.7-otp-26
 erlang 26.1.2
-nodejs 20.7.0
+nodejs 20.11.0
 adr-tools 3.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix local.hex --force && \
   mix local.rebar --force && \
   mix do deps.get --only prod
 
-FROM node:20.7.0-alpine3.17 as assets-builder
+FROM node:20.11.0-alpine3.19 as assets-builder
 
 WORKDIR /root
 ADD . .


### PR DESCRIPTION
This fixes an issue where running individual tests sometimes fails with this error:

node:internal/assert:14 throw new ERR_INTERNAL_ASSERTION(message);

More info here: https://github.com/nodejs/node/issues/48763
And here: https://github.com/nodejs/node/issues/50383