### PR TITLE
fix(ts/models/createDetourMachine): clear detour when selecting route pattern

### DIFF
--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -219,6 +219,7 @@ export const createDetourMachine = setup({
           on: {
             "detour.route-pattern.open": {
               target: "Pick Route Pattern",
+              actions: "detour.clear",
             },
             "detour.edit.clear-detour": {
               target: ".Pick Start Point",


### PR DESCRIPTION
A fix to #2652 that #2607 enables.

Split into another PR because discussing the test may block #2607 

---

Depends On:
- #2607 