### PR TITLE
fix: Updated nav buttons to use bootstrap primary token 2024 $eggplant-500

### DIFF
--- a/assets/css/_map_page.scss
+++ b/assets/css/_map_page.scss
@@ -119,7 +119,7 @@ $z-map-page-context: (
 }
 
 .c-map-page__input-and-results .c-drawer-tab {
-  @include button-primary;
+  @include button-primary-new;
   left: 100%;
   box-shadow: 1px 0px 4px rgba(0, 0, 0, 0.25);
 }

--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -64,15 +64,6 @@
   .c-route-ladder__dropdown-button {
     height: 2.25rem;
     width: 2.25rem;
-    // TODO All of this is bad and should be reverted when we fix the left nav button colors
-    &.btn-primary {
-      --bs-btn-bg: #451b83;
-      --bs-btn-border-color: #451b83;
-      --bs-btn-hover-bg: #260f54;
-      --bs-btn-hover-border-color: #260f54;
-      --bs-btn-active-bg: #260f54;
-      --bs-btn-active-border-color: #260f54;
-    }
   }
 
   .c-route-ladder__alert-icon {

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -1,5 +1,6 @@
 // colors
 @use "./color/tokens_2021" as tokens;
+@use "./color/tokens_2024" as new_tokens;
 
 $white: tokens.$white;
 $black: tokens.$black;
@@ -275,6 +276,27 @@ $color-tooltip-background: #333333;
 
   &:disabled {
     background-color: $color-gray-500;
+  }
+}
+
+@mixin button-primary-new {
+  color: $white;
+  padding: 8px;
+  background-color: new_tokens.$eggplant-500;
+  border-radius: 4px;
+
+  &:hover {
+    background-color: new_tokens.$eggplant-400;
+  }
+
+  &:focus-visible {
+    background-color: new_tokens.$eggplant-500;
+    outline: 2px solid new_tokens.$eggplant-500;
+    outline-offset: 1px;
+  }
+
+  &:disabled {
+    background-color: new_tokens.$gray-400;
   }
 }
 

--- a/assets/css/_ui_kit.scss
+++ b/assets/css/_ui_kit.scss
@@ -286,7 +286,7 @@ $color-tooltip-background: #333333;
   border-radius: 4px;
 
   &:hover {
-    background-color: new_tokens.$eggplant-400;
+    background-color: #5d3092;
   }
 
   &:focus-visible {

--- a/assets/css/nav/_bottom_nav_mobile.scss
+++ b/assets/css/nav/_bottom_nav_mobile.scss
@@ -1,3 +1,5 @@
+@use "../color/tokens_2024" as tokens;
+
 .c-bottom-nav-mobile {
   background-color: $color-gray-50;
   border-top: 1px solid $color-gray-300;
@@ -36,7 +38,7 @@
   }
 
   &.c-bottom-nav-mobile__link--active {
-    background-color: $color-eggplant-700;
+    background-color: tokens.$eggplant-500;
     font-weight: 500;
     color: $white;
 

--- a/assets/css/nav/_left_nav.scss
+++ b/assets/css/nav/_left_nav.scss
@@ -1,3 +1,5 @@
+@use "../color/tokens_2024" as tokens;
+
 .c-left-nav {
   width: calc(11.5rem + 1px);
   height: 100%;
@@ -91,12 +93,12 @@
   }
 
   &.c-left-nav__link--active {
-    background-color: $color-eggplant-700;
+    background-color: tokens.$eggplant-500;
     font-weight: 500;
     color: $white;
   }
   &:focus-visible {
-    outline: 2px solid $color-eggplant-500;
+    outline: 2px solid tokens.$eggplant-400;
     border: 1px solid $white;
   }
 }


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1205385723132845/1207446071151352

I originally thought I'd want to update the nav buttons to bootstrap, but that seemed a big scope bloat when only the colors needed shifting for now. So instead the scope bloat that I accepted was also changing the drawer-tab on the map page to be the lighter purple, since that was a simple fix (and it was obviously mismatched to the updated navbar.