### PR TITLE
refactor: make typography variables available in Bootstrap

### DIFF
--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -2,6 +2,8 @@
 @use "../color/tokens_2021" as tokens;
 @use "../color/tokens_2024" as new_tokens;
 
+@import "../typography/variables";
+
 $component-active-bg: tokens.$eggplant-700;
 $list-group-border-color: tokens.$gray-300;
 

--- a/assets/css/typography/_variables.scss
+++ b/assets/css/typography/_variables.scss
@@ -1,7 +1,8 @@
 @use "../color/tokens_2021" as tokens;
+@use "../color/definitions" as semantic;
 
 $font-family-sans-serif: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
-$body-color: $dark;
+$body-color: semantic.$dark;
 
 $headings-font-weight: 600;
 

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -76,7 +76,7 @@ export const DiversionPanel = ({
           <section className="pb-3">
             <h2 className="c-diversion-panel__h2">
               Missed Stops{" "}
-              <Badge bg="missed-stop" className="c-diversion-panel__h3">
+              <Badge bg="missed-stop" className="fs-4">
                 {missedStops.length}
               </Badge>
             </h2>


### PR DESCRIPTION
I know that just `@import`-ing the typography variables might have some fallout even without adding Reboot, but I'm going to do a Chromatic run and just see what happens.