### PR TITLE
fix: encode enum tag with string

### DIFF
--- a/assets/src/util/result.ts
+++ b/assets/src/util/result.ts
@@ -13,7 +13,7 @@ enum ResultTag {
  * This is not exported so that usages of the objects cannot be
  * accessed or modified manually outside of this module.
  */
-const tag = Symbol("result-enum-tag")
+const tag = "$result-enum-tag"
 
 /** The {@linkcode Ok<T>} variant of {@linkcode Result<T, E>} */
 export type Ok<T> = { [tag]: ResultTag.Ok; ok: T }


### PR DESCRIPTION
when using `JSON.stringify`, any `Symbol`'s are not serialized due to being ephemeral and unique. This means we'd need to have some [replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#replacer) which can handle this and reconstruct these objects on de-serialize.

So instead, changing this over to a regular string, while less encapsulated, makes this serializable when serializing the xState context.