### PR TITLE
fix[2/2]:test(TripModificationPublisher): allow timeout up to `500ms` for mosquitto integration tests

### DIFF
--- a/test/skate/detours/trip_modification_publisher_test.exs
+++ b/test/skate/detours/trip_modification_publisher_test.exs
@@ -24,7 +24,7 @@ defmodule Skate.Detours.TripModificationPublisherTest do
     {:ok, pid} =
       TripModificationPublisher.start_link(start: true, name: __MODULE__, on_connect: self())
 
-    assert_receive {:connected, ^pid}
+    assert_receive {:connected, ^pid}, 500
   end
 
   @tag "Test.Integration": :mqtt
@@ -34,8 +34,8 @@ defmodule Skate.Detours.TripModificationPublisherTest do
     {:ok, pid} =
       TripModificationPublisher.start_link(start: true, name: __MODULE__, on_connect: self())
 
-    assert_receive {:connected, ^pid}
-    assert_receive {:connected, ^reader_pid}
+    assert_receive {:connected, ^pid}, 500
+    assert_receive {:connected, ^reader_pid}, 500
 
     message = %TripModification{
       selected_trips: [


### PR DESCRIPTION
context: [flaky MQTT tests thread](https://mbta.slack.com/archives/C047ZT8ACP5/p1720728369236849?thread_ts=1720726297.170749&cid=C047ZT8ACP5)