### PR TITLE
feat(ts/hooks/useDetour): control waypoints with state machine

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo } from "react"
 import { ShapePoint } from "../schedule"
 import { fetchDetourDirections, fetchFinishedDetour } from "../api"
 
@@ -29,19 +29,31 @@ export const useDetour = (input: CreateDetourMachineInput) => {
     input,
   })
 
-  const { routePattern } = snapshot.context
-
-  const [startPoint, setStartPoint] = useState<ShapePoint | null>(null)
-  const [endPoint, setEndPoint] = useState<ShapePoint | null>(null)
-  const [waypoints, setWaypoints] = useState<ShapePoint[]>([])
+  const { routePattern, startPoint, endPoint, waypoints } = snapshot.context
+  const allPoints = useMemo(() => {
+    if (!startPoint) {
+      return []
+    } else if (!endPoint) {
+      return [startPoint].concat(waypoints)
+    } else {
+      return [startPoint].concat(waypoints).concat([endPoint])
+    }
+  }, [startPoint, waypoints, endPoint])
 
   const { result: finishedDetour } = useApiCall({
     apiCall: useCallback(async () => {
+      /* Until we have "typegen" in XState,
+       * we need to validate these exist for typescript
+       *
+       * > [Warning] XState Typegen does not fully support XState v5 yet. However,
+       * > strongly-typed machines can still be achieved without Typegen.
+       * > -- https://stately.ai/docs/migration#use-typestypegen-instead-of-tstypes
+       */
       if (routePattern && startPoint && endPoint) {
         return fetchFinishedDetour(routePattern.id, startPoint, endPoint)
-      } else {
-        return null
       }
+
+      return null
     }, [startPoint, endPoint, routePattern]),
   })
 
@@ -50,15 +62,7 @@ export const useDetour = (input: CreateDetourMachineInput) => {
     longitude: startPoint?.lon,
   })
 
-  const detourShape = useDetourDirections(
-    useMemo(
-      () =>
-        [startPoint, ...waypoints, endPoint].filter(
-          (v): v is ShapePoint => !!v
-        ),
-      [startPoint, waypoints, endPoint]
-    ) ?? []
-  )
+  const detourShape = useDetourDirections(allPoints)
 
   const coordinates =
     detourShape.result && isOk(detourShape.result)
@@ -76,38 +80,32 @@ export const useDetour = (input: CreateDetourMachineInput) => {
     })
   }
 
-  const canAddWaypoint = () => startPoint !== null && endPoint === null
+  const canAddWaypoint = () =>
+    snapshot.can({
+      type: "detour.edit.place-waypoint",
+      location: { lat: 0, lon: 0 },
+    })
+
   const addWaypoint = canAddWaypoint()
-    ? (p: ShapePoint) => {
-        setWaypoints((positions) => [...positions, p])
+    ? (location: ShapePoint) => {
+        send({ type: "detour.edit.place-waypoint", location })
       }
     : undefined
 
-  const addConnectionPoint = (point: ShapePoint) => {
-    if (startPoint === null) {
-      setStartPoint(point)
-    } else if (endPoint === null) {
-      setEndPoint(point)
-    }
-  }
+  const addConnectionPoint = (point: ShapePoint) =>
+    send({
+      type: "detour.edit.place-waypoint-on-route",
+      location: point,
+    })
 
-  const canUndo =
-    startPoint !== null && snapshot.matches({ "Detour Drawing": "Editing" })
+  const canUndo = snapshot.can({ type: "detour.edit.undo" })
 
   const undo = () => {
-    if (endPoint !== null) {
-      setEndPoint(null)
-    } else if (waypoints.length > 0) {
-      setWaypoints((positions) => positions.slice(0, positions.length - 1))
-    } else if (startPoint !== null) {
-      setStartPoint(null)
-    }
+    send({ type: "detour.edit.undo" })
   }
 
   const clear = () => {
-    setEndPoint(null)
-    setStartPoint(null)
-    setWaypoints([])
+    send({ type: "detour.edit.clear-detour" })
   }
 
   const finishDetour = () => {
@@ -208,7 +206,9 @@ export const useDetour = (input: CreateDetourMachineInput) => {
     clear,
 
     /** When present, puts this detour in "finished mode" */
-    finishDetour: endPoint !== null ? finishDetour : undefined,
+    finishDetour: snapshot.can({ type: "detour.edit.done" })
+      ? finishDetour
+      : undefined,
     /** When present, puts this detour in "edit mode" */
     editDetour,
   }


### PR DESCRIPTION
# Summary
Part 2 of the conversion of `useDetour` to a state machine!
This converts the `waypoint` (including `startPoint` and `endPoint`) to be managed by a state machine, instead of manual logic for managing the state. (Considering revisiting this decision about start and end points!)

Instead of managing separate `startPoint` and `endPoint`s, they're now derived from the waypoints array, this is done so that `startPoint` and `endPoint` are no longer containing implicit state of the status of the machine.

# Review Notes 
This PR involves a few dependencies and steps.

---

Depends on:
- #2605
	- Makes the diff on this PR a bit easier to read 
- #2602 
	- Fixes a test that would otherwise just be noise in this PR 
- #2616
	- First introduces XState and an initial conversion 

---

This PR was done in these steps and such could be reviewed in that order to make the diff a little easier to read.
1. [feat(ts/hooks/useDetour): control waypoints with state machine](https://github.com/mbta/skate/commit/0e77c2f18f461eae19c17df2a04177f644bf1e22)
4. [cleanup(ts/hooks/useDetour): move callback intermediate state into function scope to reduce recalls](https://github.com/mbta/skate/commit/67f6d956e41bf6fa2cdc85d4d5236f222bf9d6b4)


I optionally have [cleanup(ts/hooks/useDetour): convert complex match to tags](https://github.com/mbta/skate/pull/2606) this to simplify the match logic for `finishedDetour`

---

~If desired, [feat(ts/hooks/useDetour): replace state variable with state machine](https://github.com/mbta/skate/commit/3abee9746e18d6c25a7f55efbe849eb739ec2acb) and [feat(ts/hooks/useDetour): control waypoints with state machine](https://github.com/mbta/skate/commit/0e77c2f18f461eae19c17df2a04177f644bf1e22) can be split into two PRs~

**Edit**:
This has been broken into another PR
- https://github.com/mbta/skate/pull/2616

---

Asana Ticket: https://app.asana.com/0/0/1207381767522634/f