### PR TITLE
feat(ex/components/app): disable `.drift` in local dev by default

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,8 @@ import Config
 
 config :skate,
   geonames_url_base: "http://api.geonames.org",
-  log_duration_timing: false
+  log_duration_timing: false,
+  enable_drift: false
 
 config :skate, Schedule.CacheFile, cache_filename: "dev_cache.terms"
 

--- a/lib/skate_web/components/layouts.ex
+++ b/lib/skate_web/components/layouts.ex
@@ -14,5 +14,8 @@ defmodule SkateWeb.Layouts do
   @spec record_sentry?() :: boolean
   def record_sentry?, do: !is_nil(Application.get_env(:skate, :sentry_frontend_dsn))
 
+  @spec drift_enabled?() :: boolean
+  def drift_enabled?, do: Application.get_env(:skate, :enable_drift, true)
+
   embed_templates("layouts/*")
 end

--- a/lib/skate_web/components/layouts/app.html.heex
+++ b/lib/skate_web/components/layouts/app.html.heex
@@ -57,6 +57,6 @@
     </main>
     <script type="text/javascript" src={static_content_route(@conn, "/js/app.js")}>
     </script>
-    <._drift />
+    <._drift :if={drift_enabled?()} />
   </body>
 </html>


### PR DESCRIPTION
Drift tends to be really loud in the console, it's super annoying locally, so this makes that configurable.

---

After using this for a bit, I'm really strongly in favor of this, _and/or_ opening a ticket to address the logs directly. But I've benefited greatly from having less noise in the logs while doing FE work.