### PR TITLE
feat(ts/detours): add context and input to detour machine

### DIFF
--- a/assets/src/components/detours/detourDropdown.tsx
+++ b/assets/src/components/detours/detourDropdown.tsx
@@ -59,6 +59,8 @@ export const DetourDropdown = ({
               routeDirection,
               routePatternId: routePatternForVehicle.id,
               shape,
+              route,
+              routePattern: routePatternForVehicle,
               center,
               zoom,
             })

--- a/assets/src/components/detours/detourDropdown.tsx
+++ b/assets/src/components/detours/detourDropdown.tsx
@@ -36,11 +36,6 @@ export const DetourDropdown = ({
 
   const routeDescription = routePatternForVehicle.headsign
 
-  const routeOrigin = routePatternForVehicle.name
-
-  const routeDirection =
-    route.directionNames[routePatternForVehicle.directionId]
-
   const shape = routePatternForVehicle.shape
 
   if (!routeDescription || !shape) {
@@ -53,12 +48,6 @@ export const DetourDropdown = ({
         <DropdownItem
           onClick={() => {
             onClick({
-              routeName,
-              routeDescription,
-              routeOrigin,
-              routeDirection,
-              routePatternId: routePatternForVehicle.id,
-              shape,
               route,
               routePattern: routePatternForVehicle,
               center,

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -14,6 +14,25 @@ import { OriginalRoute } from "../../models/detour"
 import { joinClasses } from "../../helpers/dom"
 import { AsProp } from "react-bootstrap/esm/helpers"
 import { DetourFinishedPanel } from "./detourFinishedPanel"
+import { Route, RoutePattern } from "../../schedule"
+
+const displayFieldsFromRouteAndPattern = (
+  route: Route,
+  routePattern: RoutePattern
+) => {
+  const routeName = route.name
+
+  const routeDescription = routePattern.headsign ?? ""
+
+  const routeOrigin = routePattern?.name
+
+  const routeDirection =
+    routePattern && route.directionNames[routePattern.directionId]
+
+  const shape = routePattern.shape
+
+  return { routeName, routeDirection, routeOrigin, routeDescription, shape }
+}
 
 interface DiversionPageProps {
   originalRoute: OriginalRoute
@@ -66,11 +85,22 @@ export const DiversionPage = ({
     ? nearestIntersectionDirection.concat(directions)
     : undefined
 
+  const { route, routePattern } = snapshot.context
+  const {
+    routeName = undefined,
+    routeDirection = undefined,
+    routeOrigin = undefined,
+    routeDescription = undefined,
+    shape = undefined,
+  } = route && routePattern
+    ? displayFieldsFromRouteAndPattern(route, routePattern)
+    : {}
+
   useEffect(() => {
     setTextArea(
       [
-        `Detour ${originalRoute.routeName} ${originalRoute.routeDirection}`,
-        originalRoute.routeOrigin,
+        `Detour ${routeName} ${routeDirection}`,
+        routeOrigin,
         ,
         "Connection Points:",
         connectionPoints?.start?.name ?? "N/A",
@@ -84,7 +114,9 @@ export const DiversionPage = ({
       ].join("\n")
     )
   }, [
-    originalRoute,
+    routeName,
+    routeDirection,
+    routeOrigin,
     extendedDirections,
     missedStops,
     connectionPoints?.start?.name,
@@ -103,10 +135,10 @@ export const DiversionPage = ({
             <DiversionPanel
               directions={extendedDirections}
               missedStops={missedStops}
-              routeName={originalRoute.routeName}
-              routeDescription={originalRoute.routeDescription}
-              routeOrigin={originalRoute.routeOrigin}
-              routeDirection={originalRoute.routeDirection}
+              routeName={routeName}
+              routeDescription={routeDescription}
+              routeOrigin={routeOrigin}
+              routeDirection={routeDirection}
               detourFinished={finishDetour !== undefined}
               onFinishDetour={finishDetour}
             />
@@ -137,7 +169,7 @@ export const DiversionPage = ({
           )}
           {routingError?.type === "unknown" && <RoutingErrorAlert />}
           <DetourMap
-            originalShape={originalRoute.shape.points}
+            originalShape={shape?.points ?? []}
             center={originalRoute.center}
             zoom={originalRoute.zoom}
             detourShape={detourShape}

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -135,10 +135,10 @@ export const DiversionPage = ({
             <DiversionPanel
               directions={extendedDirections}
               missedStops={missedStops}
-              routeName={routeName}
-              routeDescription={routeDescription}
-              routeOrigin={routeOrigin}
-              routeDirection={routeDirection}
+              routeName={routeName ?? "??"}
+              routeDescription={routeDescription ?? "??"}
+              routeOrigin={routeOrigin ?? "??"}
+              routeDirection={routeDirection ?? "??"}
               detourFinished={finishDetour !== undefined}
               onFinishDetour={finishDetour}
             />

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -18,7 +18,7 @@ export const DummyDetourPage = () => {
 
   return (
     <>
-      {routePattern && routePattern.shape && (
+      {route && routePattern && routePattern.shape && (
         <DiversionPage
           originalRoute={{
             shape: routePattern.shape,
@@ -28,6 +28,8 @@ export const DummyDetourPage = () => {
             routeDirection:
               route?.directionNames[routePattern.directionId] || "?",
             routePatternId: routePattern.id,
+            route,
+            routePattern,
             center: { lat: 42.36, lng: -71.13 },
             zoom: 16,
           }}

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -21,13 +21,6 @@ export const DummyDetourPage = () => {
       {route && routePattern && routePattern.shape && (
         <DiversionPage
           originalRoute={{
-            shape: routePattern.shape,
-            routeName: routePattern.routeId,
-            routeDescription: routePattern.headsign || "?",
-            routeOrigin: routePattern.name,
-            routeDirection:
-              route?.directionNames[routePattern.directionId] || "?",
-            routePatternId: routePattern.id,
             route,
             routePattern,
             center: { lat: 42.36, lng: -71.13 },

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -1,11 +1,25 @@
 import { setup } from "xstate"
+import { Route, RoutePattern } from "../schedule"
 
 export const createDetourMachine = setup({
   types: {} as {
+    context: {
+      route: Route
+      routePattern: RoutePattern
+    }
+
+    input: {
+      // Caller has target route pattern
+      route: Route
+      routePattern: RoutePattern
+    }
     events: { type: "detour.edit.done" } | { type: "detour.edit.resume" }
   },
 }).createMachine({
   id: "Detours Machine",
+  context: ({ input }) => ({
+    ...input,
+  }),
 
   initial: "Detour Drawing",
   states: {

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -1,4 +1,4 @@
-import { setup } from "xstate"
+import { setup, ActorLogicFrom, InputFrom } from "xstate"
 import { Route, RoutePattern } from "../schedule"
 
 export const createDetourMachine = setup({
@@ -44,3 +44,11 @@ export const createDetourMachine = setup({
     },
   },
 })
+
+/**
+ * This refers to the type of `input` provided in
+ * {@linkcode createDetourMachine}'s {@linkcode setup} call
+ */
+export type CreateDetourMachineInput = InputFrom<
+  ActorLogicFrom<typeof createDetourMachine>
+>

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,5 +1,5 @@
 import { LatLngLiteral } from "leaflet"
-import { Route, RoutePattern, RoutePatternId, Shape, ShapePoint, Stop } from "../schedule"
+import { Route, RoutePattern, ShapePoint, Stop } from "../schedule"
 
 export interface DetourShape {
   coordinates: ShapePoint[]
@@ -11,12 +11,6 @@ export type DetourDirection = {
 }
 
 export interface OriginalRoute {
-  routeName: string
-  routeDescription: string
-  routeOrigin: string
-  routeDirection: string
-  routePatternId: RoutePatternId
-  shape: Shape
   route: Route
   routePattern: RoutePattern
   center: LatLngLiteral

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,5 +1,5 @@
 import { LatLngLiteral } from "leaflet"
-import { RoutePatternId, Shape, ShapePoint, Stop } from "../schedule"
+import { Route, RoutePattern, RoutePatternId, Shape, ShapePoint, Stop } from "../schedule"
 
 export interface DetourShape {
   coordinates: ShapePoint[]
@@ -17,6 +17,8 @@ export interface OriginalRoute {
   routeDirection: string
   routePatternId: RoutePatternId
   shape: Shape
+  route: Route
+  routePattern: RoutePattern
   center: LatLngLiteral
   zoom: number
 }

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   args: {
     // Provide default route settings
-    originalRoute: {
+    originalRoute: originalRouteFactory.build({
       routeDescription: "Harvard via Allston",
       routeOrigin: "from Andrew Station",
       routeDirection: "Outbound",
@@ -19,7 +19,7 @@ const meta = {
       shape: route39shape,
       zoom: 14,
       center: { lat: 42.33, lng: -71.11 },
-    },
+    }),
     showConfirmCloseModal: false,
   },
   argTypes: {

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -12,13 +12,6 @@ const meta = {
   args: {
     // Provide default route settings
     originalRoute: originalRouteFactory.build({
-      routeDescription: "Harvard via Allston",
-      routeOrigin: "from Andrew Station",
-      routeDirection: "Outbound",
-      routePatternId: "39-3-0",
-      routeName: "39",
-      shape: route39shape,
-
       routePattern: {
         id: "39-3-0",
         headsign: "Harvard via Allston",

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { DiversionPage } from "../../../src/components/detours/diversionPage"
 import { route39shape } from "../__story-data__/shape"
+import { originalRouteFactory } from "../../../tests/factories/originalRouteFactory"
 
 const meta = {
   component: DiversionPage,
@@ -17,6 +18,17 @@ const meta = {
       routePatternId: "39-3-0",
       routeName: "39",
       shape: route39shape,
+
+      routePattern: {
+        id: "39-3-0",
+        headsign: "Harvard via Allston",
+        name: "Andrew Station",
+        directionId: 0,
+        shape: route39shape,
+      },
+      route: {
+        name: "39",
+      },
       zoom: 14,
       center: { lat: 42.33, lng: -71.11 },
     }),

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -16,8 +16,6 @@ import {
   fetchNearestIntersection,
 } from "../../../src/api"
 import { DiversionPage as DiversionPageDefault } from "../../../src/components/detours/diversionPage"
-import shapeFactory from "../../factories/shape"
-import { latLngLiteralFactory } from "../../factories/latLngLiteralFactory"
 import stopFactory from "../../factories/stop"
 import userEvent from "@testing-library/user-event"
 import {
@@ -35,13 +33,15 @@ import {
 } from "../../testHelpers/selectors/components/map/markers/stopIcon"
 import { Err, Ok } from "../../../src/util/result"
 import { neverPromise } from "../../testHelpers/mockHelpers"
+import { originalRouteFactory } from "../../factories/originalRouteFactory"
+import { DeepPartial } from "fishery"
 
 const DiversionPage = (
   props: Omit<
     Partial<ComponentProps<typeof DiversionPageDefault>>,
     "originalRoute"
   > & {
-    originalRoute?: Partial<
+    originalRoute?: DeepPartial<
       ComponentProps<typeof DiversionPageDefault>["originalRoute"]
     >
   }
@@ -49,17 +49,7 @@ const DiversionPage = (
   const { originalRoute, showConfirmCloseModal, ...otherProps } = props
   return (
     <DiversionPageDefault
-      originalRoute={{
-        routeName: "66",
-        routeDescription: "Harvard via Allston",
-        routeOrigin: "from Andrew Station",
-        routeDirection: "Outbound",
-        routePatternId: "66-6-0",
-        shape: shapeFactory.build(),
-        center: latLngLiteralFactory.build(),
-        zoom: 16,
-        ...originalRoute,
-      }}
+      originalRoute={originalRouteFactory.build(originalRoute)}
       showConfirmCloseModal={showConfirmCloseModal ?? false}
       {...otherProps}
     />
@@ -1039,13 +1029,16 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          routeName,
-          routeOrigin,
-          routeDescription,
-          routeDirection,
-          shape: shapeFactory.build({
-            points: [connectionPoint],
-          }),
+          route: {
+            name: routeName,
+          },
+          routePattern: {
+            headsign: routeDescription,
+            name: routeOrigin,
+            shape: {
+              points: [connectionPoint],
+            },
+          },
         }}
       />
     )
@@ -1174,7 +1167,11 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          shape: shapeFactory.build({ stops: stopFactory.buildList(11) }),
+          routePattern: {
+            shape: {
+              stops: stopFactory.buildList(11),
+            },
+          },
         }}
       />
     )
@@ -1197,7 +1194,11 @@ describe("DiversionPage", () => {
     const { container } = render(
       <DiversionPage
         originalRoute={{
-          shape: shapeFactory.build({ stops: [stop1, stop2, stop3, stop4] }),
+          routePattern: {
+            shape: {
+              stops: [stop1, stop2, stop3, stop4],
+            },
+          },
         }}
       />
     )

--- a/assets/tests/factories/originalRouteFactory.ts
+++ b/assets/tests/factories/originalRouteFactory.ts
@@ -7,7 +7,7 @@ import shapeFactory from "./shape"
 
 export const originalRouteFactory = Factory.define<OriginalRoute>(() => {
   const route = routeFactory.build()
-  const routePattern = routePatternFactory.build()
+  const routePattern = routePatternFactory.build({ routeId: route.id })
   return {
     routeName: route.name,
     routeDescription: routePattern.headsign || "",
@@ -15,6 +15,8 @@ export const originalRouteFactory = Factory.define<OriginalRoute>(() => {
     routeDirection: "Outbound",
     routePatternId: routePattern.id,
     shape: shapeFactory.build(),
+    route,
+    routePattern,
     center: latLngLiteralFactory.build(),
     zoom: 16,
   }

--- a/assets/tests/factories/originalRouteFactory.ts
+++ b/assets/tests/factories/originalRouteFactory.ts
@@ -3,18 +3,11 @@ import { OriginalRoute } from "../../src/models/detour"
 import routeFactory from "./route"
 import { routePatternFactory } from "./routePattern"
 import { latLngLiteralFactory } from "./latLngLiteralFactory"
-import shapeFactory from "./shape"
 
 export const originalRouteFactory = Factory.define<OriginalRoute>(() => {
   const route = routeFactory.build()
   const routePattern = routePatternFactory.build({ routeId: route.id })
   return {
-    routeName: route.name,
-    routeDescription: routePattern.headsign || "",
-    routeOrigin: routePattern.name,
-    routeDirection: "Outbound",
-    routePatternId: routePattern.id,
-    shape: shapeFactory.build(),
     route,
     routePattern,
     center: latLngLiteralFactory.build(),


### PR DESCRIPTION
To be able to control the route and variant, the state machine needs to be the source of truth for the active route and pattern. This moves the values into the state machine and updates callers to send the route and pattern.

Asana Ticket: https://app.asana.com/0/0/1207481283409966/f