### PR TITLE
refactor: convert diversion panel to use layout panel components

### DIFF
--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -34,20 +34,21 @@
         "panel map" auto
         / fit-content(28ch) auto;
 
-      .c-diversion-panel,
-      .l-diversion-page__panel {
+      .l-diversion-page__panel,
+      .l-diversion-page-panel {
         display: grid;
 
         grid-template-rows: subgrid;
-        grid-template-columns: 1fr;
+        grid-template-columns: subgrid;
 
         grid-area: panel;
 
-        .c-diversion-panel__header {
+        .l-diversion-page__header,
+        .l-diversion-page-panel__header {
           grid-row: heading;
         }
 
-        .c-diversion-panel__body {
+        .l-diversion-page-panel__body {
           grid-row: 2/-1;
         }
       }

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -1,9 +1,16 @@
-import React, { ReactNode } from "react"
+import React, {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  PropsWithChildren,
+  ReactNode,
+} from "react"
 import { DiversionPanel } from "./diversionPanel"
 import { DetourMap } from "./detourMap"
 import { useDetour } from "../../hooks/useDetour"
 import { CloseButton } from "react-bootstrap"
 import { OriginalRoute } from "../../models/detour"
+import { joinClasses } from "../../helpers/dom"
+import { AsProp } from "react-bootstrap/esm/helpers"
 
 interface DiversionPageProps {
   missedStops?: ReactNode
@@ -32,7 +39,7 @@ export const DiversionPage = ({
   } = useDetour()
 
   return (
-    <article className="l-diversion-page h-100 border-box">
+    <article className="l-diversion-page h-100 border-box inherit-box">
       <header className="l-diversion-page__header text-bg-light border-bottom">
         <CloseButton className="p-4" onClick={onClose} />
       </header>
@@ -64,3 +71,61 @@ export const DiversionPage = ({
     </article>
   )
 }
+
+type AsProps<As extends React.ElementType> = ComponentProps<As> & AsProp<As>
+
+const DiversionPagePanel = <As extends React.ElementType = "article">({
+  children,
+  as: As = "article",
+  ...props
+}: PropsWithChildren<AsProps<As>>) => (
+  <As
+    {...props}
+    className={joinClasses([
+      "l-diversion-page-panel",
+      "bg-light",
+      "border-end",
+      props.className,
+    ])}
+  >
+    {children}
+  </As>
+)
+
+const DiversionPagePanelHeader = <As extends React.ElementType = "header">({
+  children,
+  as: As = "header",
+  ...props
+}: PropsWithChildren<AsProps<As>>) => (
+  <As
+    {...props}
+    className={joinClasses([
+      "l-diversion-page-panel__header",
+      "border-bottom",
+      "px-3",
+      props.className,
+    ])}
+  >
+    {children}
+  </As>
+)
+
+const DiversionPagePanelBody = ({
+  children,
+  ...props
+}: PropsWithChildren<ComponentPropsWithoutRef<"div">>) => (
+  <div
+    {...props}
+    className={joinClasses(["l-diversion-page-panel__body", props.className])}
+  >
+    {children}
+  </div>
+)
+
+DiversionPagePanel.Header = DiversionPagePanelHeader
+
+DiversionPagePanel.Body = DiversionPagePanelBody
+
+DiversionPage.Panel = DiversionPagePanel
+
+export const Panel = DiversionPagePanel

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react"
 import { RoutePill } from "../routePill"
 import { DetourShape } from "../../models/detour"
 import { ListGroup } from "react-bootstrap"
+import { Panel } from "./diversionPage"
 
 export interface DiversionPanelProps {
   directions?: DetourShape["directions"]
@@ -20,12 +21,12 @@ export const DiversionPanel = ({
   routeOrigin,
   routeDirection,
 }: DiversionPanelProps) => (
-  <article className="c-diversion-panel h-100 bg-light border-end">
-    <header className="c-diversion-panel__header border-bottom d-flex px-3">
+  <Panel as="article" className="c-diversion-panel">
+    <Panel.Header>
       <h1 className="c-diversion-panel__h2 my-3">Create Detour</h1>
-    </header>
+    </Panel.Header>
 
-    <div className="c-diversion-panel__body overflow-auto px-3">
+    <Panel.Body className="c-diversion-panel__body overflow-auto px-3">
       <section className="pb-3 border-bottom">
         <h2 className="c-diversion-panel__h3">Affected route</h2>
 
@@ -70,8 +71,8 @@ export const DiversionPanel = ({
           {missedStops}
         </section>
       )}
-    </div>
-  </article>
+    </Panel.Body>
+  </Panel>
 )
 
 const DirectionsHelpText = () => (


### PR DESCRIPTION
This sets us up to have a scrolling body with a stable footer

prepares for: https://github.com/mbta/skate/pull/2420

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206694541310027