### PR TITLE
fix(ts/components/detourFinishedPanel): convert `Tooltip` to `Popover`

### DIFF
--- a/assets/src/components/detours/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourFinishedPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, Form, OverlayTrigger, Tooltip } from "react-bootstrap"
+import { Button, Form, OverlayTrigger, Popover } from "react-bootstrap"
 import * as BsIcons from "../../helpers/bsIcons"
 import { Panel } from "./diversionPage"
 
@@ -45,7 +45,11 @@ export const DetourFinishedPanel = ({
           trigger="click"
           rootClose
           rootCloseEvent="mousedown"
-          overlay={<Tooltip>Copied to clipboard!</Tooltip>}
+          overlay={
+            <Popover>
+              <Popover.Body>Copied to clipboard!</Popover.Body>
+            </Popover>
+          }
         >
           <Button
             className="m-3 flex-grow-1"


### PR DESCRIPTION
This was caught in design review with Kathleen, `<Popover>` is what the designs use and it matches more closely.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206810341002961