### PR TITLE
cleanup(css/shuttle-map): remove selected label color override on shuttle map

### DIFF
--- a/assets/css/_shuttle_map.scss
+++ b/assets/css/_shuttle_map.scss
@@ -12,8 +12,4 @@
   height: 100%;
   position: absolute;
   width: 100%;
-
-  .c-vehicle-map__label.selected .c-vehicle-icon__label-background {
-    fill: $color-secondary-medium;
-  }
 }


### PR DESCRIPTION
This _happens_ to override the vehicle marker because it's imported after the vehicle marker css, just so we don't stumble into that later, I decided to remove it.

Context: https://mbta.slack.com/archives/C024N3SKX33/p1729517468174199?thread_ts=1729517026.304969&cid=C024N3SKX33