### PR TITLE
feat: Space out components on detour list page

### DIFF
--- a/assets/css/_detour_list_page.scss
+++ b/assets/css/_detour_list_page.scss
@@ -1,0 +1,5 @@
+.c-detour-list-page {
+  .c-detour-list-page__button {
+    margin-bottom: 2.25rem;
+  }
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -39,6 +39,7 @@ $vpp-location-padding: 1rem;
 @import "crowding";
 @import "cutout_overlay";
 @import "data_status_banner";
+@import "detour_list_page";
 @import "detours/detour_map";
 @import "detours/detour_modal";
 @import "detours/detour_table";

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -83,9 +83,12 @@ export const DetourListPage = () => {
   const [showDetourModal, setShowDetourModal] = useState(false)
 
   return (
-    <div className="h-100 overflow-y-auto">
+    <div className="c-detour-list-page h-100 overflow-y-auto p-4 bg-white">
       {userInTestGroup(TestGroups.DetoursPilot) && (
-        <Button className="icon-link" onClick={() => setShowDetourModal(true)}>
+        <Button
+          className="c-detour-list-page__button icon-link fw-light px-3 py-2"
+          onClick={() => setShowDetourModal(true)}
+        >
           <PlusSquare />
           Add detour
         </Button>

--- a/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DetourListPage renders detour list page with dummy data 1`] = `
 <div
-  className="h-100 overflow-y-auto"
+  className="c-detour-list-page h-100 overflow-y-auto p-4 bg-white"
 >
   <table
     className="c-detours-table table table-hover"


### PR DESCRIPTION
# Before

<img width="1434" alt="Screenshot 2024-08-28 at 5 52 52 PM" src="https://github.com/user-attachments/assets/fe1f4bd6-f6b0-4e1d-a234-29fbed57835c">

# After

<img width="1432" alt="Screenshot 2024-08-28 at 5 54 58 PM" src="https://github.com/user-attachments/assets/5868ff6d-3c40-4f56-a540-6ef0fc7031ac">

---

Asana Ticket: https://app.asana.com/0/1205385723132845/1208155044119311/f

Depends on:
- https://github.com/mbta/skate/pull/2762
  - Mostly because there's a git conflict if you try to merge this first, but also because this looks pretty bad without the updated table styling.