### PR TITLE
fix: Lil styling fix on the route ladder headers

### DIFF
--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -55,7 +55,8 @@
 
   .c-route-ladder__header__action-container {
     display: inline-flex;
-    .dropdown, .c-route-ladder__alert-icon {
+    .dropdown,
+    .c-route-ladder__alert-icon {
       padding-right: 0.5rem;
     }
   }

--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -55,7 +55,7 @@
 
   .c-route-ladder__header__action-container {
     display: inline-flex;
-    div {
+    .dropdown, .c-route-ladder__alert-icon {
       padding-right: 0.5rem;
     }
   }


### PR DESCRIPTION
Before
<img width="198" alt="Screenshot 2024-06-04 at 10 46 13 AM" src="https://github.com/mbta/skate/assets/69368883/efaeb283-2259-410e-a38e-63d109832479">

After
<img width="260" alt="Screenshot 2024-06-04 at 10 59 21 AM" src="https://github.com/mbta/skate/assets/69368883/2f9b8ebe-1f8d-48cb-8e39-ad08c18550e9">
