### PR TITLE
fix: replace `mix phx.gen.secret` in shell direnv 'hot path' with `openssl rand`

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -7,10 +7,10 @@
 export ERL_FLAGS="+MIscs 2048"
 
 ## Authentication/authorization secret. Generate a value using mix phx.gen.secret
-export GUARDIAN_SECRET_KEY=$(mix phx.gen.secret)
+export GUARDIAN_SECRET_KEY=$(openssl rand -base64 48)
 
 ## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret
-export SECRET_KEY_BASE=$(mix phx.gen.secret)
+export SECRET_KEY_BASE=$(openssl rand -base64 48)
 
 ## Postgres configuration: username, password, and hostname
 ## * Your local Postgres server should go here

--- a/.envrc.template
+++ b/.envrc.template
@@ -6,10 +6,12 @@
 ## Erlang/OTP settings, pass "+MIscs 2048" to allocate enough memory for literals in your local dev environment
 export ERL_FLAGS="+MIscs 2048"
 
-## Authentication/authorization secret. Generate a value using mix phx.gen.secret
+## Authentication/authorization secret. 
+## You _can_ generate a value using `mix phx.gen.secret`
 export GUARDIAN_SECRET_KEY=$(openssl rand -base64 48)
 
-## Used for writing encrypted cookies. Generate a value using mix phx.gen.secret
+## Used for writing encrypted cookies.
+## You _can_ generate a value using `mix phx.gen.secret`
 export SECRET_KEY_BASE=$(openssl rand -base64 48)
 
 ## Postgres configuration: username, password, and hostname


### PR DESCRIPTION
`mix phx.gen.secret` is apparently super slow, we recommend two invocations of it in our `.envrc.template`

```
$ time mix phx.gen.secret
vV+JV+dip2WKUSO0Im8JjAxCVcuDZzrTxAO0dx3/TmUF8R0bgbx/hyrhNRAA81LR

________________________________________________________
Executed in  702.51 millis    fish           external
   usr time  466.12 millis   49.00 micros  466.07 millis
   sys time  433.24 millis  613.00 micros  432.63 millis
```

It seems like we can instead replace this with `openssl rand`

---

Context: [Skate Dev Slack Thread](https://mbta.slack.com/archives/C047ZT8ACP5/p1714493416356879?thread_ts=1714492925.590479&cid=C047ZT8ACP5)