### PR TITLE
cleanup(ex/notifications/detour): remove changeset function

### DIFF
--- a/lib/notifications/db/detour.ex
+++ b/lib/notifications/db/detour.ex
@@ -4,7 +4,6 @@ defmodule Notifications.Db.Detour do
   """
 
   use Skate.Schema
-  import Ecto.Changeset
 
   @derive {Jason.Encoder,
            only: [
@@ -30,20 +29,7 @@ defmodule Notifications.Db.Detour do
     field :origin, :any, virtual: true
   end
 
-  def changeset(
-        %__MODULE__{} = struct,
-        attrs \\ %{}
-      ) do
-    struct
-    |> cast(attrs, [
-      :detour,
-      :status
-    ])
-    |> validate_required([
-      :detour,
-      :status
-    ])
-  end
+  # Notifications are not created from external input, so there is no changeset function
 
   defmodule Queries do
     @moduledoc """


### PR DESCRIPTION
just a little cleanup, I had originally created this function because that's what other notifications did. I think that was actually incorrect because we don't create detour notifications from external input, unlike bridge notifications or block waivers which get their data from external sources and need to validate the data.

To make it clear that detour notifications are not created from user input, I've removed the changeset function so we're not tempted to use it without question, and instead halve to think about it when/if we re-add the function