### PR TITLE
fix: Reworked route ladder header layout

### DIFF
--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -49,9 +49,15 @@
 
   .card-body {
     display: inline-grid;
-    grid-template-columns: 1fr auto auto auto 1fr;
+    grid-template-columns: 1fr auto 1fr;
     padding: 6px 8px;
-    align-items: center;
+  }
+
+  .c-route-ladder__header__action-container {
+    display: inline-flex;
+    div {
+      padding-right: 0.5rem;
+    }
   }
 
   .c-route-ladder__dropdown-button {
@@ -60,10 +66,9 @@
   }
 
   .c-route-ladder__alert-icon {
-    display: grid;
+    display: flex;
     align-items: center;
     width: 1.6rem;
-    margin: 0 0.5rem;
 
     cursor: pointer;
 
@@ -74,12 +79,11 @@
   }
 
   .c-route-ladder__route-pill {
-    grid-column: 3/4;
-    justify-self: center;
+    grid-column: 2/3;
   }
 
   .c-route-ladder__close-button-container {
-    grid-column: 5/6;
+    grid-column: 3/4;
     margin: 2px 0 2px auto;
   }
 }

--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -63,6 +63,15 @@
   .c-route-ladder__dropdown-button {
     height: 2.25rem;
     width: 2.25rem;
+    // TODO All of this is bad and should be reverted when we fix the left nav button colors
+    &.btn-primary {
+      --bs-btn-bg: #451b83;
+      --bs-btn-border-color: #451b83;
+      --bs-btn-hover-bg: #260f54;
+      --bs-btn-hover-border-color: #260f54;
+      --bs-btn-active-bg: #260f54;
+      --bs-btn-active-border-color: #260f54;
+    }
   }
 
   .c-route-ladder__alert-icon {

--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -49,7 +49,7 @@
 
   .card-body {
     display: inline-grid;
-    grid-template-columns: 1fr 1fr auto 1fr 1fr;
+    grid-template-columns: 1fr auto auto auto 1fr;
     padding: 6px 8px;
     align-items: center;
   }
@@ -63,7 +63,7 @@
     display: grid;
     align-items: center;
     width: 1.6rem;
-    margin-right: 0.5rem;
+    margin: 0 0.5rem;
 
     cursor: pointer;
 

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -91,34 +91,35 @@ export const NewHeader = ({
   return (
     <Card className="c-new-route-ladder__header">
       <Card.Body>
-        {inTestGroup(TestGroups.DetoursPilot) && (
-          <Dropdown className="border-box inherit-box">
-            <Dropdown.Toggle className="c-route-ladder__dropdown-button" />
-            <Dropdown.Menu>
-              <Dropdown.Item className="icon-link">
-                <PlusSquare />
-                Add detour
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        )}
-        {hasAlert && (
-          <Tippy
-            content="Active detour"
-            trigger="click"
-            onShow={() => tagManagerEvent("alert_tooltip_clicked")}
-          >
-            <div className="c-route-ladder__alert-icon">
-              <ExclamationTriangleFill aria-label="Route Alert" />
-            </div>
-          </Tippy>
-        )}
+        <div className="c-route-ladder__header__action-container">
+          {inTestGroup(TestGroups.DetoursPilot) && (
+            <Dropdown className="border-box inherit-box">
+              <Dropdown.Toggle className="c-route-ladder__dropdown-button" />
+              <Dropdown.Menu>
+                <Dropdown.Item className="icon-link">
+                  <PlusSquare />
+                  Add detour
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
+          )}
+          {hasAlert && (
+            <Tippy
+              content="Active detour"
+              trigger="click"
+              onShow={() => tagManagerEvent("alert_tooltip_clicked")}
+            >
+              <div className="c-route-ladder__alert-icon">
+                <ExclamationTriangleFill aria-label="Route Alert" />
+              </div>
+            </Tippy>
+          )}
+        </div>
         <RoutePill
           routeName={routeName}
           largeFormat
           className="c-route-ladder__route-pill c-route-pill"
         />
-        {hasAlert && <div className="c-route-ladder__alert-icon" />}
         <div className="c-route-ladder__close-button-container">
           <CloseButton className="p-2" onClick={onClose} />
         </div>

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -115,7 +115,8 @@ export const NewHeader = ({
         )}
         <RoutePill
           routeName={routeName}
-          className="c-route-ladder__route-pill c-route-pill--large-format"
+          largeFormat
+          className="c-route-ladder__route-pill c-route-pill"
         />
         {hasAlert && <div className="c-route-ladder__alert-icon" />}
         <div className="c-route-ladder__close-button-container">

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -1340,7 +1340,7 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
         />
       </div>
       <div
-        class="c-route-pill c-route-pill--bus c-route-ladder__route-pill c-route-pill--large-format"
+        class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
       >
         28
       </div>
@@ -1473,7 +1473,7 @@ exports[`routeLadder renders a route ladder with the new header format 1`] = `
       class="card-body"
     >
       <div
-        class="c-route-pill c-route-pill--bus c-route-ladder__route-pill c-route-pill--large-format"
+        class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
       >
         28
       </div>

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -1330,14 +1330,18 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
       class="card-body"
     >
       <div
-        class="border-box inherit-box dropdown"
+        class="c-route-ladder__header__action-container"
       >
-        <button
-          aria-expanded="false"
-          class="c-route-ladder__dropdown-button dropdown-toggle btn btn-primary"
-          id="react-aria-:r0:"
-          type="button"
-        />
+        <div
+          class="border-box inherit-box dropdown"
+        >
+          <button
+            aria-expanded="false"
+            class="c-route-ladder__dropdown-button dropdown-toggle btn btn-primary"
+            id="react-aria-:r0:"
+            type="button"
+          />
+        </div>
       </div>
       <div
         class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
@@ -1472,6 +1476,9 @@ exports[`routeLadder renders a route ladder with the new header format 1`] = `
     <div
       class="card-body"
     >
+      <div
+        class="c-route-ladder__header__action-container"
+      />
       <div
         class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
       >


### PR DESCRIPTION
After merging other PRs into the target branch and before merging the target branch into main, I realized a couple things were off. For one, the route pill needed to switch to the large format. For another, the alert icon didn't have the right margins both when visible / invisible.