### PR TITLE
Style detour close modal

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -117,7 +117,7 @@ export const DiversionPage = ({
             Are you sure you want to exit detour mode?
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body className="lh-base">
+        <Modal.Body className="lh-base pb-4">
           When you close out of this screen, you will not be able to access the
           details of your detour again. You may want to copy and paste these
           details to another application.

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -117,10 +117,12 @@ export const DiversionPage = ({
             Are you sure you want to exit detour mode?
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body className="lh-base pb-4">
-          When you close out of this screen, you will not be able to access the
-          details of your detour again. You may want to copy and paste these
-          details to another application.
+        <Modal.Body>
+          <p className="lh-base mt-0 mb-3">
+            When you close out of this screen, you will not be able to access
+            the details of your detour again. You may want to copy and paste
+            these details to another application.
+          </p>
         </Modal.Body>
         <Modal.Footer>
           <Button

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -113,9 +113,11 @@ export const DiversionPage = ({
         onHide={() => setShowConfirmCloseModal(false)}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Are you sure you want to exit detour mode?</Modal.Title>
+          <Modal.Title className="fs-3 fw-medium">
+            Are you sure you want to exit detour mode?
+          </Modal.Title>
         </Modal.Header>
-        <Modal.Body>
+        <Modal.Body className="lh-base">
           When you close out of this screen, you will not be able to access the
           details of your detour again. You may want to copy and paste these
           details to another application.


### PR DESCRIPTION
Some of these utility classes may no longer be necessary or make sense when we have Bootstrap, but for now it provides a really close match to the designs.

For the bottom padding of the modal body, design used 2rem. The Bootstrap utility classes for padding don't include an option that 2 * the base spacer size (1rem) by default, see the list [here](https://getbootstrap.com/docs/5.3/utilities/spacing/#sass-maps). I figured that 1.5rem might be a nice compromise without straying too much from Bootstrap defaults and writing our own CSS, but we'll see what design says.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206705505932433