### PR TITLE
fix: clear missed stops when detour is no longer in a finished state

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -55,6 +55,8 @@ export const useDetour = (routePatternId: RoutePatternId) => {
           }
         }
       )
+    } else {
+      setMissedStops(undefined)
     }
 
     return () => {

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -295,4 +295,25 @@ describe("useDetour", () => {
 
     expect(result.current.missedStops).toBe(missedStops)
   })
+
+  test("when `endPoint` is undone, `missedStops` is cleared", async () => {
+    const { result } = renderHook(useDetourWithFakeRoutePattern)
+
+    const missedStops = stopFactory.buildList(3)
+
+    jest.mocked(fetchDetourMissedStops).mockResolvedValue(missedStops)
+
+    act(() => result.current.addConnectionPoint({ lat: 0, lon: 0 }))
+    act(() => result.current.addConnectionPoint({ lat: 0, lon: 0 }))
+
+    await waitFor(() => {
+      expect(result.current.missedStops).not.toBeUndefined()
+    })
+
+    act(() => result.current.undo())
+
+    await waitFor(() => {
+      expect(result.current.missedStops).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
Thanks to @firestack for catching.