### PR TITLE
feat: Suppress "Return to regular route" button for non-dispatchers

### DIFF
--- a/assets/src/components/detours/activeDetourPanel.tsx
+++ b/assets/src/components/detours/activeDetourPanel.tsx
@@ -92,14 +92,16 @@ export const ActiveDetourPanel = ({
       </Panel.Body.ScrollArea>
 
       <Panel.Body.Footer>
-        <Button
-          variant="ui-alert"
-          className="flex-grow-1 m-3 icon-link text-light"
-          onClick={onOpenDeactivateModal}
-        >
-          <StopCircle />
-          Return to regular route
-        </Button>
+        {onOpenDeactivateModal && (
+          <Button
+            variant="ui-alert"
+            className="flex-grow-1 m-3 icon-link text-light"
+            onClick={onOpenDeactivateModal}
+          >
+            <StopCircle />
+            Return to regular route
+          </Button>
+        )}
       </Panel.Body.Footer>
     </Panel.Body>
     {children}

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -350,9 +350,13 @@ export const DiversionPage = ({
               routeOrigin={routeOrigin ?? "??"}
               routeDirection={routeDirection ?? "??"}
               onNavigateBack={onConfirmClose}
-              onOpenDeactivateModal={() => {
-                send({ type: "detour.active.open-deactivate-modal" })
-              }}
+              onOpenDeactivateModal={
+                userInTestGroup(TestGroups.DetoursPilot)
+                  ? () => {
+                      send({ type: "detour.active.open-deactivate-modal" })
+                    }
+                  : undefined
+              }
             >
               {snapshot.matches({
                 "Detour Drawing": { Active: "Deactivating" },

--- a/assets/tests/components/detours/diversionPage.deactivate.test.tsx
+++ b/assets/tests/components/detours/diversionPage.deactivate.test.tsx
@@ -130,4 +130,12 @@ describe("DiversionPage deactivate workflow", () => {
 
     expect(returnModalHeading.query()).not.toBeInTheDocument()
   })
+
+  test("does not have a 'Return to regular route' button for users who are not dispatchers", async () => {
+    jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
+
+    await diversionPageOnActiveDetourScreen()
+
+    expect(regularRouteButton.query()).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
No Asana Ticket, but I noticed this while playing around with detours, and didn't think it should be lumped in with https://github.com/mbta/skate/pull/2805.

Depends on:
- https://github.com/mbta/skate/pull/2805
  - Not a real semantic conflict, but doing it in sequence avoids annoying git conflicts.