### PR TITLE
fix: Remove originalShapeClickable from DetourMap stories

### DIFF
--- a/assets/stories/skate-components/detours/detourMap.stories.tsx
+++ b/assets/stories/skate-components/detours/detourMap.stories.tsx
@@ -22,7 +22,6 @@ const meta = {
     startPoint,
     waypoints: [waypoint],
     endPoint,
-    originalShapeClickable: false,
     routeSegments: {
       beforeDetour: shape.slice(0, startPointIndex),
       detour: shape.slice(startPointIndex, endPointIndex),
@@ -43,7 +42,6 @@ const meta = {
     originalShape: { table: { disable: true } },
     detourShape: { table: { disable: true } },
     waypoints: { table: { disable: true } },
-    originalShapeClickable: { table: { disable: true } },
     onClickOriginalShape: { table: { disable: true } },
     onClickMap: { table: { disable: true } },
     undoDisabled: { table: { disable: true } },
@@ -65,7 +63,6 @@ export const WithSomeWaypoints: Story = {
     routeSegments: undefined,
     detourShape: [startPoint, waypoint],
     waypoints: [waypoint],
-    originalShapeClickable: true,
     onClickMap: () => {},
   },
 }
@@ -77,7 +74,6 @@ export const Unstarted: Story = {
     routeSegments: undefined,
     detourShape: [],
     waypoints: [],
-    originalShapeClickable: true,
     undoDisabled: true,
   },
 }


### PR DESCRIPTION
In [this PR][1], we removed originalShapeClickable as an attribute for the DetourMap, but in parallel, we introduced [storybook stories for DetourMap][2], which referenced `originalShapeClickable` at the time. Those two PR's were merged in rapid succession, so the builds for [the second one][2] never caught up with the fact that [the first one][1] had removed that argument.

[1]: https://github.com/mbta/skate/pull/2459
[2]: https://github.com/mbta/skate/pull/2457