### PR TITLE
fix: Don't show connectionPoints on draw panel until they exist

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -237,10 +237,12 @@ export const DiversionPage = ({
       return (
         <DrawDetourPanel
           directions={extendedDirections}
-          connectionPoints={[
-            connectionPoints?.start?.name ?? "N/A",
-            connectionPoints?.end?.name ?? "N/A",
-          ]}
+          connectionPoints={
+            connectionPoints && [
+              connectionPoints?.start?.name ?? "N/A",
+              connectionPoints?.end?.name ?? "N/A",
+            ]
+          }
           missedStops={missedStops}
           routeName={routeName ?? "??"}
           routeDescription={routeDescription ?? "??"}


### PR DESCRIPTION
Hotfix following https://github.com/mbta/skate/pull/2872