### PR TITLE
feat: detour page exit confirmation modal

### DIFF
--- a/assets/css/_z_indexes.scss
+++ b/assets/css/_z_indexes.scss
@@ -1,0 +1,17 @@
+$z-page-layout-context: (
+  "detour-modal-hidden": -1,
+  "properties-panel-backdrop": 1000,
+  "properties-panel": 1002,
+  "view": 1100,
+  "navbar": 1200,
+  "user-info-popover": 1201,
+  "detour-modal": 2000,
+  "modal-backdrop": 2100,
+  "modal": 2101,
+);
+
+$z-properties-panel-context: (
+  "map": 9,
+  "header": 10,
+  "fullscreen-map": 11,
+);

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -9,23 +9,6 @@ $mobile-route-picker-width: 18.125rem;
 $shuttle-picker-width: 12.6rem;
 $view-header-height: 2.5rem;
 $vpp-location-padding: 1rem;
-$z-page-layout-context: (
-  "detour-modal-hidden": -1,
-  "properties-panel-backdrop": 1000,
-  "properties-panel": 1002,
-  "view": 1100,
-  "navbar": 1200,
-  "user-info-popover": 1201,
-  "detour-modal": 2000,
-  "modal-backdrop": 2100,
-  "modal": 2101,
-);
-
-$z-properties-panel-context: (
-  "map": 9,
-  "header": 10,
-  "fullscreen-map": 11,
-);
 
 @import "ui_kit";
 
