### PR TITLE
fix: disable `warnings_as_errors` when shell is ElixirLS

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,11 @@ defmodule Skate.MixProject do
       aliases: aliases(),
       deps: deps(),
       test_coverage: [tool: LcovEx],
-      elixirc_options: [warnings_as_errors: true],
+      elixirc_options:
+        cond do
+          Mix.shell() == ElixirLS.LanguageServer.MixShell -> []
+          true -> [warnings_as_errors: true]
+        end,
       consolidate_protocols: Mix.env() != :test,
       dialyzer: [
         plt_add_apps: [:mix]


### PR DESCRIPTION
Elixir LS will repeatedly restart due to `warnings_as_errors`. So the only option to get the language server to work is to remove the config line.

Turns out, that ElixirLS does set the "shell" that Mix is aware of, and Mix will tell us about that module via `Mix.shell()`, so we can set `elixirc` options based on if we're in the LSP context or not.

<details><summary>LSP Error Logs</summary>

```
[Info  - 2:44:04 PM] Starting build with MIX_ENV: test MIX_TARGET: host
[Warn  - 2:44:04 PM]     warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of ASCII letters, numbers, and underscores and not beginning with a number do not require quotes
    │
 17 │         preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test]
    │                              ~
    │
    └─ /Users/kfirestack/Documents/src/github.com/mbta/skate.d/1/deps/parallel_stream/mix.exs:17:30

[Warn  - 2:44:05 PM]     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 83 │     {:ok, config} = :file.consult('rebar.config')
    │                                   ~
    │
    └─ /Users/kfirestack/Documents/src/github.com/mbta/skate.d/1/deps/telemetry_registry/mix.exs:83:35

[Warn  - 2:44:05 PM]     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 89 │     {:ok, [{:application, name, desc}]} = :file.consult('src/telemetry_registry.app.src')
    │                                                         ~
    │
    └─ /Users/kfirestack/Documents/src/github.com/mbta/skate.d/1/deps/telemetry_registry/mix.exs:89:57

[Info  - 2:44:05 PM] Compile took 1297 milliseconds
[Info  - 2:44:05 PM] [ElixirLS WorkspaceSymbols] Updating index...
[Info  - 2:44:05 PM] [ElixirLS WorkspaceSymbols] 0 modules need reindexing
[Info  - 2:44:05 PM] [ElixirLS WorkspaceSymbols] 0 symbols added to index in 0ms
[Info  - 2:44:05 PM] Updating incremental PLT
[Info  - 2:44:07 PM] Terminating Elixir.ElixirLS.LanguageServer.ExUnitTestTracer: exited in: GenServer.call(ExMachina.Sequence, {:get_and_update, #Function<2.89761755/1 in ExMachina.Sequence.next/3>}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
[Error - 2:44:07 PM] GenServer ElixirLS.LanguageServer.ExUnitTestTracer terminating
** (stop) exited in: GenServer.call(ExMachina.Sequence, {:get_and_update, #Function<2.89761755/1 in ExMachina.Sequence.next/3>}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.17.2) lib/gen_server.ex:1121: GenServer.call/3
    test/notifications/notification_server_test.exs:81: (module)
    (elixir 1.17.2) elixir_compiler.erl:77: :elixir_compiler.dispatch/4
    (elixir 1.17.2) elixir_compiler.erl:52: :elixir_compiler.compile/4
    (elixir 1.17.2) elixir_module.erl:427: :elixir_module.eval_form/7
    (elixir 1.17.2) elixir_module.erl:129: :elixir_module.compile/7
    (elixir 1.17.2) elixir_compiler.erl:38: :elixir_compiler.maybe_fast_compile/2
    (elixir 1.17.2) elixir_lexical.erl:15: :elixir_lexical.run/3
    (elixir 1.17.2) elixir_compiler.erl:17: :elixir_compiler.quoted/3
    (elixir 1.17.2) lib/module/parallel_checker.ex:112: Module.ParallelChecker.verify/1
    (language_server 0.23.0) lib/language_server/ex_unit_test_tracer.ex:84: anonymous fn/1 in ElixirLS.LanguageServer.ExUnitTestTracer.handle_call/3
    (kernel 9.1) global.erl:477: :global.trans/4
    (language_server 0.23.0) lib/language_server/ex_unit_test_tracer.ex:77: ElixirLS.LanguageServer.ExUnitTestTracer.handle_call/3
    (stdlib 5.1.1) gen_server.erl:1113: :gen_server.try_handle_call/4
    (stdlib 5.1.1) gen_server.erl:1142: :gen_server.handle_msg/6
    (stdlib 5.1.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.3876.0>): {:get_tests, "/Users/kfirestack/Documents/src/github.com/mbta/skate.d/1/test/notifications/notification_server_test.exs"}
State: %{}
Client #PID<0.3876.0> is alive

    (stdlib 5.1.1) gen.erl:240: :gen.do_call/4
    (elixir 1.17.2) lib/gen_server.ex:1125: GenServer.call/3
    (language_server 0.23.0) lib/language_server/providers/execute_command/get_ex_unit_tests_in_file.ex:10: ElixirLS.LanguageServer.Providers.ExecuteCommand.GetExUnitTestsInFile.execute/2
    (language_server 0.23.0) lib/language_server/server.ex:1206: anonymous fn/4 in ElixirLS.LanguageServer.Server.handle_request/2
    (language_server 0.23.0) lib/language_server/server.ex:1280: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2
[Info  - 2:44:09 PM] Connection to server got closed. Server will restart.
true
[Error - 2:44:09 PM] Server process exited with code 1.
```
</details> 