### PR TITLE
 refactor(ts/api/fetchDetourDirections): use `apiCallResult`

### DIFF
--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -28,7 +28,7 @@ import {
   missedStopIcon,
   stopIcon,
 } from "../../testHelpers/selectors/components/map/markers/stopIcon"
-import { ok, loading, fetchError } from "../../../src/util/fetchResult"
+import { Err, Ok } from "../../../src/util/result"
 
 const DiversionPage = (
   props: Omit<
@@ -67,7 +67,9 @@ beforeEach(() => {
 jest.mock("../../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetourDirections).mockResolvedValue(loading())
+  jest
+    .mocked(fetchDetourDirections)
+    .mockImplementation(() => new Promise(() => {}))
   jest.mocked(fetchFinishedDetour).mockResolvedValue(null)
 })
 
@@ -120,7 +122,9 @@ describe("DiversionPage", () => {
   })
 
   test("when adding a point results in a routing error, displays an alert", async () => {
-    jest.mocked(fetchDetourDirections).mockResolvedValue(fetchError())
+    jest
+      .mocked(fetchDetourDirections)
+      .mockResolvedValue(Err({ type: "unknown" }))
 
     const { container } = render(<DiversionPage />)
 
@@ -140,7 +144,9 @@ describe("DiversionPage", () => {
   })
 
   test("routing error alert can be dismissed", async () => {
-    jest.mocked(fetchDetourDirections).mockResolvedValue(fetchError())
+    jest
+      .mocked(fetchDetourDirections)
+      .mockResolvedValue(Err({ type: "unknown" }))
 
     const { container } = render(<DiversionPage />)
 
@@ -268,7 +274,7 @@ describe("DiversionPage", () => {
 
   test("shows 'Regular Route' text when the detour is finished", async () => {
     jest.mocked(fetchDetourDirections).mockResolvedValue(
-      ok(
+      Ok(
         detourShapeFactory.build({
           directions: [
             { instruction: "Turn left on Main Street" },
@@ -298,7 +304,7 @@ describe("DiversionPage", () => {
 
   test("does not show 'Regular Route' when detour is not finished", async () => {
     jest.mocked(fetchDetourDirections).mockResolvedValue(
-      ok(
+      Ok(
         detourShapeFactory.build({
           directions: [
             { instruction: "Turn left on Main Street" },
@@ -443,7 +449,7 @@ describe("DiversionPage", () => {
     const [start, end] = stopFactory.buildList(2)
 
     jest.mocked(fetchDetourDirections).mockResolvedValue(
-      ok(
+      Ok(
         detourShapeFactory.build({
           directions: [
             { instruction: "Turn left on Main Street" },

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -11,12 +11,12 @@ import { finishedDetourFactory } from "../factories/finishedDetourFactory"
 import { routeSegmentsFactory } from "../factories/finishedDetourFactory"
 import { originalRouteFactory } from "../factories/originalRouteFactory"
 import shapeFactory from "../factories/shape"
-import { ok, loading, fetchError } from "../../src/util/fetchResult"
+import { Err, Ok } from "../../src/util/result"
 
 jest.mock("../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetourDirections).mockResolvedValue(loading())
+  jest.mocked(fetchDetourDirections).mockReturnValue(new Promise(() => {}))
 
   jest
     .mocked(fetchFinishedDetour)
@@ -106,7 +106,7 @@ describe("useDetour", () => {
 
     jest.mocked(fetchDetourDirections).mockImplementation((coordinates) => {
       expect(coordinates).toStrictEqual([start, end])
-      return Promise.resolve(ok(detourShape))
+      return Promise.resolve(Ok(detourShape))
     })
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
@@ -132,7 +132,9 @@ describe("useDetour", () => {
     const start: ShapePoint = { lat: -2, lon: -2 }
     const end: ShapePoint = { lat: -1, lon: -1 }
 
-    jest.mocked(fetchDetourDirections).mockResolvedValue(fetchError())
+    jest
+      .mocked(fetchDetourDirections)
+      .mockResolvedValue(Err({ type: "unknown" }))
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
@@ -205,7 +207,7 @@ describe("useDetour", () => {
   test("when `undo` removes the last waypoint, `detourShape` and `directions` should be empty", async () => {
     jest
       .mocked(fetchDetourDirections)
-      .mockResolvedValue(ok(detourShapeFactory.build()))
+      .mockResolvedValue(Ok(detourShapeFactory.build()))
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
@@ -267,7 +269,7 @@ describe("useDetour", () => {
   test("when `clear` is called, `detourShape` and `directions` should be empty", async () => {
     jest
       .mocked(fetchDetourDirections)
-      .mockResolvedValue(ok(detourShapeFactory.build()))
+      .mockResolvedValue(Ok(detourShapeFactory.build()))
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 


### PR DESCRIPTION
This switches `fetchDetourDirections` over to use `apiCallResult` so that we can return errors from the backend. Switching to `apiCallResult` sets us up for https://github.com/mbta/skate/pull/2543 .

There were a few unrelated test issues due to introducing promises into the mix, so the commits should be reviewable in order to help discombobulate some of the changes.

Depends On:
- #2531
- #2533 
- #2539
- #2544

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207091097322625
  - https://app.asana.com/0/0/1206816132107683