### PR TITLE
tweak: Rename detourText to copyableDetourText, fix typo

### DIFF
--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -17,7 +17,7 @@ import {
 import inTestGroup, { TestGroups } from "../../../userInTestGroup"
 
 export interface ActiveDetourPanelProps extends PropsWithChildren {
-  detourText: string
+  copyableDetourText: string
   directions?: DetourDirection[]
   connectionPoints?: [string, string]
   missedStops?: Stop[]
@@ -30,7 +30,7 @@ export interface ActiveDetourPanelProps extends PropsWithChildren {
 }
 
 export const ActiveDetourPanel = ({
-  detourText,
+  copyableDetourText,
   directions,
   connectionPoints,
   missedStops,
@@ -63,7 +63,7 @@ export const ActiveDetourPanel = ({
         {backButton}
         {/* TODO: temporary test group until I get the copy logic hooked up */}
         {inTestGroup(TestGroups.CopyButton) && (
-          <CopyButton detourText={detourText} />
+          <CopyButton detourText={copyableDetourText} />
         )}
       </Panel.Header>
 

--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -11,7 +11,7 @@ import { Stop } from "../../../schedule"
 
 interface DetourFinishedPanelProps extends PropsWithChildren {
   onNavigateBack: () => void
-  detourText: string
+  copyableDetourText: string
   connectionPoints?: [string, string]
   missedStops?: Stop[]
   onChangeDetourText: (value: string) => void
@@ -20,7 +20,7 @@ interface DetourFinishedPanelProps extends PropsWithChildren {
 
 export const DetourFinishedPanel = ({
   onNavigateBack,
-  detourText,
+  copyableDetourText,
   connectionPoints,
   missedStops,
   onChangeDetourText,
@@ -30,7 +30,7 @@ export const DetourFinishedPanel = ({
   <Panel as="article" className="c-diversion-panel">
     <Panel.Header>
       <h1 className="c-diversion-panel__h1 my-3">View Draft Detour</h1>
-      <CopyButton detourText={detourText} />
+      <CopyButton detourText={copyableDetourText} />
     </Panel.Header>
 
     <Panel.Body className="d-flex flex-column">
@@ -46,7 +46,7 @@ export const DetourFinishedPanel = ({
 
         <Form.Control
           as="textarea"
-          value={detourText}
+          value={copyableDetourText}
           onChange={({ target: { value } }) => onChangeDetourText(value)}
           className="flex-grow-1 mb-3"
           style={{

--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -2,11 +2,18 @@ import React, { PropsWithChildren } from "react"
 import { Button, Form } from "react-bootstrap"
 import * as BsIcons from "../../../helpers/bsIcons"
 import { Panel } from "../diversionPage"
-import { CopyButton } from "../detourPanelComponents"
+import {
+  ConnectionPoints,
+  CopyButton,
+  MissedStops,
+} from "../detourPanelComponents"
+import { Stop } from "../../../schedule"
 
 interface DetourFinishedPanelProps extends PropsWithChildren {
   onNavigateBack: () => void
   detourText: string
+  connectionPoints?: [string, string]
+  missedStops?: Stop[]
   onChangeDetourText: (value: string) => void
   onActivateDetour?: () => void
 }
@@ -14,6 +21,8 @@ interface DetourFinishedPanelProps extends PropsWithChildren {
 export const DetourFinishedPanel = ({
   onNavigateBack,
   detourText,
+  connectionPoints,
+  missedStops,
   onChangeDetourText,
   onActivateDetour,
   children,
@@ -44,6 +53,11 @@ export const DetourFinishedPanel = ({
             resize: "none",
           }}
         />
+
+        {connectionPoints && (
+          <ConnectionPoints connectionPoints={connectionPoints} />
+        )}
+        {missedStops && <MissedStops missedStops={missedStops} />}
       </Panel.Body.ScrollArea>
 
       <Panel.Body.Footer className="d-flex flex-column">

--- a/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
@@ -13,7 +13,7 @@ import {
 import inTestGroup, { TestGroups } from "../../../userInTestGroup"
 
 export interface PastDetourPanelProps {
-  detourText: string
+  copyableDetourText: string
   directions?: DetourDirection[]
   connectionPoints: [string, string]
   missedStops?: Stop[]
@@ -25,7 +25,7 @@ export interface PastDetourPanelProps {
 }
 
 export const PastDetourPanel = ({
-  detourText,
+  copyableDetourText,
   directions,
   connectionPoints,
   missedStops,
@@ -40,7 +40,7 @@ export const PastDetourPanel = ({
       <h1 className="c-diversion-panel__h1 my-3">View Past Detour</h1>
       {/* TODO: temporary test group until I get the copy logic hooked up */}
       {inTestGroup(TestGroups.CopyButton) && (
-        <CopyButton detourText={detourText} />
+        <CopyButton detourText={copyableDetourText} />
       )}
     </Panel.Header>
 

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -261,6 +261,11 @@ export const DiversionPage = ({
         <DetourFinishedPanel
           onNavigateBack={editDetour}
           detourText={textArea}
+          connectionPoints={[
+            connectionPoints?.start?.name ?? "N/A",
+            connectionPoints?.end?.name ?? "N/A",
+          ]}
+          missedStops={missedStops}
           onChangeDetourText={setTextArea}
           onActivateDetour={
             inTestGroup(TestGroups.DetoursList)

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -260,7 +260,7 @@ export const DiversionPage = ({
       return (
         <DetourFinishedPanel
           onNavigateBack={editDetour}
-          detourText={textArea}
+          copyableDetourText={textArea}
           connectionPoints={[
             connectionPoints?.start?.name ?? "N/A",
             connectionPoints?.end?.name ?? "N/A",
@@ -350,7 +350,7 @@ export const DiversionPage = ({
     } else if (snapshot.matches({ "Detour Drawing": "Active" })) {
       return (
         <ActiveDetourPanel
-          detourText="Hello World"
+          copyableDetourText="Hello World"
           directions={extendedDirections}
           connectionPoints={[
             connectionPoints?.start?.name ?? "N/A",
@@ -391,7 +391,7 @@ export const DiversionPage = ({
     } else if (snapshot.matches({ "Detour Drawing": "Past" })) {
       return (
         <PastDetourPanel
-          detourText="Hello World"
+          copyableDetourText="Hello World"
           directions={extendedDirections}
           connectionPoints={[
             connectionPoints?.start?.name ?? "N/A",

--- a/assets/stories/skate-components/detours/activeDetourPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/activeDetourPanel.stories.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { ActiveDetourPanel } from "../../../src/components/detours/detourPanels/activeDetourPanel"
 import { stopFactory } from "../../../tests/factories/stop"
 
-const defaulText = [
+const defaultText = [
   "Detour:",
   "66 Harvard via Allston from",
   "Andrew Station",
@@ -34,7 +34,7 @@ const meta = {
     stretch: true,
   },
   args: {
-    detourText: defaulText,
+    copyableDetourText: defaultText,
     directions: [
       { instruction: "Start at Centre St & John St" },
       { instruction: "Right on John St" },

--- a/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/detourFinishedPanel.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
     stretch: true,
   },
   args: {
-    detourText: defaultText,
+    copyableDetourText: defaultText,
   },
   // The bootstrap CSS reset is supposed to set box-sizing: border-box by
   // default, we should be able to remove this after that is added

--- a/assets/stories/skate-components/detours/pastDetourPanel.stories.tsx
+++ b/assets/stories/skate-components/detours/pastDetourPanel.stories.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { PastDetourPanel } from "../../../src/components/detours/detourPanels/pastDetourPanel"
 import { stopFactory } from "../../../tests/factories/stop"
 
-const defaulText = [
+const defaultText = [
   "Detour:",
   "66 Harvard via Allston from",
   "Andrew Station",
@@ -34,7 +34,7 @@ const meta = {
     stretch: true,
   },
   args: {
-    detourText: defaulText,
+    copyableDetourText: defaultText,
     directions: [
       { instruction: "Start at Centre St & John St" },
       { instruction: "Right on John St" },

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -457,6 +457,29 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                   class="flex-grow-1 mb-3 form-control"
                   style="resize: none;"
                 />
+                <section
+                  class="pb-3"
+                >
+                  <h2
+                    class="c-diversion-panel__h2"
+                  >
+                    Connection Points
+                  </h2>
+                  <ul
+                    class="list-group"
+                  >
+                    <div
+                      class="list-group-item"
+                    >
+                      N/A
+                    </div>
+                    <div
+                      class="list-group-item"
+                    >
+                      N/A
+                    </div>
+                  </ul>
+                </section>
               </div>
               <div
                 class="border-top d-flex mt-auto d-flex flex-column"
@@ -1233,6 +1256,29 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                 class="flex-grow-1 mb-3 form-control"
                 style="resize: none;"
               />
+              <section
+                class="pb-3"
+              >
+                <h2
+                  class="c-diversion-panel__h2"
+                >
+                  Connection Points
+                </h2>
+                <ul
+                  class="list-group"
+                >
+                  <div
+                    class="list-group-item"
+                  >
+                    N/A
+                  </div>
+                  <div
+                    class="list-group-item"
+                  >
+                    N/A
+                  </div>
+                </ul>
+              </section>
             </div>
             <div
               class="border-top d-flex mt-auto d-flex flex-column"


### PR DESCRIPTION
I renamed `detourText` to distinguish `editableDirections` from `copyableDetourText`, but splitting out into a separate PR to make review easier.

Builds off of
- https://github.com/mbta/skate/pull/2878