### PR TITLE
fix: Run database migrations before starting anything else

### DIFF
--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -37,9 +37,9 @@ defmodule Skate.Application do
           []
         end ++
         [
+          Skate.Migrate,
           {Phoenix.PubSub, name: Skate.PubSub},
           SkateWeb.Endpoint,
-          Skate.Migrate,
           {Oban, Application.fetch_env!(:skate, Oban)},
           {Skate.Detours.TripModificationPublisher,
            Application.get_env(:skate, Skate.Detours.TripModificationPublisher)}


### PR DESCRIPTION
This allows us to put migrations and code that relies on those migrations into the same commits.

If the code relies on changes made in a migration, and the migration runs after the code starts, then there's a potential race condition where that code runs before the migrations have run, which would cause an error. This eliminates that possibility.