### PR TITLE
feat: map button components

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -62,6 +62,7 @@ $vpp-location-padding: 1rem;
 @import "map_page";
 @import "map/tooltip";
 @import "map/controls/layers_control";
+@import "map/controls/map_button";
 @import "map/controls/recenter_control";
 @import "map/controls/street_view_switch";
 @import "map/controls/user_location_control";

--- a/assets/css/map/controls/_map_button.scss
+++ b/assets/css/map/controls/_map_button.scss
@@ -1,0 +1,30 @@
+@use "../../color/tokens_2024" as tokens;
+
+.c-map-button {
+  box-shadow: 0 0 0 2px rgb($black, 0.15);
+  --bs-btn-border-radius: 0.2rem;
+  --bs-btn-color: #{$black};
+  --bs-btn-hover-color: #{$black};
+  --bs-btn-hover-bg: #{tokens.$eggplant-50};
+  --bs-btn-active-color: #{tokens.$eggplant-500};
+  --bs-btn-active-bg: #{$white};
+  --bs-btn-focus-box-shadow: 0 0 0 2px #{rgb(tokens.$eggplant-500, 0.5)};
+  --bs-btn-disabled-color: #{tokens.$gray-700};
+  --bs-btn-disabled-bg: #{tokens.$gray-100};
+  --bs-btn-disabled-opacity: 1;
+}
+
+.c-map-button--s {
+  width: 2rem;
+  height: 2rem;
+}
+
+.c-map-button--m {
+  width: 2.375rem;
+  height: 2.375rem;
+}
+
+.c-map-button--l {
+  width: 3rem;
+  height: 3rem;
+}

--- a/assets/css/map/controls/_map_button.scss
+++ b/assets/css/map/controls/_map_button.scss
@@ -4,6 +4,7 @@
   box-shadow: 0 0 0 2px rgb($black, 0.15);
   --bs-btn-border-radius: 0.2rem;
   --bs-btn-color: #{$black};
+  --bs-btn-bg: #{$white};
   --bs-btn-hover-color: #{$black};
   --bs-btn-hover-bg: #{tokens.$eggplant-50};
   --bs-btn-active-color: #{tokens.$eggplant-500};

--- a/assets/css/map/controls/_map_button.scss
+++ b/assets/css/map/controls/_map_button.scss
@@ -2,6 +2,7 @@
 
 .c-map-button {
   box-shadow: 0 0 0 2px rgb($black, 0.15);
+  --bs-btn-font-size: 0.625rem;
   --bs-btn-border-radius: 0.2rem;
   --bs-btn-color: #{$black};
   --bs-btn-bg: #{$white};
@@ -13,19 +14,17 @@
   --bs-btn-disabled-color: #{tokens.$gray-700};
   --bs-btn-disabled-bg: #{tokens.$gray-100};
   --bs-btn-disabled-opacity: 1;
-}
 
-.c-map-button--s {
-  width: 2rem;
-  height: 2rem;
-}
-
-.c-map-button--m {
   width: 2.375rem;
   height: 2.375rem;
 }
 
