### PR TITLE
feat: "roll over" to new guardian tokens when enabling Keycloak

### DIFF
--- a/lib/skate_web/auth_manager.ex
+++ b/lib/skate_web/auth_manager.ex
@@ -10,20 +10,51 @@ defmodule SkateWeb.AuthManager do
   @skate_admin_group "skate-admin"
   @skate_dispatcher_group "skate-dispatcher"
   @v2_resource_prefix "v2:"
+  @v3_resource_prefix "v3:"
 
   def v2_resource_prefix, do: @v2_resource_prefix
 
+  def v3_resource_prefix, do: @v3_resource_prefix
+
   def subject_for_token(%{id: user_id}, _claims) do
-    {:ok, "#{@v2_resource_prefix}#{user_id}"}
+    keycloak_enabled? =
+      "keycloak-sso" in Enum.map(Skate.Settings.TestGroup.get_override_enabled(), & &1.name)
+
+    if keycloak_enabled? do
+      {:ok, "#{@v3_resource_prefix}#{user_id}"}
+    else
+      {:ok, "#{@v2_resource_prefix}#{user_id}"}
+    end
   end
 
   def resource_from_claims(%{"sub" => @v2_resource_prefix <> user_id}) do
     {:ok, %{id: String.to_integer(user_id)}}
   end
 
+  def resource_from_claims(%{"sub" => @v3_resource_prefix <> user_id}) do
+    {:ok, %{id: String.to_integer(user_id)}}
+  end
+
   def resource_from_claims(_), do: {:error, :invalid_claims}
 
-  def username_from_socket!(socket) do
+  def verify_claims(%{"sub" => subject} = claims, _options) do
+    keycloak_enabled? =
+      "keycloak-sso" in Enum.map(Skate.Settings.TestGroup.get_override_enabled(), & &1.name)
+
+    if keycloak_enabled? do
+      case subject do
+        @v3_resource_prefix <> _user_ -> {:ok, claims}
+        _ -> {:error, :invalid_claims}
+      end
+    else
+      case subject do
+        @v2_resource_prefix <> _user_id -> {:ok, claims}
+        _ -> {:error, :invalid_claims}
+      end
+    end
+  end
+
+  def(username_from_socket!(socket)) do
     socket
     |> Guardian.Phoenix.Socket.current_resource()
     |> username_from_resource()

--- a/lib/skate_web/auth_manager/pipeline.ex
+++ b/lib/skate_web/auth_manager/pipeline.ex
@@ -8,5 +8,6 @@ defmodule SkateWeb.AuthManager.Pipeline do
 
   plug(Guardian.Plug.VerifySession, claims: %{"typ" => "access"})
   plug(Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"})
+  plug(Guardian.Plug.EnsureAuthenticated, claims: %{"typ" => "access"})
   plug(Guardian.Plug.LoadResource, allow_blank: true)
 end

--- a/test/skate_web/auth_manager_test.exs
+++ b/test/skate_web/auth_manager_test.exs
@@ -13,6 +13,15 @@ defmodule SkateWeb.AuthManagerTest do
       assert {:ok, "v2:#{@user_id}"} ==
                AuthManager.subject_for_token(%{id: @user_id}, %{})
     end
+
+    test "returns v3 formatted user id when given user struct with Keycloak enabled" do
+      {:ok, test_group} = Skate.Settings.TestGroup.create("keycloak-sso")
+
+      Skate.Settings.TestGroup.update(%{test_group | override: :enabled})
+
+      assert {:ok, "v3:#{@user_id}"} ==
+               AuthManager.subject_for_token(%{id: @user_id}, %{})
+    end
   end
 
   describe "resource_from_claims/2" do
@@ -22,6 +31,15 @@ defmodule SkateWeb.AuthManagerTest do
       assert {:ok, %{id: ^user_id}} =
                AuthManager.resource_from_claims(%{
                  "sub" => "v2:#{user_id}"
+               })
+    end
+
+    test "returns struct when given v3 formatted user id" do
+      %{id: user_id} = User.upsert(@username, "email@test.com")
+
+      assert {:ok, %{id: ^user_id}} =
+               AuthManager.resource_from_claims(%{
+                 "sub" => "v3:#{user_id}"
                })
     end
   end


### PR DESCRIPTION
**Asana ticket:** [Better handle transition state](https://app.asana.com/0/1148853526253420/1206613654510834/f)

This will help avoid unusual states around the time that we roll out Keycloak by requiring users to log back in via the new SSO flow as opposed to continuing to use their old token.

A note on Guardian terminology: it may seem weird that we weren't calling `Guradian.Plug.EnsureAuthenticated` before, but that mainly calls the optional `verify_claims` callback. The default `verify_claims` implementation just always accepts the claims so the plug wouldn't have done anything previously.