### PR TITLE
fix: using escape key on detour modal prompts for close confirmation

### DIFF
--- a/assets/src/components/detours/detourModal.tsx
+++ b/assets/src/components/detours/detourModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useState } from "react"
 import { DiversionPage } from "./diversionPage"
 import { OriginalRoute } from "../../models/detour"
 import { Modal } from "@restart/ui"
@@ -24,23 +24,26 @@ export const DetourModal = ({
   onClose: () => void
   show: boolean
 }) => {
-  useEffect(() => {
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose()
-      }
-    }
-
-    window.addEventListener("keydown", handleEscape)
-
-    return () => {
-      window.removeEventListener("keydown", handleEscape)
-    }
-  }, [onClose])
+  const [showConfirmCloseModal, setShowConfirmCloseModal] =
+    useState<boolean>(false)
 
   return (
-    <Modal className="c-detour-modal" show={show} transition={Fade}>
-      <DiversionPage onClose={onClose} originalRoute={originalRoute} />
+    <Modal
+      className="c-detour-modal"
+      show={show}
+      transition={Fade}
+      onHide={() => setShowConfirmCloseModal(true)}
+    >
+      <DiversionPage
+        onClose={() => setShowConfirmCloseModal(true)}
+        onConfirmClose={() => {
+          setShowConfirmCloseModal(false)
+          onClose()
+        }}
+        onCancelClose={() => setShowConfirmCloseModal(false)}
+        originalRoute={originalRoute}
+        showConfirmCloseModal={showConfirmCloseModal}
+      />
     </Modal>
   )
 }

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -18,11 +18,17 @@ import { DetourFinishedPanel } from "./detourFinishedPanel"
 interface DiversionPageProps {
   originalRoute: OriginalRoute
   onClose?: () => void
+  onConfirmClose?: () => void
+  onCancelClose?: () => void
+  showConfirmCloseModal: boolean
 }
 
 export const DiversionPage = ({
   originalRoute,
   onClose,
+  onConfirmClose,
+  onCancelClose,
+  showConfirmCloseModal,
 }: DiversionPageProps) => {
   const {
     state,
@@ -78,17 +84,11 @@ export const DiversionPage = ({
     connectionPoints?.end?.name,
   ])
 
-  const [showConfirmCloseModal, setShowConfirmCloseModal] =
-    useState<boolean>(false)
-
   return (
     <>
       <article className="l-diversion-page h-100 border-box inherit-box">
         <header className="l-diversion-page__header text-bg-light border-bottom">
-          <CloseButton
-            className="p-4"
-            onClick={() => setShowConfirmCloseModal(true)}
-          />
+          <CloseButton className="p-4" onClick={onClose} />
         </header>
 
         <div className="l-diversion-page__panel bg-light">
@@ -142,7 +142,7 @@ export const DiversionPage = ({
       </article>
       <Modal
         show={showConfirmCloseModal}
-        onHide={() => setShowConfirmCloseModal(false)}
+        onHide={onCancelClose}
         animation={false}
       >
         <Modal.Header closeButton>
@@ -158,19 +158,10 @@ export const DiversionPage = ({
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <Button
-            onClick={() => {
-              setShowConfirmCloseModal(false)
-              onClose?.()
-            }}
-            variant="primary"
-          >
+          <Button onClick={onConfirmClose} variant="primary">
             Yes, I&apos;m sure
           </Button>
-          <Button
-            onClick={() => setShowConfirmCloseModal(false)}
-            variant="outline-primary"
-          >
+          <Button onClick={onCancelClose} variant="outline-primary">
             Back to Detour
           </Button>
         </Modal.Footer>

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -31,6 +31,7 @@ export const DummyDetourPage = () => {
             center: { lat: 42.36, lng: -71.13 },
             zoom: 16,
           }}
+          showConfirmCloseModal={false}
         />
       )}
     </>

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -20,9 +20,14 @@ const meta = {
       zoom: 14,
       center: { lat: 42.33, lng: -71.11 },
     },
+    showConfirmCloseModal: false,
   },
   argTypes: {
     originalRoute: { table: { disable: true } },
+    showConfirmCloseModal: { table: { disable: true } },
+    onClose: { table: { disable: true } },
+    onConfirmClose: { table: { disable: true } },
+    onCancelClose: { table: { disable: true } },
   },
 } satisfies Meta<typeof DiversionPage>
 export default meta

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -33,14 +33,15 @@ import { ok, loading } from "../../../src/util/fetchResult"
 const DiversionPage = (
   props: Omit<
     Partial<ComponentProps<typeof DiversionPageDefault>>,
-    "originalRoute"
+    "originalRoute" | "showConfirmCloseModal"
   > & {
     originalRoute?: Partial<
       ComponentProps<typeof DiversionPageDefault>["originalRoute"]
     >
+    showConfirmCloseModal?: boolean
   }
 ) => {
-  const { originalRoute, ...otherProps } = props
+  const { originalRoute, showConfirmCloseModal, ...otherProps } = props
   return (
     <DiversionPageDefault
       originalRoute={{
@@ -54,6 +55,9 @@ const DiversionPage = (
         zoom: 16,
         ...originalRoute,
       }}
+      showConfirmCloseModal={
+        showConfirmCloseModal === undefined ? false : showConfirmCloseModal
+      }
       {...otherProps}
     />
   )
@@ -377,63 +381,80 @@ describe("DiversionPage", () => {
     ).toBeVisible()
   })
 
-  test("Attempting to close the page displays a confirmation modal", () => {
-    render(<DiversionPage />)
+  test("Attempting to close the page calls the onClose callback", () => {
+    const onClose = jest.fn()
+
+    render(<DiversionPage onClose={onClose} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test("Displays a confirmation modal", () => {
+    render(<DiversionPage showConfirmCloseModal={true} />)
 
     expect(screen.getByRole("dialog")).toBeVisible()
     expect(screen.getByRole("button", { name: /yes/i })).toBeVisible()
     expect(screen.getByRole("button", { name: /back/i })).toBeVisible()
   })
 
-  test("can close page from the confirmation modal", async () => {
-    const onClose = jest.fn()
+  test("calls the onConfirmClose callback from the confirmation modal", async () => {
+    const onConfirmClose = jest.fn()
 
-    render(<DiversionPage onClose={onClose} />)
-
-    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    render(
+      <DiversionPage
+        showConfirmCloseModal={true}
+        onConfirmClose={onConfirmClose}
+      />
+    )
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /yes/i }))
     })
 
-    expect(onClose).toHaveBeenCalled()
-
-    expect(screen.queryByRole("dialog")).toBeNull()
+    expect(onConfirmClose).toHaveBeenCalled()
   })
 
-  test("can go back to the detour page from the confirmation modal", async () => {
-    const onClose = jest.fn()
+  test("canceling close from the confirmation modal calls onCancelClose", async () => {
+    const onCancelClose = jest.fn()
+    const onConfirmClose = jest.fn()
 
-    render(<DiversionPage onClose={onClose} />)
-
-    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    render(
+      <DiversionPage
+        showConfirmCloseModal={true}
+        onCancelClose={onCancelClose}
+        onConfirmClose={onConfirmClose}
+      />
+    )
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /back/i }))
     })
 
-    expect(onClose).not.toHaveBeenCalled()
-
-    expect(screen.queryByRole("dialog")).toBeNull()
+    expect(onCancelClose).toHaveBeenCalled()
+    expect(onConfirmClose).not.toHaveBeenCalled()
   })
 
-  test("closing the confirmation modal returns to the detour page", async () => {
-    const onClose = jest.fn()
+  test("closing the confirmation modal calls onCancelClose", async () => {
+    const onCancelClose = jest.fn()
+    const onConfirmClose = jest.fn()
 
-    render(<DiversionPage onClose={onClose} />)
-
-    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    render(
+      <DiversionPage
+        showConfirmCloseModal={true}
+        onCancelClose={onCancelClose}
+        onConfirmClose={onConfirmClose}
+      />
+    )
 
     await act(async () => {
       const modal = screen.getByRole("dialog")
       fireEvent.click(within(modal).getByRole("button", { name: "Close" }))
     })
 
-    expect(onClose).not.toHaveBeenCalled()
-
-    expect(screen.queryByRole("dialog")).toBeNull()
+    expect(onCancelClose).toHaveBeenCalled()
+    expect(onConfirmClose).not.toHaveBeenCalled()
   })
 
   test("stop markers are visible", async () => {

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -54,9 +54,7 @@ const DiversionPage = (
         zoom: 16,
         ...originalRoute,
       }}
-      showConfirmCloseModal={
-        showConfirmCloseModal ?? false
-      }
+      showConfirmCloseModal={showConfirmCloseModal ?? false}
       {...otherProps}
     />
   )

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -33,12 +33,11 @@ import { ok, loading } from "../../../src/util/fetchResult"
 const DiversionPage = (
   props: Omit<
     Partial<ComponentProps<typeof DiversionPageDefault>>,
-    "originalRoute" | "showConfirmCloseModal"
+    "originalRoute"
   > & {
     originalRoute?: Partial<
       ComponentProps<typeof DiversionPageDefault>["originalRoute"]
     >
-    showConfirmCloseModal?: boolean
   }
 ) => {
   const { originalRoute, showConfirmCloseModal, ...otherProps } = props

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -55,7 +55,7 @@ const DiversionPage = (
         ...originalRoute,
       }}
       showConfirmCloseModal={
-        showConfirmCloseModal === undefined ? false : showConfirmCloseModal
+        showConfirmCloseModal ?? false
       }
       {...otherProps}
     />


### PR DESCRIPTION
Asana ticket: [⚙️ [extra] Pressing escape key on detour modal should ask confirmation before closing](https://app.asana.com/0/1148853526253420/1206845632479144/f)

This ended up involving more refactoring than I thought it would but I like that we can now rely on the Restart modal's handling of the escape key event itself. I think it does sort of expose a gap in our testing of the `<DetourModal>` component so I might additionally go in and add some tests for that.