### PR TITLE
refactor(ts/hooks/usePatternsByIdForRoute): use `useApiCall`

### DIFF
--- a/assets/src/hooks/usePatternsByIdForRoute.ts
+++ b/assets/src/hooks/usePatternsByIdForRoute.ts
@@ -1,34 +1,34 @@
-import { useEffect, useState } from "react"
+import { useCallback } from "react"
 import { fetchRoutePatterns } from "../api"
 import { ByRoutePatternId, RouteId, RoutePattern } from "../schedule"
+import { useApiCall } from "./useApiCall"
+
+/**
+ * It may be useful to export this at some point in the future,
+ * right now {@linkcode usePatternsByIdForRoute} has a nicer interface,
+ * unless you need a list.
+ */
+const usePatternsForRoute = (routeId: RouteId | undefined) =>
+  useApiCall({
+    apiCall: useCallback(async () => {
+      if (routeId === undefined) {
+        return null
+      }
+
+      return fetchRoutePatterns(routeId)
+    }, [routeId]),
+  })
 
 const usePatternsByIdForRoute = (
   routeId: RouteId | null
 ): ByRoutePatternId<RoutePattern> | null => {
-  const [routePatterns, setRoutePatterns] = useState<RoutePattern[] | null>(
-    null
-  )
-  useEffect(() => {
-    let canceled = false
-    if (routeId === null) {
-      setRoutePatterns([])
-    } else {
-      fetchRoutePatterns(routeId).then((routePatterns) => {
-        if (!canceled) {
-          setRoutePatterns(routePatterns)
-        }
-      })
-    }
-    return () => {
-      canceled = true
-    }
-  }, [routeId])
+  const { result: routePatterns } = usePatternsForRoute(routeId ?? undefined)
 
-  return routePatterns == null
-    ? null
-    : routePatterns.reduce((map, rp) => {
-        return { ...map, [rp.id]: rp }
-      }, {})
+  if (routePatterns === undefined || routePatterns === null) {
+    return null
+  }
+
+  return Object.fromEntries(routePatterns.map((rp) => [rp.id, rp]))
 }
 
 export default usePatternsByIdForRoute

--- a/assets/tests/components/app.test.tsx
+++ b/assets/tests/components/app.test.tsx
@@ -122,7 +122,7 @@ describe("App", () => {
         jest.mocked(useVehicles).mockReset()
       })
 
-      test("VPP", () => {
+      test("VPP", async () => {
         mockUsePanelState({
           currentView: {
             selectedVehicleOrGhost: vehicle,
@@ -131,6 +131,7 @@ describe("App", () => {
             previousView: OpenView.None,
           },
         })
+
         render(
           <StateDispatchProvider
             state={stateFactory.build({
@@ -147,8 +148,10 @@ describe("App", () => {
             </MemoryRouter>
           </StateDispatchProvider>
         )
-        expect(vehiclePropertiesPanelHeader.get()).toBeInTheDocument()
+
+        expect(await vehiclePropertiesPanelHeader.find()).toBeInTheDocument()
       })
+
       test.each([
         ["Late View", OpenView.Late],
         ["Swings", OpenView.Swings],
@@ -183,7 +186,7 @@ describe("App", () => {
     })
   })
 
-  test("renders search map page", () => {
+  test("renders search map page", async () => {
     render(
       <MemoryRouter initialEntries={["/map"]}>
         <AppRoutes />
@@ -191,7 +194,7 @@ describe("App", () => {
     )
 
     expect(
-      screen.getByRole("generic", { name: /search map page/i })
+      await screen.findByRole("generic", { name: /search map page/i })
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
This is some work I've had sitting around that I did while trying to implement the new detours flow.

The tests get a little bit better due to now having to handle promises correctly.