### PR TITLE
feedback(design):fix(css/diversionPage): make panel width the larger of `300px` or `22.5%` of the screen

### DIFF
--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -28,7 +28,7 @@
     grid-template:
       "heading heading" min-content
       "panel map" auto
-      / fit-content(28ch) auto;
+      / max(22.5vw, 350px) auto;
 
     // Overlay the panel and make the panel header match
     // the size of the page header if subgrid is supported
@@ -36,7 +36,7 @@
       grid-template:
         [panel-start] "heading heading" min-content
         "panel map" auto
-        / fit-content(28ch) auto;
+        / max(22.5vw, 350px) auto;
 
       .l-diversion-page__panel,
       .l-diversion-page-panel {


### PR DESCRIPTION
After some interactive pairing with Design, we arrived at this combination to set the size of the panel. 

---

It's possible we'll change this later but it's so small it's pretty easy to do :)