### PR TITLE
feat: add detour deactivated notifications 

### DIFF
--- a/assets/src/components/notificationCard.tsx
+++ b/assets/src/components/notificationCard.tsx
@@ -6,6 +6,7 @@ import {
   BlockWaiverReason,
   NotificationType,
   isBlockWaiverNotification,
+  DetourNotificationStatus,
 } from "../realtime"
 import { Route } from "../schedule"
 import { formattedTime } from "../util/dateTime"
@@ -99,7 +100,17 @@ export const title = (notification: Notification) => {
     }
 
     case NotificationType.Detour: {
-      return "Detour - Active"
+      switch (notification.content.status) {
+        case DetourNotificationStatus.Activated: {
+          return "Detour - Active"
+        }
+        case DetourNotificationStatus.Deactivated: {
+          return "Detour - Closed"
+        }
+      }
+      // Typescript says this is unreachable,
+      // but eslint doesn't seem to get the memo
+      break
     }
 
     case NotificationType.BridgeMovement: {

--- a/assets/src/models/notificationData.ts
+++ b/assets/src/models/notificationData.ts
@@ -15,6 +15,7 @@ import {
 import {
   BlockWaiverNotification,
   BridgeNotification,
+  DetourNotificationStatus,
   Notification,
   NotificationContentTypes,
   NotificationType,
@@ -68,6 +69,10 @@ export const BridgeNotificationData = union([
 
 export const DetourNotificationData = type({
   __struct__: literal(NotificationType.Detour),
+  status: enums([
+    DetourNotificationStatus.Activated,
+    DetourNotificationStatus.Deactivated,
+  ]),
   detour_id: detourId,
   headsign: string(),
   route: string(),
@@ -136,6 +141,7 @@ export const notificationFromData = (
     case NotificationType.Detour: {
       content = {
         $type: NotificationType.Detour,
+        status: notificationData.content.status,
         detourId: notificationData.content.detour_id,
         direction: notificationData.content.direction,
         headsign: notificationData.content.headsign,

--- a/assets/src/realtime.ts
+++ b/assets/src/realtime.ts
@@ -92,8 +92,14 @@ export type BlockWaiverNotification = {
   endTime: Date | null
 }
 
+export enum DetourNotificationStatus {
+  Activated = "activated",
+  Deactivated = "deactivated",
+}
+
 export type DetourNotification = {
   $type: NotificationType.Detour
+  status: DetourNotificationStatus
   detourId: DetourId
   headsign: string
   route: string

--- a/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationBellIcon.test.tsx.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`NotificationBellIcon activated detour notification renders when there are new detour notifications and user is not part of DetoursList 1`] = `
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
+`;
+
+exports[`NotificationBellIcon activated detour notification renders when there are new detour notifications and user is part of DetoursList group 1`] = `
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
+`;
+
+exports[`NotificationBellIcon deactivated detour notification renders when there are new detour notifications and user is not part of DetoursList 1`] = `
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
+`;
+
+exports[`NotificationBellIcon deactivated detour notification renders when there are new detour notifications and user is part of DetoursList group 1`] = `
+<body>
+  <div>
+    <span
+      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
+    >
+      <svg />
+    </span>
+  </div>
+</body>
+`;
+
 exports[`NotificationBellIcon renders when the drawer is closed and there are new notifications 1`] = `
 <span
   className="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
@@ -42,28 +90,4 @@ exports[`NotificationBellIcon renders when the drawer is open and there are not 
     }
   }
 />
-`;
-
-exports[`NotificationBellIcon renders when there are new detour notifications and user is not part of DetoursList 1`] = `
-<body>
-  <div>
-    <span
-      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--read"
-    >
-      <svg />
-    </span>
-  </div>
-</body>
-`;
-
-exports[`NotificationBellIcon renders when there are new detour notifications and user is part of DetoursList group 1`] = `
-<body>
-  <div>
-    <span
-      class="c-notification-bell-icon c-notification-bell-icon--closed c-notification-bell-icon--unread"
-    >
-      <svg />
-    </span>
-  </div>
-</body>
 `;

--- a/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
+++ b/assets/tests/components/__snapshots__/notificationCard.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotificationCard renders detour notification if user is in DetoursList group 1`] = `
+exports[`NotificationCard renders activated detour notification if user is in DetoursList group 1`] = `
 <body>
   <div>
     <div
@@ -43,19 +43,92 @@ exports[`NotificationCard renders detour notification if user is in DetoursList 
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  2
+                  4
                 </div>
                 <div>
                   <div
                     class="fw-semibold"
                   >
-                    Headsign 2
+                    Headsign 4
                   </div>
                   <div
                     class="fw-normal text-body-secondary"
                   >
                     From 
-                    Origin station 2
+                    Origin station 4
+                  </div>
+                  <div
+                    class="fw-normal"
+                  >
+                    Outbound
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationCard renders detour deactivated notification if user is in DetoursList group 1`] = `
+<body>
+  <div>
+    <div
+      aria-labelledby="card-label-:ri:"
+      class="c-card c-card--kiwi"
+    >
+      <button
+        class="c-card__left"
+      >
+        <div
+          class="c-card__left-content"
+        >
+          <div
+            class="c-card__top-row"
+          >
+            <div
+              class="c-card__title"
+              id="card-label-:ri:"
+            >
+              <span>
+                <svg />
+              </span>
+              Detour - Closed
+            </div>
+            <div
+              class="c-card__time"
+            >
+              0 min
+            </div>
+          </div>
+          <div
+            class="c-card__contents"
+          >
+            <div
+              class="c-card__body"
+            >
+              <div
+                class="d-flex flex-row gap-2"
+              >
+                <div
+                  class="c-route-pill c-route-pill--bus"
+                >
+                  1
+                </div>
+                <div>
+                  <div
+                    class="fw-semibold"
+                  >
+                    Headsign 1
+                  </div>
+                  <div
+                    class="fw-normal text-body-secondary"
+                  >
+                    From 
+                    Origin station 1
                   </div>
                   <div
                     class="fw-normal"

--- a/assets/tests/components/notificationBellIcon.test.tsx
+++ b/assets/tests/components/notificationBellIcon.test.tsx
@@ -14,6 +14,7 @@ import { viewFactory } from "../factories/pagePanelStateFactory"
 import {
   blockWaiverNotificationFactory,
   detourActivatedNotificationFactory,
+  detourDeactivatedNotificationFactory,
 } from "../factories/notification"
 import getTestGroups from "../../src/userTestGroups"
 import { TestGroups } from "../../src/userInTestGroup"
@@ -142,28 +143,51 @@ describe("NotificationBellIcon", () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test("renders when there are new detour notifications and user is part of DetoursList group", () => {
-    jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
+  describe.each([
+    {
+      type: "activated",
+      state: {
+        ...unreadNotificationState,
+        notifications: detourActivatedNotificationFactory.buildList(2),
+      },
+    },
+    {
+      type: "deactivated",
+      state: {
+        ...unreadNotificationState,
+        notifications: detourDeactivatedNotificationFactory.buildList(2),
+      },
+    },
+  ])("$type detour notification", () => {
+    test("renders when there are new detour notifications and user is part of DetoursList group", () => {
+      jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
 
-    const { baseElement } = render(
-      <StateDispatchProvider state={stateFactory.build()} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadDetourNotificationState}>
-          <NotificationBellIcon />
-        </NotificationsContext.Provider>
-      </StateDispatchProvider>
-    )
+      const { baseElement } = render(
+        <StateDispatchProvider
+          state={stateFactory.build()}
+          dispatch={jest.fn()}
+        >
+          <NotificationsContext.Provider value={unreadDetourNotificationState}>
+            <NotificationBellIcon />
+          </NotificationsContext.Provider>
+        </StateDispatchProvider>
+      )
 
-    expect(baseElement).toMatchSnapshot()
-  })
+      expect(baseElement).toMatchSnapshot()
+    })
 
-  test("renders when there are new detour notifications and user is not part of DetoursList", () => {
-    const { baseElement } = render(
-      <StateDispatchProvider state={stateFactory.build()} dispatch={jest.fn()}>
-        <NotificationsContext.Provider value={unreadDetourNotificationState}>
-          <NotificationBellIcon />
-        </NotificationsContext.Provider>
-      </StateDispatchProvider>
-    )
-    expect(baseElement).toMatchSnapshot()
+    test("renders when there are new detour notifications and user is not part of DetoursList", () => {
+      const { baseElement } = render(
+        <StateDispatchProvider
+          state={stateFactory.build()}
+          dispatch={jest.fn()}
+        >
+          <NotificationsContext.Provider value={unreadDetourNotificationState}>
+            <NotificationBellIcon />
+          </NotificationsContext.Provider>
+        </StateDispatchProvider>
+      )
+      expect(baseElement).toMatchSnapshot()
+    })
   })
 })

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -1,6 +1,7 @@
 import { jest, describe, test, expect, beforeEach } from "@jest/globals"
 import React from "react"
-import { render } from "@testing-library/react"
+import "@testing-library/jest-dom/jest-globals"
+import { render, screen } from "@testing-library/react"
 import { NotificationCard, title } from "../../src/components/notificationCard"
 import {
   BlockWaiverReason,
@@ -12,6 +13,7 @@ import {
   bridgeLoweredNotificationFactory,
   bridgeRaisedNotificationFactory,
   detourActivatedNotificationFactory,
+  detourDeactivatedNotificationFactory,
 } from "../factories/notification"
 import routeFactory from "../factories/route"
 import userEvent from "@testing-library/user-event"
@@ -252,7 +254,7 @@ describe("NotificationCard", () => {
     expect(dispatch).toHaveBeenCalledWith({ type: "HIDE_LATEST_NOTIFICATION" })
   })
 
-  test("renders detour notification if user is in DetoursList group", () => {
+  test("renders activated detour notification if user is in DetoursList group", () => {
     const n: Notification = detourActivatedNotificationFactory.build()
     const { baseElement } = render(
       <RoutesProvider routes={routes}>
@@ -266,7 +268,7 @@ describe("NotificationCard", () => {
     expect(baseElement).toMatchSnapshot()
   })
 
-  test("does not render detour notification if user not in DetoursList group", () => {
+  test("does not render activated detour notification if user not in DetoursList group", () => {
     jest.mocked(getTestGroups).mockReturnValue([])
 
     const n: Notification = detourActivatedNotificationFactory.build()
@@ -280,6 +282,40 @@ describe("NotificationCard", () => {
       </RoutesProvider>
     )
     expect(result.queryByText(/Detour - Active/)).toBeNull()
+  })
+
+  test("renders detour deactivated notification if user is in DetoursList group", () => {
+    const n: Notification = detourDeactivatedNotificationFactory.build()
+    const { baseElement } = render(
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          currentTime={new Date()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
+    )
+    // The card's role is currently just a "button" which doesn't quite feel like
+    // the right role, so instead of asserting on role, this uses `getByText`
+    // _for now_.
+    expect(screen.getByText(/Detour - Closed/)).toBeVisible()
+    expect(baseElement).toMatchSnapshot()
+  })
+
+  test("does not render deactivated detour notification if user not in DetoursList group", () => {
+    jest.mocked(getTestGroups).mockReturnValue([])
+
+    const n: Notification = detourDeactivatedNotificationFactory.build()
+    const result = render(
+      <RoutesProvider routes={routes}>
+        <NotificationCard
+          notification={n}
+          currentTime={new Date()}
+          openVPPForCurrentVehicle={jest.fn()}
+        />
+      </RoutesProvider>
+    )
+    expect(result.queryByText(/Detour - Closed/)).toBeNull()
   })
 
   test.each<{
@@ -361,6 +397,10 @@ describe("NotificationCard", () => {
     {
       should_fire_fs_event: false,
       notification: detourActivatedNotificationFactory.build({}),
+    },
+    {
+      should_fire_fs_event: false,
+      notification: detourDeactivatedNotificationFactory.build(),
     },
   ])(
     "clicking bridge notification should trigger FS event: $notification.content.reason",

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -106,3 +106,13 @@ export const detourActivatedNotificationFactory = Factory.define<
   state: "unread",
   content: detourActivatedNotificationContentFactory.build(),
 }))
+
+const detourDeactivatedNotificationContentFactory =
+  detourActivatedNotificationContentFactory.params({
+    status: DetourNotificationStatus.Deactivated,
+  })
+
+export const detourDeactivatedNotificationFactory =
+  detourActivatedNotificationFactory.params({
+    content: detourDeactivatedNotificationContentFactory.build(),
+  })

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -5,6 +5,7 @@ import {
   BridgeLoweredNotification,
   BridgeRaisedNotification,
   DetourNotification,
+  DetourNotificationStatus,
   Notification,
   NotificationType,
 } from "../../src/realtime"
@@ -89,7 +90,7 @@ export const bridgeLoweredNotificationFactory = Factory.define<
 const detourActivatedNotificationContentFactory =
   Factory.define<DetourNotification>(({ sequence }) => ({
     $type: NotificationType.Detour,
-    status: "activated",
+    status: DetourNotificationStatus.Activated,
     detourId: sequence,
     headsign: `Headsign ${sequence}`,
     route: `${sequence}`,

--- a/lib/notifications/db/detour.ex
+++ b/lib/notifications/db/detour.ex
@@ -20,7 +20,7 @@ defmodule Notifications.Db.Detour do
     belongs_to :detour, Skate.Detours.Db.Detour
     has_one :notification, Notifications.Db.Notification
 
-    field :status, Ecto.Enum, values: [:activated]
+    field :status, Ecto.Enum, values: [:activated, :deactivated]
 
     # Derived from the associated detour
     field :headsign, :any, virtual: true

--- a/lib/notifications/detour.ex
+++ b/lib/notifications/detour.ex
@@ -21,4 +21,14 @@ defmodule Notifications.Detour do
       | status: :activated
     }
   end
+
+  @doc """
+  Creates a activated detour notification struct to insert into the database
+  """
+  def deactivated_detour(%Skate.Detours.Db.Detour{} = detour) do
+    %{
+      detour_notification(detour)
+      | status: :deactivated
+    }
+  end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -51,6 +51,23 @@ defmodule Notifications.Notification do
   ]
 
   @doc """
+  Inserts a new notification for an deactivated detour into the database
+  and returns the detour notification with notification info.
+  """
+  def create_deactivated_detour_notification_from_detour(%Skate.Detours.Db.Detour{} = detour) do
+    import Notifications.Db.Notification.Queries
+
+    notification =
+      deactivated_detour_notification(detour)
+      |> unread_notifications_for_users(Skate.Settings.User.get_all())
+      |> Skate.Repo.insert!()
+
+    # We need the associated values in the Detour JSON, so query the DB with the
+    # id to load the extra data.
+    get_detour_notification(notification.id)
+  end
+
+  @doc """
   Inserts a new notification for an activated detour into the database
   and returns the detour notification with notification info.
   """
@@ -88,6 +105,14 @@ defmodule Notifications.Notification do
     %Notifications.Db.Notification{
       new_notification_now()
       | detour: Notifications.Detour.activated_detour(detour)
+    }
+  end
+
+  # Adds a deactivated detour notification relation to a `Notifications.Db.Notification`
+  defp deactivated_detour_notification(%Skate.Detours.Db.Detour{} = detour) do
+    %Notifications.Db.Notification{
+      new_notification_now()
+      | detour: Notifications.Detour.deactivated_detour(detour)
     }
   end
 

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -64,8 +64,14 @@ defmodule Notifications.Notification do
 
     # We need the associated values in the Detour JSON, so query the DB with the
     # id to load the extra data.
+    get_detour_notification(notification.id)
+  end
+
+  def get_detour_notification(notification_id) do
+    import Notifications.Db.Notification.Queries
+
     select_detour_info()
-    |> where([notification: n], n.id == ^notification.id)
+    |> where([notification: n], n.id == ^notification_id)
     |> Skate.Repo.one!()
     |> from_db_notification()
   end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -663,4 +663,54 @@ defmodule Notifications.NotificationServerTest do
       end
     end
   end
+
+  describe "detour_deactivated/2" do
+    setup do
+      {:ok, server} = setup_server()
+
+      %{server: server}
+    end
+
+    test "saves to database" do
+      notification_count = 3
+      # create new notification
+      for _ <- 1..notification_count do
+        %{id: id} =
+          detour =
+          insert(:detour)
+
+        NotificationServer.detour_deactivated(detour, notify_finished: self(), server: __MODULE__)
+
+        assert_receive {:new_notification, detour: ^id}
+      end
+
+      # assert database contains notification
+      assert_n_notifications_in_db(notification_count)
+    end
+
+    test "broadcasts to all connected users", %{server: server} do
+      notification_count = 3
+      # connect users to channel
+      for id <- 1..notification_count do
+        NotificationServer.subscribe(id, server)
+      end
+
+      # create new notification
+      %{id: id} =
+        detour =
+        insert(:detour)
+
+      NotificationServer.detour_deactivated(detour, notify_finished: self(), server: __MODULE__)
+
+      assert_receive {:new_notification, detour: ^id}
+
+      # assert channel sends notifications to each user
+      for _ <- 1..notification_count do
+        assert_receive {:notification,
+                        %Notification{
+                          content: %Notifications.Db.Detour{status: :deactivated}
+                        }}
+      end
+    end
+  end
 end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -411,4 +411,93 @@ defmodule Notifications.NotificationTest do
       assert 0 == Skate.Repo.aggregate(Notifications.Db.Notification, :count)
     end
   end
+
+  describe "create_deactivated_detour_notification_from_detour/1" do
+    test "inserts new record into the database" do
+      count = 3
+
+      # create new notification
+      for _ <- 1..count do
+        :detour
+        |> insert()
+        |> Notifications.Notification.create_deactivated_detour_notification_from_detour()
+      end
+
+      # assert it is in the database
+      assert count == Skate.Repo.aggregate(Notifications.Db.Detour, :count)
+    end
+
+    test "creates an unread notification for all users" do
+      number_of_users = 5
+      [user | _] = insert_list(number_of_users, :user)
+
+      # create new notification
+      detour =
+        :detour
+        |> insert(
+          # don't create a new user and affect the user count
+          author: user
+        )
+        |> Notifications.Notification.create_deactivated_detour_notification_from_detour()
+
+      detour_notification =
+        Notifications.Db.Notification
+        |> Skate.Repo.get!(detour.id)
+        |> Skate.Repo.preload(:users)
+
+      # assert all users have a notification that is unread
+      assert Kernel.length(detour_notification.users) == number_of_users
+    end
+
+    test "returns detour information" do
+      # create new notification
+      %{
+        state: %{
+          "context" => %{
+            "route" => %{
+              "name" => route_name
+            },
+            "routePattern" => %{
+              "name" => route_pattern_name,
+              "headsign" => headsign
+            }
+          }
+        }
+      } =
+        detour =
+        :detour
+        |> build()
+        |> with_direction(:inbound)
+        |> insert()
+
+      detour_notification =
+        Notifications.Notification.create_deactivated_detour_notification_from_detour(detour)
+
+      # assert fields are set
+      assert %Notifications.Notification{
+               content: %Notifications.Db.Detour{
+                 status: :deactivated,
+                 route: ^route_name,
+                 origin: ^route_pattern_name,
+                 headsign: ^headsign,
+                 direction: "Inbound"
+               }
+             } = detour_notification
+    end
+
+    test "deletes associated detour notifications when detour is deleted" do
+      # create new notification and detour
+      detour = insert(:detour)
+
+      Notifications.Notification.create_deactivated_detour_notification_from_detour(detour)
+
+      # assert it is in the database
+      assert 1 == Skate.Repo.aggregate(Notifications.Db.Detour, :count)
+
+      Skate.Repo.delete!(detour)
+
+      assert 0 == Skate.Repo.aggregate(Notifications.Db.Detour, :count)
+      assert 0 == Skate.Repo.aggregate(Notifications.Db.Notification, :count)
+    end
+  end
 end

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -58,6 +58,14 @@ defmodule Skate.DetourFactory do
         put_in(state["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
       end
 
+      def deactivated(%Skate.Detours.Db.Detour{} = detour) do
+        %{detour | state: deactivated(detour.state)}
+      end
+
+      def deactivated(%{"value" => %{}} = state) do
+        put_in(state["value"], %{"Detour Drawing" => "Past"})
+      end
+
       def with_direction(%Skate.Detours.Db.Detour{} = detour, direction) do
         %{
           detour


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/1203014709808707/1208409921049870/f

This implements deactivated notifications through the entire stack, from the notification internals, all the way to the deactivated card.

TODO:
- [x] Failing CI: Checks
	- There's something up with `eslint` not properly detecting that all possible branches of the `switch` are handled. Maybe I did something wrong here and I'd love that pointed out, but if I add an explicit `break` to make `eslint` happy, typescript then complains that the break is "unreachable" and "unnecessary". Still looking into this.

Depends On:
- ~#2831~
- #2836 