### PR TITLE
fix: Include Sentry LoggerBackend

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -137,6 +137,10 @@ config :skate, Oban,
     }
   ]
 
+# Include 2 logger backends
+  config :logger,
+  backends: [:console, Sentry.LoggerBackend]
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time [$level] $metadata$message\n",


### PR DESCRIPTION
Not only log to the console (Splunk) but to Sentry