### PR TITLE
tweak: Make the missed stops count badge round

### DIFF
--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -13,8 +13,8 @@ export const MissedStops = ({ missedStops }: MissedStopsProps) => (
     {missedStops && (
       <section className="pb-3">
         <h2 className="c-diversion-panel__h2">
-          Missed Stops{" "}
-          <Badge pill bg="missed-stop" className="fs-4">
+          Missed Stops
+          <Badge pill bg="missed-stop" className="ps-2 fs-4">
             {missedStops.length}
           </Badge>
         </h2>

--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -13,7 +13,10 @@ export const MissedStops = ({ missedStops }: MissedStopsProps) => (
     {missedStops && (
       <section className="pb-3">
         <h2 className="c-diversion-panel__h2">
-          Missed Stops <Badge bg="missed-stop">{missedStops.length}</Badge>
+          Missed Stops{" "}
+          <Badge pill bg="missed-stop" className="fs-4">
+            {missedStops.length}
+          </Badge>
         </h2>
         <ListGroup as="ul">
           {uniqBy(missedStops, (stop) => stop.id).map((missedStop) => (


### PR DESCRIPTION
Asana Ticket: https://app.asana.com/0/1205385723132845/1208153509160211

Brian noted that the Bootstrap default component is ok!

![Screenshot 2024-10-16 at 8 54 17 AM](https://github.com/user-attachments/assets/cbf8fadf-137d-4185-b431-0d0f28e375b7)
