### PR TITLE
feat: function to look up route pattern by ID.

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -39,7 +39,7 @@ import {
 } from "./models/locationSearchSuggestionData"
 import { LocationSearchSuggestion } from "./models/locationSearchSuggestion"
 import { DetourShapeData, detourShapeFromData } from "./models/detourShapeData"
-import { DetourShape } from "./detour"
+import { DetourShape } from "./models/detour"
 
 export interface RouteData {
   id: string

--- a/assets/src/components/detours/detourDropdown.tsx
+++ b/assets/src/components/detours/detourDropdown.tsx
@@ -57,6 +57,7 @@ export const DetourDropdown = ({
               routeDescription,
               routeOrigin,
               routeDirection,
+              routePatternId: routePatternForVehicle.id,
               shape,
               center,
               zoom,

--- a/assets/src/components/detours/detourDropdown.tsx
+++ b/assets/src/components/detours/detourDropdown.tsx
@@ -4,7 +4,7 @@ import { Route, RoutePattern } from "../../schedule"
 import { Popup } from "react-leaflet"
 import { PointTuple } from "leaflet"
 import { LatLngLiteral } from "leaflet"
-import { OriginalRoute } from "../../detour"
+import { OriginalRoute } from "../../models/detour"
 
 export interface DetourDropdownProps {
   routePatternForVehicle: RoutePattern | null

--- a/assets/src/components/detours/detourModal.tsx
+++ b/assets/src/components/detours/detourModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react"
 import { DiversionPage } from "./diversionPage"
 import { joinClasses } from "../../helpers/dom"
-import { OriginalRoute } from "../../detour"
+import { OriginalRoute } from "../../models/detour"
 
 export const DetourModal = ({
   originalRoute,

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -3,7 +3,7 @@ import { DiversionPanel } from "./diversionPanel"
 import { DetourMap } from "./detourMap"
 import { useDetour } from "../../hooks/useDetour"
 import { CloseButton } from "react-bootstrap"
-import { OriginalRoute } from "../../detour"
+import { OriginalRoute } from "../../models/detour"
 
 interface DiversionPageProps {
   missedStops?: ReactNode

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import { RoutePill } from "../routePill"
-import { DetourShape } from "../../detour"
+import { DetourShape } from "../../models/detour"
 import { ListGroup } from "react-bootstrap"
 
 export interface DiversionPanelProps {

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -27,6 +27,7 @@ export const DummyDetourPage = () => {
             routeOrigin: routePattern.name,
             routeDirection:
               route?.directionNames[routePattern.directionId] || "?",
+            routePatternId: routePattern.id,
             center: { lat: 42.36, lng: -71.13 },
             zoom: 16,
           }}

--- a/assets/src/components/mapPage.tsx
+++ b/assets/src/components/mapPage.tsx
@@ -33,7 +33,7 @@ import { useLocationSearchResultById } from "../hooks/useLocationSearchResultByI
 import { fullStoryEvent } from "../helpers/fullStory"
 import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
 import { DetourModal } from "./detours/detourModal"
-import { OriginalRoute } from "../detour"
+import { OriginalRoute } from "../models/detour"
 
 const SearchMode = ({
   onSelectVehicleResult,

--- a/assets/src/components/mapPage/mapDisplay.tsx
+++ b/assets/src/components/mapPage/mapDisplay.tsx
@@ -64,7 +64,7 @@ import useScreenSize from "../../hooks/useScreenSize"
 import inTestGroup, { TestGroups } from "../../userInTestGroup"
 import { useRoute } from "../../contexts/routesContext"
 import { DetourDropdown } from "../detours/detourDropdown"
-import { OriginalRoute } from "../../detour"
+import { OriginalRoute } from "../../models/detour"
 
 const SecondaryRouteVehicles = ({
   selectedVehicleRoute,

--- a/assets/src/hooks/useDetour.tsx
+++ b/assets/src/hooks/useDetour.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { ShapePoint } from "../schedule"
 import { fetchDetourDirections } from "../api"
-import { DetourShape } from "../detour"
+import { DetourShape } from "../models/detour"
 
 const useDetourDirections = (shapePoints: ShapePoint[]) => {
   const [detourShape, setDetourShape] = useState<ShapePoint[]>([])

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,5 +1,5 @@
 import { LatLngLiteral } from "leaflet"
-import { Shape, ShapePoint } from "./schedule"
+import { Shape, ShapePoint } from "../schedule"
 
 export interface DetourShape {
   coordinates: ShapePoint[]

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,5 +1,5 @@
 import { LatLngLiteral } from "leaflet"
-import { Shape, ShapePoint } from "../schedule"
+import { RoutePatternId, Shape, ShapePoint } from "../schedule"
 
 export interface DetourShape {
   coordinates: ShapePoint[]
@@ -13,6 +13,7 @@ export interface OriginalRoute {
   routeDescription: string
   routeOrigin: string
   routeDirection: string
+  routePatternId: RoutePatternId
   shape: Shape
   center: LatLngLiteral
   zoom: number

--- a/assets/src/models/detourShapeData.ts
+++ b/assets/src/models/detourShapeData.ts
@@ -1,5 +1,5 @@
 import { array, Infer, number, string, type } from "superstruct"
-import { DetourShape } from "../detour"
+import { DetourShape } from "./detour"
 
 export const DetourShapeData = type({
   coordinates: array(

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
       routeDescription: "Harvard via Allston",
       routeOrigin: "from Andrew Station",
       routeDirection: "Outbound",
+      routePatternId: "39-3-0",
       routeName: "39",
       shape: route39shape,
       zoom: 14,

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -18,6 +18,7 @@ const DiversionPage = (
         routeDescription: "Harvard via Allston",
         routeOrigin: "from Andrew Station",
         routeDirection: "Outbound",
+        routePatternId: "66-6-0",
         shape: shapeFactory.build(),
         center: latLngLiteralFactory.build(),
         zoom: 16,

--- a/assets/tests/factories/detourShapeFactory.ts
+++ b/assets/tests/factories/detourShapeFactory.ts
@@ -1,5 +1,5 @@
 import { Factory } from "fishery"
-import { DetourShape } from "../../src/detour"
+import { DetourShape } from "../../src/models/detour"
 import { shapePointFactory } from "./shapePointFactory"
 
 export const directionsFactory = Factory.define<DetourShape["directions"][0]>(

--- a/lib/schedule.ex
+++ b/lib/schedule.ex
@@ -163,6 +163,11 @@ defmodule Schedule do
     call_with_data(persistent_term_key, [], :all_stops, [])
   end
 
+  @spec route_pattern(RoutePattern.id(), persistent_term_key()) :: RoutePattern.t() | nil
+  def route_pattern(route_pattern_id, persistent_term_key \\ __MODULE__) do
+    call_with_data(persistent_term_key, [route_pattern_id], :route_pattern, nil)
+  end
+
   @spec first_route_pattern_for_route_and_direction(Route.id(), Direction.id()) ::
           RoutePattern.t() | nil
   @spec first_route_pattern_for_route_and_direction(

--- a/lib/schedule/data.ex
+++ b/lib/schedule/data.ex
@@ -275,6 +275,11 @@ defmodule Schedule.Data do
     end
   end
 
+  @spec route_pattern(t(), RoutePattern.id()) :: RoutePattern.t() | nil
+  def route_pattern(%__MODULE__{route_patterns: route_patterns}, route_pattern_id) do
+    Enum.find(route_patterns, &(&1.id == route_pattern_id))
+  end
+
   @spec first_route_pattern_for_route_and_direction(t(), Route.id(), Direction.id()) ::
           RoutePattern.t() | nil
   def first_route_pattern_for_route_and_direction(

--- a/test/schedule/data_test.exs
+++ b/test/schedule/data_test.exs
@@ -666,6 +666,26 @@ defmodule Schedule.DataTest do
     end
   end
 
+  describe "route_pattern/2" do
+    setup do
+      route_patterns = [build(:gtfs_route_pattern, id: "1")]
+
+      data = %Data{
+        route_patterns: route_patterns
+      }
+
+      {:ok, data: data}
+    end
+
+    test "retrieves a route pattern by ID", %{data: data} do
+      assert %RoutePattern{id: "1"} = Data.route_pattern(data, "1")
+    end
+
+    test "returns nil of route pattern isn't found for ID", %{data: data} do
+      assert is_nil(Data.route_pattern(data, "2"))
+    end
+  end
+
   describe "first_route_pattern_for_route_and_direction/3" do
     setup do
       route_patterns = [

--- a/test/schedule_test.exs
+++ b/test/schedule_test.exs
@@ -896,6 +896,49 @@ defmodule ScheduleTest do
     end
   end
 
+  describe "route_pattern/2" do
+    setup do
+      pid =
+        Schedule.start_mocked(%{
+          gtfs: %{
+            "routes.txt" => [
+              "route_id,route_long_name,route_type,route_desc,route_short_name",
+              "39,Forest Hills - Back Bay Station,3,Key Bus,39"
+            ],
+            "route_patterns.txt" => [
+              "route_pattern_id,route_id,direction_id,representative_trip_id,route_pattern_sort_order",
+              "39-pattern,39,1,39-trip,0"
+            ],
+            "trips.txt" => [
+              "route_id,service_id,trip_id,trip_headsign,direction_id,block_id,route_pattern_id",
+              "39,service,39-trip,headsign,0,block,39-pattern"
+            ],
+            "stop_times.txt" => [
+              "trip_id,arrival_time,departure_time,stop_sequence",
+              "39-trip,,00:00:00,1",
+              "39-trip,,00:10:00,2"
+            ]
+          }
+        })
+
+      %{pid: pid}
+    end
+
+    test "returns the route pattern by its ID", %{pid: pid} do
+      assert %RoutePattern{
+               id: "39-pattern"
+             } =
+               Schedule.route_pattern(
+                 "39-pattern",
+                 pid
+               )
+    end
+
+    test "returns nil when a route pattern is not found", %{pid: pid} do
+      assert is_nil(Schedule.route_pattern("other-pattern", pid))
+    end
+  end
+
   describe "first_route_pattern_for_route_and_direction" do
     test "returns the first route pattern matching the route and direction" do
       pid =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -193,6 +193,18 @@ defmodule Skate.Factory do
     }
   end
 
+  def gtfs_route_pattern_factory do
+    %Schedule.Gtfs.RoutePattern{
+      id: "route_pattern",
+      name: "",
+      route_id: "route",
+      direction_id: 0,
+      representative_trip_id: "trip",
+      time_desc: nil,
+      sort_order: 1
+    }
+  end
+
   def trip_factory do
     %Schedule.Trip{
       id: "trip",


### PR DESCRIPTION
Asana ticket: [Provide easier access to route patterns by ID on backend](https://app.asana.com/0/0/1206644323693330/f)

My plan for the API is that the front-end is going to provide the back-end with the ID of the route pattern that the detour started from in addition to the detour shape. The route pattern will then allow the back-end to find the initial shape and, via the representative trip, get the stops. All of this needs the ability to look up a route shape by ID, though, and we don't currently have that, so I'm adding it.

I also snuck in a minor refactor (moving `detour.ts` to the models directory).