### PR TITLE
fix: Need to query the table in order of latest updates

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -58,8 +58,11 @@ defmodule Skate.Detours.Detours do
   """
   def grouped_detours(user_id) do
     detours =
-      Detour
-      |> Repo.all()
+      Repo.all(
+        from(d in Detour,
+          order_by: [desc: d.updated_at]
+        )
+      )
       |> Enum.map(fn detour -> db_detour_to_detour(detour, user_id) end)
       |> Enum.filter(& &1)
       |> Enum.group_by(fn detour -> detour.status end)


### PR DESCRIPTION
Realized the db should be queried in order of most recently updated detours, for all cases.