### PR TITLE
fix: make modal and tooltip appear over rest of application

### DIFF
--- a/assets/css/_u_isolation.scss
+++ b/assets/css/_u_isolation.scss
@@ -1,0 +1,3 @@
+.isolation-isolate {
+  isolation: isolate;
+}

--- a/assets/css/_z_indexes.scss
+++ b/assets/css/_z_indexes.scss
@@ -4,8 +4,6 @@ $z-page-layout-context: (
   "view": 1100,
   "navbar": 1200,
   "user-info-popover": 1201,
-  "modal-backdrop": 2100,
-  "modal": 2101,
 );
 
 $z-properties-panel-context: (

--- a/assets/css/_z_indexes.scss
+++ b/assets/css/_z_indexes.scss
@@ -4,7 +4,6 @@ $z-page-layout-context: (
   "view": 1100,
   "navbar": 1200,
   "user-info-popover": 1201,
-  "detour-modal": 2000,
   "modal-backdrop": 2100,
   "modal": 2101,
 );

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -120,6 +120,7 @@ $vpp-location-padding: 1rem;
 @import "vehicle_route_summary";
 @import "view_header";
 
+@import "u_isolation";
 @import "u_no_overscroll";
 
 // #region Effects
@@ -168,4 +169,8 @@ body {
   position: relative;
   flex: 1 1 0;
   min-height: 0;
+}
+
+main.container {
+  @extend .isolation-isolate;
 }

--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -1,7 +1,6 @@
 @use "../color/definitions" as semantic;
 @use "../color/tokens_2021" as tokens;
 @use "../color/tokens_2024" as new_tokens;
-@use "../z_indexes" as z_indexes;
 
 @import "../typography/variables";
 
@@ -17,9 +16,3 @@ $ui-alert: semantic.$ui-alert;
 $service-alert: semantic.$service-alert;
 $light: new_tokens.$gray-50;
 $dark: new_tokens.$gray-900;
-
-$zindex-modal: map-get(z_indexes.$z-page-layout-context, "modal");
-$zindex-modal-backdrop: map-get(
-  z_indexes.$z-page-layout-context,
-  "modal-backdrop"
-);

--- a/assets/css/detours/_detour_modal.scss
+++ b/assets/css/detours/_detour_modal.scss
@@ -1,7 +1,6 @@
 .c-detour-modal {
   inset: 0;
   position: fixed;
-  z-index: map-get($z-page-layout-context, "detour-modal");
 }
 
 .c-detour-modal__transition-appear {


### PR DESCRIPTION
By changing the main application container to start it's own stacking context, the modals and tooltips created by react-bootstrap then by default cover the application contained in the `main` element without interference because of the new stacking context created. So now modals and tooltips show up in the order they're defined (as long as they don't have wildly huge z-index's themselves, or we'd need to apply this same isolation to modals as well)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206808449589844