### PR TITLE
fix: Prevent detour list page from overflowing Skate's application size

### DIFF
--- a/assets/css/_detour_list_page.scss
+++ b/assets/css/_detour_list_page.scss
@@ -1,4 +1,6 @@
 .c-detour-list-page {
+  box-sizing: border-box;
+
   .c-detour-list-page__button {
     margin-bottom: 2.25rem;
   }


### PR DESCRIPTION
# Before

![Screenshot 2024-09-09 at 4 36 21 PM](https://github.com/user-attachments/assets/e7cb315a-5c50-4df5-ab0d-d945315d0f6c)

Notice two scroll bars, and the weird rendering (because scrolling) in the nav bar on the left.


# After
![Screenshot 2024-09-09 at 4 35 44 PM](https://github.com/user-attachments/assets/0d13de02-4e7d-4c91-806d-584f07c9729e)

---
No Asana Ticket