### PR TITLE
refactor(tests): Simplify tests for RoutePropertiesCard

### DIFF
--- a/assets/tests/components/mapPage/routePropertiesCard.test.tsx
+++ b/assets/tests/components/mapPage/routePropertiesCard.test.tsx
@@ -12,8 +12,48 @@ import stopFactory from "../../factories/stop"
 
 import { RoutesProvider } from "../../../src/contexts/routesContext"
 import userEvent from "@testing-library/user-event"
+import {
+  ByRoutePatternId,
+  Route,
+  RoutePattern,
+  RoutePatternId,
+} from "../../../src/schedule"
 
 const route66 = routeFactory.build({ id: "66", name: "66Name" })
+const [routePattern1, routePattern2] = routePatternFactory.buildList(2, {
+  routeId: "66",
+  directionId: 0,
+})
+
+const RoutePropertiesCardWithDefaults = ({
+  routes = [route66],
+  routePatterns = {
+    [routePattern1.id]: routePattern1,
+    [routePattern2.id]: routePattern2,
+  },
+  selectedRoutePatternId = routePattern1.id,
+  onClose = () => {},
+  selectRoutePattern = (_routePattern) => {},
+}: {
+  routes?: Route[]
+  routePatterns?: ByRoutePatternId<RoutePattern>
+  selectedRoutePatternId?: RoutePatternId
+  onClose?: () => void
+  selectRoutePattern?: (routePattern: RoutePattern) => void
+}) => {
+  const thing = (
+    <RoutesProvider routes={routes}>
+      <RoutePropertiesCard
+        routePatterns={routePatterns}
+        selectedRoutePatternId={selectedRoutePatternId}
+        selectRoutePattern={selectRoutePattern}
+        onClose={onClose}
+      />
+    </RoutesProvider>
+  )
+
+  return thing
+}
 
 describe("patternDisplayName", () => {
   test("When not formatted correctly with ' - '", () => {
@@ -68,14 +108,11 @@ describe("<RoutePropertiesCard/>", () => {
     test("No route data", () => {
       const routePattern = routePatternFactory.build({ routeId: "66" })
       render(
-        <RoutesProvider routes={[]}>
-          <RoutePropertiesCard
-            routePatterns={{ [routePattern.id]: routePattern }}
-            selectedRoutePatternId={routePattern.id}
-            selectRoutePattern={jest.fn()}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routes={[]}
+          routePatterns={{ [routePattern.id]: routePattern }}
+          selectedRoutePatternId={routePattern.id}
+        />
       )
 
       expect(
@@ -85,11 +122,9 @@ describe("<RoutePropertiesCard/>", () => {
     test("Selected route pattern not among route patterns", () => {
       const routePattern = routePatternFactory.build({ routeId: "66" })
       render(
-        <RoutePropertiesCard
+        <RoutePropertiesCardWithDefaults
           routePatterns={{ [routePattern.id]: routePattern }}
           selectedRoutePatternId={"missingRoutePatternId"}
-          selectRoutePattern={jest.fn()}
-          onClose={jest.fn()}
         />
       )
 
@@ -103,14 +138,12 @@ describe("<RoutePropertiesCard/>", () => {
     test("Shows the selected pattern's name", () => {
       const routePattern = routePatternFactory.build({ routeId: "66" })
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{ [routePattern.id]: routePattern }}
-            selectedRoutePatternId={routePattern.id}
-            selectRoutePattern={jest.fn()}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routePatterns={{ [routePattern.id]: routePattern }}
+          selectedRoutePatternId={routePattern.id}
+          selectRoutePattern={jest.fn()}
+          onClose={jest.fn()}
+        />
       )
 
       expect(
@@ -121,27 +154,19 @@ describe("<RoutePropertiesCard/>", () => {
     })
 
     test("Shows the route's other patterns in the same direction", async () => {
-      const [routePattern1, routePattern2] = routePatternFactory.buildList(2, {
-        routeId: "66",
-        directionId: 0,
-      })
       const routePatternOtherDirection = routePatternFactory.build({
         routeId: "66",
         directionId: 1,
       })
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePattern1.id]: routePattern1,
-              [routePattern2.id]: routePattern2,
-              [routePatternOtherDirection.id]: routePatternOtherDirection,
-            }}
-            selectedRoutePatternId={routePattern1.id}
-            selectRoutePattern={jest.fn()}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routePatterns={{
+            [routePattern1.id]: routePattern1,
+            [routePattern2.id]: routePattern2,
+            [routePatternOtherDirection.id]: routePatternOtherDirection,
+          }}
+          selectedRoutePatternId={routePattern1.id}
+        />
       )
       await userEvent.click(
         screen.getByRole("button", { name: "Show variants" })
@@ -180,17 +205,13 @@ describe("<RoutePropertiesCard/>", () => {
       })
 
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePattern1.id]: routePattern1,
-              [routePattern2.id]: routePattern2,
-            }}
-            selectedRoutePatternId={routePattern1.id}
-            selectRoutePattern={jest.fn()}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routePatterns={{
+            [routePattern1.id]: routePattern1,
+            [routePattern2.id]: routePattern2,
+          }}
+          selectedRoutePatternId={routePattern1.id}
+        />
       )
 
       await userEvent.click(
@@ -223,18 +244,15 @@ describe("<RoutePropertiesCard/>", () => {
       })
       const mockSelectRoutePattern = jest.fn()
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePatternBDirection0.id]: routePatternBDirection0,
-              [routePatternBDirection1.id]: routePatternBDirection1,
-              [routePattern7Direction1.id]: routePattern7Direction1,
-            }}
-            selectedRoutePatternId={routePatternBDirection0.id}
-            selectRoutePattern={mockSelectRoutePattern}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routePatterns={{
+            [routePatternBDirection0.id]: routePatternBDirection0,
+            [routePatternBDirection1.id]: routePatternBDirection1,
+            [routePattern7Direction1.id]: routePattern7Direction1,
+          }}
+          selectedRoutePatternId={routePatternBDirection0.id}
+          selectRoutePattern={mockSelectRoutePattern}
+        />
       )
 
       await userEvent.click(
@@ -263,18 +281,15 @@ describe("<RoutePropertiesCard/>", () => {
       })
       const mockSelectRoutePattern = jest.fn()
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePatternDirection0.id]: routePatternDirection0,
-              [routePatternDirection1_1.id]: routePatternDirection1_1,
-              [routePatternDirection1_0.id]: routePatternDirection1_0,
-            }}
-            selectedRoutePatternId={routePatternDirection0.id}
-            selectRoutePattern={mockSelectRoutePattern}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          routePatterns={{
+            [routePatternDirection0.id]: routePatternDirection0,
+            [routePatternDirection1_1.id]: routePatternDirection1_1,
+            [routePatternDirection1_0.id]: routePatternDirection1_0,
+          }}
+          selectedRoutePatternId={routePatternDirection0.id}
+          selectRoutePattern={mockSelectRoutePattern}
+        />
       )
 
       await userEvent.click(
@@ -288,23 +303,12 @@ describe("<RoutePropertiesCard/>", () => {
     })
 
     test("Clicking a different route pattern calls selectRoutePattern and closes the variants list", async () => {
-      const [routePattern1, routePattern2] = routePatternFactory.buildList(2, {
-        routeId: "66",
-        directionId: 0,
-      })
       const mockSelectRoutePattern = jest.fn()
+
       render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePattern1.id]: routePattern1,
-              [routePattern2.id]: routePattern2,
-            }}
-            selectedRoutePatternId={routePattern1.id}
-            selectRoutePattern={mockSelectRoutePattern}
-            onClose={jest.fn()}
-          />
-        </RoutesProvider>
+        <RoutePropertiesCardWithDefaults
+          selectRoutePattern={mockSelectRoutePattern}
+        />
       )
 
       await userEvent.click(
@@ -321,24 +325,8 @@ describe("<RoutePropertiesCard/>", () => {
     })
 
     test("Clicking the close button calls onClose prop", async () => {
-      const [routePattern1, routePattern2] = routePatternFactory.buildList(2, {
-        routeId: "66",
-        directionId: 0,
-      })
       const mockOnClose = jest.fn()
-      render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePattern1.id]: routePattern1,
-              [routePattern2.id]: routePattern2,
-            }}
-            selectedRoutePatternId={routePattern1.id}
-            selectRoutePattern={jest.fn()}
-            onClose={mockOnClose}
-          />
-        </RoutesProvider>
-      )
+      render(<RoutePropertiesCardWithDefaults onClose={mockOnClose} />)
 
       await userEvent.click(
         screen.getByRole("button", {
@@ -349,33 +337,13 @@ describe("<RoutePropertiesCard/>", () => {
     })
 
     test("Only one details section is open at a time", async () => {
-      const [routePattern1, routePattern2] = routePatternFactory.buildList(2, {
-        routeId: "66",
-        directionId: 0,
-      })
-      const mockOnClose = jest.fn()
-      render(
-        <RoutesProvider routes={[route66]}>
-          <RoutePropertiesCard
-            routePatterns={{
-              [routePattern1.id]: routePattern1,
-              [routePattern2.id]: routePattern2,
-            }}
-            selectedRoutePatternId={routePattern1.id}
-            selectRoutePattern={jest.fn()}
-            onClose={mockOnClose}
-          />
-        </RoutesProvider>
-      )
+      render(<RoutePropertiesCardWithDefaults />)
 
       await userEvent.click(screen.getByText("Show variants"))
-
       expect(screen.getByText("Hide variants")).toBeInTheDocument()
 
       await userEvent.click(screen.getByText("Show outbound stops"))
-
       expect(screen.getByText("Hide outbound stops")).toBeInTheDocument()
-
       expect(screen.getByText("Show variants")).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
I noticed that a lot of the tests for `<RoutePropertiesCard />` had to initialize a bunch of props that those tests didn't really care about. That cluttered up the tests and made it harder to tell what the tests actually cared about, so I copied [a pattern](https://github.com/mbta/skate/blob/6d7794c98876aeebe956dcb9340faf062a35bc8c/assets/tests/components/detours/detourMap.test.tsx#L27-L46) I saw in the `<DetourMap />` tests.