### PR TITLE
feat(ts/notifications): create notification card for detours

### DIFF
--- a/assets/src/components/notificationBellIcon.tsx
+++ b/assets/src/components/notificationBellIcon.tsx
@@ -4,6 +4,8 @@ import { joinClasses } from "../helpers/dom"
 import { NotificationBellIcon as NotificationBellIconSvg } from "../helpers/icon"
 import { OpenView } from "../state/pagePanelState"
 import { usePanelStateFromStateDispatchContext } from "../hooks/usePanelState"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
+import { NotificationType } from "../realtime"
 
 const NotificationBellIcon = ({
   extraClasses,
@@ -14,8 +16,14 @@ const NotificationBellIcon = ({
     currentView: { openView },
   } = usePanelStateFromStateDispatchContext()
   const { notifications } = useContext(NotificationsContext)
+
+  const inDetoursList = inTestGroup(TestGroups.DetoursList)
   const unreadNotifications = (notifications || []).filter(
-    (notification) => notification.state === "unread"
+    (notification) =>
+      notification.state === "unread" &&
+      !(
+        notification.content.$type === NotificationType.Detour && !inDetoursList
+      )
   )
   const unreadBadge: boolean = unreadNotifications.length > 0
 

--- a/assets/src/components/notificationCard.tsx
+++ b/assets/src/components/notificationCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react"
+import React, { ReactNode } from "react"
 import { useRoute, useRoutes } from "../contexts/routesContext"
 import {
   BlockWaiverNotification,
@@ -11,6 +11,8 @@ import { Route } from "../schedule"
 import { formattedTime } from "../util/dateTime"
 import { CardBody, CardProperties, CardReadable } from "./card"
 import { fullStoryEvent } from "../helpers/fullStory"
+import { RoutePill } from "./routePill"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 
 export const NotificationCard = ({
   notification,
@@ -24,7 +26,7 @@ export const NotificationCard = ({
   openVPPForCurrentVehicle: (notification: Notification) => void
   hideLatestNotification?: () => void
   noFocusOrHover?: boolean
-}): ReactElement<HTMLElement> => {
+}) => {
   const routes = useRoutes(
     isBlockWaiverNotification(notification) ? notification.content.routeIds : []
   )
@@ -33,6 +35,14 @@ export const NotificationCard = ({
       ? notification.content.routeIdAtCreation
       : null
   )
+
+  if (
+    notification.content.$type === NotificationType.Detour &&
+    !inTestGroup(TestGroups.DetoursList)
+  ) {
+    return null
+  }
+
   const isUnread = notification.state === "unread"
   return (
     <CardReadable
@@ -87,6 +97,11 @@ export const title = (notification: Notification) => {
     case NotificationType.BlockWaiver: {
       return blockWaiverNotificationTitle(notification.content.reason)
     }
+
+    case NotificationType.Detour: {
+      return "Detour - Active"
+    }
+
     case NotificationType.BridgeMovement: {
       switch (notification.content.status) {
         case "lowered":
@@ -156,7 +171,7 @@ const description = (
   notification: Notification,
   routes: Route[],
   routeAtCreation: Route | null
-): string => {
+): ReactNode => {
   switch (notification.content.$type) {
     case NotificationType.BlockWaiver: {
       return blockWaiverDescription(
@@ -165,6 +180,24 @@ const description = (
         routeAtCreation
       )
     }
+
+    case NotificationType.Detour: {
+      return (
+        <>
+          <div className="d-flex flex-row gap-2">
+            <RoutePill routeName={notification.content.route} />
+            <div>
+              <div className="fw-semibold">{notification.content.headsign}</div>
+              <div className="fw-normal text-body-secondary">
+                From {notification.content.origin.split(" - ")[0]}
+              </div>
+              <div className="fw-normal">{notification.content.direction}</div>
+            </div>
+          </div>
+        </>
+      )
+    }
+
     case NotificationType.BridgeMovement: {
       switch (notification.content.status) {
         case "raised":

--- a/assets/src/models/detoursList.ts
+++ b/assets/src/models/detoursList.ts
@@ -1,7 +1,8 @@
 import { array, Infer, nullable, number, string, type } from "superstruct"
 
+export type DetourId = number
 export interface SimpleDetour {
-  id: number
+  id: DetourId
   route: string
   direction: string
   name: string
@@ -9,8 +10,9 @@ export interface SimpleDetour {
   updatedAt: number
 }
 
+export const detourId = number()
 export const SimpleDetourData = type({
-  id: number(),
+  id: detourId,
   route: string(),
   direction: string(),
   name: string(),

--- a/assets/src/realtime.ts
+++ b/assets/src/realtime.ts
@@ -10,6 +10,7 @@ import {
 } from "./schedule"
 
 import { Crowding } from "./models/crowding"
+import { DetourId } from "./models/detoursList"
 
 export interface BlockWaiver {
   startTime: Date
@@ -59,6 +60,7 @@ export type NotificationId = string
 export enum NotificationType {
   BridgeMovement = "Elixir.Notifications.Db.BridgeMovement",
   BlockWaiver = "Elixir.Notifications.Db.BlockWaiver",
+  Detour = "Elixir.Notifications.Db.Detour",
 }
 
 export interface BridgeLoweredNotification {
@@ -90,9 +92,20 @@ export type BlockWaiverNotification = {
   endTime: Date | null
 }
 
+export type DetourNotification = {
+  $type: NotificationType.Detour
+  detourId: DetourId
+  headsign: string
+  route: string
+  direction: string
+  origin: string
+}
+
 export type NotificationContentTypes =
   | BridgeNotification
   | BlockWaiverNotification
+  | DetourNotification
+
 export interface Notification<
   TNotification extends NotificationContentTypes = NotificationContentTypes
 > {

--- a/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
@@ -45,23 +45,25 @@ exports[`NotificationBellIcon renders when the drawer is open and there are not 
 `;
 
 exports[`NotificationBellIcon renders when there are new detour notifications and user is not part of DetoursList 1`] = `
-<span
-  className="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
-  dangerouslySetInnerHTML={
-    {
-      "__html": "<svg/>",
-    }
-  }
-/>
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
 `;
 
 exports[`NotificationBellIcon renders when there are new detour notifications and user is part of DetoursList group 1`] = `
-<span
-  className="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
-  dangerouslySetInnerHTML={
-    {
-      "__html": "<svg/>",
-    }
-  }
-/>
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
 `;

--- a/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
@@ -43,3 +43,25 @@ exports[`NotificationBellIcon renders when the drawer is open and there are not 
   }
 />
 `;
+
+exports[`NotificationBellIcon renders when there are new detour notifications and user is not part of DetoursList 1`] = `
+<span
+  className="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
+  dangerouslySetInnerHTML={
+    {
+      "__html": "<svg/>",
+    }
+  }
+/>
+`;
+
+exports[`NotificationBellIcon renders when there are new detour notifications and user is part of DetoursList group 1`] = `
+<span
+  className="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
+  dangerouslySetInnerHTML={
+    {
+      "__html": "<svg/>",
+    }
+  }
+/>
+`;

--- a/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
@@ -43,19 +43,19 @@ exports[`NotificationCard renders detour notification if user is in DetoursList 
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  3
+                  2
                 </div>
                 <div>
                   <div
                     class="fw-semibold"
                   >
-                    Headsign 3
+                    Headsign 2
                   </div>
                   <div
                     class="fw-normal text-body-secondary"
                   >
                     From 
-                    Origin station 3
+                    Origin station 2
                   </div>
                   <div
                     class="fw-normal"

--- a/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationCard renders detour notification if user is in DetoursList group 1`] = `
+<body>
+  <div>
+    <div
+      aria-labelledby="card-label-:rh:"
+      class="c-card c-card--kiwi"
+    >
+      <button
+        class="c-card__left"
+      >
+        <div
+          class="c-card__left-content"
+        >
+          <div
+            class="c-card__top-row"
+          >
+            <div
+              class="c-card__title"
+              id="card-label-:rh:"
+            >
+              <span>
+                <svg />
+              </span>
+              Detour - Active
+            </div>
+            <div
+              class="c-card__time"
+            >
+              0 min
+            </div>
+          </div>
+          <div
+            class="c-card__contents"
+          >
+            <div
+              class="c-card__body"
+            >
+              <div
+                class="d-flex flex-row gap-2"
+              >
+                <div
+                  class="c-route-pill c-route-pill--bus"
+                >
+                  3
+                </div>
+                <div>
+                  <div
+                    class="fw-semibold"
+                  >
+                    Headsign 3
+                  </div>
+                  <div
+                    class="fw-normal text-body-secondary"
+                  >
+                    From 
+                    Origin station 3
+                  </div>
+                  <div
+                    class="fw-normal"
+                  >
+                    Outbound
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/assets/tests/components/notificationBellIcon.test.tsx
+++ b/assets/tests/components/notificationBellIcon.test.tsx
@@ -12,16 +12,18 @@ import { initialState } from "../../src/state"
 import { OpenView } from "../../src/state/pagePanelState"
 import stateFactory from "../factories/applicationState"
 import { viewFactory } from "../factories/pagePanelStateFactory"
-import { blockWaiverNotificationFactory, detourActivatedNotificationFactory } from "../factories/notification"
+import {
+  blockWaiverNotificationFactory,
+  detourActivatedNotificationFactory,
+} from "../factories/notification"
 import getTestGroups from "../../src/userTestGroups"
 import { TestGroups } from "../../src/userInTestGroup"
+import { render } from "@testing-library/react"
 
 jest.mock("../../src/userTestGroups")
 
 beforeEach(() => {
-  jest
-    .mocked(getTestGroups)
-    .mockReturnValue([])
+  jest.mocked(getTestGroups).mockReturnValue([])
 })
 
 const unreadNotification: Notification = blockWaiverNotificationFactory.build({
@@ -44,10 +46,11 @@ const unreadNotification: Notification = blockWaiverNotificationFactory.build({
   },
 })
 
-const unreadDetourNotification: Notification = detourActivatedNotificationFactory.build({
-  createdAt: new Date(0),
-  state: "unread"
-})
+const unreadDetourNotification: Notification =
+  detourActivatedNotificationFactory.build({
+    createdAt: new Date(0),
+    state: "unread",
+  })
 
 const readNotification: Notification = { ...unreadNotification, state: "read" }
 
@@ -137,34 +140,29 @@ describe("NotificationBellIcon", () => {
   })
 
   test("renders when there are new detour notifications and user is part of DetoursList group", () => {
-    jest
-      .mocked(getTestGroups)
-      .mockReturnValue([TestGroups.DetoursList])
+    jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
 
     const state = { ...initialState, openView: OpenView.None }
-    const tree = renderer
-      .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <NotificationsContext.Provider value={unreadDetourNotificationState}>
-            <NotificationBellIcon />
-          </NotificationsContext.Provider>
-        </StateDispatchProvider>
-      )
-      .toJSON()
-    expect(tree).toMatchSnapshot()
+    const { baseElement } = render(
+      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <NotificationsContext.Provider value={unreadDetourNotificationState}>
+          <NotificationBellIcon />
+        </NotificationsContext.Provider>
+      </StateDispatchProvider>
+    )
+
+    expect(baseElement).toMatchSnapshot()
   })
 
   test("renders when there are new detour notifications and user is not part of DetoursList", () => {
     const state = { ...initialState, openView: OpenView.None }
-    const tree = renderer
-      .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
-          <NotificationsContext.Provider value={unreadDetourNotificationState}>
-            <NotificationBellIcon />
-          </NotificationsContext.Provider>
-        </StateDispatchProvider>
-      )
-      .toJSON()
-    expect(tree).toMatchSnapshot()
+    const { baseElement } = render(
+      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <NotificationsContext.Provider value={unreadDetourNotificationState}>
+          <NotificationBellIcon />
+        </NotificationsContext.Provider>
+      </StateDispatchProvider>
+    )
+    expect(baseElement).toMatchSnapshot()
   })
 })

--- a/assets/tests/components/notificationBellIcon.test.tsx
+++ b/assets/tests/components/notificationBellIcon.test.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../src/contexts/notificationsContext"
 import { StateDispatchProvider } from "../../src/contexts/stateDispatchContext"
 import { Notification } from "../../src/realtime"
-import { initialState } from "../../src/state"
 import { OpenView } from "../../src/state/pagePanelState"
 import stateFactory from "../factories/applicationState"
 import { viewFactory } from "../factories/pagePanelStateFactory"
@@ -74,10 +73,12 @@ const readNotificationState: NotificationsState = {
 
 describe("NotificationBellIcon", () => {
   test("renders when the drawer is closed and there are new notifications", () => {
-    const state = { ...initialState, openView: OpenView.None }
     const tree = renderer
       .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <StateDispatchProvider
+          state={stateFactory.build()}
+          dispatch={jest.fn()}
+        >
           <NotificationsContext.Provider value={unreadNotificationState}>
             <NotificationBellIcon />
           </NotificationsContext.Provider>
@@ -108,10 +109,12 @@ describe("NotificationBellIcon", () => {
   })
 
   test("renders when the drawer is closed and there are not new notifications", () => {
-    const state = { ...initialState, openView: OpenView.None }
     const tree = renderer
       .create(
-        <StateDispatchProvider state={state} dispatch={jest.fn()}>
+        <StateDispatchProvider
+          state={stateFactory.build()}
+          dispatch={jest.fn()}
+        >
           <NotificationsContext.Provider value={readNotificationState}>
             <NotificationBellIcon />
           </NotificationsContext.Provider>
@@ -142,9 +145,8 @@ describe("NotificationBellIcon", () => {
   test("renders when there are new detour notifications and user is part of DetoursList group", () => {
     jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
 
-    const state = { ...initialState, openView: OpenView.None }
     const { baseElement } = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+      <StateDispatchProvider state={stateFactory.build()} dispatch={jest.fn()}>
         <NotificationsContext.Provider value={unreadDetourNotificationState}>
           <NotificationBellIcon />
         </NotificationsContext.Provider>
@@ -155,9 +157,8 @@ describe("NotificationBellIcon", () => {
   })
 
   test("renders when there are new detour notifications and user is not part of DetoursList", () => {
-    const state = { ...initialState, openView: OpenView.None }
     const { baseElement } = render(
-      <StateDispatchProvider state={state} dispatch={jest.fn()}>
+      <StateDispatchProvider state={stateFactory.build()} dispatch={jest.fn()}>
         <NotificationsContext.Provider value={unreadDetourNotificationState}>
           <NotificationBellIcon />
         </NotificationsContext.Provider>

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -254,7 +254,7 @@ describe("NotificationCard", () => {
 
   test("renders detour notification if user is in DetoursList group", () => {
     const n: Notification = detourActivatedNotificationFactory.build()
-    const {baseElement} = render(
+    const { baseElement } = render(
       <RoutesProvider routes={routes}>
         <NotificationCard
           notification={n}

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -1,4 +1,4 @@
-import { jest, describe, test, expect } from "@jest/globals"
+import { jest, describe, test, expect, beforeEach } from "@jest/globals"
 import React from "react"
 import { render } from "@testing-library/react"
 import { NotificationCard, title } from "../../src/components/notificationCard"
@@ -11,14 +11,22 @@ import {
   blockWaiverNotificationFactory,
   bridgeLoweredNotificationFactory,
   bridgeRaisedNotificationFactory,
+  detourActivatedNotificationFactory,
 } from "../factories/notification"
 import routeFactory from "../factories/route"
 import userEvent from "@testing-library/user-event"
 import { hideLatestNotification } from "../../src/hooks/useNotificationsReducer"
 import { RoutesProvider } from "../../src/contexts/routesContext"
 import { fullStoryEvent } from "../../src/helpers/fullStory"
+import getTestGroups from "../../src/userTestGroups"
+import { TestGroups } from "../../src/userInTestGroup"
 
 jest.mock("../../src/helpers/fullStory")
+jest.mock("../../src/userTestGroups")
+
+beforeEach(() => {
+  jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
+})
 
 const routes = [
   routeFactory.build({
@@ -244,6 +252,36 @@ describe("NotificationCard", () => {
     expect(dispatch).toHaveBeenCalledWith({ type: "HIDE_LATEST_NOTIFICATION" })
   })
 
+  test("renders detour notification if user is in DetoursList group", () => {
+    const n: Notification = detourActivatedNotificationFactory.build()
+    const {baseElement} = render(
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          currentTime={new Date()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
+    )
+    expect(baseElement).toMatchSnapshot()
+  })
+
+  test("does not render detour notification if user not in DetoursList group", () => {
+    jest.mocked(getTestGroups).mockReturnValue([])
+
+    const n: Notification = detourActivatedNotificationFactory.build()
+    const result = render(
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          currentTime={new Date()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
+    )
+    expect(result.queryByText(/Detour - Active/)).toBeNull()
+  })
+
   test.each<{
     notification: Notification
     should_fire_fs_event: boolean
@@ -319,6 +357,10 @@ describe("NotificationCard", () => {
           reason: "traffic",
         },
       }),
+    },
+    {
+      should_fire_fs_event: false,
+      notification: detourActivatedNotificationFactory.build({}),
     },
   ])(
     "clicking bridge notification should trigger FS event: $notification.content.reason",

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -4,6 +4,7 @@ import {
   BlockWaiverReason,
   BridgeLoweredNotification,
   BridgeRaisedNotification,
+  DetourNotification,
   Notification,
   NotificationType,
 } from "../../src/realtime"
@@ -83,4 +84,35 @@ export const bridgeLoweredNotificationFactory = Factory.define<
   createdAt: new Date(),
   state: "unread",
   content: bridgeLoweredNotificationContentFactory.build(),
+}))
+
+const detourActivatedNotificationContentFactory =
+  Factory.define<DetourNotification>(({ sequence }) => ({
+    $type: NotificationType.Detour,
+    status: "activated",
+    detourId: sequence,
+    headsign: `Headsign ${sequence}`,
+    route: `${sequence}`,
+    direction: "Outbound",
+    origin: `Origin station ${sequence}`,
+  }))
+
+export const detourActivatedNotificationFactory = Factory.define<
+  Notification<DetourNotification>
+>(({ sequence }) => ({
+  id: sequence.toString(),
+  createdAt: new Date(),
+  state: "unread",
+  content: detourActivatedNotificationContentFactory.build(),
+}))
+
+const detourDeactivatedNotificationContentFactory = {...detourActivatedNotificationContentFactory.build(), status: "deactivated"}
+
+export const detourDeactivatedNotificationFactory = Factory.define<
+  Notification<DetourNotification>
+>(({ sequence }) => ({
+  id: sequence.toString(),
+  createdAt: new Date(),
+  state: "unread",
+  content: detourDeactivatedNotificationContentFactory,
 }))

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -106,7 +106,10 @@ export const detourActivatedNotificationFactory = Factory.define<
   content: detourActivatedNotificationContentFactory.build(),
 }))
 
-const detourDeactivatedNotificationContentFactory = {...detourActivatedNotificationContentFactory.build(), status: "deactivated"}
+const detourDeactivatedNotificationContentFactory = {
+  ...detourActivatedNotificationContentFactory.build(),
+  status: "deactivated",
+}
 
 export const detourDeactivatedNotificationFactory = Factory.define<
   Notification<DetourNotification>

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -105,15 +105,3 @@ export const detourActivatedNotificationFactory = Factory.define<
   state: "unread",
   content: detourActivatedNotificationContentFactory.build(),
 }))
-
-const detourDeactivatedNotificationContentFactory =
-  detourActivatedNotificationContentFactory.params({ status: "deactivated" })
-
-export const detourDeactivatedNotificationFactory = Factory.define<
-  Notification<DetourNotification>
->(({ sequence }) => ({
-  id: sequence.toString(),
-  createdAt: new Date(),
-  state: "unread",
-  content: detourDeactivatedNotificationContentFactory,
-}))

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -106,7 +106,7 @@ export const detourActivatedNotificationFactory = Factory.define<
   content: detourActivatedNotificationContentFactory.build(),
 }))
 
-const detourDeactivatedNotificationContentFactory = 
+const detourDeactivatedNotificationContentFactory =
   detourActivatedNotificationContentFactory.params({ status: "deactivated" })
 
 export const detourDeactivatedNotificationFactory = Factory.define<

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -106,10 +106,8 @@ export const detourActivatedNotificationFactory = Factory.define<
   content: detourActivatedNotificationContentFactory.build(),
 }))
 
-const detourDeactivatedNotificationContentFactory = {
-  ...detourActivatedNotificationContentFactory.build(),
-  status: "deactivated",
-}
+const detourDeactivatedNotificationContentFactory = 
+  detourActivatedNotificationContentFactory.params({ status: "deactivated" })
 
 export const detourDeactivatedNotificationFactory = Factory.define<
   Notification<DetourNotification>

--- a/lib/notifications/db/detour.ex
+++ b/lib/notifications/db/detour.ex
@@ -9,6 +9,7 @@ defmodule Notifications.Db.Detour do
   @derive {Jason.Encoder,
            only: [
              :__struct__,
+             :detour_id,
              :status,
              :headsign,
              :route,


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/1203014709808707/1208393164852689/f


This creates the frontend part of notifications work, it's independent of other work because the parsing will not be triggered until the detour notification data is live and being sent.

Todo:
- [x] Tests(?)