@@ -40,6 +23,8 @@ $z-properties-panel-context: (
 @import "../node_modules/leaflet/dist/leaflet.css";
 // #endregion
 // #endregion
+
+@import "z_indexes";
 
 @import "base";
 @import "inter";

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -17,6 +17,8 @@ $z-page-layout-context: (
   "navbar": 1200,
   "user-info-popover": 1201,
   "detour-modal": 2000,
+  "modal-backdrop": 2100,
+  "modal": 2101,
 );
 
 $z-properties-panel-context: (

--- a/assets/css/bootstrap.scss
+++ b/assets/css/bootstrap.scss
@@ -39,7 +39,7 @@
 // @import "../node_modules/bootstrap/scss/grid";
 // @import "../node_modules/bootstrap/scss/images";
 @import "../node_modules/bootstrap/scss/list-group";
-// @import "../node_modules/bootstrap/scss/modal";
+@import "../node_modules/bootstrap/scss/modal";
 @import "../node_modules/bootstrap/scss/nav";
 // @import "../node_modules/bootstrap/scss/navbar";
 // @import "../node_modules/bootstrap/scss/offcanvas";

--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -1,6 +1,7 @@
 @use "../color/definitions" as semantic;
 @use "../color/tokens_2021" as tokens;
 @use "../color/tokens_2024" as new_tokens;
+@use "../z_indexes" as z_indexes;
 
 $component-active-bg: tokens.$eggplant-700;
 $list-group-border-color: tokens.$gray-300;
@@ -15,5 +16,8 @@ $service-alert: semantic.$service-alert;
 $light: new_tokens.$gray-50;
 $dark: new_tokens.$gray-900;
 
-$zindex-modal: map-get($z-page-layout-context, "modal");
-$zindex-modal-backdrop: map-get($z-page-layout-context, "modal-backdrop");
+$zindex-modal: map-get(z_indexes.$z-page-layout-context, "modal");
+$zindex-modal-backdrop: map-get(
+  z_indexes.$z-page-layout-context,
+  "modal-backdrop"
+);

--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -14,3 +14,6 @@ $ui-alert: semantic.$ui-alert;
 $service-alert: semantic.$service-alert;
 $light: new_tokens.$gray-50;
 $dark: new_tokens.$gray-900;
+
+$zindex-modal: map-get($z-page-layout-context, "modal");
+$zindex-modal-backdrop: map-get($z-page-layout-context, "modal-backdrop");

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -7,7 +7,7 @@ import React, {
 import { DiversionPanel } from "./diversionPanel"
 import { DetourMap } from "./detourMap"
 import { DetourState, useDetour } from "../../hooks/useDetour"
-import { Alert, CloseButton } from "react-bootstrap"
+import { Alert, Button, CloseButton, Modal } from "react-bootstrap"
 import * as BsIcons from "../../helpers/bsIcons"
 import { OriginalRoute } from "../../models/detour"
 import { joinClasses } from "../../helpers/dom"
@@ -47,61 +47,98 @@ export const DiversionPage = ({
   } = useDetour(originalRoute.routePatternId)
 
   const [textArea, setTextArea] = useState("")
+  const [showConfirmCloseModal, setShowConfirmCloseModal] =
+    useState<boolean>(false)
 
   return (
-    <article className="l-diversion-page h-100 border-box inherit-box">
-      <header className="l-diversion-page__header text-bg-light border-bottom">
-        <CloseButton className="p-4" onClick={onClose} />
-      </header>
+    <>
+      <article className="l-diversion-page h-100 border-box inherit-box">
+        <header className="l-diversion-page__header text-bg-light border-bottom">
+          <CloseButton
+            className="p-4"
+            onClick={() => setShowConfirmCloseModal(true)}
+          />
+        </header>
 
-      <div className="l-diversion-page__panel bg-light">
-        {state === DetourState.Edit && (
-          <DiversionPanel
-            directions={directions}
-            missedStops={missedStops}
-            routeName={originalRoute.routeName}
-            routeDescription={originalRoute.routeDescription}
-            routeOrigin={originalRoute.routeOrigin}
-            routeDirection={originalRoute.routeDirection}
-            detourFinished={finishDetour !== undefined}
-            onFinishDetour={finishDetour}
+        <div className="l-diversion-page__panel bg-light">
+          {state === DetourState.Edit && (
+            <DiversionPanel
+              directions={directions}
+              missedStops={missedStops}
+              routeName={originalRoute.routeName}
+              routeDescription={originalRoute.routeDescription}
+              routeOrigin={originalRoute.routeOrigin}
+              routeDirection={originalRoute.routeDirection}
+              detourFinished={finishDetour !== undefined}
+              onFinishDetour={finishDetour}
+            />
+          )}
+          {state === DetourState.Finished && editDetour && (
+            <DetourFinishedPanel
+              onNavigateBack={editDetour}
+              detourText={textArea}
+              onChangeDetourText={setTextArea}
+            />
+          )}
+        </div>
+        <div className="l-diversion-page__map position-relative">
+          {state === DetourState.Finished && (
+            <Alert
+              variant="info"
+              className="position-absolute top-0 left-0 m-2 icon-link z-1"
+            >
+              <BsIcons.ExclamationCircleFill />
+              Detour is not editable from this screen.
+            </Alert>
+          )}
+          <DetourMap
+            originalShape={originalRoute.shape.points}
+            center={originalRoute.center}
+            zoom={originalRoute.zoom}
+            detourShape={detourShape}
+            startPoint={startPoint ?? undefined}
+            endPoint={endPoint ?? undefined}
+            waypoints={waypoints}
+            originalShapeClickable={canAddPoints}
+            onClickMap={addWaypoint}
+            onClickOriginalShape={addConnectionPoint}
+            undoDisabled={canUndo === false}
+            onUndo={undo}
+            onClear={clear}
           />
-        )}
-        {state === DetourState.Finished && editDetour && (
-          <DetourFinishedPanel
-            onNavigateBack={editDetour}
-            detourText={textArea}
-            onChangeDetourText={setTextArea}
-          />
-        )}
-      </div>
-      <div className="l-diversion-page__map position-relative">
-        {state === DetourState.Finished && (
-          <Alert
-            variant="info"
-            className="position-absolute top-0 left-0 m-2 icon-link z-1"
+        </div>
+      </article>
+      <Modal
+        show={showConfirmCloseModal}
+        onHide={() => setShowConfirmCloseModal(false)}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Are you sure you want to exit detour mode?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          When you close out of this screen, you will not be able to access the
+          details of your detour again. You may want to copy and paste these
+          details to another application.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            onClick={() => {
+              setShowConfirmCloseModal(false)
+              onClose?.()
+            }}
+            variant="primary"
           >
-            <BsIcons.ExclamationCircleFill />
-            Detour is not editable from this screen.
-          </Alert>
-        )}
-        <DetourMap
-          originalShape={originalRoute.shape.points}
-          center={originalRoute.center}
-          zoom={originalRoute.zoom}
-          detourShape={detourShape}
-          startPoint={startPoint ?? undefined}
-          endPoint={endPoint ?? undefined}
-          waypoints={waypoints}
-          originalShapeClickable={canAddPoints}
-          onClickMap={addWaypoint}
-          onClickOriginalShape={addConnectionPoint}
-          undoDisabled={canUndo === false}
-          onUndo={undo}
-          onClear={clear}
-        />
-      </div>
-    </article>
+            Yes, I&apos;m sure
+          </Button>
+          <Button
+            onClick={() => setShowConfirmCloseModal(false)}
+            variant="outline-primary"
+          >
+            Back to Detour
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   )
 }
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -1,5 +1,12 @@
 import { jest, describe, test, expect, beforeEach } from "@jest/globals"
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import React, { ComponentProps } from "react"
 import "@testing-library/jest-dom/jest-globals"
 import { fetchDetourDirections, fetchDetourMissedStops } from "../../../src/api"
@@ -283,5 +290,64 @@ describe("DiversionPage", () => {
     expect(
       await screen.findByRole("tooltip", { name: "Copied to clipboard!" })
     ).toBeVisible()
+  })
+
+  test("Attempting to close the page displays a confirmation modal", () => {
+    render(<DiversionPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(screen.getByRole("dialog")).toBeVisible()
+    expect(screen.getByRole("button", { name: /yes/i })).toBeVisible()
+    expect(screen.getByRole("button", { name: /back/i })).toBeVisible()
+  })
+
+  test("can close page from the confirmation modal", async () => {
+    const onClose = jest.fn()
+
+    render(<DiversionPage onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /yes/i }))
+    })
+
+    expect(onClose).toHaveBeenCalled()
+
+    expect(screen.queryByRole("dialog")).toBeNull()
+  })
+
+  test("can go back to the detour page from the confirmation modal", async () => {
+    const onClose = jest.fn()
+
+    render(<DiversionPage onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /back/i }))
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    expect(screen.queryByRole("dialog")).toBeNull()
+  })
+
+  test("closing the confirmation modal returns to the detour page", async () => {
+    const onClose = jest.fn()
+
+    render(<DiversionPage onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    await act(async () => {
+      const modal = screen.getByRole("dialog")
+      fireEvent.click(within(modal).getByRole("button", { name: "Close" }))
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    expect(screen.queryByRole("dialog")).toBeNull()
   })
 })


### PR DESCRIPTION
Asana ticket: [Basic modal implementation](https://app.asana.com/0/1148853526253420/1206705505932432/f)

There is still some typography styling that I have to take care of as a follow-up.

As part of this, I moved our z-index maps out into their own file so that they could be imported without pulling the actual CSS rules in `app.scss` in. The reasoning behind this is that I wanted to reference them in our Bootstrap variable overrides, but for the Storybook stories that don't pull in the full app CSS and instead just some particular design system styles, it hit a compilation error because of not being able to find the variable.