### PR TITLE
feat(ts/detours): model pick route and pattern flow in state machine

### DIFF
--- a/assets/src/components/detours/detourDropdown.tsx
+++ b/assets/src/components/detours/detourDropdown.tsx
@@ -36,11 +36,6 @@ export const DetourDropdown = ({
 
   const routeDescription = routePatternForVehicle.headsign
 
-  const routeOrigin = routePatternForVehicle.name
-
-  const routeDirection =
-    route.directionNames[routePatternForVehicle.directionId]
-
   const shape = routePatternForVehicle.shape
 
   if (!routeDescription || !shape) {
@@ -53,12 +48,8 @@ export const DetourDropdown = ({
         <DropdownItem
           onClick={() => {
             onClick({
-              routeName,
-              routeDescription,
-              routeOrigin,
-              routeDirection,
-              routePatternId: routePatternForVehicle.id,
-              shape,
+              route,
+              routePattern: routePatternForVehicle,
               center,
               zoom,
             })

--- a/assets/src/components/detours/detourRouteSelectionPanel.tsx
+++ b/assets/src/components/detours/detourRouteSelectionPanel.tsx
@@ -56,9 +56,12 @@ export const DetourRouteSelectionPanel = ({
     <Panel.Body className="d-flex flex-column">
       <Panel.Body.ScrollArea className="d-flex flex-column">
         <section className="pb-3">
-          <h2 className="c-diversion-panel__h2">Choose route</h2>
+          <h2 className="c-diversion-panel__h2" id="choose-route-select">
+            Choose route
+          </h2>
           <FormSelect
-            defaultValue={selectedRouteInfo.selectedRoute?.id}
+            aria-labelledby="choose-route-select"
+            value={selectedRouteInfo.selectedRoute?.id}
             onChange={(changeEvent) => {
               onSelectRoute?.(
                 allRoutes.find((route) => route.id === changeEvent.target.value)

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -14,6 +14,7 @@ import { OriginalRoute } from "../../models/detour"
 import { joinClasses } from "../../helpers/dom"
 import { AsProp } from "react-bootstrap/esm/helpers"
 import { DetourFinishedPanel } from "./detourFinishedPanel"
+import { Route, RoutePattern } from "../../schedule"
 
 interface DiversionPageProps {
   originalRoute: OriginalRoute
@@ -66,11 +67,20 @@ export const DiversionPage = ({
     ? nearestIntersectionDirection.concat(directions)
     : undefined
 
+  const { route, routePattern, routePatterns } = snapshot.context
+  const {
+    routeName = undefined,
+    routeDirection = undefined,
+    routeOrigin = undefined,
+    routeDescription = undefined,
+    shape = undefined,
+  } = route && routePattern ? descriptors(route, routePattern) : {}
+
   useEffect(() => {
     setTextArea(
       [
-        `Detour ${originalRoute.routeName} ${originalRoute.routeDirection}`,
-        originalRoute.routeOrigin,
+        `Detour ${routeName} ${routeDirection}`,
+        routeOrigin,
         ,
         "Connection Points:",
         connectionPoints?.start?.name ?? "N/A",
@@ -84,7 +94,9 @@ export const DiversionPage = ({
       ].join("\n")
     )
   }, [
-    originalRoute,
+    routeName,
+    routeDirection,
+    routeOrigin,
     extendedDirections,
     missedStops,
     connectionPoints?.start?.name,
@@ -103,10 +115,10 @@ export const DiversionPage = ({
             <DiversionPanel
               directions={extendedDirections}
               missedStops={missedStops}
-              routeName={originalRoute.routeName}
-              routeDescription={originalRoute.routeDescription}
-              routeOrigin={originalRoute.routeOrigin}
-              routeDirection={originalRoute.routeDirection}
+              routeName={routeName ?? "??"}
+              routeDescription={routeDescription ?? "??"}
+              routeOrigin={routeOrigin ?? "??"}
+              routeDirection={routeDirection ?? "??"}
               detourFinished={finishDetour !== undefined}
               onFinishDetour={finishDetour}
             />
@@ -137,7 +149,7 @@ export const DiversionPage = ({
           )}
           {routingError?.type === "unknown" && <RoutingErrorAlert />}
           <DetourMap
-            originalShape={originalRoute.shape.points}
+            originalShape={shape?.points ?? []}
             center={originalRoute.center}
             zoom={originalRoute.zoom}
             detourShape={detourShape}
@@ -294,3 +306,18 @@ DiversionPagePanel.Body = DiversionPagePanelBody
 DiversionPage.Panel = DiversionPagePanel
 
 export const Panel = DiversionPagePanel
+
+function descriptors(route: Route, routePattern: RoutePattern) {
+  const routeName = route.name
+
+  const routeDescription = routePattern.headsign ?? ""
+
+  const routeOrigin = routePattern?.name
+
+  const routeDirection =
+    routePattern && route.directionNames[routePattern.directionId]
+
+  const shape = routePattern.shape
+
+  return { routeName, routeDirection, routeOrigin, routeDescription, shape }
+}

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -18,16 +18,11 @@ export const DummyDetourPage = () => {
 
   return (
     <>
-      {routePattern && routePattern.shape && (
+      {route && routePattern && routePattern.shape && (
         <DiversionPage
           originalRoute={{
-            shape: routePattern.shape,
-            routeName: routePattern.routeId,
-            routeDescription: routePattern.headsign || "?",
-            routeOrigin: routePattern.name,
-            routeDirection:
-              route?.directionNames[routePattern.directionId] || "?",
-            routePatternId: routePattern.id,
+            route,
+            routePattern,
             center: { lat: 42.36, lng: -71.13 },
             zoom: 16,
           }}

--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { useRoute } from "../../contexts/routesContext"
 import { CircleCheckIcon } from "../../helpers/icon"
 import {
@@ -208,18 +208,24 @@ const VariantPicker = ({
   selectedRoutePatternId: RoutePatternId
   selectRoutePattern: (routePattern: RoutePattern) => void
 }): JSX.Element => {
+  const id = "variant-picker" + useId()
   {
     return (
-      <fieldset>
-        {sortRoutePatterns(routePatterns).map((routePattern) => (
-          <VariantOption
-            key={routePattern.id}
-            routePattern={routePattern}
-            isSelected={routePattern.id === selectedRoutePatternId}
-            selectRoutePattern={selectRoutePattern}
-          />
-        ))}
-      </fieldset>
+      <>
+        <span id={id} className="visually-hidden">
+          Variants
+        </span>
+        <fieldset aria-labelledby={id}>
+          {sortRoutePatterns(routePatterns).map((routePattern) => (
+            <VariantOption
+              key={routePattern.id}
+              routePattern={routePattern}
+              isSelected={routePattern.id === selectedRoutePatternId}
+              selectRoutePattern={selectRoutePattern}
+            />
+          ))}
+        </fieldset>
+      </>
     )
   }
 }

--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -180,7 +180,7 @@ const VariantOption = ({
         type="radio"
         id={`variant-radio-${routePattern.id}`}
         name="variant"
-        defaultChecked={isSelected}
+        checked={isSelected}
         onChange={() => selectRoutePattern(routePattern)}
       />
 

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -4,15 +4,27 @@ import { Route, RoutePattern } from "../schedule"
 export const createDetourMachine = setup({
   types: {} as {
     context: {
-      route: Route
-      routePattern: RoutePattern
+      route?: Route
+      routePattern?: RoutePattern
     }
 
-    input: {
-      // Caller has target route pattern
-      route: Route
-      routePattern: RoutePattern
-    }
+    input:
+      | {
+          // Caller has target route pattern
+          route: Route
+          routePattern: RoutePattern
+        }
+      | {
+          // Caller has target route
+          route: Route
+          routePattern: undefined
+        }
+      | {
+          // Caller has no prior selection
+          route: undefined
+          routePattern: undefined
+        }
+
     events: { type: "detour.edit.done" } | { type: "detour.edit.resume" }
   },
 }).createMachine({

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -38,6 +38,21 @@ export const createDetourMachine = setup({
     "Detour Drawing": {
       initial: "Editing",
       states: {
+        "Pick Route Pattern": {
+          initial: "Pick Route ID",
+          states: {
+            "Pick Route ID": {
+            },
+            "Pick Route Pattern": {
+            },
+            Done: {
+              type: "final",
+            },
+          },
+          onDone: {
+            target: "Editing",
+          },
+        },
         Editing: {
           on: {
             "detour.edit.done": {

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -1,11 +1,25 @@
-import { setup } from "xstate"
+import { setup, ActorLogicFrom, InputFrom } from "xstate"
+import { Route, RoutePattern } from "../schedule"
 
 export const createDetourMachine = setup({
   types: {} as {
+    context: {
+      route: Route
+      routePattern: RoutePattern
+    }
+
+    input: {
+      // Caller has target route pattern
+      route: Route
+      routePattern: RoutePattern
+    }
     events: { type: "detour.edit.done" } | { type: "detour.edit.resume" }
   },
 }).createMachine({
   id: "Detours Machine",
+  context: ({ input }) => ({
+    ...input,
+  }),
 
   initial: "Detour Drawing",
   states: {
@@ -30,3 +44,11 @@ export const createDetourMachine = setup({
     },
   },
 })
+
+/**
+ * This refers to the type of `input` provided in
+ * {@linkcode createDetourMachine}'s {@linkcode setup} call
+ */
+export type CreateDetourMachineInput = InputFrom<
+  ActorLogicFrom<typeof createDetourMachine>
+>

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,5 +1,5 @@
 import { LatLngLiteral } from "leaflet"
-import { RoutePatternId, Shape, ShapePoint, Stop } from "../schedule"
+import { Route, RoutePattern, ShapePoint, Stop } from "../schedule"
 
 export interface DetourShape {
   coordinates: ShapePoint[]
@@ -11,12 +11,8 @@ export type DetourDirection = {
 }
 
 export interface OriginalRoute {
-  routeName: string
-  routeDescription: string
-  routeOrigin: string
-  routeDirection: string
-  routePatternId: RoutePatternId
-  shape: Shape
+  route: Route
+  routePattern: RoutePattern
   center: LatLngLiteral
   zoom: number
 }

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -8,6 +8,7 @@ export enum TestGroups {
   MinimalLadderPage = "minimal-ladder-page",
   LateView = "late-view",
   RouteLadderHeaderUpdate = "route-ladder-header-update",
+  DetourRoutePicker = "detour-route-picker",
 }
 
 const inTestGroup = (key: TestGroups): boolean => {

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { DiversionPage } from "../../../src/components/detours/diversionPage"
 import { route39shape } from "../__story-data__/shape"
+import { originalRouteFactory } from "../../../tests/factories/originalRouteFactory"
 
 const meta = {
   component: DiversionPage,
@@ -10,16 +11,20 @@ const meta = {
   },
   args: {
     // Provide default route settings
-    originalRoute: {
-      routeDescription: "Harvard via Allston",
-      routeOrigin: "from Andrew Station",
-      routeDirection: "Outbound",
-      routePatternId: "39-3-0",
-      routeName: "39",
-      shape: route39shape,
+    originalRoute: originalRouteFactory.build({
+      routePattern: {
+        id: "39-3-0",
+        headsign: "Harvard via Allston",
+        name: "Andrew Station",
+        directionId: 0,
+        shape: route39shape,
+      },
+      route: {
+        name: "39",
+      },
       zoom: 14,
       center: { lat: 42.33, lng: -71.11 },
-    },
+    }),
     showConfirmCloseModal: false,
   },
   argTypes: {

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -16,8 +16,6 @@ import {
   fetchNearestIntersection,
 } from "../../../src/api"
 import { DiversionPage as DiversionPageDefault } from "../../../src/components/detours/diversionPage"
-import shapeFactory from "../../factories/shape"
-import { latLngLiteralFactory } from "../../factories/latLngLiteralFactory"
 import stopFactory from "../../factories/stop"
 import userEvent from "@testing-library/user-event"
 import {
@@ -35,13 +33,15 @@ import {
 } from "../../testHelpers/selectors/components/map/markers/stopIcon"
 import { Err, Ok } from "../../../src/util/result"
 import { neverPromise } from "../../testHelpers/mockHelpers"
+import { originalRouteFactory } from "../../factories/originalRouteFactory"
+import { DeepPartial } from "fishery"
 
 const DiversionPage = (
   props: Omit<
     Partial<ComponentProps<typeof DiversionPageDefault>>,
     "originalRoute"
   > & {
-    originalRoute?: Partial<
+    originalRoute?: DeepPartial<
       ComponentProps<typeof DiversionPageDefault>["originalRoute"]
     >
   }
@@ -49,17 +49,7 @@ const DiversionPage = (
   const { originalRoute, showConfirmCloseModal, ...otherProps } = props
   return (
     <DiversionPageDefault
-      originalRoute={{
-        routeName: "66",
-        routeDescription: "Harvard via Allston",
-        routeOrigin: "from Andrew Station",
-        routeDirection: "Outbound",
-        routePatternId: "66-6-0",
-        shape: shapeFactory.build(),
-        center: latLngLiteralFactory.build(),
-        zoom: 16,
-        ...originalRoute,
-      }}
+      originalRoute={originalRouteFactory.build(originalRoute)}
       showConfirmCloseModal={showConfirmCloseModal ?? false}
       {...otherProps}
     />
@@ -1039,13 +1029,16 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          routeName,
-          routeOrigin,
-          routeDescription,
-          routeDirection,
-          shape: shapeFactory.build({
-            points: [connectionPoint],
-          }),
+          route: {
+            name: routeName,
+          },
+          routePattern: {
+            headsign: routeDescription,
+            name: routeOrigin,
+            shape: {
+              points: [connectionPoint],
+            },
+          },
         }}
       />
     )
@@ -1174,7 +1167,11 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          shape: shapeFactory.build({ stops: stopFactory.buildList(11) }),
+          routePattern: {
+            shape: {
+              stops: stopFactory.buildList(11),
+            },
+          },
         }}
       />
     )
@@ -1197,7 +1194,11 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          shape: shapeFactory.build({ stops: [stop1, stop2, stop3, stop4] }),
+          routePattern: {
+            shape: {
+              stops: [stop1, stop2, stop3, stop4],
+            },
+          },
         }}
       />
     )

--- a/assets/tests/factories/originalRouteFactory.ts
+++ b/assets/tests/factories/originalRouteFactory.ts
@@ -3,18 +3,13 @@ import { OriginalRoute } from "../../src/models/detour"
 import routeFactory from "./route"
 import { routePatternFactory } from "./routePattern"
 import { latLngLiteralFactory } from "./latLngLiteralFactory"
-import shapeFactory from "./shape"
 
 export const originalRouteFactory = Factory.define<OriginalRoute>(() => {
   const route = routeFactory.build()
-  const routePattern = routePatternFactory.build()
+  const routePattern = routePatternFactory.build({ routeId: route.id })
   return {
-    routeName: route.name,
-    routeDescription: routePattern.headsign || "",
-    routeOrigin: routePattern.name,
-    routeDirection: "Outbound",
-    routePatternId: routePattern.id,
-    shape: shapeFactory.build(),
+    route,
+    routePattern,
     center: latLngLiteralFactory.build(),
     zoom: 16,
   }


### PR DESCRIPTION
This models the main flow of the pick route panel, this intentionally does not wire up anything in the UI or change the interface of `useDetour` and `DiversionPage`, those will be addressed in followup PRs. These new states should also be inaccessible as they're not "called" from any of our existing flow.

---

Asana Ticket: https://app.asana.com/0/0/1207438967654848/f