-.c-map-button--l {
+.c-map-button--sm {
+  width: 2rem;
+  height: 2rem;
+}
+
+.c-map-button--lg {
   width: 3rem;
   height: 3rem;
 }

--- a/assets/src/components/map/controls/mapButton.tsx
+++ b/assets/src/components/map/controls/mapButton.tsx
@@ -1,0 +1,30 @@
+import React, { ComponentPropsWithoutRef } from "react"
+import { Button } from "react-bootstrap"
+import { joinClasses } from "../../../helpers/dom"
+
+interface MapButtonProps extends ComponentPropsWithoutRef<typeof Button> {
+  size: "s" | "m" | "l"
+}
+
+export const MapButton = (props: MapButtonProps) => {
+  const buttonProps = { ...props, size: undefined }
+
+  return (
+    <Button
+      {...buttonProps}
+      variant="outline-primary"
+      className={joinClasses([
+        "border-box",
+        "inherit-box",
+        "border-0",
+        "d-flex",
+        "justify-content-center",
+        "align-items-center",
+        "c-map-button",
+        "c-map-button--" + props.size,
+      ])}
+    >
+      {props.size}
+    </Button>
+  )
+}

--- a/assets/src/components/map/controls/mapButton.tsx
+++ b/assets/src/components/map/controls/mapButton.tsx
@@ -1,28 +1,27 @@
-import React, { ComponentPropsWithRef } from "react"
+import React, { ComponentPropsWithoutRef } from "react"
 import { Button } from "react-bootstrap"
 import { joinClasses } from "../../../helpers/dom"
 
-export const MapButton = (props: ComponentPropsWithRef<typeof Button>) => {
-  return (
-    <Button
-      {...props}
-      variant="outline-primary"
-      className={joinClasses([
-        "border-box",
-        "inherit-box",
-        "border-0",
-        "d-flex",
-        "flex-column",
-        "justify-content-center",
-        "align-items-center",
-        "c-map-button",
-        props.size && "c-map-button--" + props.size,
-      ])}
-    >
-      {props.children}
-      {props.size === "lg" && props.title && (
-        <span className="mt-1">{props.title}</span>
-      )}
-    </Button>
-  )
-}
+export const MapButton = (props: ComponentPropsWithoutRef<typeof Button>) => (
+  <Button
+    {...props}
+    variant="outline-primary"
+    className={joinClasses([
+      "border-box",
+      "inherit-box",
+      "border-0",
+      "d-flex",
+      "flex-column",
+      "justify-content-center",
+      "align-items-center",
+      "c-map-button",
+      props.size && "c-map-button--" + props.size,
+      props.className,
+    ])}
+  >
+    {props.children}
+    {props.size === "lg" && props.title && (
+      <span className="mt-1">{props.title}</span>
+    )}
+  </Button>
+)

--- a/assets/src/components/map/controls/mapButton.tsx
+++ b/assets/src/components/map/controls/mapButton.tsx
@@ -1,30 +1,28 @@
-import React, { ComponentPropsWithoutRef } from "react"
+import React, { ComponentPropsWithRef } from "react"
 import { Button } from "react-bootstrap"
 import { joinClasses } from "../../../helpers/dom"
 
-interface MapButtonProps extends ComponentPropsWithoutRef<typeof Button> {
-  size: "s" | "m" | "l"
-}
-
-export const MapButton = (props: MapButtonProps) => {
-  const buttonProps = { ...props, size: undefined }
-
+export const MapButton = (props: ComponentPropsWithRef<typeof Button>) => {
   return (
     <Button
-      {...buttonProps}
+      {...props}
       variant="outline-primary"
       className={joinClasses([
         "border-box",
         "inherit-box",
         "border-0",
         "d-flex",
+        "flex-column",
         "justify-content-center",
         "align-items-center",
         "c-map-button",
-        "c-map-button--" + props.size,
+        props.size && "c-map-button--" + props.size,
       ])}
     >
-      {props.size}
+      {props.children}
+      {props.size === "lg" && props.title && (
+        <span className="mt-1">{props.title}</span>
+      )}
     </Button>
   )
 }

--- a/assets/src/helpers/bsIcons.tsx
+++ b/assets/src/helpers/bsIcons.tsx
@@ -42,6 +42,49 @@ export const ArrowClockwise = (props: SvgProps) => (
   </svg>
 )
 
+export const ArrowLeft = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="currentColor"
+    className="bi bi-arrow-left"
+    viewBox="0 0 16 16"
+    aria-hidden
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8"
+    />
+  </svg>
+)
+
+/**
+ * @returns https://icons.getbootstrap.com/icons/box-arrow-right/
+ */
+export const BoxArrowRight = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="currentColor"
+    className="bi bi-box-arrow-right"
+    viewBox="0 0 16 16"
+    aria-hidden
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"
+    />
+    <path
+      fillRule="evenodd"
+      d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"
+    />
+  </svg>
+)
+
 /**
  * @returns https://icons.getbootstrap.com/icons/chat-fill/
  */
