### PR TITLE
fix: split up build and deploy steps

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -18,37 +18,24 @@ on:
       SLACK_WEBHOOK:
         required: true
 
+
 jobs:
-  deploy:
-    name: Deploy
+  build:
+    name: Build/push Docker Image
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     environment: ${{ inputs.env }}
-    env:
-      ECS_CLUSTER: skate
-      ECS_SERVICE: skate-${{ inputs.env }}
+    outputs:
+      docker-tag-suffix: ${{ steps.build-push.outputs.docker-tag-suffix }}
+      sentry-release: ${{ steps.version-ids.outputs.sentry-release }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
       - uses: actions/checkout@v4
       - name: Get version ids
         id: version-ids
         run: |
           echo "sentry-release=${{github.ref}}_${{github.sha}}" | tr / - >> "$GITHUB_OUTPUT"
-      - uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          environment: ${{ inputs.env }}
-          version: ${{steps.version-ids.outputs.sentry-release}}
-          ignore_missing: true
       - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
@@ -61,13 +48,38 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+
+  deploy_ecs:
+    name: Deploy (ECS)
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+    environment: ${{ inputs.env }}
+    env:
+      ECS_CLUSTER: skate
+      ECS_SERVICE: skate-${{ inputs.env }}
+    steps:
       - uses: mbta/actions/deploy-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
-          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
-      - uses: mbta/actions/notify-slack-deploy@v1
+          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ needs.build.outputs.docker-tag-suffix }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          environment: ${{ inputs.env }}
+          version: ${{needs.build.outputs.sentry-release}}
+          ignore_missing: true
+      - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
When deploying #2831 I was having difficulties with getting the deployment to succeed due to our database issues. It was getting pretty frustrating to have to build the docker container just to attempt a redeploy. I tried a few ways of parallelizing this, but so far this seems like the best option.


I was having trouble getting a deploy to work for testing this, so this also depends on #2841 
Depends on:
- #2841 