### PR TITLE
feat: Add validation to ensure no whitespace in test group names

### DIFF
--- a/lib/skate/settings/db/test_group.ex
+++ b/lib/skate/settings/db/test_group.ex
@@ -23,6 +23,7 @@ defmodule Skate.Settings.Db.TestGroup do
     |> cast(attrs, [:name, :override])
     |> cast_assoc(:test_group_users)
     |> validate_required([:name])
+    |> validate_format(:name, ~r/^[^\s]*$/, message: "can't have spaces")
     |> unique_constraint(:name, name: :test_groups_unique_index)
   end
 end

--- a/test/skate/settings/test_group_test.exs
+++ b/test/skate/settings/test_group_test.exs
@@ -6,9 +6,9 @@ defmodule Skate.Settings.TestGroupTest do
 
   describe "create/1" do
     test "creates the test group" do
-      assert {:ok, %TestGroup{name: "group name"}} = TestGroup.create("group name")
+      assert {:ok, %TestGroup{name: "group-name"}} = TestGroup.create("group-name")
 
-      assert [%TestGroup{name: "group name"}] = TestGroup.get_all()
+      assert [%TestGroup{name: "group-name"}] = TestGroup.get_all()
     end
 
     test "disallows blank group names" do
@@ -19,32 +19,39 @@ defmodule Skate.Settings.TestGroupTest do
     end
 
     test "returns an error if the test group has a duplicate name" do
-      TestGroup.create("duplicate name")
-      assert {:error, changeset} = TestGroup.create("duplicate name")
+      TestGroup.create("duplicate-name")
+      assert {:error, changeset} = TestGroup.create("duplicate-name")
 
       assert %{errors: [name: {"has already been taken", _}]} = changeset
       assert Enum.count(TestGroup.get_all()) == 1
     end
 
     test "strips leading and trailing spaces" do
-      assert {:ok, %TestGroup{name: "lost in space"}} = TestGroup.create("  lost in space   ")
+      assert {:ok, %TestGroup{name: "lost-in-space"}} = TestGroup.create("  lost-in-space   ")
 
-      assert [%TestGroup{name: "lost in space"}] = TestGroup.get_all()
+      assert [%TestGroup{name: "lost-in-space"}] = TestGroup.get_all()
     end
 
     test "treats names as duplicates if they differ by leading and trailing spaces" do
-      TestGroup.create("lost in space   ")
-      assert {:error, changeset} = TestGroup.create("     lost in space")
+      TestGroup.create("lost-in-space   ")
+      assert {:error, changeset} = TestGroup.create("     lost-in-space")
 
       assert %{errors: [name: {"has already been taken", _}]} = changeset
       assert Enum.count(TestGroup.get_all()) == 1
+    end
+
+    test "disallows non-leading or trailing spaces" do
+      assert {:error, changeset} = TestGroup.create("too much space")
+
+      assert %{errors: [name: {"can't have spaces", _}]} = changeset
+      assert Enum.empty?(TestGroup.get_all())
     end
   end
 
   describe "get/1" do
     test "retrieves the test group" do
-      {:ok, test_group} = TestGroup.create("group name")
-      assert %TestGroup{name: "group name"} = TestGroup.get(test_group.id)
+      {:ok, test_group} = TestGroup.create("group-name")
+      assert %TestGroup{name: "group-name"} = TestGroup.get(test_group.id)
     end
 
     test "returns nil when no group is found" do
@@ -54,8 +61,8 @@ defmodule Skate.Settings.TestGroupTest do
 
   describe "get_all/0" do
     test "gets all test groups" do
-      {:ok, group1} = TestGroup.create("group 1")
-      {:ok, group2} = TestGroup.create("group 2")
+      {:ok, group1} = TestGroup.create("group-1")
+      {:ok, group2} = TestGroup.create("group-2")
 
       all_groups = TestGroup.get_all()
 
@@ -68,10 +75,10 @@ defmodule Skate.Settings.TestGroupTest do
 
   describe "get_override_enabled/0" do
     test "only retrieves test groups with the :enabled override" do
-      {:ok, group1} = TestGroup.create("group 1")
-      {:ok, _group2} = TestGroup.create("group 2")
-      {:ok, _group3} = TestGroup.create("group 3")
-      {:ok, group4} = TestGroup.create("group 4")
+      {:ok, group1} = TestGroup.create("group-1")
+      {:ok, _group2} = TestGroup.create("group-2")
+      {:ok, _group3} = TestGroup.create("group-3")
+      {:ok, group4} = TestGroup.create("group-4")
 
       TestGroup.update(%{group1 | override: :enabled})
       TestGroup.update(%{group4 | override: :enabled})
