### PR TITLE
 test(ts/components/diversionPage): add helpers for route interativity 

### DIFF
--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -1733,14 +1733,12 @@ describe("DiversionPage", () => {
       )
 
       // Non-Interactive route shape
-      expect(
-        container.querySelectorAll(".c-detour_map--original-route-shape-core")
-      ).toHaveLength(1)
+      expect(originalRouteShape.not.interactive.getAll(container)).toHaveLength(
+        1
+      )
 
       // Interactive route shape
-      expect(
-        container.querySelectorAll(".c-detour_map--original-route-shape")
-      ).toHaveLength(0)
+      expect(originalRouteShape.interactive.getAll(container)).toHaveLength(0)
     })
   })
 })

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -4,6 +4,17 @@ import { byRole } from "testing-library-selector"
 export const finishDetourButton = byRole("button", { name: "Finish Detour" })
 
 export const originalRouteShape = {
+  interactive: {
+    getAll: (container: HTMLElement) =>
+      container.querySelectorAll(".c-detour_map--original-route-shape"),
+  },
+  not: {
+    interactive: {
+      getAll: (container: HTMLElement) =>
+        container.querySelectorAll(".c-detour_map--original-route-shape-core"),
+    },
+  },
+
   get(container: HTMLElement): Element {
     const maybeShape = container.querySelector(
       ".c-detour_map--original-route-shape"


### PR DESCRIPTION
Followup for https://github.com/mbta/skate/pull/2662#issuecomment-2173266737

> The query selectors are a bit hard to read though, so it may be worth doing the abstraction where we can make the selectors within the expect a bit more readable to understand _[which]_ one is _actually_ not interactive. I think we have a ticket for this?