### PR TITLE
chore: remove fallback on signout URL from Guardian claims

### DIFF
--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -91,9 +91,7 @@ defmodule SkateWeb.AuthController do
 
   @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def logout(conn, %{"provider" => "keycloak"}) do
-    claims = Guardian.Plug.current_claims(conn)
-
-    sign_out_url = get_session(conn, :sign_out_url) || Map.get(claims, "sign_out_url")
+    sign_out_url = get_session(conn, :sign_out_url)
 
     if is_nil(sign_out_url) do
       # The router makes sure we can't call `/auth/:provider/callback`

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -3,8 +3,6 @@ defmodule SkateWeb.AuthControllerTest do
 
   import Test.Support.Helpers
 
-  import Skate.Factory
-
   alias Skate.Settings.User
 
   describe "GET /auth/:provider" do
@@ -121,31 +119,6 @@ defmodule SkateWeb.AuthControllerTest do
         |> init_test_session(%{})
         |> assign(:ueberauth_auth, Skate.Factory.build(:ueberauth_auth))
         |> get(~p"/auth/keycloak/callback")
-
-      assert Guardian.Plug.authenticated?(conn)
-
-      conn = get(conn, ~p"/auth/keycloak/logout")
-
-      refute Guardian.Plug.authenticated?(conn)
-
-      assert redirected_to(conn) == redirect_url
-    end
-
-    test "falls back to `sign_out_url` from Guardian claims", %{conn: conn} do
-      redirect_url = "redirect.url.localhost"
-
-      user = insert(:user)
-
-      resource = %{id: user.id}
-
-      reassign_env(:skate, :logout_url_fn, fn _, _ ->
-        {:ok, redirect_url}
-      end)
-
-      conn =
-        conn
-        |> init_test_session(%{})
-        |> Guardian.Plug.sign_in(SkateWeb.AuthManager, resource, %{sign_out_url: redirect_url})
 
       assert Guardian.Plug.authenticated?(conn)
 


### PR DESCRIPTION
Followup on #2408. Now that the old tokens are expired, we no longer have to check for a `sign_out_url` in the Guardian claims.