@@ -57,6 +100,24 @@ export const ChatFill = (props: SvgProps) => (
     {...props}
   >
     <path d="M8 15c4.418 0 8-3.134 8-7s-3.582-7-8-7-8 3.134-8 7c0 1.76.743 3.37 1.97 4.6-.097 1.016-.417 2.13-.771 2.966-.079.186.074.394.273.362 2.256-.37 3.597-.938 4.18-1.234A9 9 0 0 0 8 15" />
+  </svg>
+)
+
+/**
+ * @returns https://icons.getbootstrap.com/icons/exclamation-circle-fill/
+ */
+export const ExclamationCircleFill = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="currentColor"
+    className="bi bi-exclamation-circle-fill"
+    viewBox="0 0 16 16"
+    aria-hidden
+    {...props}
+  >
+    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4m.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2" />
   </svg>
 )
 
@@ -93,66 +154,5 @@ export const QuestionFill = (props: SvgProps) => (
     {...props}
   >
     <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247m2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
-  </svg>
-)
-
-/**
- * @returns https://icons.getbootstrap.com/icons/box-arrow-right/
- */
-export const BoxArrowRight = (props: SvgProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    fill="currentColor"
-    className="bi bi-box-arrow-right"
-    viewBox="0 0 16 16"
-    aria-hidden
-    {...props}
-  >
-    <path
-      fillRule="evenodd"
-      d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"
-    />
-    <path
-      fillRule="evenodd"
-      d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"
-    />
-  </svg>
-)
-
-/**
- * @returns https://icons.getbootstrap.com/icons/exclamation-circle-fill/
- */
-export const ExclamationCircleFill = (props: SvgProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    fill="currentColor"
-    className="bi bi-exclamation-circle-fill"
-    viewBox="0 0 16 16"
-    aria-hidden
-    {...props}
-  >
-    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4m.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2" />
-  </svg>
-)
-
-export const ArrowLeft = (props: SvgProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    fill="currentColor"
-    className="bi bi-arrow-left"
-    viewBox="0 0 16 16"
-    aria-hidden
-    {...props}
-  >
-    <path
-      fillRule="evenodd"
-      d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8"
-    />
   </svg>
 )

--- a/assets/src/helpers/bsIcons.tsx
+++ b/assets/src/helpers/bsIcons.tsx
@@ -140,6 +140,25 @@ export const GearFill = (props: SvgProps) => (
 )
 
 /**
+ * @returns https://icons.getbootstrap.com/icons/plus-square/
+ */
+export const PlusSquare = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    fill="currentColor"
+    className="bi bi-plus-square"
+    viewBox="0 0 16 16"
+    aria-hidden
+    {...props}
+  >
+    <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z" />
+    <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4" />
+  </svg>
+)
+
+/**
  * @returns https://icons.getbootstrap.com/icons/question-circle-fill/
  */
 export const QuestionFill = (props: SvgProps) => (

--- a/assets/stories/skate-components/map/controls/mapButton.stories.tsx
+++ b/assets/stories/skate-components/map/controls/mapButton.stories.tsx
@@ -52,14 +52,12 @@ export const InMap: Story = {
     layout: "fullscreen",
     stretch: true,
   },
-  render(args) {
-    return (
-      <CustomControl position="bottomleft">
-        <MapButton {...args}>
-          <PlusSquare />
-        </MapButton>
-      </CustomControl>
-    )
-  },
+  render: (args) => (
+    <CustomControl position="bottomleft">
+      <MapButton {...args}>
+        <PlusSquare />
+      </MapButton>
+    </CustomControl>
+  ),
   decorators: [inMapDecorator],
 }

--- a/assets/stories/skate-components/map/controls/mapButton.stories.tsx
+++ b/assets/stories/skate-components/map/controls/mapButton.stories.tsx
@@ -5,30 +5,43 @@ import React from "react"
 import { MapButton } from "../../../../src/components/map/controls/mapButton"
 import { inMapDecorator } from "../../../../.storybook/inMapDecorator"
 import { CustomControl } from "../../../../src/components/map/controls/customControl"
