### PR TITLE
tweak: Detour notifications behind test group

### DIFF
--- a/assets/src/components/notificationBellIcon.tsx
+++ b/assets/src/components/notificationBellIcon.tsx
@@ -17,12 +17,15 @@ const NotificationBellIcon = ({
   } = usePanelStateFromStateDispatchContext()
   const { notifications } = useContext(NotificationsContext)
 
-  const inDetoursNotificationGroup = inTestGroup(TestGroups.DetoursList) && inTestGroup(TestGroups.DetoursNotifications)
+  const inDetoursNotificationGroup =
+    inTestGroup(TestGroups.DetoursList) &&
+    inTestGroup(TestGroups.DetoursNotifications)
   const unreadNotifications = (notifications || []).filter(
     (notification) =>
       notification.state === "unread" &&
       !(
-        notification.content.$type === NotificationType.Detour && !inDetoursNotificationGroup
+        notification.content.$type === NotificationType.Detour &&
+        !inDetoursNotificationGroup
       )
   )
   const unreadBadge: boolean = unreadNotifications.length > 0

--- a/assets/src/components/notificationBellIcon.tsx
+++ b/assets/src/components/notificationBellIcon.tsx
@@ -17,12 +17,12 @@ const NotificationBellIcon = ({
   } = usePanelStateFromStateDispatchContext()
   const { notifications } = useContext(NotificationsContext)
 
-  const inDetoursList = inTestGroup(TestGroups.DetoursList)
+  const inDetoursNotificationGroup = inTestGroup(TestGroups.DetoursList) && inTestGroup(TestGroups.DetoursNotifications)
   const unreadNotifications = (notifications || []).filter(
     (notification) =>
       notification.state === "unread" &&
       !(
-        notification.content.$type === NotificationType.Detour && !inDetoursList
+        notification.content.$type === NotificationType.Detour && !inDetoursNotificationGroup
       )
   )
   const unreadBadge: boolean = unreadNotifications.length > 0

--- a/assets/src/components/notificationCard.tsx
+++ b/assets/src/components/notificationCard.tsx
@@ -53,7 +53,7 @@ export const NotificationCard = ({
 
   if (
     notification.content.$type === NotificationType.Detour &&
-    !inTestGroup(TestGroups.DetoursList)
+    !(inTestGroup(TestGroups.DetoursList) && inTestGroup(TestGroups.DetoursNotifications))
   ) {
     return null
   }

--- a/assets/src/components/notificationCard.tsx
+++ b/assets/src/components/notificationCard.tsx
@@ -53,7 +53,10 @@ export const NotificationCard = ({
 
   if (
     notification.content.$type === NotificationType.Detour &&
-    !(inTestGroup(TestGroups.DetoursList) && inTestGroup(TestGroups.DetoursNotifications))
+    !(
+      inTestGroup(TestGroups.DetoursList) &&
+      inTestGroup(TestGroups.DetoursNotifications)
+    )
   ) {
     return null
   }

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -4,6 +4,7 @@ export enum TestGroups {
   BackwardsDetourPrevention = "backwards-detour-prevention",
   DemoMode = "demo-mode",
   DetoursList = "detours-list",
+  DetoursNotifications = "detours-notifications",
   DetoursPilot = "detours-pilot",
   MinimalLadderPage = "minimal-ladder-page",
   LateView = "late-view",

--- a/assets/tests/components/notificationBellIcon.test.tsx
+++ b/assets/tests/components/notificationBellIcon.test.tsx
@@ -160,7 +160,12 @@ describe("NotificationBellIcon", () => {
     },
   ])("$type detour notification", () => {
     test("renders when there are new detour notifications and user is part of DetoursList group", () => {
-      jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursNotifications])
+      jest
+        .mocked(getTestGroups)
+        .mockReturnValue([
+          TestGroups.DetoursList,
+          TestGroups.DetoursNotifications,
+        ])
 
       const { baseElement } = render(
         <StateDispatchProvider

--- a/assets/tests/components/notificationBellIcon.test.tsx
+++ b/assets/tests/components/notificationBellIcon.test.tsx
@@ -160,7 +160,7 @@ describe("NotificationBellIcon", () => {
     },
   ])("$type detour notification", () => {
     test("renders when there are new detour notifications and user is part of DetoursList group", () => {
-      jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
+      jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursNotifications])
 
       const { baseElement } = render(
         <StateDispatchProvider

--- a/assets/tests/components/notificationCard.openDetour.test.tsx
+++ b/assets/tests/components/notificationCard.openDetour.test.tsx
@@ -37,7 +37,11 @@ describe("NotificationCard", () => {
   test("renders detour details modal to match mocked fetchDetour", async () => {
     jest
       .mocked(getTestGroups)
-      .mockReturnValue([TestGroups.DetoursPilot, TestGroups.DetoursList, TestGroups.DetoursNotifications])
+      .mockReturnValue([
+        TestGroups.DetoursPilot,
+        TestGroups.DetoursList,
+        TestGroups.DetoursNotifications,
+      ])
 
     jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
     jest

--- a/assets/tests/components/notificationCard.openDetour.test.tsx
+++ b/assets/tests/components/notificationCard.openDetour.test.tsx
@@ -37,7 +37,7 @@ describe("NotificationCard", () => {
   test("renders detour details modal to match mocked fetchDetour", async () => {
     jest
       .mocked(getTestGroups)
-      .mockReturnValue([TestGroups.DetoursPilot, TestGroups.DetoursList])
+      .mockReturnValue([TestGroups.DetoursPilot, TestGroups.DetoursList, TestGroups.DetoursNotifications])
 
     jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
     jest

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -32,7 +32,7 @@ jest.mock("../../src/helpers/fullStory")
 jest.mock("../../src/userTestGroups")
 
 beforeEach(() => {
-  jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList])
+  jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursNotifications])
   jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
   jest
     .mocked(fetchDetour)

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -32,7 +32,9 @@ jest.mock("../../src/helpers/fullStory")
 jest.mock("../../src/userTestGroups")
 
 beforeEach(() => {
-  jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursNotifications])
+  jest
+    .mocked(getTestGroups)
+    .mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursNotifications])
   jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
   jest
     .mocked(fetchDetour)


### PR DESCRIPTION
To enable deployments while we work on getting detour notifications fixed up