### PR TITLE
fix: Simplify `useReactDivIcon`

### DIFF
--- a/assets/src/components/map/utilities/reactDivIcon.tsx
+++ b/assets/src/components/map/utilities/reactDivIcon.tsx
@@ -23,7 +23,7 @@ const defaultOptions = {}
 export function useReactDivIcon(options?: DivIconOptions) {
   const opts = options || defaultOptions
   // Persistent element for react portal to use between `divIcon` recreations
-  const iconContainer = useMemo(() => createPortalElement(), [])
+  const iconContainer = useMemo(createPortalElement, [])
   // Leaflet by default doesn't support updating a `divIcon` in place.
   // To ensure that the `divIcon` updates when `opts` change
   // regenerate the `divIcon` with the portal element and provided `opts`

--- a/assets/src/components/map/utilities/reactMarker.tsx
+++ b/assets/src/components/map/utilities/reactMarker.tsx
@@ -3,7 +3,6 @@ import { createPortal } from "react-dom"
 
 import { Marker, MarkerProps } from "react-leaflet"
 
-import Loading from "../../loading"
 import { DivIconOptions, useReactDivIcon } from "./reactDivIcon"
 
 /**
@@ -17,12 +16,6 @@ export interface ReactMarkerProps extends Omit<MarkerProps, "icon"> {
    * React Element to use as {@link Marker} Icon
    */
   icon?: ReactNode
-  /**
-   * Element to show before `divIcon` is ready
-   *
-   * Defaults to {@link Loading `<Loading/>`}
-   */
-  loadingState?: ReactNode
   /**
    * Options to pass to {@link useReactDivIcon}
    */
@@ -40,16 +33,11 @@ export interface ReactMarkerProps extends Omit<MarkerProps, "icon"> {
  */
 export const ReactMarker = ({
   icon,
-  loadingState,
   divIconSettings,
   children,
   ...markerProps
 }: ReactMarkerProps) => {
   const { divIcon, iconContainer } = useReactDivIcon(divIconSettings)
-
-  if (!(divIcon && iconContainer)) {
-    return <>{loadingState || <Loading />}</>
-  }
 
   return (
     <Marker {...(markerProps as MarkerProps)} icon={divIcon}>

--- a/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/mapPage.test.tsx.snap
@@ -1512,70 +1512,6 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 <svg />
               </div>
               <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2115px; top: 3617px; z-index: 3617;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 273px; top: 1319px; z-index: 1319;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -456px; top: -1720px; z-index: -1720;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1173px; top: -3823px; z-index: -3823;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 4158px; top: -5947px; z-index: -5947;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3032px; top: -2266px; z-index: -2266;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2539px; top: 6390px; z-index: 6390;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -65px; top: 1854px; z-index: 1854;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -57px; top: 1295px; z-index: 1295;"
@@ -1596,6 +1532,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2115px; top: 3617px; z-index: 3617;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1620,6 +1564,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 273px; top: 1319px; z-index: 1319;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 273px; top: 1319px; z-index: 1319;"
@@ -1640,6 +1592,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -456px; top: -1720px; z-index: -1720;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1664,6 +1624,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1173px; top: -3823px; z-index: -3823;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1173px; top: -3823px; z-index: -3823;"
@@ -1684,6 +1652,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 4158px; top: -5947px; z-index: -5947;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1708,6 +1684,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3032px; top: -2266px; z-index: -2266;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3032px; top: -2266px; z-index: -2266;"
@@ -1730,6 +1714,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2539px; top: 6390px; z-index: 6390;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2539px; top: 6390px; z-index: 6390;"
@@ -1750,6 +1742,14 @@ exports[`<MapPage /> Snapshot renders vehicle data 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -65px; top: 1854px; z-index: 1854;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"

--- a/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/shuttleMapPage.test.tsx.snap
@@ -285,70 +285,6 @@ exports[`Shuttle Map Page renders 1`] = `
                 <svg />
               </div>
               <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
@@ -369,6 +305,14 @@ exports[`Shuttle Map Page renders 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -393,6 +337,14 @@ exports[`Shuttle Map Page renders 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
@@ -413,6 +365,14 @@ exports[`Shuttle Map Page renders 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -437,6 +397,14 @@ exports[`Shuttle Map Page renders 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
@@ -457,6 +425,14 @@ exports[`Shuttle Map Page renders 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -481,6 +457,14 @@ exports[`Shuttle Map Page renders 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
@@ -503,6 +487,14 @@ exports[`Shuttle Map Page renders 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
@@ -523,6 +515,14 @@ exports[`Shuttle Map Page renders 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1040,70 +1040,6 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 <svg />
               </div>
               <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
@@ -1124,6 +1060,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1148,6 +1092,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
@@ -1168,6 +1120,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1192,6 +1152,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
@@ -1212,6 +1180,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1236,6 +1212,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
@@ -1258,6 +1242,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
@@ -1278,6 +1270,14 @@ exports[`Shuttle Map Page renders selected shuttle routes 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1795,70 +1795,6 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 <svg />
               </div>
               <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
@@ -1879,6 +1815,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1903,6 +1847,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
@@ -1923,6 +1875,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1947,6 +1907,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
@@ -1967,6 +1935,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -1991,6 +1967,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
@@ -2013,6 +1997,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
@@ -2033,6 +2025,14 @@ exports[`Shuttle Map Page renders with all shuttles selected 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -2888,70 +2888,6 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 <svg />
               </div>
               <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
-                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
-                role="button"
-                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
-                tabindex="0"
-              >
-                <svg />
-              </div>
-              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -280px; top: 1268px; z-index: 1268;"
@@ -2972,6 +2908,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -2338px; top: 3590px; z-index: 3590;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -2996,6 +2940,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 50px; top: 1292px; z-index: 1292;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 50px; top: 1292px; z-index: 1292;"
@@ -3016,6 +2968,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -679px; top: -1747px; z-index: -1747;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -3040,6 +3000,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -1396px; top: -3850px; z-index: -3850;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -1396px; top: -3850px; z-index: -3850;"
@@ -3060,6 +3028,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 3935px; top: -5974px; z-index: -5974;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
@@ -3084,6 +3060,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -3255px; top: -2293px; z-index: -2293;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: -3255px; top: -2293px; z-index: -2293;"
@@ -3106,6 +3090,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                 </div>
               </div>
               <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: 2316px; top: 6363px; z-index: 6363;"
+                tabindex="0"
+              >
+                <svg />
+              </div>
+              <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"
                 role="button"
                 style="margin-left: 14px; margin-top: -25px; width: 12px; height: 12px; left: 2316px; top: 6363px; z-index: 6363;"
@@ -3126,6 +3118,14 @@ exports[`Shuttle Map Page renders with train vehicles 1`] = `
                     </text>
                   </svg>
                 </div>
+              </div>
+              <div
+                class="leaflet-marker-icon c-garage-icon leaflet-zoom-hide"
+                role="button"
+                style="margin-left: -10px; margin-top: -25px; width: 21px; height: 25px; left: -288px; top: 1827px; z-index: 1827;"
+                tabindex="0"
+              >
+                <svg />
               </div>
               <div
                 class="leaflet-marker-icon c-garage-icon__label c-garage-icon__label--base leaflet-zoom-hide"


### PR DESCRIPTION
This changes `useReactDivIcon` to create the portal element and the `divIcon` at the same time so that we don't need two renders for this component to complete initialization. This prevents some issues in tests where "`An update to ReactMarker inside a test was not wrapped in act(...).`" occurs.
