### PR TITLE
fix(gh/actions/ci): run npm tests with --detectOpenHandles so that we know which tests are leaking if it happens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,4 +145,4 @@ jobs:
       - name: Check types / linting / formatting
         run: npm --prefix=assets run check
       - name: Run tests
-        run: npm --prefix=assets test
+        run: npm --prefix=assets test -- --detectOpenHandles


### PR DESCRIPTION
We occasionally run into these types of errors and we've been fighting a lot of flakeyness in our tests. I'm thinking that if we always run CI with this setting on we'll gather more information on which tests are causing this.

```
> npm --prefix=assets test
[...]
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```