### PR TITLE
fix(ts/components/detourRouteSelection): control form value from react

### DIFF
--- a/assets/src/components/detours/detourRouteSelectionPanel.tsx
+++ b/assets/src/components/detours/detourRouteSelectionPanel.tsx
@@ -58,7 +58,7 @@ export const DetourRouteSelectionPanel = ({
         <section className="pb-3">
           <h2 className="c-diversion-panel__h2">Choose route</h2>
           <FormSelect
-            defaultValue={selectedRouteInfo.selectedRoute?.id}
+            value={selectedRouteInfo.selectedRoute?.id}
             onChange={(changeEvent) => {
               onSelectRoute?.(
                 allRoutes.find((route) => route.id === changeEvent.target.value)


### PR DESCRIPTION
Without this, we fail to control this combo box when we have an initial selected value.


```
  ● DiversionPage › 'Route Selection Panel' › when a route pattern is already selected, opens to selected pattern

    expect(element).toHaveValue(route59)

    Expected the element to have value:
      route59
    Received:
      Select a route

      1444 |       expect(
      1445 |         screen.getByRole("combobox", { name: "Choose route" })
    > 1446 |       ).toHaveValue(selectedRoutePattern.routeId)
           |         ^
      1447 |       expect(
      1448 |         screen.getByRole("radio", {
      1449 |           name: RPCRadioButtonName(selectedRoutePattern),

      at tests/components/detours/diversionPage.test.tsx:1446:9
      at step (tests/components/detours/diversionPage.test.tsx:44:23)
      at Object.next (tests/components/detours/diversionPage.test.tsx:25:53)
      at fulfilled (tests/components/detours/diversionPage.test.tsx:16:58)
```