### PR TITLE
refactor: give Bootstrap access to typography variables sans Reboot

### DIFF
--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -2,6 +2,8 @@
 @use "../color/tokens_2021" as tokens;
 @use "../color/tokens_2024" as new_tokens;
 
+@import "../typography/variables";
+
 $component-active-bg: tokens.$eggplant-700;
 $list-group-border-color: tokens.$gray-300;
 

--- a/assets/css/typography/_variables.scss
+++ b/assets/css/typography/_variables.scss
@@ -1,7 +1,8 @@
 @use "../color/tokens_2021" as tokens;
+@use "../color/definitions" as semantic;
 
 $font-family-sans-serif: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
-$body-color: $dark;
+$body-color: semantic.$dark;
 
 $headings-font-weight: 600;
 

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -75,10 +75,7 @@ export const DiversionPanel = ({
         {missedStops && (
           <section className="pb-3">
             <h2 className="c-diversion-panel__h2">
-              Missed Stops{" "}
-              <Badge bg="missed-stop" className="fs-4">
-                {missedStops.length}
-              </Badge>
+              Missed Stops <Badge bg="missed-stop">{missedStops.length}</Badge>
             </h2>
             <ListGroup as="ul">
               {uniqBy(missedStops, (stop) => stop.id).map((missedStop) => (

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -76,7 +76,7 @@ export const DiversionPanel = ({
           <section className="pb-3">
             <h2 className="c-diversion-panel__h2">
               Missed Stops{" "}
-              <Badge bg="missed-stop" className="c-diversion-panel__h3">
+              <Badge bg="missed-stop" className="fs-4">
                 {missedStops.length}
               </Badge>
             </h2>


### PR DESCRIPTION
#2441 resurrected under a more descriptive branch name.

We don't need to re-add the `h2` class because it's undesired and wasn't doing anything anyway.