### PR TITLE
feat(ex/skate/detours): add `activated_at` column

### DIFF
--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -36,6 +36,8 @@ export const createDetourMachine = setup({
 
       selectedDuration?: string
       selectedReason?: string
+
+      activatedAt?: Date
     },
 
     input: {} as
@@ -624,6 +626,11 @@ export const createDetourMachine = setup({
                     },
                     "detour.share.activate-modal.activate": {
                       target: "Done",
+                      actions: assign({
+                        // Record current time, should be done on the backend,
+                        // but that requires a larger refactor of the state machine
+                        activatedAt: new Date(),
+                      }),
                     },
                   },
                 },

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -11,6 +11,7 @@ import {
 } from "../api"
 import { DetourShape, FinishedDetour } from "./detour"
 import { fullStoryEvent } from "../helpers/fullStory"
+import { type, optional, coerce, date, string } from "superstruct"
 
 export const createDetourMachine = setup({
   types: {
@@ -701,3 +702,15 @@ export const createDetourMachine = setup({
 export type CreateDetourMachineInput = InputFrom<
   ActorLogicFrom<typeof createDetourMachine>
 >
+
+/**
+ * Defines expected keys and type coercions in Superstruct to enable the
+ * {@linkcode createDetourMachine} to use rich types when rehydrating from a
+ * API response.
+ */
+export const DetourSnapshotData = type({
+  context: type({
+    // Convert serialized dates back into `Date`'s
+    activatedAt: optional(coerce(date(), string(), (str) => new Date(str))),
+  }),
+})

--- a/assets/src/models/detour.ts
+++ b/assets/src/models/detour.ts
@@ -1,7 +1,10 @@
 import { LatLngLiteral } from "leaflet"
 import { ShapePoint, Stop } from "../schedule"
-import { CreateDetourMachineInput } from "./createDetourMachine"
-import { any, Infer, number, string, type } from "superstruct"
+import {
+  CreateDetourMachineInput,
+  DetourSnapshotData,
+} from "./createDetourMachine"
+import { Infer, number, string, type } from "superstruct"
 
 export interface DetourWithState {
   author: string
@@ -11,7 +14,7 @@ export interface DetourWithState {
 
 export const DetourWithStateData = type({
   author: string(),
-  state: any(),
+  state: DetourSnapshotData,
   updated_at: number(),
 })
 

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -20,7 +20,7 @@ defmodule Skate.Detours.Db.Detour do
 
   def changeset(detour, attrs) do
     detour
-    |> cast(attrs, [:state])
+    |> cast(attrs, [:state, :activated_at])
     |> validate_required([:state])
   end
 end

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -12,6 +12,9 @@ defmodule Skate.Detours.Db.Detour do
     field :state, :map
     belongs_to :author, User
 
+    # When this detour was activated
+    field :activated_at, :utc_datetime_usec
+
     timestamps()
   end
 

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -203,7 +203,7 @@ defmodule Skate.Detours.Detours do
       |> Skate.Repo.insert(
         returning: true,
         conflict_target: [:id],
-        on_conflict: {:replace, [:state, :updated_at]}
+        on_conflict: {:replace_all_except, [:inserted_at]}
       )
 
     case detour_db_result do

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -96,7 +96,8 @@ defmodule Skate.Detours.SnapshotSerde do
       "finishedDetour" => finisheddetour_from_detour(detour),
       "editedDirections" => editeddirections_from_detour(detour),
       "selectedDuration" => selectedduration_from_detour(detour),
-      "selectedReason" => selectedreason_from_detour(detour)
+      "selectedReason" => selectedreason_from_detour(detour),
+      "activatedAt" => activated_at_from_detour(detour)
     })
   end
 
@@ -287,6 +288,11 @@ defmodule Skate.Detours.SnapshotSerde do
   end
 
   defp selectedreason_from_detour(_), do: nil
+
+  defp activated_at_from_detour(%Detour{activated_at: %DateTime{} = activated_at}),
+    do: DateTime.to_iso8601(activated_at)
+
+  defp activated_at_from_detour(%Detour{activated_at: nil}), do: nil
 
   # defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}), do: snapshot_children
   defp snapshot_children_from_detour(%Detour{

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -21,10 +21,17 @@ defmodule Skate.Detours.SnapshotSerde do
       %{
         # Save Snapshot to DB until we've fully transitioned to serializing
         # snapshots from DB data
-        state: snapshot
+        state: snapshot,
+        activated_at: activated_at_from_snapshot(snapshot)
       }
     )
   end
+
+  defp activated_at_from_snapshot(%{"context" => %{"activatedAt" => activated_at}}),
+    do: activated_at
+
+  defp activated_at_from_snapshot(_),
+    do: nil
 
   @doc """
   Extracts the Detour ID from a XState Snapshot

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -289,8 +289,22 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp selectedreason_from_detour(_), do: nil
 
-  defp activated_at_from_detour(%Detour{activated_at: %DateTime{} = activated_at}),
-    do: DateTime.to_iso8601(activated_at)
+  defp activated_at_from_detour(%Detour{activated_at: %DateTime{} = activated_at}) do
+    activated_at
+    # For the time being, the frontend is responsible for generating the
+    # `activated_at` snapshot. Because browsers are limited to millisecond
+    # resolution and Ecto doesn't preserve the `milliseconds` field of a
+    # `DateTime`, we need to truncate the date if we want it to match what's in
+    # the stored snapshot.
+    #
+    # Once we're not trying to be equivalent with the stored snapshot, we could
+    # probably remove this.
+    #
+    # See `Skate.DetourFactory.browser_date/1` and `Skate.DetourFactory.db_date`
+    # for more context.
+    |> DateTime.truncate(:millisecond)
+    |> DateTime.to_iso8601()
+  end
 
   defp activated_at_from_detour(%Detour{activated_at: nil}), do: nil
 

--- a/priv/repo/async_migrations/20241218135700_backfill_detour_activated_at.exs
+++ b/priv/repo/async_migrations/20241218135700_backfill_detour_activated_at.exs
@@ -1,0 +1,49 @@
+defmodule Skate.Repo.Migrations.BackfillDetourActivatedAt do
+  # https://fly.io/phoenix-files/backfilling-data/
+
+
+  import Ecto.Query
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # The 'backfilling-data' blog post suggests using a "throttle" function
+    # so that we don't update too many at once, but we currently have less than
+    # 1000 detours, so I think this will be negligable and not worth the
+    # complexity cost at _this_ time.
+    repo().update_all(
+      from(
+        r in Skate.Repo.Migrations.BackfillDetourActivatedAt.MigratingSchema,
+        select: r.id,
+        where: not is_nil(r.state["value"]["Detour Drawing"]["Active"]) and is_nil(r.activated_at),
+        update: [set: [activated_at: r.updated_at]]
+      ),
+      [],
+      log: :info
+    )
+   end
+
+  def down, do: :ok
+end
+
+defmodule Skate.Repo.Migrations.BackfillDetourActivatedAt.MigratingSchema do
+  @moduledoc """
+  Detours database table schema frozen at this point in time.
+  """
+
+  use Skate.Schema
+
+  alias Skate.Settings.Db.User
+
+  typed_schema "detours" do
+    field :state, :map
+    belongs_to :author, User
+
+    # When this detour was activated
+    field :activated_at, :utc_datetime_usec
+
+    timestamps()
+  end
+end

--- a/priv/repo/migrations/20241211183227_add_detour_activated_at_field.exs
+++ b/priv/repo/migrations/20241211183227_add_detour_activated_at_field.exs
@@ -1,0 +1,9 @@
+defmodule Skate.Repo.Migrations.AddDetourActivatedAtField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:detours) do
+      add :activated_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -57,12 +57,27 @@ defmodule Skate.DetourFactory do
         put_in(snapshot["context"]["uuid"], id)
       end
 
-      def activated(%Skate.Detours.Db.Detour{} = detour) do
-        %{detour | state: activated(detour.state)}
+      def update_id(%Skate.Detours.Db.Detour{id: id} = detour) do
+        with_id(detour, id)
       end
 
-      def activated(%{"value" => %{}} = state) do
-        put_in(state["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
+      def activated(update_arg, activated_at \\ DateTime.utc_now())
+
+      def activated(%Skate.Detours.Db.Detour{} = detour, activated_at) do
+        activated_at = Skate.DetourFactory.browser_date(activated_at)
+        %{detour | state: activated(detour.state, activated_at), activated_at: activated_at}
+      end
+
+      def activated(%{"value" => %{}, "context" => %{}} = state, activated_at) do
+        state =
+          put_in(state["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
+
+        put_in(
+          state["context"]["activatedAt"],
+          activated_at
+          |> Skate.DetourFactory.browser_date()
+          |> DateTime.to_iso8601()
+        )
       end
 
       def deactivated(%Skate.Detours.Db.Detour{} = detour) do
@@ -94,5 +109,33 @@ defmodule Skate.DetourFactory do
         put_in(state["context"]["routePattern"]["directionId"], 0)
       end
     end
+  end
+
+  @doc """
+  Browsers cannot generate javascript `Date` objects with more precision than a
+  `millisecond` for security reasons.
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now#reduced_time_precision
+
+  This function truncates a `DateTime` to milliseconds to create `DateTime` objects
+  that are similar to that of one made in a Browser JS context.
+  """
+  def browser_date(%DateTime{} = date \\ DateTime.utc_now()) do
+    DateTime.truncate(date, :millisecond)
+  end
+
+  @doc """
+  While a Browser may generate a date truncated to milliseconds
+  (see `browser_date` for more context) a `DateTime` stored into Postgres with
+  the `:utc_datetime_usec` type does not store the extra information about the
+  non-presence of nanoseconds that a `DateTime` object does.
+  This means a `DateTime` object that's been truncated by `browser_date` cannot
+  be compared to a `DateTime` object reconstructed by Ecto after a Database query.
+
+  This function adds 0 nanoseconds to a `DateTime` object to make the `DateTime`
+  object match what Ecto would return to make testing easier when comparing
+  values.
+  """
+  def db_date(%DateTime{} = date) do
+    DateTime.add(date, 0, :nanosecond)
   end
 end


### PR DESCRIPTION
To be able to show the activated at time in various places within Skate, as well as for sorting, we need to start recording the time of activation for a detour.
This PR
- adds the database column
- backfills the database column so that currently active detours are marked as having been active since the last modification time
- starts recording the activation time in the state machine when a detour is activated

---

Asana Ticket: https://app.asana.com/0/0/1208989312907929/f