### PR TITLE
feat: Make the part of the route shape before the start point unclickable

### DIFF
--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -11,11 +11,13 @@
   }
 }
 
+.c-detour_map--original-route-shape-after-start-point,
 .c-detour_map--original-route-shape-core {
   stroke: $color-kiwi-500;
   opacity: 50%;
 }
 
+.c-detour_map--original-route-shape-after-start-point--interactive,
 .c-detour_map--original-route-shape {
   stroke: $color-kiwi-500;
   opacity: 0%;

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -51,13 +51,17 @@ import {
 } from "./models/locationSearchSuggestionData"
 import { LocationSearchSuggestion } from "./models/locationSearchSuggestion"
 import { DetourShapeData, detourShapeFromData } from "./models/detourShapeData"
-import { DetourShape, FinishedDetour } from "./models/detour"
+import { DetourShape, FinishedDetour, UnfinishedDetour } from "./models/detour"
 import {
   FinishedDetourData,
   finishedDetourFromData,
 } from "./models/finishedDetour"
 import { FetchResult, ok, fetchError } from "./util/fetchResult"
 import { Ok, Err, Result, map } from "./util/result"
+import {
+  UnfinishedDetourData,
+  unfinishedDetourFromData,
+} from "./models/unfinishedDetour"
 
 export interface RouteData {
   id: string
@@ -248,6 +252,21 @@ export const fetchDetourDirections = (
       coordinates,
     })
   ).then((v) => map(v, detourShapeFromData))
