### PR TITLE
fix(ts/components/detourFinishedPanel): style heading with `__h1` class

### DIFF
--- a/assets/src/components/detours/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourFinishedPanel.tsx
@@ -14,7 +14,7 @@ export const DetourFinishedPanel = ({
 }) => (
   <Panel as="article">
     <Panel.Header className="">
-      <h1 className="c-diversion-panel__h2 my-3">Share Detour Details</h1>
+      <h1 className="c-diversion-panel__h1 my-3">Share Detour Details</h1>
     </Panel.Header>
 
     <Panel.Body className="d-flex flex-column">


### PR DESCRIPTION
I was wondering why the layout was shifting when switching between create and share screens, turns out this didn't get updated.

No Ticket.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206808449589848