### PR TITLE
feat:doc: stub doc headers for database tables

### DIFF
--- a/lib/notifications/db/block_waiver.ex
+++ b/lib/notifications/db/block_waiver.ex
@@ -1,5 +1,7 @@
 defmodule Notifications.Db.BlockWaiver do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `block_waivers` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/notifications/db/bridge_movement.ex
+++ b/lib/notifications/db/bridge_movement.ex
@@ -1,5 +1,7 @@
 defmodule Notifications.Db.BridgeMovement do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `bridge_movements` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -1,5 +1,7 @@
 defmodule Notifications.Db.Notification do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `notifications` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/notifications/db/notification_user.ex
+++ b/lib/notifications/db/notification_user.ex
@@ -1,5 +1,7 @@
 defmodule Notifications.Db.NotificationUser do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `notification_users` Database table
+  """
 
   use Skate.Schema
 

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Detours.Db.Detour do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `detours` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/skate/schema.ex
+++ b/lib/skate/schema.ex
@@ -5,6 +5,8 @@ defmodule Skate.Schema do
 
   defmacro __using__(_opts) do
     quote do
+      @moduledoc section: :ecto
+
       use TypedEctoSchema
     end
   end

--- a/lib/skate/settings/db/route_tab.ex
+++ b/lib/skate/settings/db/route_tab.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Settings.Db.RouteTab do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `route_tabs` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/skate/settings/db/test_group.ex
+++ b/lib/skate/settings/db/test_group.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Settings.Db.TestGroup do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `test_groups` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/skate/settings/db/test_group_user.ex
+++ b/lib/skate/settings/db/test_group_user.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Settings.Db.TestGroupUser do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `test_groups_users` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/skate/settings/db/user.ex
+++ b/lib/skate/settings/db/user.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Settings.Db.User do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `users` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/lib/skate/settings/db/user_settings.ex
+++ b/lib/skate/settings/db/user_settings.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Settings.Db.UserSettings do
-  @moduledoc false
+  @moduledoc """
+  Ecto Model for `user_settings` Database table
+  """
 
   use Skate.Schema
   import Ecto.Changeset

--- a/mix.exs
+++ b/mix.exs
@@ -15,9 +15,17 @@ defmodule Skate.MixProject do
       consolidate_protocols: Mix.env() != :test,
       dialyzer: [
         plt_add_apps: [:mix]
-      ]
+      ],
+      docs: docs_config()
     ]
   end
+
+  def docs_config,
+    do: [
+      groups_for_modules: [
+        "Ecto Schemas": &(&1[:section] == :ecto)
+      ]
+    ]
 
   # Configuration for the OTP application.
   #


### PR DESCRIPTION
`mix docs` doesn't generate anything for these modules if `@moduledoc false` is set, but we're using `TypedEctoSchema` now which _does_ generate type information, which can be surfaced by `ExDoc`.

It's also impossible to link to modules in documentation if `@moduledoc false` is set.

I've also created a ExDoc group which is enabled via setting the option on `@moduledoc` `section: :ecto`, this should make it easier to find our database related code, and easier to navigate in the documentation.

---

It is possible to do this automatically for Ecto schemas, by setting this attribute in the shared `Skate.Schema` module. I do think this is neat, but I'm not really _certain_(i.e., let's discuss) this is a good decision?

```diff
diff --git a/lib/skate/schema.ex b/lib/skate/schema.ex
index d18c8b83e3..cde6e814cd 100644
--- a/lib/skate/schema.ex
+++ b/lib/skate/schema.ex
@@ -5,6 +5,8 @@
 
   defmacro __using__(_opts) do
     quote do
+      @module_doc section: :ecto
+
       use TypedEctoSchema
     end
   end
```

I like that this means we don't need to _remember_ to add `section: :ecto` to all new Ecto schemas, because we have a growing list of "conventions" which are difficult to keep all in your head. But on the other hand, putting the `@module_doc` in the schema macro removes the choice later to easily change the `section: :ecto` value, I looked into making the `@module_doc` setting conditional, but wasn't very successful on my first attempt.