### PR TITLE
 fix:test(ts/detours): fix tests acting outside of test boundry 

### DIFF
--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -190,16 +190,20 @@ describe("DiversionPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Undo" }))
 
-    expect(
-      container.querySelectorAll(".c-detour_map-circle-marker--detour-point")
-    ).toHaveLength(0)
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".c-detour_map-circle-marker--detour-point")
+      ).toHaveLength(0)
+    )
   })
 
-  test("'Undo' and 'Clear' are disabled before detour drawing is started", () => {
+  test("'Undo' and 'Clear' are disabled before detour drawing is started", async () => {
     render(<DiversionPage />)
 
-    expect(screen.getByRole("button", { name: "Undo" })).toBeDisabled()
-    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled()
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Undo" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled()
+    })
   })
 
   test("clicking on 'Undo' removes the start point when there are no waypoints", async () => {
@@ -209,36 +213,54 @@ describe("DiversionPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Undo" }))
 
-    expect(screen.queryByTitle("Detour Start")).toBeNull()
+    await waitFor(() => expect(screen.queryByTitle("Detour Start")).toBeNull())
   })
 
   test("clicking on 'Undo' removes the end point when the detour is finished", async () => {
     const { container } = render(<DiversionPage />)
 
-    fireEvent.click(originalRouteShape.get(container))
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
 
-    fireEvent.click(originalRouteShape.get(container))
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
 
-    fireEvent.click(screen.getByRole("button", { name: "Undo" }))
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Undo" }))
+    })
 
-    expect(screen.getByTitle("Detour Start")).not.toBeNull()
-    expect(screen.queryByTitle("Detour End")).toBeNull()
+    await waitFor(() => {
+      expect(screen.getByTitle("Detour Start")).not.toBeNull()
+      expect(screen.queryByTitle("Detour End")).toBeNull()
+    })
   })
 
   test("clicking on 'Clear' removes the entire detour", async () => {
     const { container } = render(<DiversionPage />)
 
-    fireEvent.click(originalRouteShape.get(container))
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
 
-    fireEvent.click(container.querySelector(".c-vehicle-map")!)
+    act(() => {
+      fireEvent.click(container.querySelector(".c-vehicle-map")!)
+    })
 
-    fireEvent.click(originalRouteShape.get(container))
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear" }))
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Clear" }))
+    })
 
-    expect(
-      container.querySelectorAll(".c-detour_map-circle-marker--detour-point")
-    ).toHaveLength(0)
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".c-detour_map-circle-marker--detour-point")
+      ).toHaveLength(0)
+    )
 
     expect(screen.queryByTitle("Detour Start")).toBeNull()
     expect(screen.queryByTitle("Detour End")).toBeNull()
@@ -305,9 +327,13 @@ describe("DiversionPage", () => {
 
     expect(await screen.findByText("Regular Route")).toBeVisible()
 
-    fireEvent.click(screen.getByRole("button", { name: "Undo" }))
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Undo" }))
+    })
 
