### PR TITLE
fix: Add selectRoutePattern to RoutePropertiesCard story

### DIFF
--- a/assets/stories/skate-components/routePropertiesCard.stories.tsx
+++ b/assets/stories/skate-components/routePropertiesCard.stories.tsx
@@ -70,6 +70,7 @@ const meta = {
   args: {
     routePatterns: routePatterns,
     selectedRoutePatternId: routePattern0.id,
+    selectRoutePattern: () => {},
   },
   argTypes: {
     routePatterns: { table: { disable: true } },


### PR DESCRIPTION
Its absence was throwing errors in the console and hiding the auto-collapse behavior (which is being removed in https://github.com/mbta/skate/pull/2619).