### PR TITLE
refactor(tests): Use sequences for gtfs_route_pattern_factory ID's

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -196,12 +196,14 @@ defmodule Skate.Factory do
   end
 
   def gtfs_route_pattern_factory do
+    route_pattern_id = sequence("Schedule.Gtfs.RoutePattern.id:")
+
     %Schedule.Gtfs.RoutePattern{
-      id: "route_pattern",
+      id: route_pattern_id,
       name: "",
       route_id: "route",
       direction_id: 0,
-      representative_trip_id: "trip",
+      representative_trip_id: "#{route_pattern_id}_representative_trip_id",
       time_desc: nil,
       sort_order: 1
     }


### PR DESCRIPTION
No ticket, but while working on https://github.com/mbta/skate/pull/2687, I noticed that the ID's for this were hard-coded, so I figured this could be worth cleaning up.