### PR TITLE
fix(ex/Realtime.Server): use `broadcast_local` instead of `broadcast`

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,7 +105,5 @@ if config_env() == :prod do
     config :skate, Skate.Detours.TripModificationPublisher, start: true
   end
 
-  # There are currently issues with Distributed Elixir and our Data Pipelines.
-  # So we need to disable clustering in prod until we figure this out
-  # config :skate, DNSCluster, query: System.get_env("DNS_CLUSTER_QUERY") || :ignore
+  config :skate, DNSCluster, query: System.get_env("DNS_CLUSTER_QUERY") || :ignore
 end

--- a/lib/realtime/server.ex
+++ b/lib/realtime/server.ex
@@ -510,7 +510,7 @@ defmodule Realtime.Server do
         :alerts -> "realtime_alerts"
       end
 
-    Phoenix.PubSub.broadcast(pubsub_name(), topic, {:new_realtime_data, state.ets})
+    Phoenix.PubSub.local_broadcast(pubsub_name(), topic, {:new_realtime_data, state.ets})
   end
 
   @spec block_is_active?(VehicleOrGhost.t()) :: boolean


### PR DESCRIPTION
When we added distributed Elixir via `DNSCluster` in #2831, we started getting flickering data in our realtime sources. This was because we used a `Phoenix.PubSub` with the same name on both instances. Once instances were talking to eachother, those `PubSub`'s started getting messages from other instances but the messages referenced non-existent information, which caused them to send `null` or empty `[]` information to clients when they received those messages.

Switching to `broadcast_local` for our `Realtime.Server.broadcast/2` returns the code to it's previous assumptions where a message is only broadcasted to subscribers on the same node, which stopped instances from stepping on eachother.