### PR TITLE
feat: return `:no_route` error from ORS

### DIFF
--- a/lib/skate/open_route_service_api.ex
+++ b/lib/skate/open_route_service_api.ex
@@ -66,7 +66,7 @@ defmodule Skate.OpenRouteServiceAPI do
         parse_directions(payload)
 
       error ->
-        error
+        parse_error(error)
     end
   end
 
@@ -95,6 +95,10 @@ defmodule Skate.OpenRouteServiceAPI do
            }
          )
      }}
+  end
+
+  defp parse_error(error) do
+    error
   end
 
   defp client(), do: Application.get_env(:skate, Skate.OpenRouteServiceAPI)[:client]

--- a/lib/skate/open_route_service_api.ex
+++ b/lib/skate/open_route_service_api.ex
@@ -65,7 +65,7 @@ defmodule Skate.OpenRouteServiceAPI do
       {:ok, payload} ->
         parse_directions(payload)
 
-      error ->
+      {:error, error} ->
         parse_error(error)
     end
   end
@@ -97,9 +97,13 @@ defmodule Skate.OpenRouteServiceAPI do
      }}
   end
 
-  defp parse_error(error) do
-    error
-  end
+  # Convert API Error codes into specific errors for the frontend to handle
+  # https://giscience.github.io/openrouteservice/api-reference/error-codes
+
+  # 2010: Point was not found.
+  defp parse_error(%{"code" => 2010}), do: {:error, %{type: :no_route}}
+
+  defp parse_error(_error), do: {:error, %{type: :unknown}}
 
   defp client(), do: Application.get_env(:skate, Skate.OpenRouteServiceAPI)[:client]
 

--- a/lib/skate/open_route_service_api.ex
+++ b/lib/skate/open_route_service_api.ex
@@ -47,7 +47,7 @@ defmodule Skate.OpenRouteServiceAPI do
 
   ## Examples
       iex> Skate.OpenRouteServiceAPI.directions([%{"lat" => 0, "lon" => 10}, %{"lat" => 1, "lon" => 10}])
-      {:error, %{"message" => "Invalid API Key"}}
+      {:error, %{type: :unknown}}
   """
   @spec directions(list()) :: {:ok, DirectionsResponse.t()} | {:error, any()}
   def directions([]), do: {:ok, %DirectionsResponse{}}

--- a/lib/skate/open_route_service_api/client.ex
+++ b/lib/skate/open_route_service_api/client.ex
@@ -74,6 +74,9 @@ defmodule Skate.OpenRouteServiceAPI.Client do
       {:ok, %HTTPoison.Response{status_code: 400, body: body}} ->
         {:error, Jason.decode!(body)["error"]}
 
+      {:ok, %HTTPoison.Response{status_code: 404, body: body}} ->
+        {:error, Jason.decode!(body)["error"]}
+
       {:error, %HTTPoison.Error{}} ->
         {:error, "unknown"}
     end

--- a/test/skate/open_route_service_api_test.exs
+++ b/test/skate/open_route_service_api_test.exs
@@ -133,4 +133,36 @@ defmodule Skate.OpenRouteServiceAPITest do
                %{"lat" => 0, "lon" => 1}
              ])
   end
+
+  test "unknown errors from ORS return `type: :unknown`" do
+    expect(
+      Skate.OpenRouteServiceAPI.MockClient,
+      :get_directions,
+      fn _ ->
+        {:error, %{"code" => -1}}
+      end
+    )
+
+    assert {:error, %{type: :unknown}} =
+             Skate.OpenRouteServiceAPI.directions([
+               %{"lat" => 0, "lon" => 0},
+               %{"lat" => 0, "lon" => 1}
+             ])
+  end
+
+  test "point not found errors from ORS return `type: :no_route`" do
+    expect(
+      Skate.OpenRouteServiceAPI.MockClient,
+      :get_directions,
+      fn _ ->
+        {:error, %{"code" => 2010}}
+      end
+    )
+
+    assert {:error, %{type: :no_route}} =
+             Skate.OpenRouteServiceAPI.directions([
+               %{"lat" => 0, "lon" => 0},
+               %{"lat" => 0, "lon" => 1}
+             ])
+  end
 end

--- a/test/skate_web/controllers/detour_route_controller_test.exs
+++ b/test/skate_web/controllers/detour_route_controller_test.exs
@@ -177,7 +177,24 @@ defmodule SkateWeb.DetourRouteControllerTest do
           coordinates: [%{"lat" => 1, "lon" => 100}, %{"lat" => 2, "lon" => 101}]
         )
 
-      assert json_response(conn, 500)
+      assert %{"error" => %{"type" => "unknown"}} = json_response(conn, 500)
+    end
+
+    @tag :authenticated
+    test "returns a 500-level response with type: :no_route when ORS reports point not found error",
+         %{
+           conn: conn
+         } do
+      expect(Skate.OpenRouteServiceAPI.MockClient, :get_directions, fn _ ->
+        {:error, %{"code" => 2010}}
+      end)
+
+      conn =
+        post(conn, ~p"/api/detours/directions",
+          coordinates: [%{"lat" => 1, "lon" => 100}, %{"lat" => 2, "lon" => 101}]
+        )
+
+      assert %{"error" => %{"type" => "no_route"}} = json_response(conn, 500)
     end
   end
 end


### PR DESCRIPTION
This returns errors from ORS and processes it into a smaller set of error values. The frontend is currently ignoring the return value of this so this can be made out of step with the frontend and therefore reviewed in a smaller chunk.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206941188727470