@@ -80,21 +87,21 @@ defmodule Skate.Settings.TestGroupTest do
 
       assert Enum.count(groups) == 2
 
-      refute groups |> Enum.find(fn group -> group.name == "group 1" end) |> is_nil()
-      refute groups |> Enum.find(fn group -> group.name == "group 4" end) |> is_nil()
+      refute groups |> Enum.find(fn group -> group.name == "group-1" end) |> is_nil()
+      refute groups |> Enum.find(fn group -> group.name == "group-4" end) |> is_nil()
 
-      assert groups |> Enum.find(fn group -> group.name == "group 2" end) |> is_nil()
-      assert groups |> Enum.find(fn group -> group.name == "group 3" end) |> is_nil()
+      assert groups |> Enum.find(fn group -> group.name == "group-2" end) |> is_nil()
+      assert groups |> Enum.find(fn group -> group.name == "group-3" end) |> is_nil()
     end
   end
 
   describe "update/1" do
     test "updates name" do
-      {:ok, test_group} = TestGroup.create("name 1")
+      {:ok, test_group} = TestGroup.create("name-1")
 
-      new_test_group = TestGroup.update(%{test_group | name: "name 2"})
+      new_test_group = TestGroup.update(%{test_group | name: "name-2"})
 
-      assert new_test_group.name == "name 2"
+      assert new_test_group.name == "name-2"
     end
 
     test "updates users" do
@@ -121,7 +128,7 @@ defmodule Skate.Settings.TestGroupTest do
     end
 
     test "can set override to enabled" do
-      {:ok, test_group} = TestGroup.create("group name")
+      {:ok, test_group} = TestGroup.create("group-name")
 
       new_test_group = TestGroup.update(%{test_group | override: :enabled})
 
@@ -129,7 +136,7 @@ defmodule Skate.Settings.TestGroupTest do
     end
 
     test "override defaults to :none" do
-      {:ok, test_group} = TestGroup.create("group name")
+      {:ok, test_group} = TestGroup.create("group-name")
 
       assert test_group.override == :none
     end
@@ -137,7 +144,7 @@ defmodule Skate.Settings.TestGroupTest do
 
   describe "delete/1" do
     test "deletes a test group" do
-      {:ok, test_group} = TestGroup.create("group to delete")
+      {:ok, test_group} = TestGroup.create("group-to-delete")
 
       TestGroup.delete(test_group.id)
 

--- a/test/skate_web/controllers/test_group_controller_test.exs
+++ b/test/skate_web/controllers/test_group_controller_test.exs
@@ -14,13 +14,13 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "returns page with test groups listed", %{conn: conn, user: user} do
-      {:ok, test_group} = TestGroup.create("test group name")
+      {:ok, test_group} = TestGroup.create("test-group-name")
 
       TestGroup.update(%{test_group | users: [user]})
 
       conn = get(conn, ~p"/test_groups")
 
-      assert html_response(conn, 200) =~ "test group name"
+      assert html_response(conn, 200) =~ "test-group-name"
     end
   end
 
@@ -37,13 +37,13 @@ defmodule SkateWeb.TestGroupControllerTest do
       conn =
         post(conn, ~p"/test_groups/create", %{
           "test_group" => %{
-            "name" => "group to create"
+            "name" => "group-to-create"
           }
         })
 
       assert redirected_to(conn) == ~p"/test_groups"
 
-      assert [%TestGroup{name: "group to create"}] = TestGroup.get_all()
+      assert [%TestGroup{name: "group-to-create"}] = TestGroup.get_all()
     end
 
     @tag :authenticated_admin
@@ -67,12 +67,12 @@ defmodule SkateWeb.TestGroupControllerTest do
          %{
            conn: conn
          } do
-      TestGroup.create("duplicate group")
+      TestGroup.create("duplicate-group")
 
       conn =
         post(conn, ~p"/test_groups/create", %{
           "test_group" => %{
-            "name" => "duplicate group"
+            "name" => "duplicate-group"
           }
         })
 
@@ -92,7 +92,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "renders a test group", %{conn: conn, user: user} do
-      {:ok, test_group} = TestGroup.create("group to show")
+      {:ok, test_group} = TestGroup.create("group-to-show")
       test_group_with_user = TestGroup.update(%TestGroup{test_group | users: [user]})
 
       html =
@@ -100,13 +100,13 @@ defmodule SkateWeb.TestGroupControllerTest do
         |> get(~p"/test_groups/#{test_group_with_user.id}")
         |> html_response(200)
 
