### PR TITLE
fix: Update wording in 'Directions' section of the detour panel

### DIFF
--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -80,7 +80,7 @@ const DirectionsHelpText = () => (
     <i>
       Click a point on the regular route to start drawing your detour. As you
       continue to select points on the map, turn-by-turn directions will appear
-      in this drawer.
+      in this panel.
     </i>
   </p>
 )


### PR DESCRIPTION
No ticket.

This was surfaced in [design review for the detour modal](https://app.asana.com/0/1148853526253420/1206545095976211/f), but I forgot to address it before merging.