### PR TITLE
feat: Update styling for route after start point

### DIFF
--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -11,9 +11,14 @@
   }
 }
 
-.c-detour_map--original-route-shape-after-start-point,
 .c-detour_map--original-route-shape-core {
   stroke: $color-kiwi-500;
+  opacity: 50%;
+}
+
+.c-detour_map--original-route-shape-after-start-point {
+  stroke: $color-kiwi-500;
+  stroke-dasharray: 10 10;
   opacity: 50%;
 }
 

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -421,7 +421,7 @@ const UnfinishedDiversionRouteShape = ({
       className="c-detour_map--original-route-shape-core"
     />
     <Polyline
-      weight={6}
+      weight={3}
       interactive={false}
       positions={afterStartPoint.map(shapePointToLatLngLiteral)}
       className="c-detour_map--original-route-shape-after-start-point"
@@ -429,7 +429,7 @@ const UnfinishedDiversionRouteShape = ({
     {interactive && (
       <Polyline
         positions={afterStartPoint.map(shapePointToLatLngLiteral)}
-        weight={16}
+        weight={13}
         className={joinClasses([
           "c-detour_map--original-route-shape-after-start-point--interactive",
           "c-detour_map--original-route-shape__unfinished",
@@ -438,7 +438,9 @@ const UnfinishedDiversionRouteShape = ({
         eventHandlers={{
           click: onClick,
         }}
-      />
+      >
+        <MapTooltip>Click to complete detour</MapTooltip>
+      </Polyline>
     )}
   </>
 )


### PR DESCRIPTION
As part of an effort to help dispatchers avoid errors, we want to make it visually clear which side of the start point is at risk of being diverted, and which side is "safe". This augments #2638 by changing the styling of the "maybe-diverted" side of the start point to make the visual difference between before and after the start point obvious.

<img width="602" alt="Screenshot 2024-06-03 at 3 58 10 PM" src="https://github.com/mbta/skate/assets/912020/625254e7-8e0a-4a50-b796-f2cf6dc71731">

<img width="573" alt="Screenshot 2024-06-03 at 3 59 54 PM" src="https://github.com/mbta/skate/assets/912020/b51f96bd-65d8-4531-a2d8-046ac3f8cf48">

---

Asana Ticket: https://app.asana.com/0/1205385723132845/1207449517841760/f

Depends on:
- #2637 
- #2641 
- #2696 
- #2638