### PR TITLE
docs: Updated .envrc with required vars; include storybook in README

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -38,12 +38,6 @@ export ERL_FLAGS="+MIscs 2048"
 ## Source of extended schedule data
 # export SKATE_HASTUS_URL=
 
-## URL for map tile images, including {x} {y} coordinate and {z} zoom level placeholders
-# export BASE_TILESET_URL=
-
-## URL for satellite map tile images, including {x} {y} coordinate and {z} zoom level placeholders
-# export SATELLITE_TILESET_URL=
-
 ## Authentication/authorization secret. Generate a value using mix phx.gen.secret
 # export GUARDIAN_SECRET_KEY
 
@@ -54,6 +48,12 @@ export ERL_FLAGS="+MIscs 2048"
 
 ## Location of map tile images
 # export TILESET_URL=
+
+## URL for map tile images, including {x} {y} coordinate and {z} zoom level placeholders
+# export BASE_TILESET_URL=
+
+## URL for satellite map tile images, including {x} {y} coordinate and {z} zoom level placeholders
+# export SATELLITE_TILESET_URL=
 
 ## Used by Erlang (only required in production)
 # export RELEASE_COOKIE=

--- a/.envrc.template
+++ b/.envrc.template
@@ -35,19 +35,25 @@ export AWS_PLACE_INDEX=
 ## Erlang/OTP settings, pass "+MIscs 2048" to allocate enough memory for literals in your local dev environment
 export ERL_FLAGS="+MIscs 2048"
 
-## Optional Variables
-
 ## Source of extended schedule data
 # export SKATE_HASTUS_URL=
-
-## Location of map tile images
-# export TILESET_URL=
 
 ## URL for map tile images, including {x} {y} coordinate and {z} zoom level placeholders
 # export BASE_TILESET_URL=
 
 ## URL for satellite map tile images, including {x} {y} coordinate and {z} zoom level placeholders
 # export SATELLITE_TILESET_URL=
+
+## Authentication/authorization secret. Generate a value using mix phx.gen.secret
+# export GUARDIAN_SECRET_KEY
+
+## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret (only required in production)
+# export SECRET_KEY_BASE
+
+## Optional Variables
+
+## Location of map tile images
+# export TILESET_URL=
 
 ## Used by Erlang (only required in production)
 # export RELEASE_COOKIE=
@@ -77,12 +83,6 @@ export ERL_FLAGS="+MIscs 2048"
 ## Credentials for the API that gets drawbridge status
 # export BRIDGE_API_USERNAME
 # export BRIDGE_API_PASSWORD
-
-## Authentication/authorization secret. Generate a value using mix phx.gen.secret
-# export GUARDIAN_SECRET_KEY
-
-## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret (only required in production)
-# export SECRET_KEY_BASE
 
 ## Used for locally building (and eventually testing) Storybook and Snapshot tests
 ## The project token can be found in Chromatic, (Manage > Configure > Project > Project Token)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If you see the “data outage” banner when you open your local version of Skat
 - Run Elixir tests with `` mix test ``
 - Run Javascript tests with `cd assets && npm test`
 
+## Running Storybook
+
+Storybook is a tool to create and test UI components in isolation. To run: `cd assets && npm run storybook`
+
 ## Browser Support Policy
 
 We strive to support all users – but the variety of browsers, operating systems and devices available necessitates a more intentioned approach. These differences could potentially cause bugs and harm your experience with Skate. Ensure you have the best possible experience with Skate by updating your browser to the latest version.


### PR DESCRIPTION
While onboarding, noticed a couple of env vars that are no longer quite so "optional" in first getting Skate running. Those are moved to the required vars section. Also noted Storybook run command in the README