### PR TITLE
refactor: apiCallWithError function

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { ShapePoint } from "../schedule"
 import { fetchDetourDirections, fetchFinishedDetour } from "../api"
 import { DetourShape, FinishedDetour, OriginalRoute } from "../models/detour"
+import { isOk } from "../util/fetchResult"
 
 const useDetourDirections = (shapePoints: ShapePoint[]) => {
   const [detourShape, setDetourShape] = useState<ShapePoint[]>([])
@@ -21,9 +22,9 @@ const useDetourDirections = (shapePoints: ShapePoint[]) => {
     }
 
     fetchDetourDirections(shapePoints).then((detourInfo) => {
-      if (detourInfo && shouldUpdate) {
-        setDetourShape(detourInfo.coordinates)
-        setDirections(detourInfo.directions)
+      if (isOk(detourInfo) && shouldUpdate) {
+        setDetourShape(detourInfo.ok.coordinates)
+        setDirections(detourInfo.ok.directions)
       }
     })
 

--- a/assets/src/util/fetchResult.ts
+++ b/assets/src/util/fetchResult.ts
@@ -19,3 +19,9 @@ export const isOk = <T>(r: FetchResult<T>): r is Ok<T> => "ok" in r
 
 export const isFetchError = <T>(r: FetchResult<T>): r is FetchError =>
   "is_error" in r && r.is_error === true
+
+export const loading = <T>(): FetchResult<T> => ({ is_loading: true })
+
+export const ok = <T>(r: T): FetchResult<T> => ({ ok: r })
+
+export const fetchError = <T>(): FetchResult<T> => ({ is_error: true })

--- a/assets/src/util/fetchResult.ts
+++ b/assets/src/util/fetchResult.ts
@@ -20,8 +20,18 @@ export const isOk = <T>(r: FetchResult<T>): r is Ok<T> => "ok" in r
 export const isFetchError = <T>(r: FetchResult<T>): r is FetchError =>
   "is_error" in r && r.is_error === true
 
+/**
+ * Creates a {@link FetchResult} representing a loading state
+ */
 export const loading = <T>(): FetchResult<T> => ({ is_loading: true })
 
+/**
+ * Creates a {@link FetchResult} representing a success state, along
+ * with loaded data
+ */
 export const ok = <T>(r: T): FetchResult<T> => ({ ok: r })
 
+/**
+ * Creates a {@link FetchResult} representing a failure state
+ */
 export const fetchError = <T>(): FetchResult<T> => ({ is_error: true })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -28,6 +28,7 @@ import {
   fetchLocationSearchSuggestions,
   fetchAllStops,
   fetchFinishedDetour,
+  apiCallWithError,
 } from "../src/api"
 import routeFactory from "./factories/route"
 import routeTabFactory from "./factories/routeTab"
@@ -47,6 +48,7 @@ import locationSearchSuggestionDataFactory from "./factories/locationSearchSugge
 import locationSearchSuggestionFactory from "./factories/locationSearchSuggestion"
 import stopDataFactory from "./factories/stopData"
 import { shapePointFactory } from "./factories/shapePointFactory"
+import { ok, fetchError } from "../src/util/fetchResult"
 
 jest.mock("@sentry/react", () => ({
   __esModule: true,
@@ -226,6 +228,97 @@ describe("checkedApiCall", () => {
       defaultResult: "default",
     }).then((result) => {
       expect(result).toEqual("default")
+    })
+  })
+})
+
+describe("apiCallWithError", () => {
+  let browserReloadSpy: SpyInstance
+
+  beforeEach(() => {
+    browserReloadSpy = jest
+      .spyOn(browser, "reload")
+      .mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    browserReloadSpy.mockRestore()
+  })
+
+  test("returns parsed data", async () => {
+    mockFetch(200, { data: "raw" })
+
+    const parse = jest.fn(() => "parsed")
+
+    return apiCallWithError({
+      url: "/",
+      dataStruct: string(),
+      parser: parse,
+    }).then((parsed) => {
+      expect(parse).toHaveBeenCalledWith("raw")
+      expect(parsed).toEqual(ok("parsed"))
+    })
+  })
+
+  test("raises error for malformed data when no default", async () => {
+    mockFetch(200, { data: 12 })
+
+    const parse = jest.fn(() => "parsed")
+
+    await apiCallWithError({
+      url: "/",
+      dataStruct: string(),
+      parser: parse,
+    })
+
+    expect(Sentry.captureException).toHaveBeenCalled()
+  })
+
+  test("returns error when data is malformed", async () => {
+    mockFetch(200, { data: 12 })
+
+    const parse = jest.fn(() => "parsed")
+
+    await apiCallWithError({
+      url: "/",
+      dataStruct: string(),
+      parser: parse,
+    }).then((result) => expect(result).toEqual(fetchError()))
+  })
+
+  test("reloads the page if the response status is a redirect (3xx)", async () => {
+    mockFetch(302, { data: null })
+
+    return apiCallWithError({
+      url: "/",
+      dataStruct: unknown(),
+      parser: () => null,
+    }).then(() => {
+      expect(browser.reload).toHaveBeenCalled()
+    })
+  })
+
+  test("reloads the page if the response status is forbidden (403)", async () => {
+    mockFetch(403, { data: null })
+
+    return apiCallWithError({
+      url: "/",
+      dataStruct: unknown(),
+      parser: () => null,
+    }).then(() => {
+      expect(browser.reload).toHaveBeenCalled()
+    })
+  })
+
+  test("returns an error for any other response", async () => {
+    mockFetch(500, { data: null })
+
+    return apiCallWithError({
+      url: "/",
+      dataStruct: unknown(),
+      parser: () => null,
+    }).then((result) => {
+      expect(result).toEqual(fetchError())
     })
   })
 })

--- a/assets/tests/api.test.ts
+++ b/assets/tests/api.test.ts
@@ -250,28 +250,15 @@ describe("apiCallWithError", () => {
 
     const parse = jest.fn(() => "parsed")
 
-    return apiCallWithError({
-      url: "/",
-      dataStruct: string(),
-      parser: parse,
-    }).then((parsed) => {
-      expect(parse).toHaveBeenCalledWith("raw")
-      expect(parsed).toEqual(ok("parsed"))
-    })
-  })
+    await expect(
+      apiCallWithError({
+        url: "/",
+        dataStruct: string(),
+        parser: parse,
+      })
+    ).resolves.toEqual(ok("parsed"))
 
-  test("raises error for malformed data when no default", async () => {
-    mockFetch(200, { data: 12 })
-
-    const parse = jest.fn(() => "parsed")
-
-    await apiCallWithError({
-      url: "/",
-      dataStruct: string(),
-      parser: parse,
-    })
-
-    expect(Sentry.captureException).toHaveBeenCalled()
+    expect(parse).toHaveBeenCalledWith("raw")
   })
 
   test("returns error when data is malformed", async () => {
@@ -279,47 +266,49 @@ describe("apiCallWithError", () => {
 
     const parse = jest.fn(() => "parsed")
 
-    await apiCallWithError({
-      url: "/",
-      dataStruct: string(),
-      parser: parse,
-    }).then((result) => expect(result).toEqual(fetchError()))
+    await expect(
+      apiCallWithError({
+        url: "/",
+        dataStruct: string(),
+        parser: parse,
+      })
+    ).resolves.toEqual(fetchError())
   })
 
   test("reloads the page if the response status is a redirect (3xx)", async () => {
     mockFetch(302, { data: null })
 
-    return apiCallWithError({
+    await apiCallWithError({
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
-    }).then(() => {
-      expect(browser.reload).toHaveBeenCalled()
     })
+
+    expect(browser.reload).toHaveBeenCalled()
   })
 
   test("reloads the page if the response status is forbidden (403)", async () => {
     mockFetch(403, { data: null })
 
-    return apiCallWithError({
+    await apiCallWithError({
       url: "/",
       dataStruct: unknown(),
       parser: () => null,
-    }).then(() => {
-      expect(browser.reload).toHaveBeenCalled()
     })
+
+    expect(browser.reload).toHaveBeenCalled()
   })
 
   test("returns an error for any other response", async () => {
     mockFetch(500, { data: null })
 
-    return apiCallWithError({
-      url: "/",
-      dataStruct: unknown(),
-      parser: () => null,
-    }).then((result) => {
-      expect(result).toEqual(fetchError())
-    })
+    await expect(
+      apiCallWithError({
+        url: "/",
+        dataStruct: unknown(),
+        parser: () => null,
+      })
+    ).resolves.toEqual(fetchError())
   })
 })
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -28,6 +28,7 @@ import {
   missedStopIcon,
   stopIcon,
 } from "../../testHelpers/selectors/components/map/markers/stopIcon"
+import { ok, fetchError } from "../../../src/util/fetchResult"
 
 const DiversionPage = (
   props: Omit<
@@ -65,7 +66,7 @@ beforeEach(() => {
 jest.mock("../../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetourDirections).mockResolvedValue(null)
+  jest.mocked(fetchDetourDirections).mockResolvedValue(fetchError())
   jest.mocked(fetchFinishedDetour).mockResolvedValue(null)
 })
 
@@ -299,14 +300,17 @@ describe("DiversionPage", () => {
     const [start, end] = stopFactory.buildList(2)
 
     jest.mocked(fetchDetourDirections).mockResolvedValue(
-      detourShapeFactory.build({
-        directions: [
-          { instruction: "Turn left on Main Street" },
-          { instruction: "Turn right on High Street" },
-          { instruction: "Turn sharp right on Broadway" },
-        ],
-      })
+      ok(
+        detourShapeFactory.build({
+          directions: [
+            { instruction: "Turn left on Main Street" },
+            { instruction: "Turn right on High Street" },
+            { instruction: "Turn sharp right on Broadway" },
+          ],
+        })
+      )
     )
+
     jest.mocked(fetchFinishedDetour).mockResolvedValue({
       missedStops: stops,
       connectionPoint: {

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -11,11 +11,12 @@ import { finishedDetourFactory } from "../factories/finishedDetourFactory"
 import { routeSegmentsFactory } from "../factories/finishedDetourFactory"
 import { originalRouteFactory } from "../factories/originalRouteFactory"
 import shapeFactory from "../factories/shape"
+import { ok, fetchError } from "../../src/util/fetchResult"
 
 jest.mock("../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetourDirections).mockResolvedValue(null)
+  jest.mocked(fetchDetourDirections).mockResolvedValue(fetchError())
 
   jest
     .mocked(fetchFinishedDetour)
@@ -103,7 +104,7 @@ describe("useDetour", () => {
 
     jest.mocked(fetchDetourDirections).mockImplementation((coordinates) => {
       expect(coordinates).toStrictEqual([start, end])
-      return Promise.resolve(detourShape)
+      return Promise.resolve(ok(detourShape))
     })
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
@@ -184,7 +185,7 @@ describe("useDetour", () => {
   test("when `undo` removes the last waypoint, `detourShape` and `directions` should be empty", async () => {
     jest
       .mocked(fetchDetourDirections)
-      .mockResolvedValue(detourShapeFactory.build())
+      .mockResolvedValue(ok(detourShapeFactory.build()))
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
@@ -242,7 +243,7 @@ describe("useDetour", () => {
   test("when `clear` is called, `detourShape` and `directions` should be empty", async () => {
     jest
       .mocked(fetchDetourDirections)
-      .mockResolvedValue(detourShapeFactory.build())
+      .mockResolvedValue(ok(detourShapeFactory.build()))
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 


### PR DESCRIPTION
Asana ticket: [Version of apiCall that surfaces error states](https://app.asana.com/0/0/1206816132107678/f)

I'm opening this up for review as its own PR just because it's a pretty impactful change for the future of how we do API requests. I have a followup subtask to actually pass this result up through the hooks. I may or may not also do some work on [factoring out the hook logic into a general-purpose helper](https://app.asana.com/0/1148853526253420/1205240803395719/f) if it makes sense to.