### PR TITLE
fix(ts/components/rpc): make radio buttons react controlled

### DIFF
--- a/assets/src/components/mapPage/routePropertiesCard.tsx
+++ b/assets/src/components/mapPage/routePropertiesCard.tsx
@@ -180,7 +180,7 @@ const VariantOption = ({
         type="radio"
         id={`variant-radio-${routePattern.id}`}
         name="variant"
-        defaultChecked={isSelected}
+        checked={isSelected}
         onChange={() => selectRoutePattern(routePattern)}
       />
 


### PR DESCRIPTION
tests are succeeding where they should be failing because the HTML element is setting itself to `checked` even if the parent component did not instruct so.