-    expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByText("Regular Route")).not.toBeInTheDocument()
+    )
   })
 
   test("missed stops are filled in when detour is complete", async () => {
@@ -495,22 +521,26 @@ describe("DiversionPage", () => {
     ).toBeVisible()
   })
 
-  test("Attempting to close the page calls the onClose callback", () => {
+  test("Attempting to close the page calls the onClose callback", async () => {
     const onClose = jest.fn()
 
     render(<DiversionPage onClose={onClose} />)
 
-    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    })
 
-    expect(onClose).toHaveBeenCalled()
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 
-  test("Displays a confirmation modal", () => {
+  test("Displays a confirmation modal", async () => {
     render(<DiversionPage showConfirmCloseModal={true} />)
 
-    expect(screen.getByRole("dialog")).toBeVisible()
-    expect(screen.getByRole("button", { name: /yes/i })).toBeVisible()
-    expect(screen.getByRole("button", { name: /back/i })).toBeVisible()
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeVisible()
+      expect(screen.getByRole("button", { name: /yes/i })).toBeVisible()
+      expect(screen.getByRole("button", { name: /back/i })).toBeVisible()
+    })
   })
 
   test("calls the onConfirmClose callback from the confirmation modal", async () => {
@@ -580,7 +610,9 @@ describe("DiversionPage", () => {
       />
     )
 
-    expect(container.querySelectorAll(".c-stop-icon")).toHaveLength(11)
+    await waitFor(() =>
+      expect(container.querySelectorAll(".c-stop-icon")).toHaveLength(11)
+    )
   })
 
   test("missed stop markers are drawn on the map", async () => {

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -75,10 +75,12 @@ describe("DiversionPage", () => {
   test("can click on route shape to start detour", async () => {
     const { container } = render(<DiversionPage />)
 
-    fireEvent.click(originalRouteShape.get(container))
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
 
-    expect(screen.getByTitle("Detour Start")).not.toBeNull()
-    expect(screen.queryByTitle("Detour End")).toBeNull()
+    expect(await screen.findByTitle("Detour Start")).not.toBeNull()
+    expect(screen.queryByTitle("Detour End")).not.toBeInTheDocument()
   })
 
   test("can click on route shape again to end detour", async () => {

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -27,14 +27,14 @@ const useDetourWithFakeRoutePattern = () =>
   useDetour(originalRouteFactory.build())
 
 describe("useDetour", () => {
-  test("when `addConnectionPoint` is first called, `startPoint` is set", () => {
+  test("when `addConnectionPoint` is first called, `startPoint` is set", async () => {
     const start = { lat: 0, lon: 0 }
 
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
     act(() => result.current.addConnectionPoint?.(start))
 
-    expect(result.current.startPoint).toBe(start)
+    await waitFor(() => expect(result.current.startPoint).toBe(start))
   })
 
   test("when `addConnectionPoint` is called a second time, `endPoint` is set", async () => {
@@ -52,11 +52,13 @@ describe("useDetour", () => {
     })
   })
 
-  test("when `startPoint` is null, `addWaypoint` is undefined", () => {
+  test("when `startPoint` is null, `addWaypoint` is undefined", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
-    expect(result.current.startPoint).toBeNull()
-    expect(result.current.addWaypoint).toBeUndefined()
+    await waitFor(() => {
+      expect(result.current.startPoint).toBeNull()
+      expect(result.current.addWaypoint).toBeUndefined()
+    })
   })
 
   test("when `startPoint` is set and `endPoint` is null, `addWaypoint` is defined", async () => {
@@ -162,7 +164,7 @@ describe("useDetour", () => {
 
     act(() => result.current.undo?.())
 
-    expect(result.current.startPoint).toBeNull()
+    await waitFor(() => expect(result.current.startPoint).toBeNull())
   })
 
   test("when `undo` is called, removes the last `waypoint`", async () => {
@@ -178,7 +180,7 @@ describe("useDetour", () => {
 
     act(() => result.current.undo?.())
 
-    expect(result.current.waypoints).toHaveLength(0)
+    await waitFor(() => expect(result.current.waypoints).toHaveLength(0))
   })
 
   test("when `undo` is called, should call API with updated waypoints", async () => {
@@ -219,9 +221,11 @@ describe("useDetour", () => {
     act(() => result.current.undo?.())
     act(() => result.current.undo?.())
 
-    expect(result.current.waypoints).toHaveLength(0)
-    expect(result.current.directions).toBeUndefined()
-    expect(result.current.detourShape).toHaveLength(0)
+    await waitFor(() => {
+      expect(result.current.waypoints).toHaveLength(0)
+      expect(result.current.directions).toBeUndefined()
+      expect(result.current.detourShape).toHaveLength(0)
+    })
   })
 
   test("when `clear` is called, removes the start and end points", async () => {
@@ -238,8 +242,10 @@ describe("useDetour", () => {
 
     act(() => result.current.clear?.())
 
-    expect(result.current.endPoint).toBeNull()
-    expect(result.current.startPoint).toBeNull()
+    await waitFor(() => {
+      expect(result.current.endPoint).toBeNull()
+      expect(result.current.startPoint).toBeNull()
+    })
   })
 
   test("when `clear` is called, removes all waypoints", async () => {
@@ -255,7 +261,7 @@ describe("useDetour", () => {
 
     act(() => result.current.clear?.())
 
-    expect(result.current.waypoints).toHaveLength(0)
+    await waitFor(() => expect(result.current.waypoints).toHaveLength(0))
   })
 
   test("when `clear` is called, `detourShape` and `directions` should be empty", async () => {
@@ -276,16 +282,20 @@ describe("useDetour", () => {
 
     act(() => result.current.clear?.())
 
-    expect(result.current.waypoints).toHaveLength(0)
-    expect(result.current.directions).toBeUndefined()
-    expect(result.current.detourShape).toHaveLength(0)
+    await waitFor(() => {
+      expect(result.current.waypoints).toHaveLength(0)
+      expect(result.current.directions).toBeUndefined()
+      expect(result.current.detourShape).toHaveLength(0)
+    })
   })
 
   test("when `startPoint` is null, `canUndo` is `false`", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
-    expect(result.current.startPoint).toBeNull()
-    expect(result.current.canUndo).toBe(false)
+    await waitFor(() => {
+      expect(result.current.startPoint).toBeNull()
+      expect(result.current.canUndo).toBe(false)
+    })
   })
 
   test("when `startPoint` is set, `canUndo` is `true`", async () => {
@@ -293,8 +303,10 @@ describe("useDetour", () => {
 
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
 
-    expect(result.current.startPoint).not.toBeNull()
-    expect(result.current.canUndo).toBe(true)
+    await waitFor(() => {
+      expect(result.current.startPoint).not.toBeNull()
+      expect(result.current.canUndo).toBe(true)
+    })
   })
 
   test("when `endPoint` is set, `canUndo` is `true`", async () => {
@@ -426,22 +438,22 @@ describe("useDetour", () => {
     })
   })
 
-  test("initially, `finishDetour` is `undefined`", () => {
+  test("initially, `finishDetour` is `undefined`", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
-    expect(result.current.finishDetour).toBeUndefined()
+    await waitFor(() => expect(result.current.finishDetour).toBeUndefined())
   })
 
-  test("initially, `editDetour` is `undefined`", () => {
+  test("initially, `editDetour` is `undefined`", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
-    expect(result.current.editDetour).toBeUndefined()
+    await waitFor(() => expect(result.current.editDetour).toBeUndefined())
   })
 
-  test("initially, `state` is `Edit`", () => {
+  test("initially, `state` is `Edit`", async () => {
     const { result } = renderHook(useDetourWithFakeRoutePattern)
 
-    expect(result.current.state).toBe(DetourState.Edit)
+    await waitFor(() => expect(result.current.state).toBe(DetourState.Edit))
   })
 
   test("when `endPoint` is set, `finishDetour` is defined", async () => {
@@ -527,7 +539,7 @@ describe("useDetour", () => {
   })
 
   describe("stops", () => {
-    test("`stops` is initially populated with the stops from the original route shape with a `missed` field added", () => {
+    test("`stops` is initially populated with the stops from the original route shape with a `missed` field added", async () => {
       const stop1 = stopFactory.build()
       const stop2 = stopFactory.build()
 
@@ -544,7 +556,9 @@ describe("useDetour", () => {
         { ...stop2, missed: false },
       ]
 
-      expect(result.current.stops).toStrictEqual(expectedStops)
+      await waitFor(() =>
+        expect(result.current.stops).toStrictEqual(expectedStops)
+      )
     })
 
     test("when the detour is finished, missed stops are marked as missed in `stops`", async () => {


### PR DESCRIPTION
In #2534 I discovered quite a few tests fell over once I switched to using promises. These are changes that weren't specific to any changes I made in other PR's extracted for review (thanks `jj`!!).