### PR TITLE
test(ex/skate_web/auth_controller): test for csrf failure

### DIFF
--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -87,7 +87,9 @@ defmodule SkateWeb.AuthController do
     )
 
     if get_session(conn, :keycloak_csrf_retry) == 1 do
-      send_resp(conn, :unauthorized, "unauthenticated")
+      conn
+      |> delete_session(:keycloak_csrf_retry)
+      |> send_resp(:unauthorized, "unauthenticated")
     else
       conn
       |> put_session(:keycloak_csrf_retry, 1)

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -71,6 +71,27 @@ defmodule SkateWeb.AuthController do
   end
 
   def callback(
+        %{
+          assigns: %{
+            ueberauth_failure:
+              %Ueberauth.Failure{
+                provider: :keycloak,
+                errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
+              } = auth_struct
+          }
+        } = conn,
+        _params
+      ) do
+    Logger.error(
+      "#{__MODULE__} keycloak callback csrf ueberauth_failure struct=#{Kernel.inspect(auth_struct)}"
+    )
+
+    conn
+    |> Guardian.Plug.sign_out(AuthManager, [])
+    |> redirect(to: ~p"/auth/keycloak")
+  end
+
+  def callback(
         %{assigns: %{ueberauth_failure: %{provider: :keycloak} = auth_struct}} = conn,
         _params
       ) do

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -86,9 +86,14 @@ defmodule SkateWeb.AuthController do
       "#{__MODULE__} keycloak callback csrf ueberauth_failure struct=#{Kernel.inspect(auth_struct)}"
     )
 
-    conn
-    |> Guardian.Plug.sign_out(AuthManager, [])
-    |> redirect(to: ~p"/auth/keycloak")
+    if get_session(conn, :keycloak_csrf_retry) == 1 do
+      send_resp(conn, :unauthorized, "unauthenticated")
+    else
+      conn
+      |> put_session(:keycloak_csrf_retry, 1)
+      |> Guardian.Plug.sign_out(AuthManager, [])
+      |> redirect(to: ~p"/auth/keycloak")
+    end
   end
 
   def callback(

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -147,6 +147,20 @@ defmodule SkateWeb.AuthControllerTest do
 
       assert redirected_to(conn, :found) == ~p"/auth/keycloak"
     end
+
+    test "when CSRF error is encountered again, returns unauthenticated", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{username: "test_username"})
+        |> assign(:ueberauth_failure, %Ueberauth.Failure{
+          provider: :keycloak,
+          errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
+        })
+        |> put_session(:keycloak_csrf_retry, 1)
+        |> get(~p"/auth/keycloak/callback")
+
+      assert response(conn, :unauthorized) == "unauthenticated"
+    end
   end
 
   describe "GET /auth/keycloak/logout" do

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -135,14 +135,16 @@ defmodule SkateWeb.AuthControllerTest do
       assert response(conn, :unauthorized) == "unauthenticated"
     end
 
+    @ueberauth_csrf_failure %Ueberauth.Failure{
+      provider: :keycloak,
+      errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
+    }
+
     test "retries login on first ueberauth CSRF failure", %{conn: conn} do
       conn =
         conn
         |> init_test_session(%{username: "test_username"})
-        |> assign(:ueberauth_failure, %Ueberauth.Failure{
-          provider: :keycloak,
-          errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
-        })
+        |> assign(:ueberauth_failure, @ueberauth_csrf_failure)
         |> get(~p"/auth/keycloak/callback")
 
       assert redirected_to(conn, :found) == ~p"/auth/keycloak"
@@ -152,10 +154,7 @@ defmodule SkateWeb.AuthControllerTest do
       conn =
         conn
         |> init_test_session(%{username: "test_username"})
-        |> assign(:ueberauth_failure, %Ueberauth.Failure{
-          provider: :keycloak,
-          errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
-        })
+        |> assign(:ueberauth_failure, @ueberauth_csrf_failure)
         |> put_session(:keycloak_csrf_retry, 1)
         |> get(~p"/auth/keycloak/callback")
 

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -134,6 +134,19 @@ defmodule SkateWeb.AuthControllerTest do
 
       assert response(conn, :unauthorized) == "unauthenticated"
     end
+
+    test "retries login on first ueberauth CSRF failure", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{username: "test_username"})
+        |> assign(:ueberauth_failure, %Ueberauth.Failure{
+          provider: :keycloak,
+          errors: [%Ueberauth.Failure.Error{message_key: "csrf_attack"}]
+        })
+        |> get(~p"/auth/keycloak/callback")
+
+      assert redirected_to(conn, :found) == ~p"/auth/keycloak"
+    end
   end
 
   describe "GET /auth/keycloak/logout" do


### PR DESCRIPTION
If login fails due to a CSRF errors, which we usually have [happen in prod between 1 and 6 times per hour](https://mbta.splunkcloud.com/en-US/app/search/search?sid=1715186892.4890174), we currently just show a failure with the text `unauthenticated`.

If the issue is that the CSRF token used for login had expired or been used already, then retrying the login should address this by getting a new token and attempting login. This should allow us to figure out via our Splunk logs if the issue persists after retrying login.

See the individual commits for a walk through of my process on this.

---

Asana Ticket: https://app.asana.com/0/0/1207261350056001/f