### PR TITLE
fix: truncate aws location queries to 200 bytes

### DIFF
--- a/lib/skate/location_search/aws_location_request.ex
+++ b/lib/skate/location_search/aws_location_request.ex
@@ -32,7 +32,7 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
     case request_fn.(%ExAws.Operation.RestQuery{
            http_method: :post,
            path: path,
-           body: Map.merge(base_arguments(), %{Text: text}),
+           body: Map.merge(base_arguments(), %{Text: String.byte_slice(text, 0, 200)}),
            service: :places
          }) do
       {:ok, response} -> {:ok, parse_search_response(response)}
@@ -51,7 +51,7 @@ defmodule Skate.LocationSearch.AwsLocationRequest do
     case request_fn.(%ExAws.Operation.RestQuery{
            http_method: :post,
            path: path,
-           body: Map.merge(base_arguments(), %{Text: text}),
+           body: Map.merge(base_arguments(), %{Text: String.byte_slice(text, 0, 200)}),
            service: :places
          }) do
       {:ok, response} -> {:ok, parse_suggest_response(response)}

--- a/test/skate/location_search/aws_location_request_test.exs
+++ b/test/skate/location_search/aws_location_request_test.exs
@@ -148,6 +148,17 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
 
       assert {:error, "error"} = AwsLocationRequest.search("search text")
     end
+
+    test "truncates search query to 200 chars" do
+      reassign_env(:skate, :aws_request_fn, fn %{
+                                                 body: %{Text: text}
+                                               } ->
+        assert Kernel.byte_size(text) == 200
+        {:error, "error"}
+      end)
+
+      assert {:error, "error"} = AwsLocationRequest.search(String.duplicate("search text", 200))
+    end
   end
 
   describe "suggest/1" do
@@ -207,6 +218,17 @@ defmodule Skate.LocationSearch.AwsLocationRequestTest do
       end)
 
       assert {:error, "error"} = AwsLocationRequest.suggest("search text")
+    end
+
+    test "truncates suggestion query to 200 chars" do
+      reassign_env(:skate, :aws_request_fn, fn %{
+                                                 body: %{Text: text}
+                                               } ->
+        assert Kernel.byte_size(text) == 200
+        {:error, "error"}
+      end)
+
+      assert {:error, "error"} = AwsLocationRequest.search(String.duplicate("search text", 200))
     end
   end
 end


### PR DESCRIPTION
Depends-On:
- #2706 	

Asana Ticket: https://app.asana.com/0/1205385723132845/1205857827225835/f
