### PR TITLE
fix(ts/components/rpc): make it possible to find RPC routes via `getByRole`

### DIFF
--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import { useRoute } from "../../contexts/routesContext"
 import { CircleCheckIcon } from "../../helpers/icon"
 import {
@@ -208,18 +208,24 @@ const VariantPicker = ({
   selectedRoutePatternId: RoutePatternId
   selectRoutePattern: (routePattern: RoutePattern) => void
 }): JSX.Element => {
+  const id = "variant-picker" + useId()
   {
     return (
-      <fieldset>
-        {sortRoutePatterns(routePatterns).map((routePattern) => (
-          <VariantOption
-            key={routePattern.id}
-            routePattern={routePattern}
-            isSelected={routePattern.id === selectedRoutePatternId}
-            selectRoutePattern={selectRoutePattern}
-          />
-        ))}
-      </fieldset>
+      <>
+        <span id={id} className="visually-hidden">
+          Variants
+        </span>
+        <fieldset aria-labelledby={id}>
+          {sortRoutePatterns(routePatterns).map((routePattern) => (
+            <VariantOption
+              key={routePattern.id}
+              routePattern={routePattern}
+              isSelected={routePattern.id === selectedRoutePatternId}
+              selectRoutePattern={selectRoutePattern}
+            />
+          ))}
+        </fieldset>
+      </>
     )
   }
 }


### PR DESCRIPTION
When writing tests for trying to assert how many route patterns are on screen, it wasn't actually possible to identify the group which contained all the radio buttons.

This enables test assertions such as the following
```ts
expect(
  await within(
    screen.getByRole("group", { name: "Variants" })
  ).findAllByRole("radio")
).toHaveLength(2)
```