### PR TITLE
feat(ex/application): add deployment version to startup log

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -6,9 +6,11 @@ defmodule Skate.Application do
   use Application
   require Logger
 
+  @version Application.compile_env(:skate, :version)
+
   @impl true
   def start(_type, _args) do
-    Logger.info("Skate application starting")
+    Logger.info("Skate application starting, deployment_id=#{@version}")
 
     load_runtime_config()
 


### PR DESCRIPTION
I was working on [Splunk CSRF Login Issue Dashboard](https://mbta.splunkcloud.com/en-US/app/search/skate_login_csrf_issue_tracking) and didn't have access to deployment version info in Splunk, so this felt like it should be easy to add.


Asana Ticket: https://app.asana.com/0/0/1207280328006578/f