### PR TITLE
fix: Update `Realtime.Shape`'s pattern-matching so that it can accept `Util.Location.From`'s

### DIFF
--- a/lib/realtime/shape.ex
+++ b/lib/realtime/shape.ex
@@ -111,6 +111,14 @@ defmodule Realtime.Shape do
       encoded_polyline:
         (before_detour ++ detour_coordinates ++ after_detour)
         |> Enum.map(fn
+          %Schedule.Gtfs.Shape.Point{} = point ->
+            {:ok, location} = Util.Location.From.as_location(point)
+            location
+
+          other ->
+            other
+        end)
+        |> Enum.map(fn
           # The coordinates that come from the route segments are
           # formatted as `Util.Location`'s.
           %Location{latitude: latitude, longitude: longitude} ->

--- a/lib/realtime/shape.ex
+++ b/lib/realtime/shape.ex
@@ -111,23 +111,19 @@ defmodule Realtime.Shape do
       encoded_polyline:
         (before_detour ++ detour_coordinates ++ after_detour)
         |> Enum.map(fn
-          %Schedule.Gtfs.Shape.Point{} = point ->
-            {:ok, location} = Util.Location.From.as_location(point)
-            location
-
-          other ->
-            other
-        end)
-        |> Enum.map(fn
-          # The coordinates that come from the route segments are
-          # formatted as `Util.Location`'s.
-          %Location{latitude: latitude, longitude: longitude} ->
+          # The coordinates that come from the detour shape, from
+          # `OpenRouteServiceAPI`, are formatted as "lat"/"lon"
+          # `Map`'s,
+          %{"lat" => latitude, "lon" => longitude} ->
             {longitude, latitude}
 
-          # ...but the coordinates that come from the detour shape, from
-          # `OpenRouteServiceAPI`, are formatted as "lat"/"lon" `Map`'s,
-          # so we need to handle both cases.
-          %{"lat" => latitude, "lon" => longitude} ->
+          # ...but the coordinates that come from the route segments
+          # are formatted as `Util.Location.From`'s, so we need to
+          # handle both cases.
+          point ->
+            %Location{latitude: latitude, longitude: longitude} =
+              Util.Location.as_location!(point)
+
             {longitude, latitude}
         end)
         |> Polyline.encode()

--- a/test/realtime/shape_test.exs
+++ b/test/realtime/shape_test.exs
@@ -4,22 +4,23 @@ defmodule Realtime.ShapeTest do
   alias Realtime.Shape
   alias Skate.Detours.RouteSegments
   use ExUnit.Case
+  import Skate.Factory
 
   doctest Shape
 
   test "translates route segments and detour shape into encoded polyline shape" do
     route_segments = %RouteSegments.Result{
       before_detour: [
-        Location.new(42.425, -70.99),
-        Location.new(42.431, -70.99)
+        build(:gtfs_stop, %{latitude: 42.425, longitude: -70.99}),
+        build(:gtfs_stop, %{latitude: 42.431, longitude: -70.99})
       ],
       detour: [
-        Location.new(42.431, -70.99),
-        Location.new(42.439, -70.99)
+        build(:gtfs_stop, %{latitude: 42.431, longitude: -70.99}),
+        build(:gtfs_stop, %{latitude: 42.439, longitude: -70.99})
       ],
       after_detour: [
-        Location.new(42.439, -70.99),
-        Location.new(42.445, -70.99)
+        build(:gtfs_stop, %{latitude: 42.439, longitude: -70.99}),
+        build(:gtfs_stop, %{latitude: 42.445, longitude: -70.99})
       ]
     }
 


### PR DESCRIPTION
Co-authored-by: Kayla Firestack <kfirestack@mbta.com>

Blocking:
- https://github.com/mbta/skate/pull/2687