### PR TITLE
feat(ts/components/map): allow zooming in more than the tileset native zoom

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -127,6 +127,8 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
         attributionControl={false}
       >
         <TileLayer
+          maxZoom={21}
+          maxNativeZoom={18}
           url={`${tilesetUrlForType(tileType)}`}
           attribution={
             tileType === "base"

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -298,7 +298,7 @@ exports[`<MapPage /> Snapshot renders the empty state 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -884,7 +884,7 @@ exports[`<MapPage /> Snapshot renders the null state 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -1471,7 +1471,7 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`Shuttle Map Page renders 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -938,7 +938,7 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -1693,7 +1693,7 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -2313,7 +2313,7 @@ exports[`Shuttle Map Page renders with shapes selected 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""
@@ -2757,7 +2757,7 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
             >
               <div
                 class="leaflet-tile-container leaflet-zoom-animated"
-                style="z-index: 18; left: 0px; top: 0px;"
+                style="z-index: 21; left: 0px; top: 0px;"
               >
                 <img
                   alt=""


### PR DESCRIPTION
This temporarily fixes issues we've had with detours where you can't zoom in enough to precisely place waypoints. We'd ideally "just" render more zoom levels from our tile-server, but that's been difficult. If that cannot be done easily, merging this is a stopgap to make the detours experience better till we can fix our tiles in some form.

---

Asana Ticket: https://app.asana.com/0/0/1207286076249270/f