### PR TITLE
refactor: Have useDetour use the new useNearestIntersection

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -5,8 +5,7 @@ import { FinishedDetour, OriginalRoute } from "../models/detour"
 
 import { useApiCall } from "./useApiCall"
 import { Ok, isErr, isOk } from "../util/result"
-import { isOk as FetchIsOk } from "../util/fetchResult"
-import { useNearestIntersectionFetchResult } from "./useNearestIntersection"
+import { useNearestIntersection } from "./useNearestIntersection"
 
 const useDetourDirections = (shapePoints: ShapePoint[]) =>
   useApiCall({
@@ -56,14 +55,10 @@ export const useDetour = ({ routePatternId, shape }: OriginalRoute) => {
     }
   }, [routePatternId, startPoint, endPoint])
 
-  const nearestIntersectionResult = useNearestIntersectionFetchResult(
-    startPoint?.lat,
-    startPoint?.lon
-  )
-
-  const nearestIntersection = FetchIsOk(nearestIntersectionResult)
-    ? nearestIntersectionResult.ok
-    : null
+  const { result: nearestIntersection } = useNearestIntersection({
+    latitude: startPoint?.lat,
+    longitude: startPoint?.lon,
+  })
 
   const detourShape = useDetourDirections(
     useMemo(

--- a/assets/src/hooks/useNearestIntersection.ts
+++ b/assets/src/hooks/useNearestIntersection.ts
@@ -30,7 +30,7 @@ export const useNearestIntersectionFetchResult = (
   }
 }
 
-const useNearestIntersection = ({
+export const useNearestIntersection = ({
   latitude,
   longitude,
 }: {

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -13,6 +13,7 @@ import {
   FetchDetourDirectionsError,
   fetchDetourDirections,
   fetchFinishedDetour,
+  fetchNearestIntersection,
 } from "../../../src/api"
 import { DiversionPage as DiversionPageDefault } from "../../../src/components/detours/diversionPage"
 import shapeFactory from "../../factories/shape"
@@ -33,8 +34,7 @@ import {
   stopIcon,
 } from "../../testHelpers/selectors/components/map/markers/stopIcon"
 import { Err, Ok } from "../../../src/util/result"
-import { useNearestIntersectionFetchResult } from "../../../src/hooks/useNearestIntersection"
-import { loading, ok } from "../../../src/util/fetchResult"
+import { neverPromise } from "../../testHelpers/mockHelpers"
 
 const DiversionPage = (
   props: Omit<
@@ -72,14 +72,12 @@ beforeEach(() => {
 
 jest.mock("../../../src/api")
 
-jest.mock("../../../src/hooks/useNearestIntersection")
-
 beforeEach(() => {
   jest
     .mocked(fetchDetourDirections)
     .mockImplementation(() => new Promise(() => {}))
   jest.mocked(fetchFinishedDetour).mockResolvedValue(null)
-  jest.mocked(useNearestIntersectionFetchResult).mockReturnValue(loading())
+  jest.mocked(fetchNearestIntersection).mockReturnValue(neverPromise())
 })
 
 describe("DiversionPage", () => {
@@ -108,9 +106,9 @@ describe("DiversionPage", () => {
     )
 
     const intersection = "Avenue 1 & Street 2"
-    jest.mocked(useNearestIntersectionFetchResult).mockReturnValue({
-      ok: intersection,
-    })
+    jest
+      .mocked(fetchNearestIntersection)
+      .mockReturnValue(Promise.resolve(intersection))
 
     const { container } = render(<DiversionPage />)
 
@@ -524,8 +522,8 @@ describe("DiversionPage", () => {
 
     const intersection = "Avenue 1 & Street 2"
     jest
-      .mocked(useNearestIntersectionFetchResult)
-      .mockReturnValue(ok(intersection))
+      .mocked(fetchNearestIntersection)
+      .mockReturnValue(Promise.resolve(intersection))
 
     userEvent.setup() // Configure the clipboard API
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -104,9 +104,7 @@ describe("DiversionPage", () => {
     )
 
     const intersection = "Avenue 1 & Street 2"
-    jest
-      .mocked(fetchNearestIntersection)
-      .mockReturnValue(Promise.resolve(intersection))
+    jest.mocked(fetchNearestIntersection).mockResolvedValue(intersection)
 
     const { container } = render(<DiversionPage />)
 
@@ -519,9 +517,7 @@ describe("DiversionPage", () => {
     })
 
     const intersection = "Avenue 1 & Street 2"
-    jest
-      .mocked(fetchNearestIntersection)
-      .mockReturnValue(Promise.resolve(intersection))
+    jest.mocked(fetchNearestIntersection).mockResolvedValue(intersection)
 
     userEvent.setup() // Configure the clipboard API
 

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -73,10 +73,8 @@ beforeEach(() => {
 jest.mock("../../../src/api")
 
 beforeEach(() => {
-  jest
-    .mocked(fetchDetourDirections)
-    .mockImplementation(() => new Promise(() => {}))
-  jest.mocked(fetchFinishedDetour).mockResolvedValue(null)
+  jest.mocked(fetchDetourDirections).mockReturnValue(neverPromise())
+  jest.mocked(fetchFinishedDetour).mockReturnValue(neverPromise())
   jest.mocked(fetchNearestIntersection).mockReturnValue(neverPromise())
 })
 

--- a/assets/tests/components/mapPage.test.tsx
+++ b/assets/tests/components/mapPage.test.tsx
@@ -63,6 +63,7 @@ import {
   mockScreenSize,
   mockTileUrls,
   mockUsePatternsByIdForVehicles,
+  neverPromise,
 } from "../testHelpers/mockHelpers"
 import usePatternsByIdForRoute from "../../src/hooks/usePatternsByIdForRoute"
 import { routePatternFactory } from "../factories/routePattern"
@@ -92,8 +93,7 @@ import pieceFactory from "../factories/piece"
 import { mockUsePanelState } from "../testHelpers/usePanelStateMocks"
 import getTestGroups from "../../src/userTestGroups"
 import { TestGroups } from "../../src/userInTestGroup"
-import { useNearestIntersectionFetchResult } from "../../src/hooks/useNearestIntersection"
-import { loading } from "../../src/util/fetchResult"
+import { fetchNearestIntersection } from "../../src/api"
 
 jest.mock("../../src/hooks/useLocationSearchResults", () => ({
   useLocationSearchResults: jest.fn(() => null),
@@ -112,8 +112,6 @@ jest.mock("../../src/hooks/usePatternsByIdForRoute", () => ({
   __esModule: true,
   default: jest.fn(() => null),
 }))
-
-jest.mock("../../src/hooks/useNearestIntersection")
 
 jest.mock("../../src/hooks/useVehicleForId", () => ({
   __esModule: true,
@@ -150,8 +148,10 @@ jest.mock("../../src/hooks/usePanelState")
 
 jest.mock("../../src/userTestGroups")
 
+jest.mock("../../src/api")
+
 beforeEach(() => {
-  jest.mocked(useNearestIntersectionFetchResult).mockReturnValue(loading())
+  jest.mocked(fetchNearestIntersection).mockReturnValue(neverPromise())
 })
 
 const mockVehicleSearchResultsCategory = (


### PR DESCRIPTION
Follow-up to #2566, both to start stress-testing the new `useNearestIntersection` (and `useApiCall`) and because the deprecation warning was annoying in `useDetour`.

Related:
- #2566 