### PR TITLE
fix: Avoid using non-unique stop names as key

### DIFF
--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -269,7 +269,7 @@ export const DetourMap = ({
             <>
               {uniqBy(stops, (stop) => stop.id).map((stop) => (
                 <StopMarkerWithStopCard
-                  key={stop.name}
+                  key={stop.id}
                   stop={stop}
                   zoomLevel={zoomLevel}
                   interactionStatesDisabled={false}


### PR DESCRIPTION
The 1 has two stops called Mass Ave & Albany! One in Cambridge, one in Boston. This suppresses some rowdy console errors