### PR TITLE
chore: Upgrade various workflow actions to get rid of Node 16 deprecation warnings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
@@ -40,7 +40,7 @@ jobs:
           $ASDF_DIR/bin/asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
@@ -29,7 +29,7 @@ jobs:
           $ASDF_DIR/bin/asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -62,9 +62,9 @@ jobs:
           POSTGRES_DB: ${{env.DATABASE_NAME}}
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
@@ -79,7 +79,7 @@ jobs:
           $ASDF_DIR/bin/asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -107,7 +107,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elixir-lcov
           path: cover/
@@ -118,9 +118,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ASDF cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
@@ -135,7 +135,7 @@ jobs:
           $ASDF_DIR/bin/asdf reshim
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get version ids
         id: version-ids
         run: |

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -45,7 +45,7 @@ jobs:
           unzip elixir-lcov.zip
           echo "PR_SHA=$(cat PR_SHA)" >> $GITHUB_ENV
           echo "PR_NUMBER=$(cat PR_NUMBER)" >> $GITHUB_ENV
-      - uses: actions/checkout@v3 # UNTRUSTED CODE - do not run scripts from it
+      - uses: actions/checkout@v4 # UNTRUSTED CODE - do not run scripts from it
         with:
           ref: ${{ env.PR_SHA }}
       - name: Upload coverage artifact and post comment


### PR DESCRIPTION
No ticket.

There's still one deprecation warning in the `mbta/actions/dialyzer` action, but that will involve (I think) upgrading [this](https://github.com/mbta/actions/blob/119bf30dc6bdb9f7fc7264e3814462f397147689/dialyzer/action.yml#L17), which will take a bit more effort, just to make sure we do it right.

[Example of some of the warnings](https://github.com/mbta/skate/actions/runs/8113620719?pr=2451)

<img width="1147" alt="Screenshot 2024-03-01 at 11 29 31 AM" src="https://github.com/mbta/skate/assets/912020/95b45340-d6cd-4861-93b9-40534d84530a">
