### PR TITLE
feat: Add mfa to dev logs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -76,7 +76,9 @@ config :skate, SkateWeb.Endpoint,
 config :skate, Skate.Repo, database: "skate_dev"
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+config :logger, :console,
+  format: "[$level] $metadata$message\n",
+  metadata: [:mfa]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.


### PR DESCRIPTION
As a follow-up to https://github.com/mbta/skate/pull/2733, it would be good to restore module names to dev logs. 

No Asana Ticket.

Follow-up to:
- https://github.com/mbta/skate/pull/2733