### PR TITLE
fix: Fix text color on the detour dropdown

### DIFF
--- a/assets/css/_dropdown.scss
+++ b/assets/css/_dropdown.scss
@@ -1,5 +1,3 @@
-@use "./color/tokens_2024" as tokens;
-
 .c-dropdown-popup-wrapper {
   visibility: hidden;
 }
@@ -7,8 +5,4 @@
 .c-dropdown-popup-menu {
   position: static;
   visibility: visible;
-}
-
-.c-dropdown-popup-item {
-    color: tokens.$gray-900 !important;
 }

--- a/assets/css/_dropdown.scss
+++ b/assets/css/_dropdown.scss
@@ -1,3 +1,5 @@
+@use "./color/tokens_2024" as tokens;
+
 .c-dropdown-popup-wrapper {
   visibility: hidden;
 }
@@ -5,4 +7,8 @@
 .c-dropdown-popup-menu {
   position: static;
   visibility: visible;
+}
+
+.c-dropdown-popup-item {
+    color: tokens.$gray-900 !important;
 }

--- a/assets/src/components/map/dropdown.tsx
+++ b/assets/src/components/map/dropdown.tsx
@@ -1,27 +1,16 @@
-import React, { PropsWithChildren } from "react"
+import React, { ComponentProps } from "react"
 import { Dropdown } from "react-bootstrap"
 
-interface DropdownMenuProps extends PropsWithChildren {}
-
-export const DropdownMenu = ({ children }: DropdownMenuProps) => {
+export const DropdownMenu = (props: ComponentProps<typeof Dropdown.Menu>) => {
   return (
     <Dropdown.Menu
       className="c-dropdown-popup-menu border-box inherit-box"
       show
-    >
-      {children}
-    </Dropdown.Menu>
+      {...props}
+    />
   )
 }
 
-interface DropdownItemProps extends PropsWithChildren {
-  onClick?: () => void
-}
-
-export const DropdownItem = ({ children, onClick }: DropdownItemProps) => {
-  return (
-    <Dropdown.Item as="button" onClick={onClick}>
-      {children}
-    </Dropdown.Item>
-  )
+export const DropdownItem = (props: ComponentProps<typeof Dropdown.Item>) => {
+  return <Dropdown.Item as="button" {...props} />
 }

--- a/assets/src/components/map/dropdown.tsx
+++ b/assets/src/components/map/dropdown.tsx
@@ -20,7 +20,7 @@ interface DropdownItemProps extends PropsWithChildren {
 
 export const DropdownItem = ({ children, onClick }: DropdownItemProps) => {
   return (
-    <Dropdown.Item className="c-dropdown-popup-item" onClick={onClick}>
+    <Dropdown.Item as="button" onClick={onClick}>
       {children}
     </Dropdown.Item>
   )

--- a/assets/src/components/map/dropdown.tsx
+++ b/assets/src/components/map/dropdown.tsx
@@ -14,4 +14,14 @@ export const DropdownMenu = ({ children }: DropdownMenuProps) => {
   )
 }
 
-export const DropdownItem = Dropdown.Item
+interface DropdownItemProps extends PropsWithChildren {
+  onClick?: () => void
+}
+
+export const DropdownItem = ({ children, onClick }: DropdownItemProps) => {
+  return (
+    <Dropdown.Item className="c-dropdown-popup-item" onClick={onClick}>
+      {children}
+    </Dropdown.Item>
+  )
+}

--- a/assets/src/components/map/dropdown.tsx
+++ b/assets/src/components/map/dropdown.tsx
@@ -1,16 +1,14 @@
 import React, { ComponentProps } from "react"
 import { Dropdown } from "react-bootstrap"
 
-export const DropdownMenu = (props: ComponentProps<typeof Dropdown.Menu>) => {
-  return (
-    <Dropdown.Menu
-      className="c-dropdown-popup-menu border-box inherit-box"
-      show
-      {...props}
-    />
-  )
-}
+export const DropdownMenu = (props: ComponentProps<typeof Dropdown.Menu>) => (
+  <Dropdown.Menu
+    className="c-dropdown-popup-menu border-box inherit-box"
+    show
+    {...props}
+  />
+)
 
-export const DropdownItem = (props: ComponentProps<typeof Dropdown.Item>) => {
-  return <Dropdown.Item as="button" {...props} />
-}
+export const DropdownItem = (props: ComponentProps<typeof Dropdown.Item>) => (
+  <Dropdown.Item as="button" {...props} />
+)


### PR DESCRIPTION
From the design review for the detour modal - I missed this when doing the original detour dropdown work.

[Design Review Asana Ticket](https://app.asana.com/0/1148853526253420/1206545095976211/f)

> The default text should use the body font color (#252627, Gray-900), not blue. 