### PR TITLE
fix: Remove auto-close feature from RoutePropertiesCard

### DIFF
--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -291,7 +291,6 @@ const RoutePropertiesCard = ({
           selectedRoutePatternId={selectedRoutePattern.id}
           selectRoutePattern={(routePattern: RoutePattern) => {
             selectRoutePattern(routePattern)
-            setOpenedDetails(null)
           }}
         />
       </DetailSection>

--- a/assets/tests/components/mapPage/routePropertiesCard.test.tsx
+++ b/assets/tests/components/mapPage/routePropertiesCard.test.tsx
@@ -306,7 +306,7 @@ describe("<RoutePropertiesCard/>", () => {
       )
     })
 
-    test("Clicking a different route pattern calls selectRoutePattern and closes the variants list", async () => {
+    test("Clicking a different route pattern calls selectRoutePattern", async () => {
       const mockSelectRoutePattern = jest.fn()
 
       render(
@@ -325,7 +325,27 @@ describe("<RoutePropertiesCard/>", () => {
 
       await userEvent.click(routePattern2Radio)
       expect(mockSelectRoutePattern).toHaveBeenCalledWith(routePattern2)
-      expect(routePattern2Radio).not.toBeVisible()
+    })
+
+    test("Clicking a different route pattern does not close the variants list", async () => {
+      const mockSelectRoutePattern = jest.fn()
+
+      render(
+        <RoutePropertiesCardWithDefaults
+          selectRoutePattern={mockSelectRoutePattern}
+        />
+      )
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Show variants" })
+      )
+
+      const routePattern2Radio = screen.getByRole("radio", {
+        name: new RegExp(patternDisplayName(routePattern2).name),
+      })
+
+      await userEvent.click(routePattern2Radio)
+      expect(routePattern2Radio).toBeVisible()
     })
 
     test("Clicking the close button calls onClose prop", async () => {


### PR DESCRIPTION
Context: https://mbta.slack.com/archives/C024N3SKX33/p1716485471935489?thread_ts=1716483946.893499&cid=C024N3SKX33