### PR TITLE
fix: Detour modal header should be blank on new creation workflow

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -427,9 +427,9 @@ export const DiversionPage = ({
                 {useDetourProps.author}
               </span>
             </>
-          ) : (
+          ) : isMobile(displayType) ? (
             <div className="flex-grow-1 fw-semibold text-center">Detours</div>
-          )}
+          ) : null}
           <CloseButton className="p-4" onClick={onClose} />
         </header>
 


### PR DESCRIPTION
Realized there was a case I had not accounted for, leading to `Detours` appearing on desktop when it shouldn't!

before
![Screenshot 2024-10-11 at 9 58 51 AM](https://github.com/user-attachments/assets/893d7ce5-4883-44d8-ad49-42816243eff4)

after
![Screenshot 2024-10-11 at 10 38 50 AM](https://github.com/user-attachments/assets/7ec4d7e4-fc1c-4ee9-98e0-222c9a62fef8)
