### PR TITLE
refactor:test(ts/testHelpers): move `PromiseWithResolvers` to own file

### DIFF
--- a/assets/tests/hooks/useApiCall.test.ts
+++ b/assets/tests/hooks/useApiCall.test.ts
@@ -1,30 +1,12 @@
 import { describe, expect, jest, test } from "@jest/globals"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { useApiCall } from "../../src/hooks/useApiCall"
+import { PromiseWithResolvers } from "../testHelpers/PromiseWithResolvers"
 
 const renderUseApiCall = (initialProps: Parameters<typeof useApiCall>[0]) =>
   renderHook(useApiCall, {
     initialProps,
   })
-
-const PromiseWithResolvers = <T>(): {
-  promise: Promise<T>
-  resolve: (value: T | PromiseLike<T>) => void
-  reject: (reason?: any) => void
-} => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | undefined = undefined
-  let reject: ((reason?: any) => void) | undefined = undefined
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-
-  if (resolve === undefined || reject === undefined) {
-    throw Error("Promise failed to assign `resolve` and/or `reject`")
-  }
-
-  return { promise, resolve, reject }
-}
 
 describe("when first rendered", () => {
   test("should return loading state", () => {

--- a/assets/tests/testHelpers/PromiseWithResolvers.ts
+++ b/assets/tests/testHelpers/PromiseWithResolvers.ts
@@ -1,0 +1,32 @@
+/**
+ * The {@linkcode PromiseWithResolvers} function returns an object containing a
+ * new `Promise` object and two functions to `resolve` or `reject` it,
+ * corresponding to the two parameters passed to the executor of the `Promise()`
+ * constructor.
+ *
+ * ---
+ *
+ * Polyfill for [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers)
+ *
+ * Made following the [example implementation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers#description)
+ *
+ * Deprecate once `Promise.withResolvers` can be used in our test environment.
+ */
+export const PromiseWithResolvers = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+} => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | undefined = undefined
+  let reject: ((reason?: any) => void) | undefined = undefined
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  if (resolve === undefined || reject === undefined) {
+    throw Error("Promise failed to assign `resolve` and/or `reject`")
+  }
+
+  return { promise, resolve, reject }
+}


### PR DESCRIPTION
I've needed this in a few refactors I've considered making. Any refactors to use `useApiCall` from #2533 require making changes to tests which made previously incorrect assumptions about promises. Often, there are tests which test out of order resolution, so a refactor where all tests are kept require this kind of helper.