### PR TITLE
feat(ex/skate/open_route_service_api): add `vehicle_type` to ORS API call

### DIFF
--- a/lib/skate/open_route_service_api/directions_request.ex
+++ b/lib/skate/open_route_service_api/directions_request.ex
@@ -25,8 +25,8 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
       defstruct [:restrictions]
     end
 
-    @type t :: %{profile_params: ProfileParams.t()}
-    defstruct [:profile_params]
+    @type t :: %{profile_params: ProfileParams.t(), vehicle_type: String.t()}
+    defstruct [:profile_params, :vehicle_type]
   end
 
   @typedoc """
@@ -41,6 +41,7 @@ defmodule Skate.OpenRouteServiceAPI.DirectionsRequest do
   defstruct coordinates: [],
             continue_straight: true,
             options: %{
+              vehicle_type: "bus",
               profile_params: %{
                 restrictions:
                   Skate.OpenRouteServiceAPI.DirectionsRequest.Options.ProfileParams.HgvRestrictions.bus_40ft()

--- a/test/skate_web/controllers/detour_route_controller_test.exs
+++ b/test/skate_web/controllers/detour_route_controller_test.exs
@@ -40,6 +40,7 @@ defmodule SkateWeb.DetourRouteControllerTest do
       expect(Skate.OpenRouteServiceAPI.MockClient, :get_directions, fn args ->
         assert args.coordinates == [[0, 0], [1, 1]]
         assert args.continue_straight == true
+        assert args.options.vehicle_type == "bus"
 
         assert %{
                  length: 12.192,


### PR DESCRIPTION
I realized we hadn't set the bus type on our HGV profile, so this adds that to the API request.