### PR TITLE
feat: add api helper function to return `Result<T, E>` from API requests

### DIFF
--- a/assets/src/util/result.ts
+++ b/assets/src/util/result.ts
@@ -1,0 +1,56 @@
+/**
+ * The discriminator value used to determine if a {@linkcode Result<T, E>} is
+ * {@linkcode Ok<T>} or {@linkcode Err<E>}.
+ */
+enum ResultTag {
+  Ok,
+  Err,
+}
+
+/**
+ * The key of the {@linkcode Result<T, E>} discriminator value.
+ *
+ * This is not exported so that usages of the objects cannot be
+ * accessed or modified manually outside of this module.
+ */
+const tag = Symbol("result-enum-tag")
+
+/** The {@linkcode Ok<T>} variant of {@linkcode Result<T, E>} */
+export type Ok<T> = { [tag]: ResultTag.Ok; ok: T }
+
+/** The {@linkcode Err<E>} variant of {@linkcode Result<T, E>} */
+export type Err<E> = { [tag]: ResultTag.Err; err: E }
+
+/**
+ * Type which may contain an {@linkcode Ok<T>} state, or a {@linkcode Err<E>} state
+ *
+ * useful for requiring a caller of a function to handle the Error state of a return value.
+ */
+export type Result<T, E> = Ok<T> | Err<E>
+
+/** Determines if a {@linkcode Result<T, E>} is a {@linkcode Ok<T>} */
+export const isOk = <T, E>(r: Result<T, E>): r is Ok<T> =>
+  tag in r && r[tag] === ResultTag.Ok
+
+/** Determines if a {@linkcode Result<T, E>} is a {@linkcode Err<E>} */
+export const isErr = <T, E>(r: Result<T, E>): r is Err<E> =>
+  tag in r && r[tag] === ResultTag.Err
+
+/** Constructs a {@linkcode Ok<T>} with {@linkcode v} as the value */
+export const Ok = <T>(v: T): Ok<T> => ({
+  [tag]: ResultTag.Ok,
+  ok: v,
+})
+
+/** Constructs a {@linkcode Err<E>} with {@linkcode v} as the value */
+export const Err = <E>(v: E): Err<E> => ({
+  [tag]: ResultTag.Err,
+  err: v,
+})
+
+/**
+ * If {@linkcode r} is {@linkcode Ok<T>}, it applies {@linkcode fn} to
+ * the value contained in {@linkcode r}. Otherwise returns {@linkcode r}.
+ */
+export const map = <T, U, E>(r: Result<T, E>, fn: (v: T) => U): Result<U, E> =>
+  isOk(r) ? Ok(fn(r.ok)) : r

--- a/assets/tests/util/result.test.ts
+++ b/assets/tests/util/result.test.ts
@@ -32,14 +32,13 @@ describe("Result<T, E>::isErr", () => {
 })
 
 describe("Result<T, E>::map", () => {
-  test("applies function if Ok<T>", () => {
-    const fn = jest.fn(() => true)
+  test("if Ok<T> applies function and returns Ok<U>", () => {
+    const value = Symbol("unique value")
 
-    expect(map(Ok(undefined), fn)).toEqual(Ok(true))
-    expect(fn).toHaveBeenCalledWith(undefined)
+    expect(map(Ok(value), (x) => x === value)).toEqual(Ok(true))
   })
 
-  test("returns input if Err<E>", () => {
+  test("if Err<E> returns input", () => {
     const fn = jest.fn(() => false)
 
     expect(map(Err(true), fn)).toEqual(Err(true))

--- a/assets/tests/util/result.test.ts
+++ b/assets/tests/util/result.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, jest, test } from "@jest/globals"
+import { Err, Ok, Result, isErr, isOk, map } from "../../src/util/result"
+
+describe("Result<T, E>::isOk", () => {
+  test("returns true for Ok<T>", () => {
+    expect(isOk(Ok(undefined))).toBe(true)
+  })
+  test("returns false for Err<E>", () => {
+    expect(isOk(Err(undefined))).toBe(false)
+  })
+
+  test("when `isOk`, allows accessing the internal value", () => {
+    const value = Ok(10) as Result<number, unknown>
+
+    expect(isOk(value) && value.ok).toEqual(10)
+  })
+})
+
+describe("Result<T, E>::isErr", () => {
+  test("returns true for Err<E>", () => {
+    expect(isErr(Err(undefined))).toBe(true)
+  })
+  test("returns false for Ok<T>", () => {
+    expect(isErr(Ok(undefined))).toBe(false)
+  })
+
+  test("when `isErr`, allows accessing the internal value", () => {
+    const value = Err(10) as Result<unknown, number>
+
+    expect(isErr(value) && value.err).toEqual(10)
+  })
+})
+
+describe("Result<T, E>::map", () => {
+  test("applies function if Ok<T>", () => {
+    const fn = jest.fn(() => true)
+
+    expect(map(Ok(undefined), fn)).toEqual(Ok(true))
+    expect(fn).toHaveBeenCalledWith(undefined)
+  })
+
+  test("returns input if Err<E>", () => {
+    const fn = jest.fn(() => false)
+
+    expect(map(Err(true), fn)).toEqual(Err(true))
+    expect(fn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This creates a new `Result` type and also uses it immediately in `api.ts` to show an example of it's usage. 

---

You can see this code in use on the PR https://github.com/mbta/skate/pull/2534

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207056301082043