### PR TITLE
 feat: add `activated-at` column to frontend detours list 

### DIFF
--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { Table } from "react-bootstrap"
 import { RoutePill } from "./routePill"
-import { useCurrentTimeSeconds } from "../hooks/useCurrentTime"
-import { timeAgoLabel } from "../util/dateTime"
+import { useCurrentTime } from "../hooks/useCurrentTime"
+import { timeAgoLabel, timeAgoLabelFromDate } from "../util/dateTime"
 import { SimpleDetour } from "../models/detoursList"
 import { EmptyDetourTableIcon } from "../helpers/skateIcons"
 import { joinClasses } from "../helpers/dom"
@@ -55,7 +55,11 @@ export const DetoursTable = ({
     </thead>
     <tbody>
       {data ? (
-        <PopulatedDetourRows data={data} onOpenDetour={onOpenDetour} />
+        <PopulatedDetourRows
+          status={status}
+          data={data}
+          onOpenDetour={onOpenDetour}
+        />
       ) : (
         <EmptyDetourRows message={`No ${status} detours.`} />
       )}
@@ -65,12 +69,15 @@ export const DetoursTable = ({
 
 const PopulatedDetourRows = ({
   data,
+  status,
   onOpenDetour,
 }: {
   data: SimpleDetour[]
+  status: DetourStatus
   onOpenDetour: (detourId: number) => void
 }) => {
-  const epochNowInSeconds = useCurrentTimeSeconds()
+  const epochNow = useCurrentTime()
+  const epochNowInSeconds = epochNow.valueOf() / 1000
 
   return (
     <>
@@ -91,7 +98,9 @@ const PopulatedDetourRows = ({
             {detour.intersection}
           </td>
           <td className="align-middle p-3 u-hide-for-mobile">
-            {timeAgoLabel(epochNowInSeconds, detour.updatedAt)}
+            {status === DetourStatus.Active && detour.activatedAt
+              ? timeAgoLabelFromDate(detour.activatedAt, epochNow)
+              : timeAgoLabel(epochNowInSeconds, detour.updatedAt)}
           </td>
         </tr>
       ))}

--- a/assets/src/hooks/useCurrentTime.ts
+++ b/assets/src/hooks/useCurrentTime.ts
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { now } from "../util/dateTime"
 import useInterval from "./useInterval"
 
-const useCurrentTime = (): Date => {
+export const useCurrentTime = (): Date => {
   const [currentTime, setCurrentTime] = useState(now())
   useInterval(() => setCurrentTime(now()), 1000)
   return currentTime

--- a/assets/src/models/detoursList.ts
+++ b/assets/src/models/detoursList.ts
@@ -1,4 +1,13 @@
-import { array, Infer, nullable, number, string, type } from "superstruct"
+import {
+  array,
+  coerce,
+  date,
+  Infer,
+  nullable,
+  number,
+  string,
+  type,
+} from "superstruct"
 
 export type DetourId = number
 export interface SimpleDetour {
@@ -8,6 +17,7 @@ export interface SimpleDetour {
   name: string
   intersection: string
   updatedAt: number
+  activatedAt?: Date
 }
 
 export const detourId = number()
@@ -22,6 +32,13 @@ export const SimpleDetourData = type({
 
 export type SimpleDetourData = Infer<typeof SimpleDetourData>
 
+export const ActivatedDetourData = type({
+  activated_at: coerce(date(), string(), (dateStr) => new Date(dateStr)),
+  details: SimpleDetourData,
+})
+
+export type ActivatedDetourData = Infer<typeof ActivatedDetourData>
+
 export const simpleDetourFromData = (
   detourData: SimpleDetourData
 ): SimpleDetour => ({
@@ -33,6 +50,13 @@ export const simpleDetourFromData = (
   updatedAt: detourData.updated_at,
 })
 
+export const simpleDetourFromActivatedData = (
+  detourData: ActivatedDetourData
+) => ({
+  ...simpleDetourFromData(detourData.details),
+  activatedAt: detourData.activated_at,
+})
+
 export interface GroupedSimpleDetours {
   active?: SimpleDetour[]
   draft?: SimpleDetour[]
@@ -40,7 +64,7 @@ export interface GroupedSimpleDetours {
 }
 
 export const GroupedDetoursData = type({
-  active: nullable(array(SimpleDetourData)),
+  active: nullable(array(ActivatedDetourData)),
   draft: nullable(array(SimpleDetourData)),
   past: nullable(array(SimpleDetourData)),
 })
@@ -50,7 +74,7 @@ export type GroupedDetoursData = Infer<typeof GroupedDetoursData>
 export const groupedDetoursFromData = (
   groupedDetours: GroupedDetoursData
 ): GroupedSimpleDetours => ({
-  active: groupedDetours.active?.map((detour) => simpleDetourFromData(detour)),
+  active: groupedDetours.active?.map(simpleDetourFromActivatedData),
   draft: groupedDetours.draft?.map((detour) => simpleDetourFromData(detour)),
   past: groupedDetours.past?.map((detour) => simpleDetourFromData(detour)),
 })

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -98,9 +98,19 @@ export const timeAgoLabel = (
   epochNowInSeconds: number,
   epochTime: number
 ): string => {
-  const duration = epochNowInSeconds - epochTime
-  const diffHours = Math.floor(duration / 3_600)
-  const diffMinutes = Math.floor((duration % 3_600) / 60)
+  const second = 1
+  const minute = second * 60
+  const hour = minute * 60
 
-  return diffHours >= 1 ? `${diffHours} hours ago` : `${diffMinutes} min ago`
+  const duration = epochNowInSeconds - epochTime
+
+  if (duration > 1 * hour) {
+    return `${Math.floor(duration / hour)} hours ago`
+  }
+
+  if (duration > 1 * minute) {
+    return `${Math.floor(duration / minute)} min ago`
+  }
+
+  return "Just now"
 }

--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -114,3 +114,8 @@ export const timeAgoLabel = (
 
   return "Just now"
 }
+
+export const timeAgoLabelFromDate = (start: Date, end: Date) => {
+  const second = 1000
+  return timeAgoLabel(end.valueOf() / second, start.valueOf() / second)
+}

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
           </tr>
           <tr>
@@ -163,7 +163,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
           </tr>
         </tbody>
@@ -971,7 +971,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
           </tr>
           <tr>
@@ -1010,7 +1010,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -41,6 +41,7 @@ describe("DetourListPage", () => {
             name: "Headsign A",
             intersection: "Street A & Avenue B",
             updatedAt: 1724866392,
+            activatedAt: new Date(1724866392000),
           },
           {
             id: 8,
@@ -49,6 +50,7 @@ describe("DetourListPage", () => {
             name: "Headsign B",
             intersection: "Street C & Avenue D",
             updatedAt: 1724856392,
+            activatedAt: new Date(1724856392000),
           },
         ],
         draft: undefined,
@@ -99,6 +101,7 @@ describe("DetourListPage", () => {
             name: "Headsign A",
             intersection: "Street A & Avenue B",
             updatedAt: 1724866392,
+            activatedAt: new Date(1724866392000),
           },
           {
             id: 8,
@@ -107,6 +110,7 @@ describe("DetourListPage", () => {
             name: "Headsign B",
             intersection: "Street C & Avenue D",
             updatedAt: 1724856392,
+            activatedAt: new Date(1724856392000),
           },
         ],
         draft: undefined,

--- a/assets/tests/factories/detourListFactory.ts
+++ b/assets/tests/factories/detourListFactory.ts
@@ -1,16 +1,18 @@
 import { Factory } from "fishery"
 import {
+  ActivatedDetourData,
   GroupedSimpleDetours,
   SimpleDetourData,
+  simpleDetourFromActivatedData,
   simpleDetourFromData,
 } from "../../src/models/detoursList"
 
 export const detourListFactory = Factory.define<GroupedSimpleDetours>(() => {
   return {
     active: [
-      simpleDetourFromData(simpleDetourDataFactory.build()),
-      simpleDetourFromData(
-        simpleDetourDataFactory.build({ direction: "Outbound" })
+      simpleDetourFromActivatedData(activeDetourDataFactory.build()),
+      simpleDetourFromActivatedData(
+        activeDetourDataFactory.build({ details: { direction: "Outbound" } })
       ),
     ],
     draft: undefined,
@@ -30,5 +32,12 @@ export const simpleDetourDataFactory = Factory.define<SimpleDetourData>(
     name: `Headsign ${sequence}`,
     intersection: `Street A${sequence} & Avenue B${sequence}`,
     updated_at: 1724866392,
+  })
+)
+
+export const activeDetourDataFactory = Factory.define<ActivatedDetourData>(
+  () => ({
+    details: simpleDetourDataFactory.build(),
+    activated_at: new Date(),
   })
 )

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -30,6 +30,59 @@ defmodule Skate.Detours.Detour do
       :author_id,
       :status
     ]
+
+    def from(
+          status,
+          %{
+            state: %{
+              "context" => %{
+                "route" => %{"name" => route_name, "directionNames" => direction_names},
+                "routePattern" => %{"headsign" => headsign, "directionId" => direction_id},
+                "nearestIntersection" => nearest_intersection
+              }
+            }
+          } = db_detour
+        ) do
+      direction = Map.get(direction_names, Integer.to_string(direction_id))
+
+      %__MODULE__{
+        id: db_detour.id,
+        route: route_name,
+        direction: direction,
+        name: headsign,
+        intersection: nearest_intersection,
+        updated_at: timestamp_to_unix(db_detour.updated_at),
+        author_id: db_detour.author_id,
+        status: status
+      }
+    end
+
+    def from(_status, _attrs), do: nil
+
+    # Converts the db timestamp to unix
+    defp timestamp_to_unix(db_date) do
+      db_date
+      |> DateTime.from_naive!("Etc/UTC")
+      |> DateTime.to_unix()
+    end
+  end
+
+  defmodule ActivatedDetourDetails do
+    @moduledoc """
+    Extended information for active detours
+    """
+
+    @type t :: %__MODULE__{
+            activated_at: DateTime.t(),
+            details: Detailed.t()
+          }
+
+    @derive Jason.Encoder
+
+    defstruct [
+      :activated_at,
+      :details
+    ]
   end
 
   defmodule WithState do

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -4,6 +4,7 @@ defmodule Skate.Detours.Detours do
   """
 
   import Ecto.Query, warn: false
+  alias Skate.Detours.Detour.ActivatedDetourDetails
   alias Skate.Repo
   alias Skate.Detours.Db.Detour
   alias Skate.Detours.SnapshotSerde
@@ -67,7 +68,10 @@ defmodule Skate.Detours.Detours do
       list_detours()
       |> Enum.map(&db_detour_to_detour/1)
       |> Enum.filter(& &1)
-      |> Enum.group_by(fn detour -> detour.status end)
+      |> Enum.group_by(fn
+        %ActivatedDetourDetails{details: %{status: status}} -> status
+        %{status: status} -> status
+      end)
 
     %{
       active: Map.get(detours, :active, []),
@@ -80,34 +84,34 @@ defmodule Skate.Detours.Detours do
   end
 
   @spec db_detour_to_detour(Detour.t()) :: DetailedDetour.t() | nil
-  def db_detour_to_detour(
-        %{
-          state: %{
-            "context" => %{
-              "route" => %{"name" => route_name, "directionNames" => direction_names},
-              "routePattern" => %{"headsign" => headsign, "directionId" => direction_id},
-              "nearestIntersection" => nearest_intersection
-            }
-          }
-        } = db_detour
-      ) do
-    direction = Map.get(direction_names, Integer.to_string(direction_id))
-
-    %DetailedDetour{
-      id: db_detour.id,
-      route: route_name,
-      direction: direction,
-      name: headsign,
-      intersection: nearest_intersection,
-      updated_at: timestamp_to_unix(db_detour.updated_at),
-      author_id: db_detour.author_id,
-      status: categorize_detour(db_detour)
-    }
+  @spec db_detour_to_detour(status :: detour_type(), Detour.t()) :: DetailedDetour.t() | nil
+  def db_detour_to_detour(%{} = db_detour) do
+    db_detour_to_detour(categorize_detour(db_detour), db_detour)
   end
 
-  def db_detour_to_detour(invalid_detour) do
+  def db_detour_to_detour(
+        :active,
+        %Detour{activated_at: activated_at} = db_detour
+      ) do
+    details = DetailedDetour.from(:active, db_detour)
+
+    details &&
+      %ActivatedDetourDetails{
+        activated_at: activated_at,
+        details: details
+      }
+  end
+
+  def db_detour_to_detour(
+        status,
+        %{} = db_detour
+      ) do
+    DetailedDetour.from(status, db_detour)
+  end
+
+  def db_detour_to_detour(state, invalid_detour) do
     Sentry.capture_message("Detour error: the detour has an outdated schema",
-      extra: %{error: invalid_detour}
+      extra: %{error: invalid_detour, state: state}
     )
 
     nil

--- a/lib/skate_web/channels/detours_channel.ex
+++ b/lib/skate_web/channels/detours_channel.ex
@@ -41,7 +41,10 @@ defmodule SkateWeb.DetoursChannel do
   end
 
   @impl SkateWeb.AuthenticatedChannel
-  def handle_info_authenticated({:detour_activated, detour}, socket) do
+  def handle_info_authenticated(
+        {:detour_activated, %Skate.Detours.Detour.ActivatedDetourDetails{} = detour},
+        socket
+      ) do
     :ok = push(socket, "activated", %{data: detour})
     {:noreply, socket}
   end

--- a/test/skate_web/channels/detours_channel_test.exs
+++ b/test/skate_web/channels/detours_channel_test.exs
@@ -48,25 +48,29 @@ defmodule SkateWeb.DetoursChannelTest do
       assert {:ok,
               %{
                 data: [
-                  %Skate.Detours.Detour.Detailed{
-                    author_id: _,
-                    direction: _,
-                    id: 2,
-                    intersection: "detour_nearest_intersection:" <> _,
-                    name: "detour_route_pattern_headsign:" <> _,
-                    route: "57",
-                    status: :active,
-                    updated_at: _
+                  %Skate.Detours.Detour.ActivatedDetourDetails{
+                    details: %Skate.Detours.Detour.Detailed{
+                      author_id: _,
+                      direction: _,
+                      id: 2,
+                      intersection: "detour_nearest_intersection:" <> _,
+                      name: "detour_route_pattern_headsign:" <> _,
+                      route: "57",
+                      status: :active,
+                      updated_at: _
+                    }
                   },
-                  %Skate.Detours.Detour.Detailed{
-                    author_id: _,
-                    direction: _,
-                    id: 3,
-                    intersection: "detour_nearest_intersection:" <> _,
-                    name: "detour_route_pattern_headsign:" <> _,
-                    route: "66",
-                    status: :active,
-                    updated_at: _
+                  %Skate.Detours.Detour.ActivatedDetourDetails{
+                    details: %Skate.Detours.Detour.Detailed{
+                      author_id: _,
+                      direction: _,
+                      id: 3,
+                      intersection: "detour_nearest_intersection:" <> _,
+                      name: "detour_route_pattern_headsign:" <> _,
+                      route: "66",
+                      status: :active,
+                      updated_at: _
+                    }
                   }
                 ]
               },
@@ -97,15 +101,17 @@ defmodule SkateWeb.DetoursChannelTest do
       assert {:ok,
               %{
                 data: [
-                  %Skate.Detours.Detour.Detailed{
-                    author_id: _,
-                    direction: _,
-                    id: 3,
-                    intersection: "detour_nearest_intersection:" <> _,
-                    name: "detour_route_pattern_headsign:" <> _,
-                    route: "66",
-                    status: :active,
-                    updated_at: _
+                  %Skate.Detours.Detour.ActivatedDetourDetails{
+                    details: %Skate.Detours.Detour.Detailed{
+                      author_id: _,
+                      direction: _,
+                      id: 3,
+                      intersection: "detour_nearest_intersection:" <> _,
+                      name: "detour_route_pattern_headsign:" <> _,
+                      route: "66",
+                      status: :active,
+                      updated_at: _
+                    }
                   }
                 ]
               },
@@ -129,15 +135,17 @@ defmodule SkateWeb.DetoursChannelTest do
       assert {:ok,
               %{
                 data: [
-                  %Skate.Detours.Detour.Detailed{
-                    author_id: _,
-                    direction: _,
-                    id: 2,
-                    intersection: "detour_nearest_intersection:" <> _,
-                    name: "detour_route_pattern_headsign:" <> _,
-                    route: "SL1",
-                    status: :active,
-                    updated_at: _
+                  %Skate.Detours.Detour.ActivatedDetourDetails{
+                    details: %Skate.Detours.Detour.Detailed{
+                      author_id: _,
+                      direction: _,
+                      id: 2,
+                      intersection: "detour_nearest_intersection:" <> _,
+                      name: "detour_route_pattern_headsign:" <> _,
+                      route: "SL1",
+                      status: :active,
+                      updated_at: _
+                    }
                   }
                 ]
               },
@@ -277,7 +285,8 @@ defmodule SkateWeb.DetoursChannelTest do
     test "pushes newly activated detour onto the active detour socket", %{socket: socket} do
       {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:active")
 
-      detour = :detour_snapshot |> build() |> activated
+      detour =
+        :detour |> build() |> activated |> insert() |> Skate.Detours.Detours.db_detour_to_detour()
 
       assert {:noreply, _socket} =
                DetoursChannel.handle_info(
@@ -298,7 +307,8 @@ defmodule SkateWeb.DetoursChannelTest do
       {:ok, _, socket} =
         subscribe_and_join(socket, DetoursChannel, "detours:draft:" <> Integer.to_string(user_id))
 
-      detour = :detour_snapshot |> build() |> activated
+      detour =
+        :detour |> build() |> activated |> insert() |> Skate.Detours.Detours.db_detour_to_detour()
 
       assert {:noreply, _socket} =
                DetoursChannel.handle_info(

--- a/test/skate_web/controllers/detours_controller_test.exs
+++ b/test/skate_web/controllers/detours_controller_test.exs
@@ -146,25 +146,29 @@ defmodule SkateWeb.DetoursControllerTest do
   defp populate_db_and_get_user(conn) do
     # Active detour
     put(conn, "/api/detours/update_snapshot", %{
-      "snapshot" => %{
-        "context" => %{
-          "route" => %{
-            "id" => "23",
-            "name" => "23",
-            "directionNames" => %{
-              "0" => "Outbound",
-              "1" => "Inbound"
-            }
+      "snapshot" =>
+        activated(
+          %{
+            "context" => %{
+              "route" => %{
+                "id" => "23",
+                "name" => "23",
+                "directionNames" => %{
+                  "0" => "Outbound",
+                  "1" => "Inbound"
+                }
+              },
+              "routePattern" => %{
+                "headsign" => "Headsign",
+                "directionId" => 0
+              },
+              "nearestIntersection" => "Street A & Avenue B",
+              "uuid" => 1
+            },
+            "value" => %{"Detour Drawing" => %{"Active" => "Reviewing"}}
           },
-          "routePattern" => %{
-            "headsign" => "Headsign",
-            "directionId" => 0
-          },
-          "nearestIntersection" => "Street A & Avenue B",
-          "uuid" => 1
-        },
-        "value" => %{"Detour Drawing" => %{"Active" => "Reviewing"}}
-      }
+          ~U[2024-01-01 13:00:00.000000Z]
+        )
     })
 
     # Past detour
@@ -367,13 +371,15 @@ defmodule SkateWeb.DetoursControllerTest do
                "data" => %{
                  "active" => [
                    %{
-                     "author_id" => ^author_id,
-                     "direction" => "Outbound",
-                     "intersection" => "Street A & Avenue B",
-                     "name" => "Headsign",
-                     "route" => "23",
-                     "status" => "active",
-                     "updated_at" => _
+                     "details" => %{
+                       "author_id" => ^author_id,
+                       "direction" => "Outbound",
+                       "intersection" => "Street A & Avenue B",
+                       "name" => "Headsign",
+                       "route" => "23",
+                       "status" => "active",
+                       "updated_at" => _
+                     }
                    }
                  ],
                  "draft" => [
@@ -433,15 +439,7 @@ defmodule SkateWeb.DetoursControllerTest do
       assert %{
                "data" => %{
                  "active" => [
-                   %{
-                     "author_id" => ^current_user_id,
-                     "direction" => "Outbound",
-                     "intersection" => "Street A & Avenue B",
-                     "name" => "Headsign",
-                     "route" => "23",
-                     "status" => "active",
-                     "updated_at" => _
-                   }
+                   _
                  ],
                  "draft" => [
                    %{
@@ -520,13 +518,16 @@ defmodule SkateWeb.DetoursControllerTest do
                "data" => %{
                  "active" => [
                    %{
-                     "author_id" => ^author_id,
-                     "direction" => "Outbound",
-                     "intersection" => "Street A & Avenue B",
-                     "name" => "Headsign",
-                     "route" => "23",
-                     "status" => "active",
-                     "updated_at" => _
+                     "activated_at" => "2024-01-01T13:00:00.000000Z",
+                     "details" => %{
+                       "author_id" => ^author_id,
+                       "direction" => "Outbound",
+                       "intersection" => "Street A & Avenue B",
+                       "name" => "Headsign",
+                       "route" => "23",
+                       "status" => "active",
+                       "updated_at" => _
+                     }
                    }
                  ],
                  "draft" => [


### PR DESCRIPTION
This uses the work in #2910 to fix the Activated At column to use the _real_ activated at time, in the Activated Detours table.

Asana Ticket: https://app.asana.com/0/0/1208989312907930/f
Depends on:
- #2910 