-      assert html =~ "group to show"
+      assert html =~ "group-to-show"
       assert html =~ user.email
     end
 
     @tag :authenticated_admin
     test "includes a button for setting the enabled override", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("group to show")
+      {:ok, test_group} = TestGroup.create("group-to-show")
 
       html =
         conn
@@ -121,7 +121,7 @@ defmodule SkateWeb.TestGroupControllerTest do
     test "includes a button for removing the override when the override is already there", %{
       conn: conn
     } do
-      {:ok, test_group} = TestGroup.create("group to show")
+      {:ok, test_group} = TestGroup.create("group-to-show")
       test_group = TestGroup.update(%{test_group | override: :enabled})
 
       html =
@@ -156,7 +156,7 @@ defmodule SkateWeb.TestGroupControllerTest do
       user1 = User.upsert("user1", "user1@test.com")
       user2 = User.upsert("user2", "user2@test.com")
 
-      {:ok, test_group} = TestGroup.create("group to add users to")
+      {:ok, test_group} = TestGroup.create("group-to-add-users-to")
       test_group_with_user = TestGroup.update(%TestGroup{test_group | users: [user1]})
 
       html =
@@ -188,7 +188,7 @@ defmodule SkateWeb.TestGroupControllerTest do
     test "adds user to test group", %{conn: conn} do
       user = User.upsert("user", "user@test.com")
 
-      {:ok, test_group} = TestGroup.create("group to add user to")
+      {:ok, test_group} = TestGroup.create("group-to-add-user-to")
 
       conn =
         post(conn, ~p"/test_groups/#{test_group.id}/add_user", %{
@@ -214,7 +214,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "handles case where no user is found", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("group to add user to")
+      {:ok, test_group} = TestGroup.create("group-to-add-user-to")
 
       conn =
         post(conn, ~p"/test_groups/#{test_group.id}/add_user", %{
@@ -238,7 +238,7 @@ defmodule SkateWeb.TestGroupControllerTest do
       user1 = User.upsert("user1", "user1@test.com")
       user2 = User.upsert("user2", "user2@test.com")
 
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       test_group_with_users = TestGroup.update(%TestGroup{test_group | users: [user1, user2]})
 
       conn =
@@ -257,7 +257,7 @@ defmodule SkateWeb.TestGroupControllerTest do
       user1 = User.upsert("user1", "user1@test.com")
       user2 = User.upsert("user2", "user2@test.com")
 
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       TestGroup.update(%TestGroup{test_group | users: [user1]})
 
       conn =
@@ -289,7 +289,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "redirects to test groups index page", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       conn = delete(conn, ~p"/test_groups/#{test_group.id}")
 
       assert redirected_to(conn) == ~p"/test_groups"
@@ -297,7 +297,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "deletes the test group", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       delete(conn, ~p"/test_groups/#{test_group.id}")
 
       assert Enum.empty?(TestGroup.get_all())
@@ -307,7 +307,7 @@ defmodule SkateWeb.TestGroupControllerTest do
   describe "enable_override/2" do
     @tag :authenticated_admin
     test "redirects to the test group page", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       conn = post(conn, ~p"/test_groups/#{test_group.id}/enable_override")
 
       assert redirected_to(conn) == ~p"/test_groups/#{test_group.id}"
@@ -315,7 +315,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "sets the override to enabled", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       post(conn, ~p"/test_groups/#{test_group.id}/enable_override")
 
       test_group = TestGroup.get(test_group.id)
@@ -326,7 +326,7 @@ defmodule SkateWeb.TestGroupControllerTest do
   describe "remove_override/2" do
     @tag :authenticated_admin
     test "redirects to the test group page", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       test_group = TestGroup.update(%{test_group | override: :enabled})
       conn = post(conn, ~p"/test_groups/#{test_group.id}/remove_override")
 
@@ -335,7 +335,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
     @tag :authenticated_admin
     test "sets the override to :none", %{conn: conn} do
-      {:ok, test_group} = TestGroup.create("test group")
+      {:ok, test_group} = TestGroup.create("test-group")
       test_group = TestGroup.update(%{test_group | override: :enabled})
       post(conn, ~p"/test_groups/#{test_group.id}/remove_override")
 


### PR DESCRIPTION
This is the first part of a multi-part (I think two-part, but who knows) effort to change test-group URL's to be `/test_groups/<name>` instead of `/test_groups/<database_id>`, so for instance, `https://skate.mbta.com/test_groups/detours-pilot` instead of `https://skate.mbta.com/test_groups/10`.

This will only work (nicely) if test group names aren't allowed to have spaces, so I figured it could be a good idea to enforce that now.

No Asana Ticket.