### PR TITLE
feat(ex/skate/open_route_service_api): send 40ft bus info to ORS for HGV profile routing

### DIFF
--- a/lib/skate/open_route_service_api/directions_request.ex
+++ b/lib/skate/open_route_service_api/directions_request.ex
@@ -9,8 +9,19 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
   """
   @type t() :: %__MODULE__{
           coordinates: [[float()]],
-          continue_straight: boolean()
+          continue_straight: boolean(),
+          options: map()
         }
 
-  defstruct coordinates: [], continue_straight: true
+  defstruct coordinates: [],
+            continue_straight: true,
+            options: %{
+              profile_params: %{
+                restrictions: %{
+                  length: 12.192,
+                  width: 3.2004,
+                  height: 3.5052
+                }
+              }
+            }
 end

--- a/lib/skate/open_route_service_api/directions_request.ex
+++ b/lib/skate/open_route_service_api/directions_request.ex
@@ -12,6 +12,13 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
         @moduledoc false
         @type t :: %{length: float(), width: float(), height: float()}
         defstruct [:length, :width, :height]
+
+        def bus_40ft,
+          do: %{
+            length: 12.192,
+            width: 3.2004,
+            height: 3.5052
+          }
       end
 
       @type t :: %{restrictions: HgvRestrictions.t()}
@@ -35,11 +42,8 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
             continue_straight: true,
             options: %{
               profile_params: %{
-                restrictions: %{
-                  length: 12.192,
-                  width: 3.2004,
-                  height: 3.5052
-                }
+                restrictions:
+                  Skate.OpenRouteServiceAPI.DirectionsRequest.Options.ProfileParams.HgvRestrictions.bus_40ft()
               }
             }
 end

--- a/lib/skate/open_route_service_api/directions_request.ex
+++ b/lib/skate/open_route_service_api/directions_request.ex
@@ -4,13 +4,31 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
   """
   @derive Jason.Encoder
 
+  defmodule Options do
+    @moduledoc false
+    defmodule ProfileParams do
+      @moduledoc false
+      defmodule HgvRestrictions do
+        @moduledoc false
+        @type t :: %{length: float(), width: float(), height: float()}
+        defstruct [:length, :width, :height]
+      end
+
+      @type t :: %{restrictions: HgvRestrictions.t()}
+      defstruct [:restrictions]
+    end
+
+    @type t :: %{profile_params: ProfileParams.t()}
+    defstruct [:profile_params]
+  end
+
   @typedoc """
     Type that represents a request made to OpenRouteService's Directions API
   """
   @type t() :: %__MODULE__{
           coordinates: [[float()]],
           continue_straight: boolean(),
-          options: map()
+          options: Options.t()
         }
 
   defstruct coordinates: [],

--- a/test/skate_web/controllers/detour_route_controller_test.exs
+++ b/test/skate_web/controllers/detour_route_controller_test.exs
@@ -41,6 +41,12 @@ defmodule SkateWeb.DetourRouteControllerTest do
         assert args.coordinates == [[0, 0], [1, 1]]
         assert args.continue_straight == true
 
+        assert %{
+                 length: 12.192,
+                 width: 3.2004,
+                 height: 3.5052
+               } = args.options.profile_params.restrictions
+
         {:ok, build(:ors_directions_json)}
       end)
 


### PR DESCRIPTION
The the first commit is the actual functionality and tests, the other commits are just me trying to make it a bit cleaner. I can easily drop the later two commits if they're disliked.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206826435176362