+import { PlusSquare } from "../../../../src/helpers/bsIcons"
 
 const meta = {
   component: MapButton,
   args: {
-    size: "m",
+    size: undefined,
+    title: "Button",
     active: false,
     disabled: false,
   },
   argTypes: {
-    size: { options: ["s", "m", "l"] },
+    size: {
+      control: {
+        type: "select",
+        labels: { sm: "Small", undefined: "Medium", lg: "Large" },
+      },
+      options: ["sm", undefined, "lg"],
+    },
     active: { control: "boolean" },
     disabled: { control: "boolean" },
   },
+  render: (args) => (
+    <MapButton {...args}>
+      <PlusSquare />
+    </MapButton>
+  ),
 } satisfies Meta<typeof MapButton>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Small: Story = { args: { size: "s" } }
+export const Small: Story = { args: { size: "sm" } }
 
-export const Medium: Story = { args: { size: "m" } }
+export const Medium: Story = { args: { size: undefined } }
 
-export const Large: Story = { args: { size: "l" } }
+export const Large: Story = { args: { size: "lg" } }
 
 export const Active: Story = { args: { active: true } }
 
@@ -42,7 +55,9 @@ export const InMap: Story = {
   render(args) {
     return (
       <CustomControl position="bottomleft">
-        <MapButton {...args} />
+        <MapButton {...args}>
+          <PlusSquare />
+        </MapButton>
       </CustomControl>
     )
   },

--- a/assets/stories/skate-components/map/controls/mapButton.stories.tsx
+++ b/assets/stories/skate-components/map/controls/mapButton.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import React from "react"
+
 import { MapButton } from "../../../../src/components/map/controls/mapButton"
+import { inMapDecorator } from "../../../../.storybook/inMapDecorator"
+import { CustomControl } from "../../../../src/components/map/controls/customControl"
 
 const meta = {
   component: MapButton,
@@ -25,3 +29,22 @@ export const Small: Story = { args: { size: "s" } }
 export const Medium: Story = { args: { size: "m" } }
 
 export const Large: Story = { args: { size: "l" } }
+
+export const Active: Story = { args: { active: true } }
+
+export const Disabled: Story = { args: { disabled: true } }
+
+export const InMap: Story = {
+  parameters: {
+    layout: "fullscreen",
+    stretch: true,
+  },
+  render(args) {
+    return (
+      <CustomControl position="bottomleft">
+        <MapButton {...args} />
+      </CustomControl>
+    )
+  },
+  decorators: [inMapDecorator],
+}

--- a/assets/stories/skate-components/map/controls/mapButton.stories.tsx
+++ b/assets/stories/skate-components/map/controls/mapButton.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { MapButton } from "../../../../src/components/map/controls/mapButton"
+
+const meta = {
+  component: MapButton,
+  args: {
+    size: "m",
+    active: false,
+    disabled: false,
+  },
+  argTypes: {
+    size: { options: ["s", "m", "l"] },
+    active: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof MapButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Small: Story = { args: { size: "s" } }
+
+export const Medium: Story = { args: { size: "m" } }
+
+export const Large: Story = { args: { size: "l" } }


### PR DESCRIPTION
Asana ticket: [Create underlying button components](https://app.asana.com/0/1148853526253420/1206753759080074/f)

The main things I'm looking for feedback on here are:
1. The use of the `title` prop for the text in the button at large sizes and both how that should ultimately render in the HTML and how it should be exposed to users of the component.
2. The `size` property and whether or not the way it's used is weird (though nobody will be setting it explicitly to `undefined` except in Storybook so I don't think it's much of an issue).
3. The way I actually customized the Bootstrap buttons via overriding CSS variables in `_map_button.scss` wherever possible.

Also I would like to add at least a couple of basic automated tests, I think those will mostly be around the functionality for question 1 above.