### PR TITLE
fix: Basic check missed stops exists

### DIFF
--- a/lib/skate_web/controllers/detours_controller.ex
+++ b/lib/skate_web/controllers/detours_controller.ex
@@ -81,6 +81,7 @@ defmodule SkateWeb.DetoursController do
                route_segments: route_segments,
                detour_shape: ors_result
              }),
+           # credo:disable-for-next-line
            # TODO: Revisit the idea of `TripModification`s without missed stops
            false <- missed_stops == [],
            {:ok, modification} <-

--- a/lib/skate_web/controllers/detours_controller.ex
+++ b/lib/skate_web/controllers/detours_controller.ex
@@ -81,6 +81,7 @@ defmodule SkateWeb.DetoursController do
                route_segments: route_segments,
                detour_shape: ors_result
              }),
+           false <- length(missed_stops) == 0,
            {:ok, modification} <-
              TripModification.new(%TripModification.Input{
                route_pattern: route_pattern,

--- a/lib/skate_web/controllers/detours_controller.ex
+++ b/lib/skate_web/controllers/detours_controller.ex
@@ -81,7 +81,7 @@ defmodule SkateWeb.DetoursController do
                route_segments: route_segments,
                detour_shape: ors_result
              }),
-           false <- length(missed_stops) == 0,
+           false <- missed_stops == [],
            {:ok, modification} <-
              TripModification.new(%TripModification.Input{
                route_pattern: route_pattern,

--- a/lib/skate_web/controllers/detours_controller.ex
+++ b/lib/skate_web/controllers/detours_controller.ex
@@ -81,6 +81,7 @@ defmodule SkateWeb.DetoursController do
                route_segments: route_segments,
                detour_shape: ors_result
              }),
+           # TODO: Revisit the idea of `TripModification`s without missed stops
            false <- missed_stops == [],
            {:ok, modification} <-
              TripModification.new(%TripModification.Input{


### PR DESCRIPTION
Had a new BadMapError when drawing a detour the wrong way. We should not try to send a published detour in that case.

https://mbtace.sentry.io/issues/5644599926/?project=5303878&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0