### PR TITLE
fix(tests): Don't change the input on every useDetour test rerender

### DIFF
--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -14,7 +14,6 @@ import { finishedDetourFactory } from "../factories/finishedDetourFactory"
 import { routeSegmentsFactory } from "../factories/finishedDetourFactory"
 import { originalRouteFactory } from "../factories/originalRouteFactory"
 import { Err, Ok } from "../../src/util/result"
-import { OriginalRoute } from "../../src/models/detour"
 
 jest.mock("../../src/api")
 
@@ -27,9 +26,6 @@ beforeEach(() => {
 
   jest.mocked(fetchNearestIntersection).mockReturnValue(new Promise(() => {}))
 })
-
-const useDetourWithFakeRoutePattern = (originalRoute: OriginalRoute) => () =>
-  useDetour(originalRoute)
 
 describe("useDetour", () => {
   test("when `addWaypoint` is called, should update `detourShape`", async () => {
@@ -49,9 +45,8 @@ describe("useDetour", () => {
       return Promise.resolve(Ok(detourShape))
     })
 
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -77,9 +72,8 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Err({ type: "unknown" }))
 
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -95,9 +89,8 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -120,9 +113,8 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -141,9 +133,8 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is set, `routeSegments` is filled in", async () => {
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     const routeSegments = routeSegmentsFactory.build()
 
@@ -162,9 +153,8 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is undone, `routeSegments` is cleared", async () => {
-    const { result } = renderHook(
-      useDetourWithFakeRoutePattern(originalRouteFactory.build())
-    )
+    const originalRoute = originalRouteFactory.build()
+    const { result } = renderHook(() => useDetour(originalRoute))
 
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -27,6 +27,11 @@ beforeEach(() => {
   jest.mocked(fetchNearestIntersection).mockReturnValue(new Promise(() => {}))
 })
 
+const renderDetourHook = () =>
+  renderHook(useDetour, {
+    initialProps: originalRouteFactory.build(),
+  })
+
 describe("useDetour", () => {
   test("when `addWaypoint` is called, should update `detourShape`", async () => {
     const start: ShapePoint = { lat: -2, lon: -2 }
@@ -45,9 +50,7 @@ describe("useDetour", () => {
       return Promise.resolve(Ok(detourShape))
     })
 
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -73,9 +76,7 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Err({ type: "unknown" }))
 
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -91,9 +92,7 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -116,9 +115,7 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -137,9 +134,7 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is set, `routeSegments` is filled in", async () => {
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     const routeSegments = routeSegmentsFactory.build()
 
@@ -158,9 +153,7 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is undone, `routeSegments` is cleared", async () => {
-    const { result } = renderHook(useDetour, {
-      initialProps: originalRouteFactory.build(),
-    })
+    const { result } = renderDetourHook()
 
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -45,8 +45,9 @@ describe("useDetour", () => {
       return Promise.resolve(Ok(detourShape))
     })
 
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -72,8 +73,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Err({ type: "unknown" }))
 
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -89,8 +91,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -113,8 +116,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -133,8 +137,9 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is set, `routeSegments` is filled in", async () => {
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     const routeSegments = routeSegmentsFactory.build()
 
@@ -153,8 +158,9 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is undone, `routeSegments` is cleared", async () => {
-    const originalRoute = originalRouteFactory.build()
-    const { result } = renderHook(() => useDetour(originalRoute))
+    const { result } = renderHook(useDetour, {
+      initialProps: originalRouteFactory.build(),
+    })
 
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -14,6 +14,7 @@ import { finishedDetourFactory } from "../factories/finishedDetourFactory"
 import { routeSegmentsFactory } from "../factories/finishedDetourFactory"
 import { originalRouteFactory } from "../factories/originalRouteFactory"
 import { Err, Ok } from "../../src/util/result"
+import { OriginalRoute } from "../../src/models/detour"
 
 jest.mock("../../src/api")
 
@@ -27,8 +28,8 @@ beforeEach(() => {
   jest.mocked(fetchNearestIntersection).mockReturnValue(new Promise(() => {}))
 })
 
-const useDetourWithFakeRoutePattern = () =>
-  useDetour(originalRouteFactory.build())
+const useDetourWithFakeRoutePattern = (originalRoute: OriginalRoute) => () =>
+  useDetour(originalRoute)
 
 describe("useDetour", () => {
   test("when `addWaypoint` is called, should update `detourShape`", async () => {
@@ -48,7 +49,9 @@ describe("useDetour", () => {
       return Promise.resolve(Ok(detourShape))
     })
 
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -74,7 +77,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Err({ type: "unknown" }))
 
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     act(() => result.current.addConnectionPoint?.(start))
     act(() => result.current.addWaypoint?.(end))
@@ -90,7 +95,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -113,7 +120,9 @@ describe("useDetour", () => {
       .mocked(fetchDetourDirections)
       .mockResolvedValue(Ok(detourShapeFactory.build()))
 
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     act(() => result.current.addConnectionPoint?.(shapePointFactory.build()))
     act(() => result.current.addWaypoint?.(shapePointFactory.build()))
@@ -132,7 +141,9 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is set, `routeSegments` is filled in", async () => {
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     const routeSegments = routeSegmentsFactory.build()
 
@@ -151,7 +162,9 @@ describe("useDetour", () => {
   })
 
   test("when `endPoint` is undone, `routeSegments` is cleared", async () => {
-    const { result } = renderHook(useDetourWithFakeRoutePattern)
+    const { result } = renderHook(
+      useDetourWithFakeRoutePattern(originalRouteFactory.build())
+    )
 
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))
     act(() => result.current.addConnectionPoint?.({ lat: 0, lon: 0 }))


### PR DESCRIPTION
While debugging test issues with [this PR][1], I noticed that useDetour.test.ts was re-invoking originalRouteFactory.build() every time something would cause the hook to rerender, which can cause any hooks that depend on the input to rerender as well (which is not what would happen in real life, since the input isn't randomly changing).

This change updates `useDetourWithFakeRoutePattern` to take in the `originalRoute` as an argument so that the input is only computed once.

[1]: https://github.com/mbta/skate/pull/2638

Blocks:
- https://github.com/mbta/skate/pull/2638