### PR TITLE
chore: Make skate-developers the codeowners for dependency lockfiles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,2 @@
 # The Skate team is the default owner for the entire codebase.
 *       @mbta/skate-developers
-
-# Lock-files managed by Dependabot do not automatically add reviewers
-mix.exs
-mix.lock
-assets/package.json
-assets/package-lock.json


### PR DESCRIPTION
Even if dependabot is running upgrades for us (or trying to), upgrades still need to go through a human review cycle.

Not tagging us in dependency-related PR's has led to dependency-related PR's sitting open for longer than they need to.