### PR TITLE
fix(tests): Remove an unnecessary variable from RoutePropertiesCard tests

### DIFF
--- a/assets/tests/components/mapPage/routePropertiesCard.test.tsx
+++ b/assets/tests/components/mapPage/routePropertiesCard.test.tsx
@@ -43,21 +43,17 @@ const RoutePropertiesCardWithDefaults = ({
   onClose?: () => void
   selectRoutePattern?: (routePattern: RoutePattern) => void
   defaultOpened?: RoutePropertiesCardOpened
-}) => {
-  const thing = (
-    <RoutesProvider routes={routes}>
-      <RoutePropertiesCard
-        routePatterns={routePatterns}
-        selectedRoutePatternId={selectedRoutePatternId}
-        selectRoutePattern={selectRoutePattern}
-        onClose={onClose}
-        defaultOpened={defaultOpened}
-      />
-    </RoutesProvider>
-  )
-
-  return thing
-}
+}) => (
+  <RoutesProvider routes={routes}>
+    <RoutePropertiesCard
+      routePatterns={routePatterns}
+      selectedRoutePatternId={selectedRoutePatternId}
+      selectRoutePattern={selectRoutePattern}
+      onClose={onClose}
+      defaultOpened={defaultOpened}
+    />
+  </RoutesProvider>
+)
 
 describe("patternDisplayName", () => {
   test("When not formatted correctly with ' - '", () => {


### PR DESCRIPTION
It got left in as an intermediate step while debugging when <RoutePropertiesCardWithDefaults /> was added, and is no longer needed.