### PR TITLE
[WIP] feat(eslint): no-restricted-exports

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -32,6 +32,16 @@ module.exports = {
     "no-console": "error",
     "prefer-rest-params": "off",
     "no-sparse-arrays": "off",
+    "no-restricted-exports": ["warn",
+      {
+        "restrictDefaultExports": {
+          "direct": true,
+          "named": true,
+          "defaultFrom": true,
+          "namedFrom": true,
+          "namespaceFrom": true
+        }
+      }],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
Default exports have many downsides, from requiring the user to give it a name to only being able to have a single default export. I'd like to formally propose and lint that we don't use default exports.

This unfortunately can't be merged at this moment without fixing all of our existing default usages, or marking them all as allowed for now.