### PR TITLE
fix(ts/components/grouped-autocomplete): use constructor for autocomplete group

### DIFF
--- a/assets/src/components/groupedAutocomplete.tsx
+++ b/assets/src/components/groupedAutocomplete.tsx
@@ -455,14 +455,7 @@ export const GroupedAutocomplete = ({
 
   // Fallback option and group
   if (optionGroups.length === 0) {
-    optionGroups = [
-      {
-        group: {
-          title: null,
-          options: [fallbackOption],
-        },
-      },
-    ]
+    optionGroups = [autocompleteGroup(null, fallbackOption)]
   }
 
   const { cursorLocation, updateCursorLocation, setCursorLocation } =


### PR DESCRIPTION
Small fix for something I noticed from #2655 