### PR TITLE
fix(ex/test): make tests against user data dynamic

### DIFF
--- a/test/skate_web/controllers/detours_controller_test.exs
+++ b/test/skate_web/controllers/detours_controller_test.exs
@@ -197,7 +197,10 @@ defmodule SkateWeb.DetoursControllerTest do
 
   describe "detour/2" do
     @tag :authenticated
-    test "fetches single detour with its state from database", %{conn: conn} do
+    test "fetches single detour with its state from database", %{
+      conn: conn,
+      user: %{email: email}
+    } do
       populate_db_and_get_user(conn)
 
       conn = get(conn, "/api/detours/1")
@@ -206,7 +209,7 @@ defmodule SkateWeb.DetoursControllerTest do
 
       assert %{
                "data" => %{
-                 "author" => "test_user@test.com",
+                 "author" => ^email,
                  "state" => %{
                    "context" => %{
                      "nearestIntersection" => "Street A & Avenue B",

--- a/test/skate_web/controllers/page_controller_test.exs
+++ b/test/skate_web/controllers/page_controller_test.exs
@@ -222,17 +222,17 @@ defmodule SkateWeb.PageControllerTest do
     end
 
     @tag :authenticated
-    test "correct username set", %{conn: conn} do
+    test "correct username set", %{conn: conn, user: %{username: username}} do
       conn = get(conn, "/")
-      assert html_response(conn, 200) =~ "<meta name=\"username\" content=\"test_user\">"
+      assert html_response(conn, 200) =~ "<meta name=\"username\" content=\"#{username}\">"
     end
 
     @tag :authenticated
-    test "correct email address set", %{conn: conn} do
+    test "correct email address set", %{conn: conn, user: %{email: email}} do
       conn = get(conn, "/")
 
       assert html_response(conn, 200) =~
-               "data-email-address=\"test_user@test.com\""
+               "data-email-address=\"#{email}\""
     end
 
     @tag :authenticated

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -17,7 +17,6 @@ defmodule SkateWeb.ConnCase do
 
   use ExUnit.CaseTemplate
   import Plug.Test
-  alias Skate.Settings.User
 
   using do
     quote do
@@ -36,17 +35,12 @@ defmodule SkateWeb.ConnCase do
   setup tags do
     Skate.DataCase.setup_sandbox(tags)
 
-    username = "test_user"
-    email = "test_user@test.com"
-
-    user = User.upsert(username, email)
+    user = Skate.Factory.insert(:user)
     resource = %{id: user.id}
 
     {conn, user} =
       cond do
         tags[:authenticated] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
@@ -55,8 +49,6 @@ defmodule SkateWeb.ConnCase do
           {conn, user}
 
         tags[:authenticated_admin] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
@@ -67,8 +59,6 @@ defmodule SkateWeb.ConnCase do
           {conn, user}
 
         tags[:authenticated_dispatcher] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})


### PR DESCRIPTION
There are a few tests which assume what user information they're going to get, but https://github.com/mbta/skate/pull/2864 "revealed" that we hardcode the user for `ConnCase`, but with https://github.com/mbta/skate/pull/2873 we can now generate dynamic users, so this fixes the tests so that we can dynamically create users.