### PR TITLE
tests: Add tests that assert on visible route sections

### DIFF
--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -932,6 +932,50 @@ describe("DiversionPage", () => {
     })
   })
 
+  test("has (only) an original route shape at the beginning", async () => {
+    const { container } = render(<DiversionPage />)
+
+    await waitFor(() => {
+      expect(originalRouteShape.get(container)).toBeVisible()
+    })
+
+    expect(originalRouteShape.diverted.getAll(container)).toHaveLength(0)
+  })
+
+  test("keeps the original route shape after the start point is added", async () => {
+    const { container } = render(<DiversionPage />)
+
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    await waitFor(() => {
+      expect(originalRouteShape.get(container)).toBeVisible()
+    })
+  })
+
+  test("replaces the original route shape with a diverted segment after the end point is added", async () => {
+    jest
+      .mocked(fetchFinishedDetour)
+      .mockResolvedValue(finishedDetourFactory.build())
+
+    const { container } = render(<DiversionPage />)
+
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    act(() => {
+      fireEvent.click(originalRouteShape.get(container))
+    })
+
+    await waitFor(() => {
+      expect(originalRouteShape.interactive.getAll(container)).toHaveLength(0)
+    })
+
+    expect(originalRouteShape.diverted.getAll(container)).toHaveLength(1)
+  })
+
   test("calls the fetch-detour-directions endpoint after undo'ing if there is still at least one waypoint left", async () => {
     const { container } = render(<DiversionPage />)
 

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -14,6 +14,12 @@ export const originalRouteShape = {
         container.querySelectorAll(".c-detour_map--original-route-shape-core"),
     },
   },
+  diverted: {
+    getAll: (container: HTMLElement) =>
+      container.querySelectorAll(
+        ".c-detour_map--original-route-shape-diverted"
+      ),
+  },
 
   get(container: HTMLElement): Element {
     const maybeShape = container.querySelector(


### PR DESCRIPTION
This is a prequel to some work that we're doing to disable clicking on the portion of a route shape that comes before the start point, in order to make it less likely that a dispatcher will draw a detour backwards. 

We need some tests to validate that we are doing ☝️ correctly, and that it's only enabled when the user is in a particular test group. This PR adds tests that validate the existing behavior.

---

Asana Ticket: https://app.asana.com/0/1205385723132845/1207475016947553/f

Blocks:
- #2638
- #2639