### PR TITLE
tweak: reorganize diversion page

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -396,7 +396,7 @@ export const DiversionPage = ({
 
   return (
     <>
-      <article className={`l-diversion-page h-100 border-box inherit-box`}>
+      <article className="l-diversion-page h-100 border-box inherit-box">
         <header
           className={joinClasses([
             "l-diversion-page__header",


### PR DESCRIPTION
I found it mildly easier to read extracting the detourPanel logic out of the rest of the JSX tree, but this isn't expressly necessary if you prefer it the old way!