### PR TITLE
fix(Dockerfile): update checksum for aws cert bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,10 @@ RUN apk add --no-cache --update curl
 
 WORKDIR /root
 
-RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
-    -o aws-cert-bundle.pem
-RUN echo "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede  aws-cert-bundle.pem" | sha256sum -c -
+ADD \
+  --checksum=sha256:390fdc813e2e58ec5a0def8ce6422b83d75032899167052ab981d8e1b3b14ff2 \
+  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+  aws-cert-bundle.pem
 
 # Add frontend assets compiled in node container, required by phx.digest
 COPY --from=assets-builder /root/priv/static ./priv/static


### PR DESCRIPTION
The AWS RDS Cert bundle updated again and builds have been failing due to that.

Turns out, there is now a [`Dockerfile` `--checksum` argument to the `ADD` command](https://docs.docker.com/reference/dockerfile/#add---checksum) which both pulls something from the internet (like `curl`) but _also_ can check the hash of the content at the same time. 

This will also give us better logs when builds fail, and tell us what the new checksum is.  
(Example log from when I initially added the `ADD` command, with a dummy checksum from the docs)
```
ERROR: failed to solve: digest mismatch sha256:390fdc813e2e58ec5a0def8ce6422b83d75032899167052ab981d8e1b3b14ff2: sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d
```

Previously: #2746 
Asana Ticket: https://app.asana.com/0/1148853526253420/1208798175282938/f