### PR TITLE
fix: Remove useless Params

### DIFF
--- a/lib/skate/detours/route_segments.ex
+++ b/lib/skate/detours/route_segments.ex
@@ -3,13 +3,6 @@ defmodule Skate.Detours.RouteSegments do
   Break a route into segments based on `connection_start` and `connection_end` points
   """
 
-  defmodule Params do
-    @moduledoc false
-    @type t :: %__MODULE__{}
-    @enforce_keys [:connection_start, :connection_end, :shape]
-    defstruct [:connection_start, :connection_end, :shape]
-  end
-
   defmodule Result do
     @moduledoc false
     @type t :: %__MODULE__{


### PR DESCRIPTION
Per some [feedback](https://github.com/mbta/skate/pull/2438#discussion_r1507643206) in the PR where this was introduced, I removed the usage of this Params struct, but I forgot to remove the struct itself.