### PR TITLE
fix: Fix hover behavior for missed stop icons

### DIFF
--- a/assets/css/map/markers/_missed_stop_icon.scss
+++ b/assets/css/map/markers/_missed_stop_icon.scss
@@ -36,9 +36,7 @@
   }
 }
 
-.c-missed-stop-icon-container:not(
-    .c-missed-stop-icon-container--interactions-disabled
-  ) {
+.c-stop-icon-container:not(.c-stop-icon-container--interactions-disabled) {
   &:focus-visible {
     outline-offset: 2px;
   }

--- a/assets/stories/skate-components/map/markers/missedStopMarker.stories.tsx
+++ b/assets/stories/skate-components/map/markers/missedStopMarker.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   component: MissedStopIcon,
   decorators: [
     (Story) => (
-      <div className="c-missed-stop-icon-container">
+      <div className="c-stop-icon-container">
         <Story />
       </div>
     ),


### PR DESCRIPTION
In context, the missed stop icons are contained in a `c-stop-icon-container`, not a `c-missed-stop-icon-container`, so the hover behavior worked in the stories for the icons themselves, but not when they were actually drawn on the map.