### PR TITLE
feat: Contents for past detour page

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -366,7 +366,19 @@ export const DiversionPage = ({
               ) : null}
             </ActiveDetourPanel>
           ) : snapshot.matches({ "Detour Drawing": "Past" }) ? (
-            <PastDetourPanel />
+            <PastDetourPanel
+              directions={extendedDirections}
+              connectionPoints={[
+                connectionPoints?.start?.name ?? "N/A",
+                connectionPoints?.end?.name ?? "N/A",
+              ]}
+              missedStops={missedStops}
+              routeName={routeName ?? "??"}
+              routeDescription={routeDescription ?? "??"}
+              routeOrigin={routeOrigin ?? "??"}
+              routeDirection={routeDirection ?? "??"}
+              onNavigateBack={onConfirmClose}
+            />
           ) : null}
         </div>
         <div className="l-diversion-page__map position-relative">

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -377,7 +377,7 @@ export const DiversionPage = ({
               routeDescription={routeDescription ?? "??"}
               routeOrigin={routeOrigin ?? "??"}
               routeDirection={routeDirection ?? "??"}
-              onNavigateBack={onConfirmClose}
+              onNavigateBack={onClose}
             />
           ) : null}
         </div>

--- a/assets/src/components/detours/pastDetourPanel.tsx
+++ b/assets/src/components/detours/pastDetourPanel.tsx
@@ -8,7 +8,7 @@ import { AffectedRoute, MissedStops } from "./detourPanelComponents"
 
 export interface PastDetourPanelProps {
   directions?: DetourDirection[]
-  connectionPoints?: string[]
+  connectionPoints: [string, string]
   missedStops?: Stop[]
   routeName: string
   routeDescription: string
@@ -19,7 +19,7 @@ export interface PastDetourPanelProps {
 
 export const PastDetourPanel = ({
   directions,
-  connectionPoints,
+  connectionPoints: [connectionPointStart, connectionPointEnd],
   missedStops,
   routeName,
   routeDescription,
@@ -53,15 +53,13 @@ export const PastDetourPanel = ({
           routeDirection={routeDirection}
         />
 
-        {connectionPoints && (
-          <section className="pb-3">
-            <h2 className="c-diversion-panel__h2">Connection Points</h2>
-            <ListGroup as="ul">
-              <ListGroup.Item>{connectionPoints[0]}</ListGroup.Item>
-              <ListGroup.Item>{connectionPoints[1]}</ListGroup.Item>
-            </ListGroup>
-          </section>
-        )}
+        <section className="pb-3">
+          <h2 className="c-diversion-panel__h2">Connection Points</h2>
+          <ListGroup as="ul">
+            <ListGroup.Item>{connectionPointStart}</ListGroup.Item>
+            <ListGroup.Item>{connectionPointEnd}</ListGroup.Item>
+          </ListGroup>
+        </section>
 
         <MissedStops missedStops={missedStops} />
 

--- a/assets/src/components/detours/pastDetourPanel.tsx
+++ b/assets/src/components/detours/pastDetourPanel.tsx
@@ -1,12 +1,87 @@
 import React from "react"
 import { Panel } from "./diversionPage"
+import { DetourDirection } from "../../models/detour"
+import { Stop } from "../../schedule"
+import { ArrowLeft } from "../../helpers/bsIcons"
+import { Button, ListGroup } from "react-bootstrap"
+import { AffectedRoute, MissedStops } from "./detourPanelComponents"
 
-export const PastDetourPanel = () => (
+export interface PastDetourPanelProps {
+  directions?: DetourDirection[]
+  connectionPoints?: string[]
+  missedStops?: Stop[]
+  routeName: string
+  routeDescription: string
+  routeOrigin: string
+  routeDirection: string
+  onNavigateBack: () => void
+}
+
+export const PastDetourPanel = ({
+  directions,
+  connectionPoints,
+  missedStops,
+  routeName,
+  routeDescription,
+  routeOrigin,
+  routeDirection,
+  onNavigateBack,
+}: PastDetourPanelProps) => (
   <Panel as="article">
     <Panel.Header className="">
       <h1 className="c-diversion-panel__h1 my-3">Past Detour</h1>
     </Panel.Header>
 
-    <Panel.Body className="d-flex flex-column"></Panel.Body>
+    <Panel.Body className="d-flex flex-column">
+      <Panel.Body.ScrollArea>
+        <div className="d-flex justify-content-between align-items-center">
+          {onNavigateBack && (
+            <Button
+              className="icon-link my-3"
+              variant="outline-primary"
+              onClick={onNavigateBack}
+            >
+              <ArrowLeft />
+              Back
+            </Button>
+          )}
+        </div>
+        <AffectedRoute
+          routeName={routeName}
+          routeDescription={routeDescription}
+          routeOrigin={routeOrigin}
+          routeDirection={routeDirection}
+        />
+
+        {connectionPoints && (
+          <section className="pb-3">
+            <h2 className="c-diversion-panel__h2">Connection Points</h2>
+            <ListGroup as="ul">
+              <ListGroup.Item>{connectionPoints[0]}</ListGroup.Item>
+              <ListGroup.Item>{connectionPoints[1]}</ListGroup.Item>
+            </ListGroup>
+          </section>
+        )}
+
+        <MissedStops missedStops={missedStops} />
+
+        <section className="pb-3">
+          <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+          {directions ? (
+            <ListGroup as="ol">
+              {directions.map((d) => (
+                <ListGroup.Item key={d.instruction} as="li">
+                  {d.instruction == "Regular Route" ? (
+                    <strong className="fw-medium">{d.instruction}</strong>
+                  ) : (
+                    d.instruction
+                  )}
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          ) : null}
+        </section>
+      </Panel.Body.ScrollArea>
+    </Panel.Body>
   </Panel>
 )

--- a/assets/src/components/detours/pastDetourPanel.tsx
+++ b/assets/src/components/detours/pastDetourPanel.tsx
@@ -29,7 +29,7 @@ export const PastDetourPanel = ({
 }: PastDetourPanelProps) => (
   <Panel as="article">
     <Panel.Header className="">
-      <h1 className="c-diversion-panel__h1 my-3">Past Detour</h1>
+      <h1 className="c-diversion-panel__h1 my-3">View Past Detour</h1>
     </Panel.Header>
 
     <Panel.Body className="d-flex flex-column">

--- a/assets/stories/skate-components/detours/pastDetourPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/pastDetourPanel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import React from "react"
 import { PastDetourPanel } from "../../../src/components/detours/pastDetourPanel"
+import { stopFactory } from "../../../tests/factories/stop"
 
 const meta = {
   component: PastDetourPanel,
@@ -9,7 +10,26 @@ const meta = {
     layout: "fullscreen",
     stretch: true,
   },
-  args: {},
+  args: {
+    directions: [
+      { instruction: "Start at Centre St & John St" },
+      { instruction: "Right on John St" },
+      { instruction: "Left on Abbotsford Rd" },
+      { instruction: "Right on Boston St" },
+      { instruction: "Regular Route" },
+    ],
+    connectionPoints: ["Centre St & John St", "Boston St"],
+    missedStops: [
+      stopFactory.build({ name: "Example St @ Sample Ave" }),
+      stopFactory.build({ name: "Example St opp Random Way" }),
+      stopFactory.build({ name: "Example St @ Fake Blvd" }),
+    ],
+    routeName: "66",
+    routeDescription: "Harvard via Allston",
+    routeOrigin: "from Andrew Station",
+    routeDirection: "Outbound",
+    onNavigateBack: undefined,
+  },
   // The bootstrap CSS reset is supposed to set box-sizing: border-box by
   // default, we should be able to remove this after that is added
   decorators: [

--- a/assets/tests/components/detours/diversionPage.deactivate.test.tsx
+++ b/assets/tests/components/detours/diversionPage.deactivate.test.tsx
@@ -82,7 +82,7 @@ const threeHoursRadio = byRole("radio", { name: "3 hours" })
 const constructionRadio = byRole("radio", { name: "Construction" })
 
 const activeDetourHeading = byRole("heading", { name: "Active Detour" })
-const pastDetourHeading = byRole("heading", { name: "Past Detour" })
+const pastDetourHeading = byRole("heading", { name: "View Past Detour" })
 const returnModalHeading = byRole("heading", {
   name: "Return to regular route?",
 })


### PR DESCRIPTION
# Before

![Screenshot 2024-09-25 at 3 56 20 PM](https://github.com/user-attachments/assets/81b8f666-7aa4-4979-ab0f-6916fe6ea384)

# After

<img width="1386" alt="Screenshot 2024-09-26 at 11 59 31 AM" src="https://github.com/user-attachments/assets/67815d73-758f-4c9c-bfde-89e14911bf86">

---

This doesn't _exactly_ match the hi-fi designs, but I think it's still worth merging so that we don't have the obnoxious experience of having all the content disappear when a detour is deactivated.

The remaining things that I'm thinking of at the moment, which I think should be follow-up PR's are:
- Copy Details button in the header
- Created by and `Last used` in the header (kinda sorta blocked by https://github.com/mbta/skate/pull/2806, since that does this hi-fi task for the active detour panel)

Asana Ticket: https://app.asana.com/0/1205385723132845/1208391763317540/f