### PR TITLE
feat: persist last detour state to localStorage

### DIFF
--- a/assets/src/components/detours/detourModal.tsx
+++ b/assets/src/components/detours/detourModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react"
-import { DiversionPage } from "./diversionPage"
-import { OriginalRoute } from "../../models/detour"
+import { DiversionPage, DiversionPageStateProps } from "./diversionPage"
 import { Modal } from "@restart/ui"
 import { ModalTransitionProps } from "@restart/ui/esm/Modal"
 import { CSSTransition } from "react-transition-group"
@@ -16,14 +15,13 @@ const Fade = ({ children, ...props }: ModalTransitionProps) => (
 )
 
 export const DetourModal = ({
-  originalRoute,
   onClose,
   show,
+  ...useDetourProps
 }: {
-  originalRoute: OriginalRoute
   onClose: () => void
   show: boolean
-}) => {
+} & DiversionPageStateProps) => {
   const [showConfirmCloseModal, setShowConfirmCloseModal] =
     useState<boolean>(false)
 
@@ -35,13 +33,13 @@ export const DetourModal = ({
       onHide={() => setShowConfirmCloseModal(true)}
     >
       <DiversionPage
+        {...useDetourProps}
         onClose={() => setShowConfirmCloseModal(true)}
         onConfirmClose={() => {
           setShowConfirmCloseModal(false)
           onClose()
         }}
         onCancelClose={() => setShowConfirmCloseModal(false)}
-        originalRoute={originalRoute}
         showConfirmCloseModal={showConfirmCloseModal}
       />
     </Modal>

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -78,7 +78,9 @@ export const DiversionPage = ({
     clear,
     reviewDetour,
     editDetour,
-  } = useDetour(originalRoute)
+  } = useDetour({
+    input: originalRoute
+  })
 
   const [textArea, setTextArea] = useState("")
 

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -18,7 +18,6 @@ import { DetourFinishedPanel } from "./detourFinishedPanel"
 import { DetourRouteSelectionPanel } from "./detourRouteSelectionPanel"
 import { Route, RoutePattern } from "../../schedule"
 import RoutesContext from "../../contexts/routesContext"
-import inTestGroup, { TestGroups } from "../../userInTestGroup"
 import { Snapshot } from "xstate"
 
 const displayFieldsFromRouteAndPattern = (
@@ -46,18 +45,21 @@ interface DiversionPageFunctions {
   showConfirmCloseModal: boolean
 }
 
-interface DiversionPageFromInput extends DiversionPageFunctions {
+interface DiversionPageFromInput {
   originalRoute: OriginalRoute
 }
 
-interface DiversionPageFromSnapshot extends DiversionPageFunctions {
+interface DiversionPageFromSnapshot {
   /** A _validated_ snapshot from which to initialize {@linkcode createDetourMachine} with */
   snapshot: Snapshot<unknown>
 }
 
-export type DiversionPageProps =
+export type DiversionPageStateProps =
   | DiversionPageFromInput
   | DiversionPageFromSnapshot
+
+export type DiversionPageProps = DiversionPageStateProps &
+  DiversionPageFunctions
 
 export const DiversionPage = ({
   onClose,

--- a/assets/src/components/dummyDetourPage.tsx
+++ b/assets/src/components/dummyDetourPage.tsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { fetchRoutePatterns } from "../api"
 import { RoutePattern } from "../schedule"
 import { DiversionPage } from "./detours/diversionPage"
 import { useRoute } from "../contexts/routesContext"
+import { createDetourMachine } from "../models/createDetourMachine"
+import { reload } from "../models/browser"
+import { isOk, Err } from "../util/result"
+import { isValidSnapshot } from "../util/isValidSnapshot"
 
 export const DummyDetourPage = () => {
   const [routePattern, setRoutePattern] = useState<RoutePattern | null>(null)
@@ -16,18 +20,58 @@ export const DummyDetourPage = () => {
   }, [])
   const route = useRoute(routePattern?.routeId)
 
+  // The state machine won't "reinitialize", if it's inputs change, so only
+  // compute the snapshot from `localStorage` once.
+  const snapshot = useMemo(() => {
+    const snapshot_string = localStorage.getItem("snapshot")
+
+    if (!snapshot_string) {
+      return Err<"No Snapshot Present">("No Snapshot Present")
+    }
+
+    let persisted_snapshot
+    try {
+      persisted_snapshot = JSON.parse(snapshot_string)
+    } catch (error) {
+      return Err<"Parsing JSON Failed">("Parsing JSON Failed")
+    }
+
+    return isValidSnapshot(createDetourMachine, persisted_snapshot)
+  }, [])
+
   return (
     <>
-      {route && routePattern && routePattern.shape && (
+      {isOk(snapshot) ? (
         <DiversionPage
-          originalRoute={{
-            route,
-            routePattern,
-            center: { lat: 42.36, lng: -71.13 },
-            zoom: 16,
-          }}
+          snapshot={snapshot.ok}
           showConfirmCloseModal={false}
+          onClose={() => {
+            // If the close button is clicked,
+            // clear snapshot from storage and reinitialize state machine
+            localStorage.setItem("snapshot", "")
+            reload()
+          }}
         />
+      ) : (
+        <>
+          {
+            /* temp: since this is an internal page, show snapshot error as text
+             */
+            snapshot.err
+          }
+          {route && routePattern && routePattern.shape && (
+            <DiversionPage
+              originalRoute={{
+                center: { lat: 42.36, lng: -71.13 },
+                zoom: 16,
+                route,
+                routePattern,
+              }}
+              showConfirmCloseModal={false}
+              onClose={() => {}}
+            />
+          )}
+        </>
       )}
     </>
   )

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -22,6 +22,17 @@ export type UseDetourInput =
 export const useDetour = (input: UseDetourInput) => {
   const [snapshot, send, actorRef] = useMachine(createDetourMachine, input)
 
+  // Record snapshots when changed
+  useEffect(() => {
+    const snapshotSubscription = actorRef.subscribe(() => {
+      const serializedSnapshot = JSON.stringify(actorRef.getPersistedSnapshot())
+      localStorage.setItem("snapshot", serializedSnapshot)
+    })
+
+    return () => {
+      snapshotSubscription.unsubscribe()
+    }
+  }, [actorRef])
 
   const {
     routePattern,

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -6,11 +6,22 @@ import {
   CreateDetourMachineInput,
   createDetourMachine,
 } from "../models/createDetourMachine"
+import { Snapshot } from "xstate"
+import { useEffect } from "react"
 
-export const useDetour = (input: CreateDetourMachineInput) => {
-  const [snapshot, send] = useMachine(createDetourMachine, {
-    input,
-  })
+export type UseDetourInput =
+  | {
+      /** Initial arguments for {@linkcode createDetourMachine} */
+      input: CreateDetourMachineInput
+    }
+  | {
+      /** A _validated_ snapshot from which to initialize {@linkcode createDetourMachine} with */
+      snapshot: Snapshot<unknown>
+    }
+
+export const useDetour = (input: UseDetourInput) => {
+  const [snapshot, send, actorRef] = useMachine(createDetourMachine, input)
+
 
   const {
     routePattern,

--- a/assets/src/util/isValidSnapshot.ts
+++ b/assets/src/util/isValidSnapshot.ts
@@ -1,0 +1,27 @@
+import { AnyActorLogic, Snapshot, createActor } from "xstate"
+import { Result, Err, Ok } from "./result"
+
+/**
+ * Checks if the provided object, {@linkcode snapshot}, is a "valid" snapshot
+ * for the provided state machine {@linkcode actorLogic}.
+ */
+export const isValidSnapshot = (
+  actorLogic: AnyActorLogic,
+  snapshot: unknown
+): Result<Snapshot<unknown>, "Invalid Snapshot Type" | "Bad Snapshot"> => {
+  if (typeof snapshot !== "object" || snapshot === null) {
+    return Err("Invalid Snapshot Type")
+  }
+
+  // Check that machine initializes from snapshot without errors
+  const actor = createActor(actorLogic, {
+    snapshot: snapshot as any,
+    input: undefined,
+  })
+
+  if (actor.getSnapshot().status === "error") {
+    return Err("Bad Snapshot")
+  }
+
+  return Ok(snapshot as Snapshot<unknown>)
+}

--- a/assets/stories/skate-components/detours/diversionPage.stories.tsx
+++ b/assets/stories/skate-components/detours/diversionPage.stories.tsx
@@ -39,4 +39,8 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    originalRoute: meta.args.originalRoute,
+  },
+}

--- a/assets/tests/components/detours/diversionPage.test.tsx
+++ b/assets/tests/components/detours/diversionPage.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react"
-import React, { ComponentProps } from "react"
+import React from "react"
 import "@testing-library/jest-dom/jest-globals"
 import {
   FetchDetourDirectionsError,
@@ -16,7 +16,7 @@ import {
   fetchNearestIntersection,
   fetchRoutePatterns,
 } from "../../../src/api"
-import { DiversionPage as DiversionPageDefault } from "../../../src/components/detours/diversionPage"
+import { DiversionPage as DiversionPageDefault, DiversionPageProps } from "../../../src/components/detours/diversionPage"
 import stopFactory from "../../factories/stop"
 import userEvent from "@testing-library/user-event"
 import {
@@ -35,7 +35,6 @@ import {
 import { Err, Ok } from "../../../src/util/result"
 import { neverPromise } from "../../testHelpers/mockHelpers"
 import { originalRouteFactory } from "../../factories/originalRouteFactory"
-import { DeepPartial } from "fishery"
 import getTestGroups from "../../../src/userTestGroups"
 import { routePatternFactory } from "../../factories/routePattern"
 import { RoutesProvider } from "../../../src/contexts/routesContext"
@@ -43,22 +42,13 @@ import routeFactory from "../../factories/route"
 import { patternDisplayName } from "../../../src/components/mapPage/routePropertiesCard"
 import { RoutePattern } from "../../../src/schedule"
 
-const DiversionPage = (
-  props: Omit<
-    Partial<ComponentProps<typeof DiversionPageDefault>>,
-    "originalRoute"
-  > & {
-    originalRoute?: DeepPartial<
-      ComponentProps<typeof DiversionPageDefault>["originalRoute"]
-    >
-  }
-) => {
-  const { originalRoute, showConfirmCloseModal, ...otherProps } = props
+
+const DiversionPage = (props: Partial<DiversionPageProps>) => {
   return (
     <DiversionPageDefault
-      originalRoute={originalRouteFactory.build(originalRoute)}
-      showConfirmCloseModal={showConfirmCloseModal ?? false}
-      {...otherProps}
+      originalRoute={originalRouteFactory.build()}
+      showConfirmCloseModal={false}
+      {...props}
     />
   )
 }
@@ -1210,7 +1200,7 @@ describe("DiversionPage", () => {
     const connectionPoint = { lat: 10, lon: 10 }
     const { container } = render(
       <DiversionPage
-        originalRoute={{
+        originalRoute={originalRouteFactory.build({
           route: {
             name: routeName,
           },
@@ -1221,7 +1211,7 @@ describe("DiversionPage", () => {
               points: [connectionPoint],
             },
           },
-        }}
+        })}
       />
     )
 
@@ -1348,13 +1338,13 @@ describe("DiversionPage", () => {
   test("stop markers are visible", async () => {
     const { container } = render(
       <DiversionPage
-        originalRoute={{
+        originalRoute={originalRouteFactory.build({
           routePattern: {
             shape: {
               stops: stopFactory.buildList(11),
             },
           },
-        }}
+        })}
       />
     )
 
@@ -1375,13 +1365,13 @@ describe("DiversionPage", () => {
 
     const { container } = render(
       <DiversionPage
-        originalRoute={{
+        originalRoute={originalRouteFactory.build({
           routePattern: {
             shape: {
               stops: [stop1, stop2, stop3, stop4],
             },
           },
-        }}
+        })}
       />
     )
 
@@ -1405,7 +1395,11 @@ describe("DiversionPage", () => {
         .mockResolvedValue(routePatternFactory.buildList(1, { id: "66_666" }))
 
       render(
-        <DiversionPage originalRoute={{ routePattern: { id: "66_666" } }} />
+        <DiversionPage
+          originalRoute={originalRouteFactory.build({
+            routePattern: { id: "66_666" },
+          })}
+        />
       )
 
       expect(
@@ -1421,7 +1415,11 @@ describe("DiversionPage", () => {
       const [routePattern] = routePatterns
       jest.mocked(fetchRoutePatterns).mockResolvedValue(routePatterns)
 
-      render(<DiversionPage originalRoute={{ routePattern }} />)
+      render(
+        <DiversionPage
+          originalRoute={originalRouteFactory.build({ routePattern })}
+        />
+      )
 
       await userEvent.click(
         await screen.findByRole("button", { name: "Change route or direction" })
@@ -1442,10 +1440,10 @@ describe("DiversionPage", () => {
       const { container } = render(
         <RoutesProvider routes={[route]}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               route,
               routePattern: routePatterns[0],
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1537,10 +1535,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={routes}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               routePattern: initialRoutePattern,
               route: initialRoute,
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1579,7 +1577,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={[route]}>
           <DiversionPage
-            originalRoute={{ routePattern: startingRoutePattern, route }}
+            originalRoute={originalRouteFactory.build({
+              routePattern: startingRoutePattern,
+              route,
+            })}
           />
         </RoutesProvider>
       )
@@ -1608,7 +1609,12 @@ describe("DiversionPage", () => {
 
       render(
         <RoutesProvider routes={[route]}>
-          <DiversionPage originalRoute={{ routePattern: rp1, route }} />
+          <DiversionPage
+            originalRoute={originalRouteFactory.build({
+              routePattern: rp1,
+              route,
+            })}
+          />
         </RoutesProvider>
       )
 
@@ -1640,7 +1646,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={[route]}>
           <DiversionPage
-            originalRoute={{ route, routePattern: selectedRoutePattern }}
+            originalRoute={originalRouteFactory.build({
+              route,
+              routePattern: selectedRoutePattern,
+            })}
           />
         </RoutesProvider>
       )
@@ -1680,10 +1689,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={routes}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               route: route1,
               routePattern: routePatternFactory.build({ routeId: route1.id }),
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1722,10 +1731,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={[route]}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               route,
               routePattern,
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1778,10 +1787,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={routes}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               route: route1,
               routePattern: routePatternFactory.build({ routeId: route1.id }),
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1812,10 +1821,10 @@ describe("DiversionPage", () => {
       render(
         <RoutesProvider routes={routes}>
           <DiversionPage
-            originalRoute={{
+            originalRoute={originalRouteFactory.build({
               routePattern: undefined,
               route: undefined,
-            }}
+            })}
           />
         </RoutesProvider>
       )
@@ -1861,7 +1870,9 @@ describe("DiversionPage", () => {
 
       const { container } = render(
         <RoutesProvider routes={[route]}>
-          <DiversionPage originalRoute={{ route, routePattern }} />
+          <DiversionPage
+            originalRoute={originalRouteFactory.build({ route, routePattern })}
+          />
         </RoutesProvider>
       )
 

--- a/assets/tests/hooks/useDetour.test.ts
+++ b/assets/tests/hooks/useDetour.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 const renderDetourHook = () =>
   renderHook(useDetour, {
-    initialProps: originalRouteFactory.build(),
+    initialProps: { input: originalRouteFactory.build() },
   })
 
 describe("useDetour", () => {


### PR DESCRIPTION
This persists the state machine to `localStorage` and retrieves the last stored snapshot when the dummy detour page is opened.

> [!note]
> This is reviewable by commit to make it easier to understand all the changes.

----


Asana Ticket: https://app.asana.com/0/1205385723132845/1207529620198256/f