### PR TITLE
tweak: Margin needed on missed stops badge, not padding

### DIFF
--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -14,7 +14,7 @@ export const MissedStops = ({ missedStops }: MissedStopsProps) => (
       <section className="pb-3">
         <h2 className="c-diversion-panel__h2">
           Missed Stops
-          <Badge pill bg="missed-stop" className="ps-2 fs-4">
+          <Badge pill bg="missed-stop" className="ms-2 fs-4">
             {missedStops.length}
           </Badge>
         </h2>


### PR DESCRIPTION
Fix to follow: https://github.com/mbta/skate/pull/2857