### PR TITLE
cleanup: move MBTA API config into runtime.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,6 @@ config :skate, ecto_repos: [Skate.Repo]
 
 config :skate,
   # Default. Can be configured via environment variable, which is loaded in application.ex
-  api_url: {:system, "API_URL"},
-  api_key: {:system, "API_KEY"},
   restrict_environment_access?: false,
   google_tag_manager_id: {:system, "GOOGLE_TAG_MANAGER_ID"},
   tileset_url: {:system, "TILESET_URL"},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -11,6 +11,11 @@ config :skate,
   aws_place_index: System.get_env("AWS_PLACE_INDEX"),
   environment_name: System.get_env("ENVIRONMENT_NAME", "missing-env")
 
+# MBTA API
+config :skate,
+  api_key: System.get_env("API_KEY"),
+  api_url: System.get_env("API_URL")
+
 # Swiftly API
 config :skate,
   swiftly_authorization_key: System.get_env("SWIFTLY_AUTHORIZATION_KEY"),

--- a/lib/skate/application.ex
+++ b/lib/skate/application.ex
@@ -67,8 +67,6 @@ defmodule Skate.Application do
   @spec load_runtime_config() :: :ok
   def load_runtime_config() do
     application_keys = [
-      :api_url,
-      :api_key,
       :google_tag_manager_id,
       :tileset_url,
       :gtfs_url,


### PR DESCRIPTION
Some small cleanup related to removing our `Skate.Application.load_runtime_config/0` function

Related
 - #2758 