### PR TITLE
fix: Moved "Return to Regular Route" into root directions list

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -68,7 +68,6 @@ export const DiversionPage = ({
         ,
         "Turn-by-Turn Directions:",
         ...(directions?.map((v) => v.instruction) ?? []),
-        "Return to Regular Route",
         ,
         "Connection Points:",
         connectionPoints?.start?.name ?? "N/A",

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -63,7 +63,7 @@ export const DiversionPanel = ({
             <ListGroup as="ol">
               {directions.map((d) => (
                 <ListGroup.Item key={d.instruction} as="li">
-                  {d.instruction == "Return to Regular Route" ? (
+                  {d.instruction == "Regular Route" ? (
                     <strong className="fw-medium">{d.instruction}</strong>
                   ) : (
                     d.instruction

--- a/assets/src/components/detours/diversionPanel.tsx
+++ b/assets/src/components/detours/diversionPanel.tsx
@@ -63,14 +63,13 @@ export const DiversionPanel = ({
             <ListGroup as="ol">
               {directions.map((d) => (
                 <ListGroup.Item key={d.instruction} as="li">
-                  {d.instruction}
+                  {d.instruction == "Return to Regular Route" ? (
+                    <strong className="fw-medium">{d.instruction}</strong>
+                  ) : (
+                    d.instruction
+                  )}
                 </ListGroup.Item>
               ))}
-              {detourFinished && (
-                <ListGroup.Item as="li">
-                  <strong className="fw-medium">Return to Regular Route</strong>
-                </ListGroup.Item>
-              )}
             </ListGroup>
           ) : (
             <DirectionsHelpText />

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -92,7 +92,7 @@ export const useDetour = ({ routePatternId, shape }: OriginalRoute) => {
   const directions = isOk(detourShape)
     ? finishedDetour
       ? detourShape.ok.directions?.concat({
-          instruction: "Return to Regular Route",
+          instruction: "Regular Route",
         })
       : detourShape.ok.directions
     : undefined

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -88,10 +88,13 @@ export const useDetour = ({ routePatternId, shape }: OriginalRoute) => {
   )
 
   const coordinates = isOk(detourShape) ? detourShape.ok.coordinates : []
+  // Only append direction "Regular Route" after detour is finished
   const directions = isOk(detourShape)
-    ? detourShape.ok.directions?.concat({
-        instruction: "Return to Regular Route",
-      })
+    ? finishedDetour
+      ? detourShape.ok.directions?.concat({
+          instruction: "Return to Regular Route",
+        })
+      : detourShape.ok.directions
     : undefined
 
   const canAddWaypoint = () => startPoint !== null && endPoint === null

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -88,7 +88,11 @@ export const useDetour = ({ routePatternId, shape }: OriginalRoute) => {
   )
 
   const coordinates = isOk(detourShape) ? detourShape.ok.coordinates : []
-  const directions = isOk(detourShape) ? detourShape.ok.directions : undefined
+  const directions = isOk(detourShape)
+    ? detourShape.ok.directions?.concat({
+        instruction: "Return to Regular Route",
+      })
+    : undefined
 
   const canAddWaypoint = () => startPoint !== null && endPoint === null
   const addWaypoint = canAddWaypoint()

--- a/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
@@ -13,7 +13,7 @@ const defaultText = [
   "Turn-by-Turn Directions:",
   "From Harvard St & Babcock St",
   "Right on Babcock St.",
-  "Return to Regular Route",
+  "Regular Route",
   "",
   "Connection Points:",
   "Harvard St @ Beacon St",

--- a/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
@@ -13,7 +13,7 @@ const defaultText = [
   "Turn-by-Turn Directions:",
   "From Harvard St & Babcock St",
   "Right on Babcock St.",
-  "Regular Route",
+  "Return to Regular Route",
   "",
   "Connection Points:",
   "Harvard St @ Beacon St",

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -261,11 +261,11 @@ describe("DiversionPage", () => {
 
     const { container } = render(<DiversionPage />)
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(originalRouteShape.get(container))
     })
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(originalRouteShape.get(container))
     })
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -410,7 +410,7 @@ describe("DiversionPage", () => {
           "Turn left on Main Street",
           "Turn right on High Street",
           "Turn sharp right on Broadway",
-          "Return to Regular Route",
+          "Regular Route",
           ,
           "Connection Points:",
           start.name,

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -242,6 +242,74 @@ describe("DiversionPage", () => {
     expect(screen.queryByTitle("Detour End")).toBeNull()
   })
 
+  test("shows 'Regular Route' text when the detour is finished", async () => {
+    jest.mocked(fetchDetourDirections).mockResolvedValue(
+      ok(
+        detourShapeFactory.build({
+          directions: [
+            { instruction: "Turn left on Main Street" },
+            { instruction: "Turn right on High Street" },
+            { instruction: "Turn sharp right on Broadway" },
+          ],
+        })
+      )
+    )
+
+    jest
+      .mocked(fetchFinishedDetour)
+      .mockResolvedValue(
+        finishedDetourFactory.build()
+      )
+    
+    const { container } = render(<DiversionPage />)
+
+    await act(async () => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    await act(async () => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    expect((await screen.findByText("Regular Route"))).toBeVisible()
+  })
+
+  test("does not show 'Regular Route' when detour not finished", async () => {
+    jest.mocked(fetchDetourDirections).mockResolvedValue(
+      ok(
+        detourShapeFactory.build({
+          directions: [
+            { instruction: "Turn left on Main Street" },
+            { instruction: "Turn right on High Street" },
+            { instruction: "Turn sharp right on Broadway" },
+          ],
+        })
+      )
+    )
+
+    jest
+      .mocked(fetchFinishedDetour)
+      .mockResolvedValue(
+        finishedDetourFactory.build()
+      )
+    
+    const { container } = render(<DiversionPage />)
+
+    expect(screen.queryByText("Regular Route")).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    await act(async () => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }))
+
+    expect(screen.queryByText("Regular Route")).toBeNull()
+  })
+
   test("missed stops are filled in when detour is complete", async () => {
     const stop1 = stopFactory.build()
     const stop2 = stopFactory.build()

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -293,11 +293,11 @@ describe("DiversionPage", () => {
 
     expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(originalRouteShape.get(container))
     })
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(originalRouteShape.get(container))
     })
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -272,7 +272,7 @@ describe("DiversionPage", () => {
     expect(await screen.findByText("Regular Route")).toBeVisible()
   })
 
-  test("does not show 'Regular Route' when detour not finished", async () => {
+  test("does not show 'Regular Route' when detour is not finished", async () => {
     jest.mocked(fetchDetourDirections).mockResolvedValue(
       ok(
         detourShapeFactory.build({

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -257,10 +257,8 @@ describe("DiversionPage", () => {
 
     jest
       .mocked(fetchFinishedDetour)
-      .mockResolvedValue(
-        finishedDetourFactory.build()
-      )
-    
+      .mockResolvedValue(finishedDetourFactory.build())
+
     const { container } = render(<DiversionPage />)
 
     await act(async () => {
@@ -271,7 +269,7 @@ describe("DiversionPage", () => {
       fireEvent.click(originalRouteShape.get(container))
     })
 
-    expect((await screen.findByText("Regular Route"))).toBeVisible()
+    expect(await screen.findByText("Regular Route")).toBeVisible()
   })
 
   test("does not show 'Regular Route' when detour not finished", async () => {
@@ -289,10 +287,8 @@ describe("DiversionPage", () => {
 
     jest
       .mocked(fetchFinishedDetour)
-      .mockResolvedValue(
-        finishedDetourFactory.build()
-      )
-    
+      .mockResolvedValue(finishedDetourFactory.build())
+
     const { container } = render(<DiversionPage />)
 
     expect(screen.queryByText("Regular Route")).toBeNull()

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -291,7 +291,7 @@ describe("DiversionPage", () => {
 
     const { container } = render(<DiversionPage />)
 
-    expect(screen.queryByText("Regular Route")).toBeNull()
+    expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()
 
     await act(async () => {
       fireEvent.click(originalRouteShape.get(container))
@@ -303,7 +303,7 @@ describe("DiversionPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Undo" }))
 
-    expect(screen.queryByText("Regular Route")).toBeNull()
+    expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()
   })
 
   test("missed stops are filled in when detour is complete", async () => {

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -301,6 +301,8 @@ describe("DiversionPage", () => {
       fireEvent.click(originalRouteShape.get(container))
     })
 
+    expect(await screen.findByText("Regular Route")).toBeVisible()
+
     fireEvent.click(screen.getByRole("button", { name: "Undo" }))
 
     expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()


### PR DESCRIPTION
The little things I like about this approach is that
- "Return to Regular Route" is put with other directions, which I think it should be!
- The direction is in the root hook instead of scattered in multiple components
- The test for `diversionPage` now sufficiently covers the check "was 'Return to Regular Route' added to the directions sequence"
- We can still choose to make directions more structured with typing later (per Josh's suggestion)

Also included, updating the Storybook story for this!