### PR TITLE
chore(ex): configure check_origin for all transports on the `SkateWeb.Endpoint`

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -31,12 +31,11 @@ config :skate, SkateWeb.Endpoint,
     port: {:system, "STATIC_PORT"},
     path: {:system, "STATIC_PATH"}
   ],
-  cache_static_manifest: "priv/static/cache_manifest.json"
-
-config :skate, :websocket_check_origin, [
-  "https://*.mbta.com",
-  "https://*.mbtace.com"
-]
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  check_origin: [
+    "https://*.mbta.com",
+    "https://*.mbtace.com"
+  ]
 
 config :skate, Skate.Repo,
   database: "skate",

--- a/lib/skate_web/endpoint.ex
+++ b/lib/skate_web/endpoint.ex
@@ -14,8 +14,7 @@ defmodule SkateWeb.Endpoint do
 
   socket "/socket", SkateWeb.UserSocket,
     websocket: [
-      connect_info: [session: @session_options],
-      check_origin: Application.compile_env(:skate, :websocket_check_origin, false)
+      connect_info: [session: @session_options]
     ],
     longpoll: false
 


### PR DESCRIPTION
This configuration has always confused me a little, mainly that we had to "implement" it ourselves.

So I tracked this down and confirmed that this can be configured via Application config
- https://hexdocs.pm/phoenix/1.7.11/Phoenix.Endpoint.html#socket/3-common-configuration
	- > `:check_origin` - if the transport should check the origin of requests when the origin header is present. [...]. **_Defaults to `:check_origin` setting at endpoint configuration_**.

I do not know if this option was available at the time of https://github.com/mbta/skate/pull/36/ but now we can configure this via `SkateWeb.Endpoint`.

I loaded this up on dev-green and saw no changes or issues when loading the application.

This also seems to match other "modern" TID applications.

---

Depends on:
- #2894 