### PR TITLE
fix(ex/db/notifications): update or delete notifications if detour is updated or deleted

### DIFF
--- a/priv/repo/migrations/20240924125339_fix_detour_delete.exs
+++ b/priv/repo/migrations/20240924125339_fix_detour_delete.exs
@@ -1,0 +1,42 @@
+defmodule Skate.Repo.Migrations.FixDetourDelete do
+  use Ecto.Migration
+
+  # excellent_migrations:safety-assured-for-this-file column_reference_added
+  # https://github.com/Artur-Sulej/excellent_migrations/blob/45c358d736ad51d9a32fba81f8d1373ff36043a6/README.md#adding-a-reference
+  # https://github.com/fly-apps/safe-ecto-migrations/blob/bb21e2409a25a2a8c0cae2d6e8fed046eaa0928f/README.md#adding-a-reference-or-foreign-key
+
+  def change do
+    # If a detour is deleted, delete the associated detour notifications
+    alter table(:detour_notifications) do
+      modify :detour_id,
+             references(
+               :detours,
+               on_delete: :delete_all,
+               on_update: :update_all,
+               validate: false
+             ),
+             from:
+               references(
+                 :posts,
+                 on_delete: :nothing,
+                 validate: false
+               )
+    end
+
+    # If a detour notification is deleted, delete the associated notification
+    alter table(:notifications) do
+      modify :detour_id,
+             references(
+               :detour_notifications,
+               on_delete: :delete_all,
+               on_update: :update_all,
+               validate: false
+             ),
+             from:
+               references(
+                 :detour_notifications,
+                 validate: false
+               )
+    end
+  end
+end

--- a/priv/repo/migrations/20240930144411_fix_detour_delete_validate.exs
+++ b/priv/repo/migrations/20240930144411_fix_detour_delete_validate.exs
@@ -1,0 +1,14 @@
+defmodule Skate.Repo.Migrations.FixDetourDeleteValidate do
+  use Ecto.Migration
+  # excellent_migrations:safety-assured-for-this-file raw_sql_executed
+  # https://github.com/Artur-Sulej/excellent_migrations/blob/45c358d736ad51d9a32fba81f8d1373ff36043a6/README.md#adding-a-reference
+  # https://github.com/fly-apps/safe-ecto-migrations/blob/bb21e2409a25a2a8c0cae2d6e8fed046eaa0928f/README.md#adding-a-reference-or-foreign-key
+  # https://github.com/Artur-Sulej/excellent_migrations/blob/45c358d736ad51d9a32fba81f8d1373ff36043a6/README.md#executing-sql-directly
+
+  def change do
+    execute "ALTER TABLE detour_notifications VALIDATE CONSTRAINT detour_notifications_detour_id_fkey",
+            ""
+
+    execute "ALTER TABLE notifications VALIDATE CONSTRAINT notifications_detour_id_fkey", ""
+  end
+end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -394,5 +394,20 @@ defmodule Notifications.NotificationTest do
                }
              } = detour_notification
     end
+
+    test "deletes associated detour notifications when detour is deleted" do
+      # create new notification and detour
+      detour = insert(:detour)
+
+      Notifications.Notification.create_activated_detour_notification_from_detour(detour)
+
+      # assert it is in the database
+      assert 1 == Skate.Repo.aggregate(Notifications.Db.Detour, :count)
+
+      Skate.Repo.delete!(detour)
+
+      assert 0 == Skate.Repo.aggregate(Notifications.Db.Detour, :count)
+      assert 0 == Skate.Repo.aggregate(Notifications.Db.Notification, :count)
+    end
   end
 end


### PR DESCRIPTION
Turns out, you need to specify this explicitly so that you don't get fkey constraint errors.
I also added `on_update` in case for some reason we change a detour's primary key so that notifications don't get broken and have constraint errors.