### PR TITLE
chore: Remove Skate.Endpoint.init/2, deprecated in Phoenix 1.17.11

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,6 @@ config :skate, SkateWeb.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________",
   watchers: [
     node: [
       "node_modules/webpack/bin/webpack.js",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,13 +5,14 @@ Application.ensure_all_started(:hackney)
 Application.ensure_all_started(:ex_aws)
 
 config :skate,
-  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   restrict_environment_access?: System.get_env("RESTRICT_ENVIRONMENT_ACCESS") == "true",
   base_tileset_url: System.get_env("BASE_TILESET_URL"),
   satellite_tileset_url: System.get_env("SATELLITE_TILESET_URL"),
   aws_place_index: System.get_env("AWS_PLACE_INDEX")
 
-config :skate, SkateWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
+if config_env() != :test do
+  config :skate, SkateWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
+end
 
 config :skate, Skate.OpenRouteServiceAPI,
   api_base_url: System.get_env("OPEN_ROUTE_SERVICE_API_URL"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,6 +5,7 @@ Application.ensure_all_started(:hackney)
 Application.ensure_all_started(:ex_aws)
 
 config :skate,
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   restrict_environment_access?: System.get_env("RESTRICT_ENVIRONMENT_ACCESS") == "true",
   base_tileset_url: System.get_env("BASE_TILESET_URL"),
   satellite_tileset_url: System.get_env("SATELLITE_TILESET_URL"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,11 +5,12 @@ Application.ensure_all_started(:hackney)
 Application.ensure_all_started(:ex_aws)
 
 config :skate,
-  secret_key_base: System.get_env("SECRET_KEY_BASE"),
   restrict_environment_access?: System.get_env("RESTRICT_ENVIRONMENT_ACCESS") == "true",
   base_tileset_url: System.get_env("BASE_TILESET_URL"),
   satellite_tileset_url: System.get_env("SATELLITE_TILESET_URL"),
   aws_place_index: System.get_env("AWS_PLACE_INDEX")
+
+config :skate, SkateWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :skate, Skate.OpenRouteServiceAPI,
   api_base_url: System.get_env("OPEN_ROUTE_SERVICE_API_URL"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -10,7 +10,7 @@ config :skate,
   satellite_tileset_url: System.get_env("SATELLITE_TILESET_URL"),
   aws_place_index: System.get_env("AWS_PLACE_INDEX")
 
-if config_env() != :test do
+if System.get_env("SECRET_KEY_BASE") do
   config :skate, SkateWeb.Endpoint, secret_key_base: System.get_env("SECRET_KEY_BASE")
 end
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,8 +1,7 @@
 import Config
 
 config :skate,
-  start_data_processes: false,
-  secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________"
+  start_data_processes: false
 
 config :skate, Schedule.CacheFile, cache_filename: "test_cache.terms"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,8 @@
 import Config
 
-config :skate, start_data_processes: false
+config :skate,
+  start_data_processes: false,
+  secret_key_base: "local_secret_key_base_at_least_64_bytes_________________________________"
 
 config :skate, Schedule.CacheFile, cache_filename: "test_cache.terms"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,6 @@
 import Config
 
-config :skate,
-  start_data_processes: false
+config :skate, start_data_processes: false
 
 config :skate, Schedule.CacheFile, cache_filename: "test_cache.terms"
 

--- a/lib/skate_web/endpoint.ex
+++ b/lib/skate_web/endpoint.ex
@@ -46,19 +46,4 @@ defmodule SkateWeb.Endpoint do
     signing_salt: "jkUgGkwy"
 
   plug SkateWeb.Router
-
-  # callback for runtime configuration
-  def init(:supervisor, config) do
-    secret_key_base = Application.get_env(:skate, :secret_key_base)
-
-    config =
-      if secret_key_base do
-        Keyword.put(config, :secret_key_base, secret_key_base)
-      else
-        config[:secret_key_base] || raise "No SECRET_KEY_BASE ENV var!"
-        config
-      end
-
-    {:ok, config}
-  end
 end


### PR DESCRIPTION
When I [upgraded from Phoenix 1.17.10 to 1.17.11][0], I missed [the note in the changelog][1] indicating that Endpoint.init/2 was being deprecated.

It was deprecated in [this commit][2].

[0]: https://github.com/mbta/skate/pull/2393
[1]: https://github.com/phoenixframework/phoenix/blob/main/CHANGELOG.md#deprecation
[2]: https://github.com/phoenixframework/phoenix/commit/55395900f39a56a0431575f0f88eb89dd24c7a46#diff-28a3e2f0a9ad390131d7da1927ea8c13c9018a0f5319afe899c32cbeebdf2397R34-R37