### PR TITLE
fix: Set the start and end point markers to display: block

### DIFF
--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -51,11 +51,13 @@
 .c-detour_map-circle-marker--start {
   stroke: tokens.$detour-start-point;
   fill: tokens.$detour-start-point;
+  display: block;
 }
 
 .c-detour_map-circle-marker--end {
   stroke: $color-strawberry-700;
   fill: $color-strawberry-700;
+  display: block;
 }
 
 .c-detour_map-circle-marker--detour-point {


### PR DESCRIPTION
As a follow-up to https://github.com/mbta/skate/pull/2559, there's no reason to have the waypoint markers be the only ones with `display: block`.