### PR TITLE
cleanup: Rename c-new-route-ladder to c-route-ladder in CSS

### DIFF
--- a/assets/css/_route_ladder.scss
+++ b/assets/css/_route_ladder.scss
@@ -1,9 +1,9 @@
-.c-new-route-ladder__header,
+.c-route-ladder__header,
 .c-route-ladder__controls {
   margin: 0 0.5rem;
 }
 
-.c-new-route-ladder__header {
+.c-route-ladder__header {
   min-width: max-content;
 
   .card-body {

--- a/assets/src/components/routeLadder.tsx
+++ b/assets/src/components/routeLadder.tsx
@@ -61,7 +61,7 @@ export const Header = ({
   const routePillId = "route-pill" + useId()
   const routeOptionsToggleId = "route-options-toggle" + useId()
   return (
-    <Card className="c-new-route-ladder__header">
+    <Card className="c-route-ladder__header">
       <Card.Body>
         <div className="c-route-ladder__header__action-container">
           {showDropdown && (

--- a/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/ladderPage.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`LadderPage renders with alerts 1`] = `
         data-testid="route-ladders-div"
       >
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -331,7 +331,7 @@ exports[`LadderPage renders with alerts 1`] = `
         </div>
         loading...
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -600,7 +600,7 @@ exports[`LadderPage renders with route tabs 1`] = `
         data-testid="route-ladders-div"
       >
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -820,7 +820,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         data-testid="route-ladders-div"
       >
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -861,7 +861,7 @@ exports[`LadderPage renders with selectedRoutes in different order than routes d
         </div>
         loading...
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -1081,7 +1081,7 @@ exports[`LadderPage renders with timepoints 1`] = `
         data-testid="route-ladders-div"
       >
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"
@@ -1240,7 +1240,7 @@ exports[`LadderPage renders with timepoints 1`] = `
           class="c-incoming-box"
         />
         <div
-          class="c-new-route-ladder__header card"
+          class="c-route-ladder__header card"
         >
           <div
             class="card-body"

--- a/assets/tests/components/__snapshots__/minimalLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/minimalLadder.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`MinimalLadders renders route ladders 1`] = `
       data-testid="route-ladders-div"
     >
       <div
-        class="c-new-route-ladder__header card"
+        class="c-route-ladder__header card"
       >
         <div
           class="card-body"
@@ -169,7 +169,7 @@ exports[`MinimalLadders renders route ladders 1`] = `
         class="c-incoming-box"
       />
       <div
-        class="c-new-route-ladder__header card"
+        class="c-route-ladder__header card"
       >
         <div
           class="card-body"

--- a/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadder.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`routeLadder displays loading if we are fetching the timepoints 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -49,7 +49,7 @@ exports[`routeLadder displays loading if we are fetching the timepoints 1`] = `
 exports[`routeLadder displays no crowding data for a bus coming off a route with no crowding data onto a route with crowding data 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -318,7 +318,7 @@ exports[`routeLadder displays no crowding data for a bus coming off a route with
 exports[`routeLadder doesn't display crowding data for a vehicle coming off a route with crowding data onto a route with none 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -530,7 +530,7 @@ exports[`routeLadder doesn't display crowding data for a vehicle coming off a ro
 exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -709,7 +709,7 @@ exports[`routeLadder doesn't render a bus that's off-course but nonrevenue 1`] =
 exports[`routeLadder renders a route ladder 1`] = `
 <div>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -846,7 +846,7 @@ exports[`routeLadder renders a route ladder 1`] = `
 exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -1119,7 +1119,7 @@ exports[`routeLadder renders a route ladder with crowding instead of vehicles 1`
 exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -1331,7 +1331,7 @@ exports[`routeLadder renders a route ladder with laying over vehicles 1`] = `
 exports[`routeLadder renders a route ladder with the new header and detour dropdown 1`] = `
 <div>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -1487,7 +1487,7 @@ exports[`routeLadder renders a route ladder with the new header and detour dropd
 exports[`routeLadder renders a route ladder with the new header format 1`] = `
 <div>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -1624,7 +1624,7 @@ exports[`routeLadder renders a route ladder with the new header format 1`] = `
 exports[`routeLadder renders a route ladder with vehicles 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"
@@ -1928,7 +1928,7 @@ exports[`routeLadder renders a route ladder with vehicles 1`] = `
 exports[`routeLadder renders a route ladder with vehicles in the incoming box 1`] = `
 <DocumentFragment>
   <div
-    class="c-new-route-ladder__header card"
+    class="c-route-ladder__header card"
   >
     <div
       class="card-body"

--- a/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/routeLadders.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RouteLadders renders a route ladder 1`] = `
     data-testid="route-ladders-div"
   >
     <div
-      class="c-new-route-ladder__header card"
+      class="c-route-ladder__header card"
     >
       <div
         class="card-body"
@@ -166,7 +166,7 @@ exports[`RouteLadders renders a route ladder 1`] = `
       class="c-incoming-box"
     />
     <div
-      class="c-new-route-ladder__header card"
+      class="c-route-ladder__header card"
     >
       <div
         class="card-body"

--- a/assets/tests/components/ladderPage.test.tsx
+++ b/assets/tests/components/ladderPage.test.tsx
@@ -554,7 +554,7 @@ describe("LadderPage", () => {
       </StateDispatchProvider>
     )
 
-    expect(container.querySelector(".c-new-route-ladder__header")).toBeVisible()
+    expect(container.querySelector(".c-route-ladder__header")).toBeVisible()
 
     expect(
       container.querySelector(".c-route-ladder__dropdown-button")


### PR DESCRIPTION
Follow-up to:
- https://github.com/mbta/skate/pull/2697

Depends on:
- https://github.com/mbta/skate/pull/2710