### PR TITLE
 cleanup(ts/hooks/useDetour): convert compound match to tags

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -30,20 +30,18 @@ export enum DetourState {
 
 const selectFinishedState = (
   snapshot: SnapshotFrom<typeof createDetourMachine>
-) => {
+) =>
   /*
-   * There's probably a better way to do this? Tags or maybe context?
-   * Tags seem more appropriate, but weird to manage Out-Of-Bounds state via tags.
+   * There's probably a better way to do this? maybe context or sub-machines?
+   * It seems okay to manage this state via tags if we can keep things documented,
+   * but it feels slightly leaky to have the concern for this API call to be
+   * distinguished as a tag within the machine, I think it works temporarily
+   * and while the machine is small though
+   *
    * Maybe this entire API call could be moved to and managed by an actor
    * combined with parallel child states within the state machine?
    * -- https://stately.ai/docs/promise-actors */
-  const isFinishedDrawing = snapshot.matches({
-    "Detour Drawing": { Editing: "Finished Drawing" },
-  })
-  const isSharingDetour = snapshot.matches({ "Detour Drawing": "Share Detour" })
-  const isInFinishedDetourState = isFinishedDrawing || isSharingDetour
-  return isInFinishedDetourState
-}
+  snapshot.hasTag("is-finished-drawing")
 
 /** This selects the detour waypoints in-between the detour start and end points  */
 const selectWaypoints = (snapshot: SnapshotFrom<typeof createDetourMachine>) =>

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -6,6 +6,7 @@ export const createDetourMachine = setup({
     context: {
       waypoints: ShapePoint[]
     }
+
     events:
       | { type: "detour.edit.clear-detour" }
       | { type: "detour.edit.done" }
@@ -14,6 +15,11 @@ export const createDetourMachine = setup({
       | { type: "detour.edit.resume" }
       | { type: "detour.edit.undo" }
       | { type: "detour.share.copy-detour"; detourText: string }
+
+    tags:
+      | "" // Placeholder for the formatter
+      // When we should fetch finished detour details
+      | "is-finished-drawing"
   },
   actions: {
     "detour.add-waypoint": assign({
@@ -100,6 +106,7 @@ export const createDetourMachine = setup({
               },
             },
             "Finished Drawing": {
+              tags: ["is-finished-drawing"],
               on: {
                 "detour.edit.undo": {
                   actions: "detour.remove-last-waypoint",
@@ -120,6 +127,7 @@ export const createDetourMachine = setup({
           },
         },
         "Share Detour": {
+          tags: ["is-finished-drawing"],
           on: {
             "detour.edit.resume": {
               target: "Editing.Finished Drawing",


### PR DESCRIPTION
Follow on to #2607 which attempts to simplify the conditions to check for finished