### PR TITLE
refactor: Update boostrap breakpoints and use them for u-hide-for-mobile

### DIFF
--- a/assets/css/bootstrap/_variable_overrides.scss
+++ b/assets/css/bootstrap/_variable_overrides.scss
@@ -16,3 +16,21 @@ $ui-alert: semantic.$ui-alert;
 $service-alert: semantic.$service-alert;
 $light: new_tokens.$gray-50;
 $dark: new_tokens.$gray-900;
+
+// These breakpoints are overridden in order to match with our old set
+// of breakpoints, defined in _skate_ui.scss. Our long-term goal is to
+// replace our "custom" breakpoint system with these bootstrap
+// breakpoints, and then possibly to change these values to match our
+// forward-looking designs.
+$grid-breakpoints: (
+  xs: 0,
+
+  // sm - Breakpoint between mobile and tablet
+  sm: 480px,
+
+  // md - Breakpoint between tablet and desktop
+  md: 800px,
+
+  // lg - Breakpoint between desktop and wide-screen desktop
+  lg: 1340px,
+);

--- a/assets/css/utilities/_hideable.scss
+++ b/assets/css/utilities/_hideable.scss
@@ -11,7 +11,7 @@
 }
 
 .u-hide-for-mobile {
-  @media screen and (max-width: map-get($breakpoints, "max-mobile-landscape-tablet-portrait-width")) {
+  @include media-breakpoint-down(md) {
     display: none;
   }
 }


### PR DESCRIPTION
No Asana Ticket.

We had our own custom collection of breakpoints, but Bootstrap also provides a ton of utility classes that allow us to easily make things responsive. The catch: Bootstrap's default breakpoints are different from the ones we were using.

This updates Skate's bootstrap-breakpoint variable to use our previous breakpoints, and the `u-hide-for-mobile` utility class to use the bootstrap breakpoint instead of our home-rolled one.