### PR TITLE
feat: create detour notification table

### DIFF
--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -69,7 +69,7 @@ export const NotificationData = type({
   id: coerce(string(), number(), (i) => i.toString()),
   created_at: dateFromSeconds,
   state: enums(["unread", "read", "deleted"]),
-  // Requires a field named `$type` to be present as the discriminator
+  // Requires a field named `__struct__` to be present as the discriminator
   content: union([BridgeNotificationData, BlockWaiverNotificationData]),
 })
 export type NotificationData = Infer<typeof NotificationData>

--- a/lib/notifications/db/detour.ex
+++ b/lib/notifications/db/detour.ex
@@ -1,0 +1,36 @@
+defmodule Notifications.Db.Detour do
+  @moduledoc """
+  Ecto Model for Detour Notifications struct and Database table
+  """
+
+  use Skate.Schema
+  import Ecto.Changeset
+
+  @derive {Jason.Encoder,
+           only: [
+             :__struct__,
+             :status
+           ]}
+
+  typed_schema "detour_notifications" do
+    belongs_to :detour, Skate.Detours.Db.Detour
+    has_one :notification, Notifications.Db.Notification
+
+    field :status, Ecto.Enum, values: [:activated]
+  end
+
+  def changeset(
+        %__MODULE__{} = struct,
+        attrs \\ %{}
+      ) do
+    struct
+    |> cast(attrs, [
+      :detour,
+      :status
+    ])
+    |> validate_required([
+      :detour,
+      :status
+    ])
+  end
+end

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -19,6 +19,7 @@ defmodule Notifications.Db.Notification do
 
     belongs_to(:block_waiver, DbBlockWaiver)
     belongs_to(:bridge_movement, DbBridgeMovement)
+    belongs_to(:detour, Notifications.Db.Detour)
   end
 
   def block_waiver_changeset(notification, attrs \\ %{}) do

--- a/priv/repo/migrations/20240909134311_create_detour_notifications_table.exs
+++ b/priv/repo/migrations/20240909134311_create_detour_notifications_table.exs
@@ -1,0 +1,10 @@
+defmodule Skate.Repo.Migrations.CreateDetourNotificationsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:detour_notifications) do
+      add :detour_id, references(:detours, on_delete: :nothing)
+      add :status, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20240909134742_create_detour_notifications_index.exs
+++ b/priv/repo/migrations/20240909134742_create_detour_notifications_index.exs
@@ -1,0 +1,10 @@
+defmodule Skate.Repo.Migrations.CreateDetourNotificationsIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create index(:detour_notifications, [:detour_id], concurrently: true)
+  end
+end

--- a/priv/repo/migrations/20240909200808_create_detour_notifications_reference.exs
+++ b/priv/repo/migrations/20240909200808_create_detour_notifications_reference.exs
@@ -1,0 +1,9 @@
+defmodule Skate.Repo.Migrations.CreateDetourNotificationsReference do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      add(:detour_id, references(:detour_notifications))
+    end
+  end
+end


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/0/1208312289539633/f

Not sure if this PR is too small, but I'm fairly certain this will be the final shape of the table and that could be merged first.

This adds a field to the notifications table, because there were errors if it wasn't added, but it's intended that this table is entirely unused as of this PR, following PRs will use this table.

If this PR is too small I can roll this table creation into a PR that uses it.