### PR TITLE
feat: Update detour list page and table styles for mobile

### DIFF
--- a/assets/css/detours/_detour_table.scss
+++ b/assets/css/detours/_detour_table.scss
@@ -30,7 +30,9 @@ $table-border-radius: 0.5rem;
   tr {
     th:first-child,
     td:first-child {
-      border-left: $table-border;
+      @include media-breakpoint-up(md) {
+        border-left: $table-border;
+      }
     }
 
     th:last-child,

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -83,10 +83,10 @@ export const DetourListPage = () => {
   const [showDetourModal, setShowDetourModal] = useState(false)
 
   return (
-    <div className="c-detour-list-page h-100 overflow-y-auto p-4 bg-white">
+    <div className="c-detour-list-page h-100 overflow-y-auto p-0 p-md-4 bg-white">
       {userInTestGroup(TestGroups.DetoursPilot) && (
         <Button
-          className="c-detour-list-page__button icon-link fw-light px-3 py-2"
+          className="c-detour-list-page__button icon-link fw-light px-3 py-2 u-hide-for-mobile"
           onClick={() => setShowDetourModal(true)}
         >
           <PlusSquare />

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -14,7 +14,7 @@ export const DetoursTable = ({ data }: DetoursTableProps) => {
 
   return (
     <Table hover className="c-detours-table">
-      <thead>
+      <thead className="u-hide-for-mobile">
         <tr>
           <th className="px-3 py-4">Route and direction</th>
           <th className="px-3 py-4 u-hide-for-mobile">Starting Intersection</th>

--- a/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/detourListPage.test.tsx.snap
@@ -2,12 +2,14 @@
 
 exports[`DetourListPage renders detour list page with dummy data 1`] = `
 <div
-  className="c-detour-list-page h-100 overflow-y-auto p-4 bg-white"
+  className="c-detour-list-page h-100 overflow-y-auto p-0 p-md-4 bg-white"
 >
   <table
     className="c-detours-table table table-hover"
   >
-    <thead>
+    <thead
+      className="u-hide-for-mobile"
+    >
       <tr>
         <th
           className="px-3 py-4"


### PR DESCRIPTION
# Desktop

<img width="1128" alt="Screenshot 2024-09-05 at 4 54 05 PM" src="https://github.com/user-attachments/assets/8cf32b47-893e-48fc-8258-ebeb8a5b4c7a">

# Tablet Portrait

<img width="728" alt="Screenshot 2024-09-05 at 4 50 21 PM" src="https://github.com/user-attachments/assets/cbc76b93-8e2a-435f-b75f-df7c144b7c90">

# Mobile

<img width="431" alt="Screenshot 2024-09-05 at 4 50 35 PM" src="https://github.com/user-attachments/assets/f8893a29-ffe7-4de4-9f6a-530598437665">

---

Asana Ticket: https://app.asana.com/0/1205385723132845/1208226797938041/f

Depends on:
- https://github.com/mbta/skate/pull/2778
