### PR TITLE
feat: use relative path for `directions_path` to merge with base url

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -14,8 +14,6 @@ config :skate,
 config :skate, Skate.OpenRouteServiceAPI,
   api_base_url: System.get_env("OPEN_ROUTE_SERVICE_API_URL"),
   api_key: System.get_env("OPEN_ROUTE_SERVICE_API_KEY"),
-  directions_path:
-    System.get_env("OPEN_ROUTE_SERVICE_DIRECTIONS_PATH", "/v2/directions/driving-hgv/geojson"),
   client: Skate.OpenRouteServiceAPI.Client
 
 config :ueberauth, Ueberauth.Strategy.Cognito,

--- a/lib/skate/open_route_service_api/client.ex
+++ b/lib/skate/open_route_service_api/client.ex
@@ -91,7 +91,7 @@ defmodule Skate.OpenRouteServiceAPI.Client do
   defp api_base_url, do: Application.get_env(:skate, Skate.OpenRouteServiceAPI)[:api_base_url]
 
   defp directions_path,
-    do: Application.get_env(:skate, Skate.OpenRouteServiceAPI)[:directions_path]
+    do: "v2/directions/driving-hgv/geojson"
 
   defp api_key, do: Application.get_env(:skate, Skate.OpenRouteServiceAPI)[:api_key]
 end


### PR DESCRIPTION
## TLDR
this will require changes in dev infra to update the environment variables for locally hosted ORS.

`OPEN_ROUTE_SERVICE_DIRECTIONS_PATH` is no longer needed because the endpoint should be the same across ORS deployments with a proper `base_url`

---

## Summary
I don't know how I didn't catch this in code review, but I realized that the API endpoint that the code expects to interact with doesn't change, and instead we were encoding part of the base url into the directions url due to starting with a root prefix `/`.

This makes the path controlled by the code so that what endpoint is expected cannot be changed out from under it, potentially giving it an incompatible endpoint. Now, we can encode a base url with a path suffix like so
```
OPEN_ROUTE_SERVICE_API_URL="http://localhost:8080/ors/" mix phx.server
```
And it's one less env var to manage!