### PR TITLE
cleanup: deprecate instant promise

### DIFF
--- a/assets/tests/testHelpers/mockHelpers.ts
+++ b/assets/tests/testHelpers/mockHelpers.ts
@@ -12,6 +12,8 @@ import { TileType, tilesetUrlForType } from "../../src/tilesetUrls"
 
 /**
  * A promise that resolves synchronously.
+ *
+ * @deprecated use {@linkcode Promise.resolve}
  */
 export const instantPromise = <T>(value: T): Promise<T> =>
   ({ then: (onfulfilled: (v: T) => any) => onfulfilled(value) } as Promise<T>)


### PR DESCRIPTION
Instant promise pretends to be a promise, but doesn't actually trigger the right behavior in react tests due to faking it. I'm not sure this was intendded when it was originally added, but I believe we can replace this with `Promise.resolve`