### PR TITLE
feat: add jest linter

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     "@typescript-eslint",
     "react",
     "jsx-a11y",
+    "jest"
   ],
   extends: [
     "eslint:recommended",
@@ -13,7 +14,8 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
     "prettier",
-    "plugin:storybook/recommended"
+    "plugin:storybook/recommended",
+    "plugin:jest/recommended"
   ],
   "settings": {
     "react": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -64,6 +64,7 @@
         "css-minimizer-webpack-plugin": "^5.0.1",
         "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -10958,6 +10959,131 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -82,6 +82,7 @@
     "css-minimizer-webpack-plugin": "^5.0.1",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -76,58 +76,54 @@ describe("apiCall", () => {
     browserReloadSpy.mockRestore()
   })
 
-  test("returns parsed data", (done) => {
+  test("returns parsed data", () => {
     mockFetch(200, { data: "raw" })
 
     const parse = jest.fn(() => "parsed")
 
-    apiCall({
+    return apiCall({
       url: "/",
       parser: parse,
       defaultResult: "default",
     }).then((parsed) => {
       expect(parse).toHaveBeenCalledWith("raw")
       expect(parsed).toEqual("parsed")
-      done()
     })
   })
 
-  test("reloads the page if the response status is a redirect (3xx)", (done) => {
+  test("reloads the page if the response status is a redirect (3xx)", () => {
     mockFetch(302, { data: null })
 
-    apiCall({
+    return apiCall({
       url: "/",
       parser: () => null,
       defaultResult: "default",
     }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
-      done()
     })
   })
 
-  test("reloads the page if the response status is forbidden (403)", (done) => {
+  test("reloads the page if the response status is forbidden (403)", () => {
     mockFetch(403, { data: null })
 
-    apiCall({
+    return apiCall({
       url: "/",
       parser: () => null,
       defaultResult: "default",
     }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
-      done()
     })
   })
 
-  test("returns a default for any other response", (done) => {
+  test("returns a default for any other response", () => {
     mockFetch(500, { data: null })
 
-    apiCall({
+    return apiCall({
       url: "/",
       parser: () => null,
       defaultResult: "default",
     }).then((result) => {
       expect(result).toEqual("default")
-      done()
     })
   })
 })
@@ -145,12 +141,12 @@ describe("checkedApiCall", () => {
     browserReloadSpy.mockRestore()
   })
 
-  test("returns parsed data", (done) => {
+  test("returns parsed data", () => {
     mockFetch(200, { data: "raw" })
 
     const parse = jest.fn(() => "parsed")
 
-    checkedApiCall({
+    return checkedApiCall({
       url: "/",
       dataStruct: string(),
       parser: parse,
@@ -158,7 +154,6 @@ describe("checkedApiCall", () => {
     }).then((parsed) => {
       expect(parse).toHaveBeenCalledWith("raw")
       expect(parsed).toEqual("parsed")
-      done()
     })
   })
 
@@ -190,51 +185,48 @@ describe("checkedApiCall", () => {
     }).then((result) => expect(result).toBeNull())
   })
 
-  test("reloads the page if the response status is a redirect (3xx)", (done) => {
+  test("reloads the page if the response status is a redirect (3xx)", () => {
     mockFetch(302, { data: null })
 
-    checkedApiCall({
+    return checkedApiCall({
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
       defaultResult: "default",
     }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
-      done()
     })
   })
 
-  test("reloads the page if the response status is forbidden (403)", (done) => {
+  test("reloads the page if the response status is forbidden (403)", () => {
     mockFetch(403, { data: null })
 
-    checkedApiCall({
+    return checkedApiCall({
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
       defaultResult: "default",
     }).then(() => {
       expect(browser.reload).toHaveBeenCalled()
-      done()
     })
   })
 
-  test("returns a default for any other response", (done) => {
+  test("returns a default for any other response", () => {
     mockFetch(500, { data: null })
 
-    checkedApiCall({
+    return checkedApiCall({
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
       defaultResult: "default",
     }).then((result) => {
       expect(result).toEqual("default")
-      done()
     })
   })
 })
 
 describe("fetchRoutes", () => {
-  test("fetches a list of routes", (done) => {
+  test("fetches a list of routes", () => {
     mockFetch(200, {
       data: [
         {
@@ -264,7 +256,7 @@ describe("fetchRoutes", () => {
       ],
     })
 
-    fetchRoutes().then((routes) => {
+    return fetchRoutes().then((routes) => {
       expect(routes).toEqual([
         routeFactory.build({
           id: "28",
@@ -282,13 +274,12 @@ describe("fetchRoutes", () => {
           name: undefined,
         }),
       ])
-      done()
     })
   })
 })
 
 describe("fetchRoutePatterns", () => {
-  test("fetches route patterns for route", (done) => {
+  test("fetches route patterns for route", () => {
     mockFetch(200, {
       data: [
         {
@@ -314,7 +305,7 @@ describe("fetchRoutePatterns", () => {
       ],
     })
 
-    fetchRoutePatterns("66").then((routePatterns) => {
+    return fetchRoutePatterns("66").then((routePatterns) => {
       expect(routePatterns).toEqual([
         {
           id: "rp1",
@@ -335,13 +326,12 @@ describe("fetchRoutePatterns", () => {
           headsign: "Headsign",
         },
       ])
-      done()
     })
   })
 })
 
 describe("fetchShapeForRoute", () => {
-  test("fetches a shape for the route", (done) => {
+  test("fetches a shape for the route", () => {
     const shapeData = [
       {
         id: "shape1",
@@ -390,24 +380,22 @@ describe("fetchShapeForRoute", () => {
 
     mockFetch(200, { data: shapeData })
 
-    fetchShapeForRoute("28").then((response) => {
+    return fetchShapeForRoute("28").then((response) => {
       expect(response).toEqual(shapes)
-      done()
     })
   })
 
-  test("defaults to [] if there's an error", (done) => {
+  test("defaults to [] if there's an error", () => {
     mockFetch(500, { data: null })
 
-    fetchShapeForRoute("28").then((result) => {
+    return fetchShapeForRoute("28").then((result) => {
       expect(result).toEqual([])
-      done()
     })
   })
 })
 
 describe("fetchFinishedDetour", () => {
-  test("fetches missed stops in finished detour", (done) => {
+  test("fetches missed stops in finished detour", () => {
     const stopData = stopDataFactory.buildList(3)
 
     const stops = stopsFromData(stopData)
@@ -427,7 +415,7 @@ describe("fetchFinishedDetour", () => {
       },
     })
 
-    fetchFinishedDetour(
+    return fetchFinishedDetour(
       "route_pattern_id",
       shapePointFactory.build(),
       shapePointFactory.build()
@@ -440,26 +428,24 @@ describe("fetchFinishedDetour", () => {
           afterDetour,
         },
       })
-      done()
     })
   })
 
-  test("defaults to null if there's an error", (done) => {
+  test("defaults to null if there's an error", () => {
     mockFetch(500, { data: null })
 
-    fetchFinishedDetour(
+    return fetchFinishedDetour(
       "route_pattern_id",
       shapePointFactory.build(),
       shapePointFactory.build()
     ).then((result) => {
       expect(result).toBeNull()
-      done()
     })
   })
 })
 
 describe("fetchShapeForTrip", () => {
-  test("fetches a shape for the trip", (done) => {
+  test("fetches a shape for the trip", () => {
     const shapeData = {
       id: "shape",
       points: [
@@ -484,24 +470,22 @@ describe("fetchShapeForTrip", () => {
 
     mockFetch(200, { data: shapeData })
 
-    fetchShapeForTrip("trip").then((response) => {
+    return fetchShapeForTrip("trip").then((response) => {
       expect(response).toEqual(shape)
-      done()
     })
   })
 
-  test("defaults to null if there's an error", (done) => {
+  test("defaults to null if there's an error", () => {
     mockFetch(500, { data: null })
 
-    fetchShapeForTrip("28").then((result) => {
+    return fetchShapeForTrip("28").then((result) => {
       expect(result).toEqual(null)
-      done()
     })
   })
 })
 
 describe("fetchShuttleRoutes", () => {
-  test("fetches a list of shuttle routes", (done) => {
+  test("fetches a list of shuttle routes", () => {
     mockFetch(200, {
       data: [
         {
@@ -528,7 +512,7 @@ describe("fetchShuttleRoutes", () => {
       ],
     })
 
-    fetchShuttleRoutes().then((routes) => {
+    return fetchShuttleRoutes().then((routes) => {
       expect(routes).toEqual([
         {
           directionNames: {
@@ -552,13 +536,12 @@ describe("fetchShuttleRoutes", () => {
           id: "71",
         },
       ])
-      done()
     })
   })
 })
 
 describe("fetchStations", () => {
-  test("fetches a list stations", (done) => {
+  test("fetches a list stations", () => {
     const [station1, station2] = stopFactory.buildList(2, {
       locationType: LocationType.Station,
       vehicleType: null,
@@ -584,26 +567,24 @@ describe("fetchStations", () => {
       ],
     })
 
-    fetchStations().then((stations) => {
+    return fetchStations().then((stations) => {
       expect(stations).toEqual([station1, station2])
-      done()
     })
   })
 
-  test("returns empty list on error", (done) => {
+  test("returns empty list on error", () => {
     mockFetch(500, {
       data: null,
     })
 
-    fetchStations().then((stations) => {
+    return fetchStations().then((stations) => {
       expect(stations).toEqual([])
-      done()
     })
   })
 })
 
 describe("fetchAllStops", () => {
-  test("fetches a list of stops", (done) => {
+  test("fetches a list of stops", () => {
     const route1 = routeFactory.build()
     const [station1, stop1] = [
       stopFactory.build({
@@ -644,46 +625,42 @@ describe("fetchAllStops", () => {
       ],
     })
 
-    fetchAllStops().then((stops) => {
+    return fetchAllStops().then((stops) => {
       expect(stops).toEqual([station1, stop1])
-      done()
     })
   })
 
-  test("returns empty list on error", (done) => {
+  test("returns empty list on error", () => {
     mockFetch(500, {
       data: null,
     })
 
-    fetchStations().then((stations) => {
+    return fetchStations().then((stations) => {
       expect(stations).toEqual([])
-      done()
     })
   })
 })
 
 describe("fetchTimepointsForRoute", () => {
-  test("fetches a list of timepoints for a route", (done) => {
+  test("fetches a list of timepoints for a route", () => {
     mockFetch(200, { data: ["MATPN", "WELLH", "MORTN"] })
 
-    fetchTimepointsForRoute("28").then((timepoints) => {
+    return fetchTimepointsForRoute("28").then((timepoints) => {
       expect(timepoints).toEqual(["MATPN", "WELLH", "MORTN"])
-      done()
     })
   })
 
-  test("defaults to [] if there's an error", (done) => {
+  test("defaults to [] if there's an error", () => {
     mockFetch(500, { data: null })
 
-    fetchTimepointsForRoute("28").then((result) => {
+    return fetchTimepointsForRoute("28").then((result) => {
       expect(result).toEqual([])
-      done()
     })
   })
 })
 
 describe("fetchScheduleRun", () => {
-  test("fetches a run with a break", (done) => {
+  test("fetches a run with a break", () => {
     mockFetch(200, {
       data: {
         id: "run",
@@ -697,7 +674,7 @@ describe("fetchScheduleRun", () => {
       },
     })
 
-    fetchScheduleRun("trip", "run").then((result) => {
+    return fetchScheduleRun("trip", "run").then((result) => {
       expect(result).toEqual({
         id: "run",
         activities: [
@@ -708,21 +685,19 @@ describe("fetchScheduleRun", () => {
           },
         ],
       })
-      done()
     })
   })
 
-  test("can return null", (done) => {
+  test("can return null", () => {
     mockFetch(200, { data: null })
-    fetchScheduleRun("trip", "run").then((result) => {
+    return fetchScheduleRun("trip", "run").then((result) => {
       expect(result).toEqual(null)
-      done()
     })
   })
 })
 
 describe("fetchScheduleBlock", () => {
-  test("fetches a block with a piece", (done) => {
+  test("fetches a block with a piece", () => {
     mockFetch(200, {
       data: {
         id: "block",
@@ -761,7 +736,7 @@ describe("fetchScheduleBlock", () => {
       },
     })
 
-    fetchScheduleBlock("trip").then((result) => {
+    return fetchScheduleBlock("trip").then((result) => {
       expect(result).toEqual({
         id: "block",
         pieces: [
@@ -797,45 +772,41 @@ describe("fetchScheduleBlock", () => {
           },
         ],
       })
-      done()
     })
   })
 
-  test("can return null", (done) => {
+  test("can return null", () => {
     mockFetch(200, { data: null })
-    fetchScheduleBlock("trip").then((result) => {
+    return fetchScheduleBlock("trip").then((result) => {
       expect(result).toEqual(null)
-      done()
     })
   })
 })
 
 describe("fetchNearestIntersection", () => {
-  test("parses an intersection name", (done) => {
+  test("parses an intersection name", () => {
     mockFetch(200, {
       data: "Broadway & 7th Ave",
     })
 
-    fetchNearestIntersection(0, 0).then((intersection) => {
+    return fetchNearestIntersection(0, 0).then((intersection) => {
       expect(intersection).toEqual("Broadway & 7th Ave")
-      done()
     })
   })
 
-  test("handles a missing intersection", (done) => {
+  test("handles a missing intersection", () => {
     mockFetch(200, {
       data: null,
     })
 
-    fetchNearestIntersection(0, 0).then((intersection) => {
+    return fetchNearestIntersection(0, 0).then((intersection) => {
       expect(intersection).toEqual(null)
-      done()
     })
   })
 })
 
 describe("fetchSwings", () => {
-  test("parses swings", (done) => {
+  test("parses swings", () => {
     const swing = {
       block_id: "B1",
       from_route_id: "1",
@@ -851,7 +822,7 @@ describe("fetchSwings", () => {
       data: [swing],
     })
 
-    fetchSwings(["1"]).then((swings) => {
+    return fetchSwings(["1"]).then((swings) => {
       expect(swings).toEqual([
         {
           blockId: "B1",
@@ -864,13 +835,12 @@ describe("fetchSwings", () => {
           time: 100,
         },
       ])
-      done()
     })
   })
 })
 
 describe("fetchLocationSearchResults", () => {
-  test("parses location search results", (done) => {
+  test("parses location search results", () => {
     const result = locationSearchResultDataFactory.build({
       name: "Some Landmark",
       address: "123 Test St",
@@ -882,7 +852,7 @@ describe("fetchLocationSearchResults", () => {
       data: [result],
     })
 
-    fetchLocationSearchResults("query").then((results) => {
+    return fetchLocationSearchResults("query").then((results) => {
       expect(results).toEqual([
         locationSearchResultFactory.build({
           name: "Some Landmark",
@@ -891,13 +861,12 @@ describe("fetchLocationSearchResults", () => {
           longitude: 2,
         }),
       ])
-      done()
     })
   })
 })
 
 describe("fetchLocationSearchResultById", () => {
-  test("parses location returned", (done) => {
+  test("parses location returned", () => {
     const result = locationSearchResultDataFactory.build({
       name: "Some Landmark",
       address: "123 Test St",
@@ -909,7 +878,7 @@ describe("fetchLocationSearchResultById", () => {
       data: result,
     })
 
-    fetchLocationSearchResultById("query").then((results) => {
+    return fetchLocationSearchResultById("query").then((results) => {
       expect(results).toEqual(
         locationSearchResultFactory.build({
           name: "Some Landmark",
@@ -918,13 +887,12 @@ describe("fetchLocationSearchResultById", () => {
           longitude: 2,
         })
       )
-      done()
     })
   })
 })
 
 describe("fetchLocationSearchSuggestions", () => {
-  test("parses location search suggestions", (done) => {
+  test("parses location search suggestions", () => {
     const result = locationSearchSuggestionDataFactory.build({
       text: "Some Landmark",
       place_id: "test-place",
@@ -934,14 +902,13 @@ describe("fetchLocationSearchSuggestions", () => {
       data: [result],
     })
 
-    fetchLocationSearchSuggestions("query").then((result) => {
+    return fetchLocationSearchSuggestions("query").then((result) => {
       expect(result).toEqual([
         locationSearchSuggestionFactory.build({
           text: "Some Landmark",
           placeId: "test-place",
         }),
       ])
-      done()
     })
   })
 })

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -122,7 +122,7 @@ describe("App", () => {
         ;(useVehicles as jest.Mock).mockReset()
       })
 
-      test("VPP ", () => {
+      test("VPP", () => {
         mockUsePanelState({
           currentView: {
             selectedVehicleOrGhost: vehicle,

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -269,7 +269,7 @@ describe("LadderPage", () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       promptToSaveOrCreatePreset(mockState.routeTabs[1])
     )
-    expect(mockedFSEvent).toBeCalledWith(
+    expect(mockedFSEvent).toHaveBeenCalledWith(
       'User clicked Route Tab "Save" Button',
       {}
     )
@@ -324,7 +324,7 @@ describe("LadderPage", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(createRouteTab())
     expect(tagManagerEvent).toHaveBeenCalledWith("new_tab_added")
-    expect(mockedFSEvent).toBeCalledWith(
+    expect(mockedFSEvent).toHaveBeenCalledWith(
       "User added a new Route Ladder Tab",
       {}
     )

--- a/assets/tests/components/lateView.test.tsx
+++ b/assets/tests/components/lateView.test.tsx
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectIndeterminateValue", "expectCheckedValue"] }] */
 import { jest, describe, test, expect, afterEach } from "@jest/globals"
 import React from "react"
 import renderer from "react-test-renderer"

--- a/assets/tests/components/map.test.tsx
+++ b/assets/tests/components/map.test.tsx
@@ -452,7 +452,7 @@ describe("<MapFollowingPrimaryVehicles />", () => {
     ).not.toBeInTheDocument()
   })
 
-  test("sets selected vehicle id as selected ", () => {
+  test("sets selected vehicle id as selected", () => {
     const vehicle = vehicleFactory.build()
 
     const { container } = render(

--- a/assets/tests/components/mapMarkers.test.tsx
+++ b/assets/tests/components/mapMarkers.test.tsx
@@ -126,7 +126,7 @@ describe("StationMarker", () => {
 })
 
 describe("StopMarkers", () => {
-  test("When zoom = 14, renders no markers ", () => {
+  test("When zoom = 14, renders no markers", () => {
     const { container } = renderInMap(
       <StopMarkers stops={[stop, station]} zoomLevel={14} />
     )

--- a/assets/tests/components/mapPage/vehiclePropertiesCard.test.tsx
+++ b/assets/tests/components/mapPage/vehiclePropertiesCard.test.tsx
@@ -81,7 +81,7 @@ describe("<VehiclePropertiesCard/>", () => {
         screen.getByRole("button", { name: "Route Variant Name" })
       )
 
-      expect(event).toBeCalledTimes(1)
+      expect(event).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -250,11 +250,13 @@ describe("NotificationCard", () => {
       await user.click(result.getByText(/run1/))
 
       if (should_fire_fs_event) {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockedFSEvent).toHaveBeenCalledWith(
           "User clicked Chelsea Bridge Notification",
           {}
         )
       } else {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockedFSEvent).not.toHaveBeenCalledWith(
           "User clicked Chelsea Bridge Notification",
           {}

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -213,26 +213,9 @@ describe("vehicleProperties", () => {
   })
 
   test("operator information gives last name if that's all that's available", () => {
-    const vehicleSansOperator = {
-      ...vehicle,
-      operatorId: "1234",
-      operatorFirstName: null,
-      operatorLastName: "SMITH",
-    } as unknown
-
-    const properties = vehicleProperties(
-      vehicleSansOperator as VehicleInScheduledService
-    )
-
-    expect(properties.find((prop) => prop.label === "Operator")!.value).toEqual(
-      "SMITH #1234"
-    )
-  })
-
-  test("operator information gives last name if that's all that's available", () => {
     const properties = vehicleProperties(
       vehicleFactory.build({
-        operatorFirstName: "JOHN",
+        operatorFirstName: null,
         operatorLastName: "SMITH",
         operatorId: "1234",
       }),

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -213,9 +213,26 @@ describe("vehicleProperties", () => {
   })
 
   test("operator information gives last name if that's all that's available", () => {
+    const vehicleSansOperator = {
+      ...vehicle,
+      operatorId: "1234",
+      operatorFirstName: null,
+      operatorLastName: "SMITH",
+    } as unknown
+
+    const properties = vehicleProperties(
+      vehicleSansOperator as VehicleInScheduledService
+    )
+
+    expect(properties.find((prop) => prop.label === "Operator")!.value).toEqual(
+      "SMITH #1234"
+    )
+  })
+
+  test("operator information gives last name if that's all that's available", () => {
     const properties = vehicleProperties(
       vehicleFactory.build({
-        operatorFirstName: null,
+        operatorFirstName: "JOHN",
         operatorLastName: "SMITH",
         operatorId: "1234",
       }),

--- a/assets/tests/components/propertiesList.test.tsx
+++ b/assets/tests/components/propertiesList.test.tsx
@@ -229,7 +229,7 @@ describe("vehicleProperties", () => {
     )
   })
 
-  test("operator information gives last name if that's all that's available", () => {
+  test("only includes operator last name when `operatorLastNameOnly` is set", () => {
     const properties = vehicleProperties(
       vehicleFactory.build({
         operatorFirstName: "JOHN",

--- a/assets/tests/hooks/useAppcues.test.tsx
+++ b/assets/tests/hooks/useAppcues.test.tsx
@@ -2,9 +2,6 @@ import { jest, describe, test, expect, afterEach } from "@jest/globals"
 import { renderHook } from "@testing-library/react"
 import useAppcues, { cleanUsername } from "../../src/hooks/useAppcues"
 
-// Indicate that the file is a module so we can declare global
-export {}
-
 declare global {
   interface Window {
     Appcues?: {

--- a/assets/tests/hooks/useNearestIntersection.test.ts
+++ b/assets/tests/hooks/useNearestIntersection.test.ts
@@ -69,7 +69,7 @@ function CoordinateIntersectionMap(
   }
 }
 
-export const MockIntersectionWithCoordinateIntersectionMap = (
+const MockIntersectionWithCoordinateIntersectionMap = (
   numberOfEntries = 1,
   errorValue: any = null
 ) => {

--- a/assets/tests/hooks/useNearestIntersection.test.ts
+++ b/assets/tests/hooks/useNearestIntersection.test.ts
@@ -148,7 +148,7 @@ describe("useNearestIntersection", () => {
       rerender(latLng2)
 
       expect(result.current).toEqual(LoadingOk(intersection1))
-      expect(fetchFn).toBeCalledWith(latLng2.latitude, latLng2.longitude)
+      expect(fetchFn).toHaveBeenCalledWith(latLng2.latitude, latLng2.longitude)
 
       await waitFor(async () =>
         expect(result.current).toEqual(Ok(intersection2))

--- a/assets/tests/hooks/useNearestIntersection.test.ts
+++ b/assets/tests/hooks/useNearestIntersection.test.ts
@@ -163,7 +163,7 @@ describe("useNearestIntersection", () => {
         localGeoCoordinateFactory.build()
       )
 
-      expect(mockNearestIntersection).toBeCalledTimes(1)
+      expect(mockNearestIntersection).toHaveBeenCalledTimes(1)
 
       rerender(localGeoCoordinateFactory.build())
 

--- a/assets/tests/hooks/useNotifications.test.tsx
+++ b/assets/tests/hooks/useNotifications.test.tsx
@@ -89,7 +89,7 @@ describe("useNotifications", () => {
     })
   })
 
-  test("parses initial notification message", () => {
+  test("parses notification message", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel()
     mockChannel.on.mockImplementation((event, handler) => {

--- a/assets/tests/hooks/useNotificationsReducer.test.tsx
+++ b/assets/tests/hooks/useNotificationsReducer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectPut"] }] */
 import { jest, describe, test, expect } from "@jest/globals"
 import React from "react"
 import { act, renderHook } from "@testing-library/react"

--- a/assets/tests/hooks/useScreenSize.test.ts
+++ b/assets/tests/hooks/useScreenSize.test.ts
@@ -37,7 +37,7 @@ const mockWindowWidth = (value: number) =>
   jest.spyOn(window, "innerWidth", "get").mockReturnValue(value)
 
 describe("useScreenSize", () => {
-  test.only.each([
+  test.each([
     { screenWidth: 0, deviceType: "mobile" },
     { screenWidth: 480, deviceType: "mobile" },
     { screenWidth: 481, deviceType: "mobile_landscape_tablet_portrait" },

--- a/assets/tests/hooks/useVehicleForNotification.test.tsx
+++ b/assets/tests/hooks/useVehicleForNotification.test.tsx
@@ -89,7 +89,7 @@ describe("useVehicleForNotification", () => {
     expect(result.current).toEqual(ghostFromData(ghostData))
 
     expect(tagManagerEvent).toHaveBeenCalledWith("notification_linked_to_vpp")
-    expect(mockedFSEvent).toBeCalledWith(
+    expect(mockedFSEvent).toHaveBeenCalledWith(
       "User clicked Notification and linked to VPP",
       {}
     )
@@ -143,7 +143,7 @@ describe("useVehicleForNotification", () => {
     expect(tagManagerEvent).toHaveBeenCalledWith(
       "notification_linked_to_inactive_modal"
     )
-    expect(mockedFSEvent).toBeCalledWith(
+    expect(mockedFSEvent).toHaveBeenCalledWith(
       "User clicked Notification and linked to Inactive Modal",
       {}
     )
@@ -171,7 +171,7 @@ describe("useVehicleForNotification", () => {
     expect(tagManagerEvent).toHaveBeenCalledWith(
       "notification_linked_to_inactive_modal"
     )
-    expect(mockedFSEvent).toBeCalledWith(
+    expect(mockedFSEvent).toHaveBeenCalledWith(
       "User clicked Notification and linked to Inactive Modal",
       {}
     )

--- a/assets/tests/mapLimits.test.ts
+++ b/assets/tests/mapLimits.test.ts
@@ -40,7 +40,7 @@ describe("getMapLimits", () => {
       ;(appData as jest.Mock).mockImplementationOnce(() => ({
         mapLimits: mockTestGroupData,
       }))
-      expect(() => getMapLimits()).toThrowError(expectedError)
+      expect(() => getMapLimits()).toThrow(expectedError)
     }
   )
 })

--- a/assets/tests/models/vehicleStatus.test.ts
+++ b/assets/tests/models/vehicleStatus.test.ts
@@ -120,15 +120,17 @@ describe("statusClasses", () => {
     ).toEqual(["logged-out"])
   })
 
-  test("other statuses have a class", () => {
-    expect(
-      statusClasses("off-course", defaultUserSettings.vehicleAdherenceColors)
-    ).toEqual(["off-course", "early-red"])
-  })
+  describe("other statuses have a class", () => {
+    test("early-red by default", () => {
+      expect(
+        statusClasses("off-course", defaultUserSettings.vehicleAdherenceColors)
+      ).toEqual(["off-course", "early-red"])
+    })
 
-  test("other statuses have a class", () => {
-    expect(
-      statusClasses("off-course", VehicleAdherenceColorsSetting.EarlyBlue)
-    ).toEqual(["off-course", "early-blue"])
+    test("early-blue if user setting is `EarlyBlue`", () => {
+      expect(
+        statusClasses("off-course", VehicleAdherenceColorsSetting.EarlyBlue)
+      ).toEqual(["off-course", "early-blue"])
+    })
   })
 })

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -42,5 +42,6 @@ document.createElementNS = function (namespaceURI, qualifiedName) {
 }
 
 beforeEach(() => {
+  // eslint-disable-next-line jest/no-standalone-expect
   expect.hasAssertions()
 })

--- a/assets/tests/state.test.ts
+++ b/assets/tests/state.test.ts
@@ -854,6 +854,7 @@ describe("reducer", () => {
     switch (newState.openInputModal?.type) {
       case "CREATE_PRESET":
         newState.openInputModal.createCallback("Preset name", mockDispatch)
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.createPreset(routeTab.uuid, "Preset name")
         )
@@ -862,6 +863,7 @@ describe("reducer", () => {
           "uuid",
           mockDispatch
         )
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.promptToOverwritePreset("Preset name", routeTab, "uuid")
         )
@@ -886,7 +888,9 @@ describe("reducer", () => {
     switch (newState.openInputModal?.type) {
       case "SAVE_PRESET":
         newState.openInputModal.saveCallback(mockDispatch)
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(newState.openInputModal.presetName).toBe("My preset")
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.savePreset(routeTab.uuid)
         )
@@ -921,7 +925,9 @@ describe("reducer", () => {
     switch (newState.openInputModal?.type) {
       case "DELETE_PRESET":
         newState.openInputModal.deleteCallback(mockDispatch)
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(newState.openInputModal.presetName).toBe("My preset")
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.deletePreset(routeTab.uuid)
         )
@@ -943,10 +949,13 @@ describe("reducer", () => {
     switch (newState.openInputModal?.type) {
       case "OVERWRITE_PRESET":
         newState.openInputModal.confirmCallback(mockDispatch)
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(newState.openInputModal.presetName).toBe("My Preset")
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.deletePreset(routeTab.uuid)
         )
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(mockDispatch).toHaveBeenCalledWith(
           State.createPreset(routeTab.uuid, "My Preset")
         )

--- a/assets/tests/state/pagePanelState.test.ts
+++ b/assets/tests/state/pagePanelState.test.ts
@@ -98,7 +98,7 @@ test("openPreviousView returns to the previous view, deselects vehicle", () => {
   )
 
   expect(state.state[state.currentPath].openView).toBe(previousView)
-  expect(state.state[state.currentPath].selectedVehicleOrGhost).toBeUndefined
+  expect(state.state[state.currentPath].selectedVehicleOrGhost).toBeUndefined()
 })
 
 describe("closeView", () => {

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -8,6 +8,7 @@ export const originalRouteShape = {
     const maybeShape = container.querySelector(
       ".c-detour_map--original-route-shape"
     )
+    /* eslint-disable-next-line jest/no-standalone-expect */
     expect(maybeShape).not.toBeNull()
     return maybeShape as Element
   },

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -8,7 +8,7 @@ export const originalRouteShape = {
     const maybeShape = container.querySelector(
       ".c-detour_map--original-route-shape"
     )
-    /* eslint-disable-next-line jest/no-standalone-expect */
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(maybeShape).not.toBeNull()
     return maybeShape as Element
   },

--- a/assets/tests/userTestGroups.test.ts
+++ b/assets/tests/userTestGroups.test.ts
@@ -41,7 +41,7 @@ describe("getTestGroups", () => {
       ;(appData as jest.Mock).mockImplementationOnce(() => ({
         userTestGroups: mockTestGroupData,
       }))
-      expect(() => getTestGroups()).toThrowError(expectedError)
+      expect(() => getTestGroups()).toThrow(expectedError)
     }
   )
 })

--- a/assets/tests/util/operatorFormatting.test.ts
+++ b/assets/tests/util/operatorFormatting.test.ts
@@ -35,13 +35,6 @@ describe("formatOperatorName", () => {
     expect(formatOperatorName(first, last, id)).toBe(`${first} ${last}`)
   })
 
-  test("when given null id, should return formatted operator name without that field", () => {
-    const first = "FirstName"
-    const last = "LastName"
-    const id = null
-    expect(formatOperatorName(first, last, id)).toBe(`${first} ${last}`)
-  })
-
   test("when all inputs are null and there is no fallback parameter, should return default fallback string", () => {
     expect(formatOperatorName(null, null, null)).toBe(defaultFallbackString)
   })


### PR DESCRIPTION
I almost committed a `test.only` in #2463 and was surprised that the linter didn't prevent me from doing so. Commits should be reviewable in order and auditable via `npm run lint:check` at each point in time