### PR TITLE
fix: Block dummy detour page unless the test group is enabled

### DIFF
--- a/assets/src/components/app.tsx
+++ b/assets/src/components/app.tsx
@@ -29,6 +29,7 @@ import PropertiesPanel from "./propertiesPanel"
 import { isGhost, isVehicle } from "../models/vehicle"
 import { TabMode } from "./propertiesPanel/tabPanels"
 import { DummyDetourPage } from "./dummyDetourPage"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 
 export const AppRoutes = () => {
   useAppcues()
@@ -86,7 +87,9 @@ export const AppRoutes = () => {
                   element={<ShuttleMapPage />}
                 />
                 <BrowserRoute path="/settings" element={<SettingsPage />} />
-                <BrowserRoute path="/detours" element={<DummyDetourPage />} />
+                {inTestGroup(TestGroups.DummyDetourPage) && (
+                  <BrowserRoute path="/detours" element={<DummyDetourPage />} />
+                )}
               </Route>
               <Route
                 element={


### PR DESCRIPTION
What's here is only a partial solution, because navigating to `/detours` will still give you a nav menu and a blank screen (rather than an actual, fully functioning dummy detour page). I think an "Actual Solution" would involve fiddling with the routes in `router.ex`, or would involve creating a real 404 page in the frontend, and I'm not sure that's worth the effort right now.