### PR TITLE
 feat(direnv/template): source secrets directly from `mix phx.gen.secret`

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -39,10 +39,10 @@ export ERL_FLAGS="+MIscs 2048"
 # export SKATE_HASTUS_URL=
 
 ## Authentication/authorization secret. Generate a value using mix phx.gen.secret
-# export GUARDIAN_SECRET_KEY
+export GUARDIAN_SECRET_KEY
 
 ## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret (only required in production)
-# export SECRET_KEY_BASE
+export SECRET_KEY_BASE
 
 ## Optional Variables
 

--- a/.envrc.template
+++ b/.envrc.template
@@ -39,10 +39,10 @@ export ERL_FLAGS="+MIscs 2048"
 # export SKATE_HASTUS_URL=
 
 ## Authentication/authorization secret. Generate a value using mix phx.gen.secret
-export GUARDIAN_SECRET_KEY
+export GUARDIAN_SECRET_KEY=$(mix phx.gen.secret)
 
-## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret (only required in production)
-export SECRET_KEY_BASE
+## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret
+export SECRET_KEY_BASE=$(mix phx.gen.secret)
 
 ## Optional Variables
 


### PR DESCRIPTION
Instead of having users fill this in manually, we can source it directly from mix when we load direnv. 
