### PR TITLE
feat: Add properly-formatted headers to the detours list page

### DIFF
--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -61,16 +61,21 @@ export const DetourListPage = () => {
       )}
       {detours && (
         <>
+          <Title title="Active detours" />
           <DetoursTable
             data={detours.active}
             status={DetourStatus.Active}
             onOpenDetour={onOpenDetour}
+            classNames={["mb-5"]}
           />
+          <Title title="Draft detours" />
           <DetoursTable
             data={detours.draft}
             status={DetourStatus.Draft}
             onOpenDetour={onOpenDetour}
+            classNames={["mb-5"]}
           />
+          <Title title="Closed detours" />
           <DetoursTable
             data={detours.past}
             status={DetourStatus.Closed}
@@ -95,3 +100,7 @@ export const DetourListPage = () => {
     </div>
   )
 }
+
+const Title = ({ title }: { title: string }) => (
+  <h2 className="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0">{title}</h2>
+)

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -5,11 +5,13 @@ import { useCurrentTimeSeconds } from "../hooks/useCurrentTime"
 import { timeAgoLabel } from "../util/dateTime"
 import { SimpleDetour } from "../models/detoursList"
 import { EmptyDetourTableIcon } from "../helpers/skateIcons"
+import { joinClasses } from "../helpers/dom"
 
 interface DetoursTableProps {
   data: SimpleDetour[] | undefined
   onOpenDetour: (detourId: number) => void
   status: DetourStatus
+  classNames?: string[]
 }
 
 export enum DetourStatus {
@@ -35,8 +37,12 @@ export const DetoursTable = ({
   data,
   onOpenDetour,
   status,
+  classNames = [],
 }: DetoursTableProps) => (
-  <Table hover={!!data} className="c-detours-table">
+  <Table
+    hover={!!data}
+    className={joinClasses([...classNames, "c-detours-table"])}
+  >
     <thead className="u-hide-for-mobile">
       <tr>
         <th className="px-3 py-4">Route and direction</th>

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -6,8 +6,13 @@ exports[`DetourListPage renders detour list page 1`] = `
     <div
       class="c-detour-list-page h-100 overflow-y-auto p-0 p-md-4 bg-white"
     >
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Active detours
+      </h2>
       <table
-        class="c-detours-table table table-hover"
+        class="mb-5 c-detours-table table table-hover"
       >
         <thead
           class="u-hide-for-mobile"
@@ -111,8 +116,13 @@ exports[`DetourListPage renders detour list page 1`] = `
           </tr>
         </tbody>
       </table>
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Draft detours
+      </h2>
       <table
-        class="c-detours-table table"
+        class="mb-5 c-detours-table table"
       >
         <thead
           class="u-hide-for-mobile"
@@ -180,6 +190,11 @@ exports[`DetourListPage renders detour list page 1`] = `
           </tr>
         </tbody>
       </table>
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Closed detours
+      </h2>
       <table
         class="c-detours-table table table-hover"
       >

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -9,8 +9,13 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
     <div
       class="c-detour-list-page h-100 overflow-y-auto p-0 p-md-4 bg-white"
     >
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Active detours
+      </h2>
       <table
-        class="c-detours-table table table-hover"
+        class="mb-5 c-detours-table table table-hover"
       >
         <thead
           class="u-hide-for-mobile"
@@ -114,8 +119,13 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
           </tr>
         </tbody>
       </table>
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Draft detours
+      </h2>
       <table
-        class="c-detours-table table"
+        class="mb-5 c-detours-table table"
       >
         <thead
           class="u-hide-for-mobile"
@@ -183,6 +193,11 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
           </tr>
         </tbody>
       </table>
+      <h2
+        class="fw-semibold fs-1 mt-3 mt-md-0 mb-3 mx-3 mx-md-0"
+      >
+        Closed detours
+      </h2>
       <table
         class="c-detours-table table table-hover"
       >


### PR DESCRIPTION
# Desktop

<img width="1287" alt="Screenshot 2024-09-11 at 10 15 34 AM" src="https://github.com/user-attachments/assets/951a348e-1b9c-48f8-8868-b4f679e50262">

# Mobile

<img width="400" alt="Screenshot 2024-09-11 at 10 15 45 AM" src="https://github.com/user-attachments/assets/36dbef87-34a3-4365-a97b-f2a17d09a137">

---

Asana Ticket: https://app.asana.com/0/1205718271156548/1208214740600735/f

Depends on:
- https://github.com/mbta/skate/pull/2777 (a git-conflict dependency - if needed, I can move things around so that this gets released first)