### PR TITLE
cleanup: Remove originalShapeClickable

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -42,12 +42,6 @@ interface DetourMapProps {
   waypoints: ShapePoint[]
 
   /**
-   * User signal to show whether the original shape should be
-   * highlighted
-   */
-  originalShapeClickable: boolean
-
-  /**
    * Three partial route-shape segments: before, during, and after the detour
    */
   routeSegments?: RouteSegments
@@ -91,7 +85,6 @@ export const DetourMap = ({
   endPoint,
   waypoints,
 
-  originalShapeClickable,
   onClickOriginalShape,
   onClickMap,
 
@@ -154,7 +147,6 @@ export const DetourMap = ({
               ? ["c-detour_map--original-route-shape__unstarted"]
               : []
           }
-          clickable={originalShapeClickable}
           onClick={(e) => {
             const { position } =
               closestPosition(
@@ -235,7 +227,6 @@ const DetourPointMarker = ({ position }: { position: LatLngLiteral }) => (
 interface OriginalRouteShapeProps extends PropsWithChildren {
   positions: LatLngLiteral[]
   classNames: string[]
-  clickable: boolean
   onClick: (e: LeafletMouseEvent) => void
 }
 
@@ -243,7 +234,6 @@ const OriginalRouteShape = ({
   positions,
   children,
   classNames,
-  clickable,
   onClick,
 }: OriginalRouteShapeProps) => (
   <>
@@ -252,22 +242,20 @@ const OriginalRouteShape = ({
       positions={positions}
       className="c-detour_map--original-route-shape-core"
     />
-    {clickable && (
-      <Polyline
-        positions={positions}
-        weight={16}
-        className={joinClasses([
-          "c-detour_map--original-route-shape",
-          ...classNames,
-        ])}
-        bubblingMouseEvents={false}
-        eventHandlers={{
-          click: onClick,
-        }}
-      >
-        {children}
-      </Polyline>
-    )}
+    <Polyline
+      positions={positions}
+      weight={16}
+      className={joinClasses([
+        "c-detour_map--original-route-shape",
+        ...classNames,
+      ])}
+      bubblingMouseEvents={false}
+      eventHandlers={{
+        click: onClick,
+      }}
+    >
+      {children}
+    </Polyline>
   </>
 )
 

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -29,7 +29,6 @@ export const DiversionPage = ({
     addConnectionPoint,
     addWaypoint,
 
-    canAddPoints,
     startPoint,
     endPoint,
     waypoints,
@@ -101,7 +100,6 @@ export const DiversionPage = ({
             endPoint={endPoint ?? undefined}
             waypoints={waypoints}
             routeSegments={routeSegments}
-            originalShapeClickable={canAddPoints}
             onClickMap={addWaypoint ?? (() => {})}
             onClickOriginalShape={addConnectionPoint ?? (() => {})}
             undoDisabled={canUndo === false}

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -96,7 +96,6 @@ export const useDetour = (routePatternId: RoutePatternId) => {
     }
   }
 
-  const canAddPoints = endPoint === null
   const canUndo = startPoint !== null && state === DetourState.Edit
 
   const undo = () => {
@@ -141,10 +140,6 @@ export const useDetour = (routePatternId: RoutePatternId) => {
     addConnectionPoint:
       state === DetourState.Finished ? undefined : addConnectionPoint,
 
-    /**
-     * Reports whether it's possible to add points to the detour.
-     */
-    canAddPoints,
     /**
      * The starting connection point of the detour.
      */

--- a/assets/tests/components/detours/detourMap.test.tsx
+++ b/assets/tests/components/detours/detourMap.test.tsx
@@ -21,7 +21,6 @@ const DetourMapWithDefaults = (
     endPoint={undefined}
     waypoints={[]}
     undoDisabled={false}
-    originalShapeClickable={true}
     onClickMap={() => {}}
     onClickOriginalShape={() => {}}
     onUndo={() => {}}
@@ -173,10 +172,8 @@ describe("DetourMap", () => {
     expect(undoButton).toBeDisabled()
   })
 
-  test("when `originalShapeClickable` is true, there should be two route shape elements", () => {
-    const { container } = render(
-      <DetourMapWithDefaults originalShapeClickable={true} />
-    )
+  test("when `routeSegments` are absent, there should be two route shape elements", () => {
+    const { container } = render(<DetourMapWithDefaults />)
 
     expect(
       container.querySelector(".c-detour_map--original-route-shape-core")
@@ -184,27 +181,11 @@ describe("DetourMap", () => {
     expect(
       container.querySelector(".c-detour_map--original-route-shape")
     ).toBeInTheDocument()
-  })
-
-  test("when `originalShapeClickable` is false, there should be only be one (non-clickable) route shape element", () => {
-    const { container } = render(
-      <DetourMapWithDefaults originalShapeClickable={false} />
-    )
-
-    expect(
-      container.querySelector(".c-detour_map--original-route-shape-core")
-    ).toBeInTheDocument()
-    expect(
-      container.querySelector(".c-detour_map--original-route-shape")
-    ).not.toBeInTheDocument()
   })
 
   test("when `routeSegments` are present, there should be two core original route shapes and one diverted route shape", () => {
     const { container } = render(
-      <DetourMapWithDefaults
-        originalShapeClickable={false}
-        routeSegments={routeSegmentsFactory.build()}
-      />
+      <DetourMapWithDefaults routeSegments={routeSegmentsFactory.build()} />
     )
 
     expect(

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -280,36 +280,6 @@ describe("useDetour", () => {
     expect(result.current.canUndo).toBe(true)
   })
 
-  test("when `startPoint` is null, `canAddPoints` is `true`", async () => {
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
-
-    expect(result.current.startPoint).toBeNull()
-    expect(result.current.canAddPoints).toBe(true)
-  })
-
-  test("when `startPoint` is set, `canAddPoints` is `true`", async () => {
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
-
-    act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
-
-    expect(result.current.startPoint).not.toBeNull()
-    expect(result.current.canAddPoints).toBe(true)
-  })
-
-  test("when `endPoint` is set, `canAddPoints` is `false`", async () => {
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
-
-    act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
-    act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
-
-    await waitFor(() => {
-      expect(result.current.missedStops).not.toBeUndefined()
-    })
-
-    expect(result.current.endPoint).not.toBeNull()
-    expect(result.current.canAddPoints).toBe(false)
-  })
-
   test("when `endPoint` is set, `missedStops` is filled in", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 


### PR DESCRIPTION
With the addition of DivertedRouteShape, OriginalRouteShape will always be clickable (since when it's not, we'll use DiveredRouteShape instead), so we no longer need a boolean to tell us to make it clickable.