### PR TITLE
fix: Missed Stops should not display until detour finished

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -133,9 +133,11 @@ export const useDetour = ({ routePatternId, shape }: OriginalRoute) => {
     setState(DetourState.Edit)
   }
 
-  const missedStops = finishedDetour?.missedStops || []
+  const missedStops = finishedDetour?.missedStops || undefined
 
-  const missedStopIds = new Set(missedStops.map((stop) => stop.id))
+  const missedStopIds = missedStops
+    ? new Set(missedStops.map((stop) => stop.id))
+    : new Set()
   const stops = (shape.stops || []).map((stop) => ({
     ...stop,
     missed: missedStopIds.has(stop.id),

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -388,7 +388,7 @@ describe("useDetour", () => {
     act(() => result.current.undo?.())
 
     await waitFor(() => {
-      expect(result.current.missedStops).toHaveLength(0)
+      expect(result.current.missedStops).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Asana task: [🚧⚙️🐛 Missed Stops section shows up in the detour panel before a route is connected](https://app.asana.com/0/1205385723132845/1206843243488989)

The `useDetour` hook is already aware of whether the detour has been completed or not, and uses that to decide whether `missedStops` should have stops or be an empty list. Instead of setting conditionals in each of the areas where `missedStops` is used (to verify that the detour is complete), I figured I could just set `missedStops` to undefined when detour not finished. It didn't break any tests (other than the obvious) so I hope that assumption makes sense!