### PR TITLE
fix: Don't consolidate Elixir protocols in test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Skate.MixProject do
       deps: deps(),
       test_coverage: [tool: LcovEx],
       elixirc_options: [warnings_as_errors: true],
+      consolidate_protocols: Mix.env() != :test,
       dialyzer: [
         plt_add_apps: [:mix]
       ]


### PR DESCRIPTION
This should have been added in [this PR](https://github.com/mbta/skate/pull/2449), but I must have goofed at actually committing it (I know I added it in order to get the tests to run correctly on my machine, so I have no idea what happened).