+
+export const fetchUnfinishedDetour = (
+  routePatternId: RoutePatternId,
+  connectionStart: ShapePoint
+): Promise<UnfinishedDetour | null> =>
+  checkedApiCall<UnfinishedDetourData, UnfinishedDetour | null>({
+    url: "/api/detours/unfinished_detour",
+    parser: unfinishedDetourFromData,
+    dataStruct: UnfinishedDetourData,
+    defaultResult: null,
+    fetchArgs: postJsonParameter({
+      route_pattern_id: routePatternId,
+      connection_start: connectionStart,
+    }),
+  })
 
 export const fetchFinishedDetour = (
   routePatternId: RoutePatternId,

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -19,6 +19,7 @@ import { DetourRouteSelectionPanel } from "./detourRouteSelectionPanel"
 import { Route, RoutePattern } from "../../schedule"
 import RoutesContext from "../../contexts/routesContext"
 import { Snapshot } from "xstate"
+import inTestGroup, { TestGroups } from "../../userInTestGroup"
 
 const displayFieldsFromRouteAndPattern = (
   route: Route,
@@ -83,6 +84,8 @@ export const DiversionPage = ({
     directions,
     routingError,
     nearestIntersection,
+
+    unfinishedRouteSegments,
 
     stops,
     missedStops,
@@ -266,6 +269,11 @@ export const DiversionPage = ({
             startPoint={startPoint ?? undefined}
             endPoint={endPoint ?? undefined}
             waypoints={waypoints}
+            unfinishedRouteSegments={
+              inTestGroup(TestGroups.BackwardsDetourPrevention)
+                ? unfinishedRouteSegments
+                : undefined
+            }
             routeSegments={routeSegments}
             onAddWaypoint={addWaypoint}
             onClickOriginalShape={addConnectionPoint ?? (() => {})}

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -1,4 +1,7 @@
+import { useCallback } from "react"
 import { ShapePoint } from "../schedule"
+import { fetchUnfinishedDetour } from "../api"
+import { useApiCall } from "./useApiCall"
 import { isErr, isOk } from "../util/result"
 import { useNearestIntersection } from "./useNearestIntersection"
 import { useMachine } from "@xstate/react"
@@ -42,6 +45,16 @@ export const useDetour = (input: UseDetourInput) => {
     finishedDetour,
     detourShape,
   } = snapshot.context
+
+  const { result: unfinishedDetour } = useApiCall({
+    apiCall: useCallback(async () => {
+      if (startPoint && routePattern?.id) {
+        return fetchUnfinishedDetour(routePattern.id, startPoint)
+      } else {
+        return null
+      }
+    }, [startPoint, routePattern]),
+  })
 
   const { result: nearestIntersection } = useNearestIntersection({
     latitude: startPoint?.lat,
@@ -146,6 +159,8 @@ export const useDetour = (input: UseDetourInput) => {
      */
     routingError:
       detourShape && isErr(detourShape) ? detourShape.err : undefined,
+
+    unfinishedRouteSegments: unfinishedDetour?.unfinishedRouteSegments,
 
     /**
      * Stops that are not missed by the detour (starts out as all of the stops)

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -17,6 +17,15 @@ export interface OriginalRoute {
   zoom?: number
 }
 
+export interface UnfinishedRouteSegments {
+  beforeStartPoint: ShapePoint[]
+  afterStartPoint: ShapePoint[]
+}
+
+export interface UnfinishedDetour {
+  unfinishedRouteSegments: UnfinishedRouteSegments
+}
+
 export interface RouteSegments {
   beforeDetour: ShapePoint[]
   detour: ShapePoint[]

--- a/assets/src/models/unfinishedDetour.ts
+++ b/assets/src/models/unfinishedDetour.ts
@@ -1,0 +1,28 @@
+import { array, Infer, number, type } from "superstruct"
+import { UnfinishedDetour } from "./detour"
+
+const Coordinate = type({
+  lat: number(),
+  lon: number(),
+})
+
+export const UnfinishedDetourData = type({
+  unfinished_route_segments: type({
+    before_start_point: array(Coordinate),
+    after_start_point: array(Coordinate),
+  }),
+})
+export type UnfinishedDetourData = Infer<typeof UnfinishedDetourData>
+
+export const unfinishedDetourFromData = (
+  unfinishedDetour: UnfinishedDetourData
+): UnfinishedDetour => {
+  return {
+    unfinishedRouteSegments: {
+      beforeStartPoint:
+        unfinishedDetour.unfinished_route_segments.before_start_point,
+      afterStartPoint:
+        unfinishedDetour.unfinished_route_segments.after_start_point,
+    },
+  }
+}

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -1,6 +1,7 @@
 import getTestGroups from "./userTestGroups"
 
 export enum TestGroups {
+  BackwardsDetourPrevention = "backwards-detour-prevention",
   DemoMode = "demo-mode",
   DetoursPilot = "detours-pilot",
   DummyDetourPage = "dummy-detour-page",

--- a/assets/stories/skate-components/detours/detourMap.stories.tsx
+++ b/assets/stories/skate-components/detours/detourMap.stories.tsx
@@ -97,6 +97,7 @@ const meta = {
     startPoint,
     waypoints: [waypoint],
     endPoint,
+    unfinishedRouteSegments: undefined,
     routeSegments: {
       beforeDetour: shape.slice(0, startPointIndex),
       detour: shape.slice(startPointIndex, endPointIndex),
@@ -138,6 +139,10 @@ export const WithSomeWaypoints: Story = {
   args: {
     stops: allStops,
     endPoint: undefined,
+    unfinishedRouteSegments: {
+      beforeStartPoint: shape.slice(0, startPointIndex),
+      afterStartPoint: shape.slice(startPointIndex, -1),
+    },
     routeSegments: undefined,
     detourShape: [startPoint, waypoint],
     waypoints: [waypoint],

--- a/assets/tests/factories/finishedDetourFactory.ts
+++ b/assets/tests/factories/finishedDetourFactory.ts
@@ -1,8 +1,23 @@
 import { Factory } from "fishery"
-import { FinishedDetour, RouteSegments } from "../../src/models/detour"
+import {
+  FinishedDetour,
+  RouteSegments,
+  UnfinishedDetour,
+  UnfinishedRouteSegments,
+} from "../../src/models/detour"
 import { shapePointFactory } from "./shapePointFactory"
 import stopFactory from "./stop"
 import { detourShapeFactory } from "./detourShapeFactory"
+
+export const unfinishedRouteSegmentsFactory =
+  Factory.define<UnfinishedRouteSegments>(() => ({
+    beforeStartPoint: shapePointFactory.buildList(3),
+    afterStartPoint: shapePointFactory.buildList(3),
+  }))
+
+export const unfinishedDetourFactory = Factory.define<UnfinishedDetour>(() => ({
+  unfinishedRouteSegments: unfinishedRouteSegmentsFactory.build(),
+}))
 
 export const routeSegmentsFactory = Factory.define<RouteSegments>(() => ({
   beforeDetour: shapePointFactory.buildList(3),

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -20,6 +20,22 @@ export const originalRouteShape = {
         ".c-detour_map--original-route-shape-diverted"
       ),
   },
+  afterStartPoint: {
+    interactive: {
+      getAll: (container: HTMLElement) =>
+        container.querySelectorAll(
+          ".c-detour_map--original-route-shape-after-start-point--interactive"
+        ),
+    },
+    not: {
+      interactive: {
+        getAll: (container: HTMLElement) =>
+          container.querySelectorAll(
+            ".c-detour_map--original-route-shape-after-start-point"
+          ),
+      },
+    },
+  },
 
   get(container: HTMLElement): Element {
     const maybeShape = container.querySelector(


### PR DESCRIPTION
As part of an effort to help dispatchers avoid errors, we want to prevent them from clicking on the portion of a route shape that would cause them to draw the detour backwards.

<img width="597" alt="Screenshot 2024-06-03 at 3 52 49 PM" src="https://github.com/mbta/skate/assets/912020/22884702-3e56-4d4c-a4bd-64eef65504c5">

(In the above screenshot, the route flows from south to north, so the part of the route shape lying to the south of the start point is disabled.)

---

Asana Ticket: https://app.asana.com/0/1205385723132845/1207449517841759/f

Depends on:
- #2637
- #2641
- #2696

Blocks:
- #2639