### PR TITLE
refactor: Don't fix the height and width for detour marker icons

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -223,8 +223,8 @@ export const EndIcon = () => <StartOrEndIcon classSuffix={"end"} />
 
 const StartOrEndIcon = ({ classSuffix }: { classSuffix: string }) => (
   <svg
-    height="16"
-    width="16"
+    height="100%"
+    width="100%"
     viewBox="0 0 16 16"
     className={"c-detour_map-circle-marker--" + classSuffix}
   >
@@ -248,8 +248,8 @@ const WaypointMarker = ({ position }: { position: LatLngLiteral }) => (
 
 export const WaypointIcon = () => (
   <svg
-    width="10"
-    height="10"
+    width="100%"
+    height="100%"
     viewBox="0 0 10 10"
     fill="none"
     className="c-detour_map-circle-marker--detour-point"


### PR DESCRIPTION
This mostly affects storybook right now, but also allows us to use these icons at different sizes in the future.

The sizes in-context are already fixed by the markers that wrap the icons, so this should have no user-facing effect