### PR TITLE
chore: Reduce number of allowable Dependabot PR's to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 1
 - package-ecosystem: npm
   directory: "/assets"
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 1
   versioning-strategy: increase
   ignore:
     - dependency-name: "phoenix"


### PR DESCRIPTION
We seem to be struggling to keep up with Dependabot PR's, which is causing us to leave older Dependabot PR's open for a long time. Reducing the number of PR's we allow to be open at a time might help us keep these under control more easily.