### PR TITLE
Revert "feat: Add connectionPoints and missedStops to the “Review Det…

### DIFF
--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -2,18 +2,11 @@ import React, { PropsWithChildren } from "react"
 import { Button, Form } from "react-bootstrap"
 import * as BsIcons from "../../../helpers/bsIcons"
 import { Panel } from "../diversionPage"
-import {
-  ConnectionPoints,
-  CopyButton,
-  MissedStops,
-} from "../detourPanelComponents"
-import { Stop } from "../../../schedule"
+import { CopyButton } from "../detourPanelComponents"
 
 interface DetourFinishedPanelProps extends PropsWithChildren {
   onNavigateBack: () => void
   detourText: string
-  connectionPoints?: [string, string]
-  missedStops?: Stop[]
   onChangeDetourText: (value: string) => void
   onActivateDetour?: () => void
 }
@@ -21,8 +14,6 @@ interface DetourFinishedPanelProps extends PropsWithChildren {
 export const DetourFinishedPanel = ({
   onNavigateBack,
   detourText,
-  connectionPoints,
-  missedStops,
   onChangeDetourText,
   onActivateDetour,
   children,
@@ -54,11 +45,6 @@ export const DetourFinishedPanel = ({
           }}
           data-fs-element="Detour Text"
         />
-
-        {connectionPoints && (
-          <ConnectionPoints connectionPoints={connectionPoints} />
-        )}
-        {missedStops && <MissedStops missedStops={missedStops} />}
       </Panel.Body.ScrollArea>
 
       <Panel.Body.Footer className="d-flex flex-column">

--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -261,11 +261,6 @@ export const DiversionPage = ({
         <DetourFinishedPanel
           onNavigateBack={editDetour}
           detourText={textArea}
-          connectionPoints={[
-            connectionPoints?.start?.name ?? "N/A",
-            connectionPoints?.end?.name ?? "N/A",
-          ]}
-          missedStops={missedStops}
           onChangeDetourText={setTextArea}
           onActivateDetour={
             inTestGroup(TestGroups.DetoursList)

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -460,29 +460,6 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                   data-fs-element="Detour Text"
                   style="resize: none;"
                 />
-                <section
-                  class="pb-3"
-                >
-                  <h2
-                    class="c-diversion-panel__h2"
-                  >
-                    Connection Points
-                  </h2>
-                  <ul
-                    class="list-group"
-                  >
-                    <div
-                      class="list-group-item"
-                    >
-                      N/A
-                    </div>
-                    <div
-                      class="list-group-item"
-                    >
-                      N/A
-                    </div>
-                  </ul>
-                </section>
               </div>
               <div
                 class="border-top d-flex mt-auto d-flex flex-column"
@@ -1262,29 +1239,6 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                 data-fs-element="Detour Text"
                 style="resize: none;"
               />
-              <section
-                class="pb-3"
-              >
-                <h2
-                  class="c-diversion-panel__h2"
-                >
-                  Connection Points
-                </h2>
-                <ul
-                  class="list-group"
-                >
-                  <div
-                    class="list-group-item"
-                  >
-                    N/A
-                  </div>
-                  <div
-                    class="list-group-item"
-                  >
-                    N/A
-                  </div>
-                </ul>
-              </section>
             </div>
             <div
               class="border-top d-flex mt-auto d-flex flex-column"


### PR DESCRIPTION
Reverts mbta/skate#2878

This was merged prematurely, and subsequent PR https://github.com/mbta/skate/pull/2883 fixes the problem introduced here, which is that the textArea takes up too little space