### PR TITLE
fix(ex/realtime/shape): add spec for `new/1` so that autocomplete works

### DIFF
--- a/lib/realtime/shape.ex
+++ b/lib/realtime/shape.ex
@@ -98,6 +98,7 @@ defmodule Realtime.Shape do
       ...> ])
       "_j{`GfkjpL?fE???~iA???vQ" # Does not match the polyline in the %Shape{...}
   """
+  @spec new(Realtime.Shape.Input.t()) :: Realtime.Shape.t()
   def new(%Input{
         shape_id: shape_id,
         route_segments: %RouteSegments.Result{


### PR DESCRIPTION
Co-authored-by: Kayla Firestack <kfirestack@mbta.com>