### PR TITLE
chore(ex/skate_web/endpoint): pull `Plug.Session` options into compile time constant

### DIFF
--- a/lib/skate_web/endpoint.ex
+++ b/lib/skate_web/endpoint.ex
@@ -2,8 +2,21 @@ defmodule SkateWeb.Endpoint do
   use Sentry.PlugCapture
   use Phoenix.Endpoint, otp_app: :skate
 
+  # The session will be stored in the cookie and signed,
+  # this means its contents can be read but not tampered with.
+  # Set :encryption_salt if you would also like to encrypt it.
+  @session_options [
+    store: :cookie,
+    key: "_skate_key",
+    signing_salt: "jkUgGkwy",
+    same_site: "Lax"
+  ]
+
   socket "/socket", SkateWeb.UserSocket,
-    websocket: [check_origin: Application.compile_env(:skate, :websocket_check_origin, false)],
+    websocket: [
+      connect_info: [session: @session_options],
+      check_origin: Application.compile_env(:skate, :websocket_check_origin, false)
+    ],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.
@@ -36,14 +49,7 @@ defmodule SkateWeb.Endpoint do
   plug Sentry.PlugContext
   plug Plug.MethodOverride
   plug Plug.Head
-
-  # The session will be stored in the cookie and signed,
-  # this means its contents can be read but not tampered with.
-  # Set :encryption_salt if you would also like to encrypt it.
-  plug Plug.Session,
-    store: :cookie,
-    key: "_skate_key",
-    signing_salt: "jkUgGkwy"
+  plug Plug.Session, @session_options
 
   plug SkateWeb.Router
 end


### PR DESCRIPTION
Aligns our implementation with the `phx.new` template
- https://github.com/phoenixframework/phoenix/blob/main/installer/templates/phx_web/endpoint.ex#L7-L12
- https://github.com/phoenixframework/phoenix/blob/main/installer/templates/phx_web/endpoint.ex#L51
