### PR TITLE
feat(ts/components/diversionPage): add share screen text stub

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
   "rules": {
     "no-console": "error",
     "prefer-rest-params": "off",
+    "no-sparse-arrays": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-unused-vars": [

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -2,6 +2,7 @@ import React, {
   ComponentProps,
   ComponentPropsWithoutRef,
   PropsWithChildren,
+  useEffect,
   useState,
 } from "react"
 import { DiversionPanel } from "./diversionPanel"
@@ -48,6 +49,24 @@ export const DiversionPage = ({
   } = useDetour(originalRoute.routePatternId)
 
   const [textArea, setTextArea] = useState("")
+
+  useEffect(() => {
+    setTextArea(
+      [
+        "Detour:",
+        `${originalRoute.routeName} ${originalRoute.routeDescription} from`,
+        originalRoute.routeOrigin,
+        originalRoute.routeDirection,
+        ,
+        "Turn-by-Turn Directions:",
+        ...(directions?.map((v) => v.instruction) ?? []),
+        ,
+        `Missed Stops (${missedStops?.length}):`,
+        ...(missedStops?.map(({ name }) => name) ?? ["no stops"]),
+      ].join("\n")
+    )
+  }, [originalRoute, directions, missedStops])
+
   const [showConfirmCloseModal, setShowConfirmCloseModal] =
     useState<boolean>(false)
 


### PR DESCRIPTION
This gets the information we have into the text box on the share screen. This does not include connection points as that information is only available in the backend right now, I'm intending to open another PR which adds connection points to the API and adds it to this text.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206710026837345