### PR TITLE
refactor: Factor out `OriginalRouteShape` in `DetourMap`

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -1,5 +1,5 @@
-import React, { useId } from "react"
-import { LatLngLiteral } from "leaflet"
+import React, { PropsWithChildren, useId } from "react"
+import { LatLngLiteral, LeafletMouseEvent } from "leaflet"
 import { Polyline, useMapEvents } from "react-leaflet"
 import Leaflet from "leaflet"
 import Map from "../map"
@@ -115,30 +115,27 @@ export const DetourMap = ({
       className="c-detour_map--detour-route-shape"
     />
 
-    <Polyline
+    <OriginalRouteShape
       positions={originalShape.map(shapePointToLatLngLiteral)}
-      className={joinClasses([
-        "c-detour_map--original-route-shape",
-        startPoint === undefined &&
-          "c-detour_map--original-route-shape__unstarted",
-      ])}
       key={`detour-map-original-route-shape-${useId()}-${
         startPoint === undefined
       }`}
-      bubblingMouseEvents={false}
-      eventHandlers={{
-        click: (e) => {
-          const { position } =
-            closestPosition(
-              originalShape.map(shapePointToLatLngLiteral),
-              e.latlng
-            ) ?? {}
-          position && onClickOriginalShape(latLngLiteralToShapePoint(position))
-        },
+      classNames={
+        startPoint === undefined
+          ? ["c-detour_map--original-route-shape__unstarted"]
+          : []
+      }
+      onClick={(e) => {
+        const { position } =
+          closestPosition(
+            originalShape.map(shapePointToLatLngLiteral),
+            e.latlng
+          ) ?? {}
+        position && onClickOriginalShape(latLngLiteralToShapePoint(position))
       }}
     >
       {!startPoint && <MapTooltip>Click to start detour</MapTooltip>}
-    </Polyline>
+    </OriginalRouteShape>
   </Map>
 )
 
@@ -201,3 +198,35 @@ const DetourPointMarker = ({ position }: { position: LatLngLiteral }) => (
     }
   />
 )
+
+interface OriginalRouteShapeProps extends PropsWithChildren {
+  key: string
+  positions: LatLngLiteral[]
+  classNames: string[]
+  onClick: (e: LeafletMouseEvent) => void
+}
+
+const OriginalRouteShape = ({
+  key,
+  positions,
+  children,
+  classNames,
+  onClick,
+}: OriginalRouteShapeProps) => {
+  return (
+    <Polyline
+      positions={positions}
+      className={joinClasses([
+        "c-detour_map--original-route-shape",
+        ...classNames,
+      ])}
+      key={key}
+      bubblingMouseEvents={false}
+      eventHandlers={{
+        click: onClick,
+      }}
+    >
+      {children}
+    </Polyline>
+  )
+}

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -207,7 +207,6 @@ interface OriginalRouteShapeProps extends PropsWithChildren {
 }
 
 const OriginalRouteShape = ({
-  key,
   positions,
   children,
   classNames,
@@ -220,7 +219,6 @@ const OriginalRouteShape = ({
         "c-detour_map--original-route-shape",
         ...classNames,
       ])}
-      key={key}
       bubblingMouseEvents={false}
       eventHandlers={{
         click: onClick,

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -211,20 +211,18 @@ const OriginalRouteShape = ({
   children,
   classNames,
   onClick,
-}: OriginalRouteShapeProps) => {
-  return (
-    <Polyline
-      positions={positions}
-      className={joinClasses([
-        "c-detour_map--original-route-shape",
-        ...classNames,
-      ])}
-      bubblingMouseEvents={false}
-      eventHandlers={{
-        click: onClick,
-      }}
-    >
-      {children}
-    </Polyline>
-  )
-}
+}: OriginalRouteShapeProps) => (
+  <Polyline
+    positions={positions}
+    className={joinClasses([
+      "c-detour_map--original-route-shape",
+      ...classNames,
+    ])}
+    bubblingMouseEvents={false}
+    eventHandlers={{
+      click: onClick,
+    }}
+  >
+    {children}
+  </Polyline>
+)


### PR DESCRIPTION
This is in preparation for work to [widen and highlight the route shape on hover](https://app.asana.com/0/1205385723132845/1206423114607620). 

My plan for that is to paint two polylines with the same positions, one that's transparent (until hover) and has all the click and hover behavior, and one that is only the portion that's visible when not hovering. This refactor felt like a helpful precursor to that.

I could be persuaded to combine these into a single PR, but this actually did feel reasonable as a standalone change.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206698934433014