### PR TITLE
init(ts/hooks/useApiCall): add hook for consuming api promises

### DIFF
--- a/assets/src/hooks/useApiCall.ts
+++ b/assets/src/hooks/useApiCall.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react"
+
+/**
+ * Return type of {@linkcode useApiCall}
+ */
+interface ApiLoadingResult<T> {
+  /**
+   * Indicates if {@linkcode useApiCall} is in the process of computing a new
+   * value
+   */
+  isLoading: boolean
+
+  /**
+   * The last value that {@linkcode useApiCall} resolved.
+   *
+   * Is `undefined` when it has not resolved or it resolves to `undefined`
+   */
+  result: T | undefined
+}
+
+/** Hook prop arguments for {@linkcode useApiCall} */
+interface UseApiCallProps<T> {
+  /**
+   * Function which returns a promise that is called every time it changes.
+   * @param abortSignal An {@linkcode AbortSignal} that signals if the promise
+   *    should attempt to cancel early
+   */
+  apiCall: (abortSignal: AbortSignal) => Promise<undefined | T>
+}
+
+/**
+ * Calls the provided function returning a {@linkcode Promise} and tracks the
+ * loading state and the previously resolved value.
+ *
+ * @returns {ApiLoadingResult<T>}
+ */
+export const useApiCall = <T>({
+  apiCall,
+}: UseApiCallProps<T>): ApiLoadingResult<T> => {
+  const [apiResult, setApiResult] = useState<T | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    setIsLoading(true)
+    apiCall(controller.signal).then((value) => {
+      if (controller.signal.aborted) {
+        return
+      }
+
+      setApiResult(value)
+      setIsLoading(false)
+    })
+
+    return () => {
+      controller.abort()
+    }
+  }, [apiCall, setApiResult, setIsLoading])
+
+  return {
+    isLoading,
+    result: apiResult,
+  }
+}

--- a/assets/tests/hooks/useApiCall.test.ts
+++ b/assets/tests/hooks/useApiCall.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, jest, test } from "@jest/globals"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { useApiCall } from "../../src/hooks/useApiCall"
+
+const renderUseApiCall = (initialProps: Parameters<typeof useApiCall>[0]) =>
+  renderHook(useApiCall, {
+    initialProps,
+  })
+
+const PromiseWithResolvers = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+} => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | undefined = undefined
+  let reject: ((reason?: any) => void) | undefined = undefined
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  if (resolve === undefined || reject === undefined) {
+    throw Error("Promise failed to assign `resolve` and/or `reject`")
+  }
+
+  return { promise, resolve, reject }
+}
+
+describe("when first rendered", () => {
+  test("should return loading state", () => {
+    const { result } = renderUseApiCall({
+      apiCall: () => new Promise(() => {}),
+    })
+
+    expect(result.current?.isLoading).toBe(true)
+  })
+
+  test("should call the input function", () => {
+    const fn = jest.fn(() => new Promise(() => {}))
+
+    renderUseApiCall({
+      apiCall: fn,
+    })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("when the input function changes", () => {
+  test("should change to loading state", async () => {
+    const fn = jest.fn(() => Promise.resolve(undefined))
+    const fn2 = jest.fn(() => Promise.resolve(undefined))
+
+    const { result, rerender } = renderUseApiCall({
+      apiCall: fn,
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), {
+      interval: 1,
+    })
+
+    rerender({ apiCall: fn2 })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true), {
+      interval: 1,
+    })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
+  test("should call the input function", () => {
+    const fn = jest.fn(() => new Promise(() => {}))
+    const fn2 = jest.fn(() => new Promise(() => {}))
+
+    const { rerender } = renderUseApiCall({
+      apiCall: fn,
+    })
+
+    rerender({ apiCall: fn2 })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
+  test("should return the previous result until promise resolves", async () => {
+    const fn = jest.fn(() => Promise.resolve("first result"))
+    const fn2 = jest.fn(() => Promise.resolve("second result"))
+
+    const { result, rerender } = renderUseApiCall({
+      apiCall: fn,
+    })
+
+    await waitFor(() => expect(result.current.result).toBe("first result"), {
+      interval: 1,
+    })
+
+    rerender({ apiCall: fn2 })
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(true)
+        expect(result.current.result).toBe("first result")
+      },
+      { interval: 1 }
+    )
+
+    await waitFor(() => expect(result.current.result).toBe("second result"), {
+      interval: 1,
+    })
+
+    expect(result.current.isLoading).toBe(false)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
+  test("previous functions that resolve out of order should not change the return value", async () => {
+    const { promise, resolve } = PromiseWithResolvers()
+
+    const fn = jest.fn(() => promise)
+    const fn2 = jest.fn(() => Promise.resolve("second result"))
+
+    const { result, rerender } = renderUseApiCall({
+      apiCall: fn,
+    })
+
+    rerender({ apiCall: fn2 })
+
+    await waitFor(() => expect(result.current.result).toBe("second result"), {
+      interval: 1,
+    })
+
+    act(() => {
+      resolve("first result")
+    })
+
+    expect(result.current.result).toBe("second result")
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("when the input function does not change", () => {
+  test("should not call the input function again", () => {
+    const apiCall = jest.fn(() => new Promise(() => {}))
+    const initialProps = { apiCall }
+
+    const { rerender } = renderUseApiCall({
+      apiCall,
+    })
+
+    rerender(initialProps)
+
+    expect(apiCall).toHaveBeenCalledTimes(1)
+  })
+
+  test("should return last result", async () => {
+    const apiCall = jest.fn(() => Promise.resolve("result"))
+    const initialProps = { apiCall }
+
+    const { rerender, result } = renderUseApiCall({
+      apiCall,
+    })
+
+    rerender(initialProps)
+
+    await waitFor(() => expect(result.current.result).toEqual("result"), {
+      interval: 1,
+    })
+  })
+})
+
+describe("when unmounted", () => {
+  test("input function receives cancelation signal", () => {
+    const apiCall = async (abortSignal: AbortSignal): Promise<void> => {
+      await waitFor(() => expect(abortSignal.aborted).toBe(true), {
+        interval: 1,
+      })
+    }
+
+    const { unmount } = renderUseApiCall({
+      apiCall,
+    })
+
+    unmount()
+  })
+})


### PR DESCRIPTION
This adds a generic hook for consuming Promise's, we currently only have a need for this with API results.

This will be combined with #2531 to make implementing API endpoints which may return an error easier.

---

You can see this code in use on the PR https://github.com/mbta/skate/pull/2534

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207056301082042
  - https://app.asana.com/0/0/1207091097322621