### PR TITLE
feat(ex/test/conn-case): make default user dynamic from factory 

### DIFF
--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -45,8 +45,6 @@ defmodule SkateWeb.ConnCase do
     {conn, user} =
       cond do
         tags[:authenticated] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
@@ -55,8 +53,6 @@ defmodule SkateWeb.ConnCase do
           {conn, user}
 
         tags[:authenticated_admin] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})
@@ -67,8 +63,6 @@ defmodule SkateWeb.ConnCase do
           {conn, user}
 
         tags[:authenticated_dispatcher] ->
-          User.upsert(username, email)
-
           conn =
             Phoenix.ConnTest.build_conn()
             |> init_test_session(%{})

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -17,7 +17,6 @@ defmodule SkateWeb.ConnCase do
 
   use ExUnit.CaseTemplate
   import Plug.Test
-  alias Skate.Settings.User
 
   using do
     quote do
@@ -36,10 +35,7 @@ defmodule SkateWeb.ConnCase do
   setup tags do
     Skate.DataCase.setup_sandbox(tags)
 
-    username = "test_user"
-    email = "test_user@test.com"
-
-    user = User.upsert(username, email)
+    user = Skate.Factory.insert(:user)
     resource = %{id: user.id}
 
     {conn, user} =


### PR DESCRIPTION
#2874 
> There are a few tests which assume what user information they're going to get, but https://github.com/mbta/skate/pull/2864 "revealed" that we hardcode the user for ConnCase, but with https://github.com/mbta/skate/pull/2873 we can now generate dynamic users, so this fixes the tests so that we can dynamically create users.

Depends on:
- ~https://github.com/mbta/skate/pull/2864~
- #2873 
- #2874 

