### PR TITLE
feat: Styling for components in detours table cells

### DIFF
--- a/assets/css/detours/_detour_table.scss
+++ b/assets/css/detours/_detour_table.scss
@@ -15,16 +15,16 @@ $table-border-radius: 0.5rem;
     background-color: tokens.$gray-50;
     color: tokens.$gray-700;
 
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
-
     white-space: nowrap;
+  }
+
+  td {
+    color: tokens.$gray-900;
   }
 
   th,
   td {
     border-bottom: $table-border;
-    padding-left: 1rem;
   }
 
   tr {
@@ -62,13 +62,12 @@ $table-border-radius: 0.5rem;
   }
 }
 
-.c-detours-table__route-info-cell {
-  display: flex;
-  align-items: center;
-}
-
 .c-detours-table__route-info-text {
   display: flex;
   flex-direction: column;
   margin-left: 10px;
+}
+
+.c-detours-table__route-info-direction {
+  color: tokens.$gray-600;
 }

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -16,27 +16,29 @@ export const DetoursTable = ({ data }: DetoursTableProps) => {
     <Table hover className="c-detours-table">
       <thead>
         <tr>
-          <th>Route</th>
-          <th className="u-hide-for-mobile">Starting Intersection</th>
-          <th className="u-hide-for-mobile">On detour since</th>
+          <th className="px-3 py-4">Route and direction</th>
+          <th className="px-3 py-4 u-hide-for-mobile">Starting Intersection</th>
+          <th className="px-3 py-4 u-hide-for-mobile">On detour since</th>
         </tr>
       </thead>
       <tbody>
         {data.map((detour, index) => (
           <tr key={index}>
-            <td className="align-middle">
-              <div className="c-detours-table__route-info-cell">
+            <td className="align-middle p-3">
+              <div className="d-flex">
                 <RoutePill routeName={detour.route} />
-                <div className="c-detours-table__route-info-text">
-                  <span>{detour.direction}</span>
-                  <span className="fw-bold">{detour.name}</span>
+                <div className="c-detours-table__route-info-text d-inline-block">
+                  <div className="pb-1 fs-4 fw-bold">{detour.name}</div>
+                  <div className="c-detours-table__route-info-direction fs-6">
+                    {detour.direction}
+                  </div>
                 </div>
               </div>
             </td>
-            <td className="align-middle u-hide-for-mobile">
+            <td className="align-middle p-3 u-hide-for-mobile">
               {detour.intersection}
             </td>
-            <td className="align-middle u-hide-for-mobile">
+            <td className="align-middle p-3 u-hide-for-mobile">
               {timeAgoLabel(epochNowInSeconds, detour.activeSince)}
             </td>
           </tr>

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -28,7 +28,7 @@ export const DetoursTable = ({ data }: DetoursTableProps) => {
               <div className="d-flex">
                 <RoutePill routeName={detour.route} />
                 <div className="c-detours-table__route-info-text d-inline-block">
-                  <div className="pb-1 fs-4 fw-bold">{detour.name}</div>
+                  <div className="pb-1 fs-4 fw-semibold">{detour.name}</div>
                   <div className="c-detours-table__route-info-direction fs-6">
                     {detour.direction}
                   </div>

--- a/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
@@ -9,16 +9,18 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
   >
     <thead>
       <tr>
-        <th>
-          Route
+        <th
+          className="px-3 py-4"
+        >
+          Route and direction
         </th>
         <th
-          className="u-hide-for-mobile"
+          className="px-3 py-4 u-hide-for-mobile"
         >
           Starting Intersection
         </th>
         <th
-          className="u-hide-for-mobile"
+          className="px-3 py-4 u-hide-for-mobile"
         >
           On detour since
         </th>
@@ -27,10 +29,10 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
     <tbody>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -38,36 +40,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               45
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Franklin Park via Ruggles Station
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           John F. Kennedy St & Memorial Drive
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           400 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -75,36 +79,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Inbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Central Square
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Inbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           403 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -112,36 +118,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Rindge Ave
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           680 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -149,36 +157,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               45
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Franklin Park via Ruggles Station
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           John F. Kennedy St & Memorial Drive
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           400 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -186,36 +196,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Inbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Central Square
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Inbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           403 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -223,36 +235,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Rindge Ave
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           680 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -260,36 +274,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               45
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Franklin Park via Ruggles Station
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           John F. Kennedy St & Memorial Drive
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           400 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -297,36 +313,38 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Inbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Central Square
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Inbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           403 hours ago
         </td>
       </tr>
       <tr>
         <td
-          className="align-middle"
+          className="align-middle p-3"
         >
           <div
-            className="c-detours-table__route-info-cell"
+            className="d-flex"
           >
             <div
               className="c-route-pill c-route-pill--bus"
@@ -334,26 +352,28 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               83
             </div>
             <div
-              className="c-detours-table__route-info-text"
+              className="c-detours-table__route-info-text d-inline-block"
             >
-              <span>
-                Outbound
-              </span>
-              <span
-                className="fw-bold"
+              <div
+                className="pb-1 fs-4 fw-bold"
               >
                 Rindge Ave
-              </span>
+              </div>
+              <div
+                className="c-detours-table__route-info-direction fs-6"
+              >
+                Outbound
+              </div>
             </div>
           </div>
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           Pearl Street & Clearwell Ave
         </td>
         <td
-          className="align-middle u-hide-for-mobile"
+          className="align-middle p-3 u-hide-for-mobile"
         >
           680 hours ago
         </td>

--- a/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Franklin Park via Ruggles Station
               </div>
@@ -82,7 +82,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Central Square
               </div>
@@ -121,7 +121,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Rindge Ave
               </div>
@@ -160,7 +160,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Franklin Park via Ruggles Station
               </div>
@@ -199,7 +199,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Central Square
               </div>
@@ -238,7 +238,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Rindge Ave
               </div>
@@ -277,7 +277,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Franklin Park via Ruggles Station
               </div>
@@ -316,7 +316,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Central Square
               </div>
@@ -355,7 +355,7 @@ exports[`DetourListPage renders detour list page with dummy data 1`] = `
               className="c-detours-table__route-info-text d-inline-block"
             >
               <div
-                className="pb-1 fs-4 fw-bold"
+                className="pb-1 fs-4 fw-semibold"
               >
                 Rindge Ave
               </div>


### PR DESCRIPTION
# Before

<img width="352" alt="Screenshot 2024-09-04 at 2 26 13 PM" src="https://github.com/user-attachments/assets/7c689bb9-193f-493a-99d2-fffdba2bdf01">

# After

<img width="411" alt="Screenshot 2024-09-04 at 2 25 16 PM" src="https://github.com/user-attachments/assets/2209c3eb-6219-45eb-898e-79df26c4942c">

---

Asana Ticket: https://app.asana.com/0/1205718271156548/1208155044119313/f

Depends on:
- https://github.com/mbta/skate/pull/2762

---

I considered extracting this to a separate component, but didn't for now because it's not exactly the same as other instances of similar-looking things. I'm open to doing that, either as a follow-up, or as a pre-work to this, if you all think it's a good idea.