### PR TITLE
feat(ts/components/routeLadder): add accessible name to route ladder toggle

### DIFF
--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -64,6 +64,11 @@
   .c-route-ladder__dropdown-button {
     height: 2.25rem;
     width: 2.25rem;
+
+    &.dropdown-toggle::after {
+      // Force bootstrap carat to center even with hidden text
+      margin-left: 0;
+    }
   }
 
   .c-route-ladder__alert-icon {

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useId } from "react"
 import {
   AlertIcon,
   CrowdingIcon,
@@ -32,6 +32,7 @@ import inTestGroup, { TestGroups } from "../userInTestGroup"
 import { ExclamationTriangleFill, PlusSquare } from "../helpers/bsIcons"
 import { RoutePill } from "./routePill"
 import { Card, CloseButton, Dropdown } from "react-bootstrap"
+import { joinTruthy } from "../helpers/dom"
 
 interface Props {
   route: Route
@@ -96,14 +97,24 @@ export const NewHeader = ({
 
   onClickAddDetour?: () => void
 }) => {
+  const routePillId = "route-pill" + useId()
+  const routeOptionsToggleId = "route-options-toggle" + useId()
   return (
     <Card className="c-new-route-ladder__header">
       <Card.Body>
         <div className="c-route-ladder__header__action-container">
           {showDropdown && (
             <Dropdown className="border-box inherit-box">
-              <Dropdown.Toggle className="c-route-ladder__dropdown-button">
-                <span className="visually-hidden">Route Options</span>
+              <Dropdown.Toggle
+                className="c-route-ladder__dropdown-button"
+                aria-labelledby={joinTruthy([
+                  routePillId,
+                  routeOptionsToggleId,
+                ])}
+              >
+                <span className="visually-hidden" id={routeOptionsToggleId}>
+                  Route Options
+                </span>
               </Dropdown.Toggle>
               <Dropdown.Menu>
                 <Dropdown.Item className="icon-link" onClick={onClickAddDetour}>
@@ -126,6 +137,7 @@ export const NewHeader = ({
           )}
         </div>
         <RoutePill
+          id={routePillId}
           routeName={routeName}
           largeFormat
           className="c-route-ladder__route-pill c-route-pill"

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -102,7 +102,9 @@ export const NewHeader = ({
         <div className="c-route-ladder__header__action-container">
           {showDropdown && (
             <Dropdown className="border-box inherit-box">
-              <Dropdown.Toggle className="c-route-ladder__dropdown-button" />
+              <Dropdown.Toggle className="c-route-ladder__dropdown-button">
+                <span className="visually-hidden">Route Options</span>
+              </Dropdown.Toggle>
               <Dropdown.Menu>
                 <Dropdown.Item className="icon-link" onClick={onClickAddDetour}>
                   <PlusSquare />

--- a/assets/src/components/routePill.tsx
+++ b/assets/src/components/routePill.tsx
@@ -1,15 +1,16 @@
-import React from "react"
+import React, { ComponentPropsWithoutRef } from "react"
 import { joinClasses } from "../helpers/dom"
 
 export const RoutePill = ({
   routeName,
   largeFormat,
   className,
+  ...props
 }: {
   routeName: string
   largeFormat?: boolean
   className?: string
-}): JSX.Element => {
+} & ComponentPropsWithoutRef<"div">): JSX.Element => {
   const classes = joinClasses([
     "c-route-pill",
     modeClass(routeName),
@@ -17,7 +18,11 @@ export const RoutePill = ({
     className,
   ])
 
-  return <div className={classes}>{routeNameTransform(routeName)}</div>
+  return (
+    <div {...props} className={classes}>
+      {routeNameTransform(routeName)}
+    </div>
+  )
 }
 
 const modeClass = (routeName: string): string => {

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -1476,7 +1476,13 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
             class="c-route-ladder__dropdown-button dropdown-toggle btn btn-primary"
             id="react-aria-:r0:"
             type="button"
-          />
+          >
+            <span
+              class="visually-hidden"
+            >
+              Route Options
+            </span>
+          </button>
         </div>
       </div>
       <div

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -326,6 +326,7 @@ exports[`routeLadder does not include the detour dropdown if the 'RouteLadderHea
       />
       <div
         class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
+        id="route-pill:r5:"
       >
         28
       </div>
@@ -1473,12 +1474,14 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
         >
           <button
             aria-expanded="false"
+            aria-labelledby="route-pill:r2: route-options-toggle:r3:"
             class="c-route-ladder__dropdown-button dropdown-toggle btn btn-primary"
-            id="react-aria-:r0:"
+            id="react-aria-:r4:"
             type="button"
           >
             <span
               class="visually-hidden"
+              id="route-options-toggle:r3:"
             >
               Route Options
             </span>
@@ -1487,6 +1490,7 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
       </div>
       <div
         class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
+        id="route-pill:r2:"
       >
         28
       </div>
@@ -1623,6 +1627,7 @@ exports[`routeLadder renders a route ladder with the new header format 1`] = `
       />
       <div
         class="c-route-pill c-route-pill--bus c-route-pill--large-format c-route-ladder__route-pill c-route-pill"
+        id="route-pill:r0:"
       >
         28
       </div>

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -7,7 +7,7 @@ import {
   afterEach,
 } from "@jest/globals"
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import RouteLadder from "../../src/components/routeLadder"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { LadderCrowdingToggles } from "../../src/models/ladderCrowdingToggle"
@@ -261,6 +261,8 @@ describe("routeLadder", () => {
         hasAlert={false}
       />
     )
+
+    expect(screen.getByRole("button", { name: "Route Options" })).toBeVisible()
 
     expect(tree).toMatchSnapshot()
   })

--- a/assets/tests/components/routeLadder.test.tsx
+++ b/assets/tests/components/routeLadder.test.tsx
@@ -262,7 +262,9 @@ describe("routeLadder", () => {
       />
     )
 
-    expect(screen.getByRole("button", { name: "Route Options" })).toBeVisible()
+    expect(
+      screen.getByRole("button", { name: "28 Route Options" })
+    ).toBeVisible()
 
     expect(tree).toMatchSnapshot()
   })


### PR DESCRIPTION
Tests are a bit annoying to comprehend when trying to get this button solely via class names, this instead makes it possible to do `screen.getByRole("button", { name: "Route Options" })`

---

While reviewing the [tests](https://github.com/mbta/skate/blob/e47aa0764f9a0a259897026543c9194eec20744a/assets/tests/components/ladderPage.test.tsx#L565-L571) in #2647, I found it a little annoying to translate the class names into the actual button that was being referenced. For both accessibility and avoiding class names in our tests, this makes it possible to find the button solely on it's textual meaning.