### PR TITLE
fix:test: assert that detour is activated in test

### DIFF
--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -658,7 +658,7 @@ defmodule Notifications.NotificationServerTest do
       for _ <- 1..notification_count do
         assert_receive {:notification,
                         %Notification{
-                          content: %Notifications.Db.Detour{}
+                          content: %Notifications.Db.Detour{status: :activated}
                         }}
       end
     end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -387,6 +387,7 @@ defmodule Notifications.NotificationTest do
       # assert fields are set
       assert %Notifications.Notification{
                content: %Notifications.Db.Detour{
+                 status: :activated,
                  route: ^route_name,
                  origin: ^route_pattern_name,
                  headsign: ^headsign,


### PR DESCRIPTION
small fix that I noticed when doing the detour deactivated notifications