### PR TITLE
feat: add `estimated-duration` column to frontend detours list 

### DIFF
--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -51,6 +51,9 @@ export const DetoursTable = ({
         <th className="px-3 py-4 u-hide-for-mobile">
           {timestampLabelFromStatus(status)}
         </th>
+        {status === DetourStatus.Active && (
+          <th className="px-3 py-4 u-hide-for-mobile">Est. Duration</th>
+        )}
       </tr>
     </thead>
     <tbody>
@@ -102,6 +105,11 @@ const PopulatedDetourRows = ({
               ? timeAgoLabelFromDate(detour.activatedAt, epochNow)
               : timeAgoLabel(epochNowInSeconds, detour.updatedAt)}
           </td>
+          {detour.estimatedDuration && (
+            <td className="align-middle p-3 u-hide-for-mobile">
+              {detour.estimatedDuration}
+            </td>
+          )}
         </tr>
       ))}
     </>

--- a/assets/src/models/detoursList.ts
+++ b/assets/src/models/detoursList.ts
@@ -18,6 +18,7 @@ export interface SimpleDetour {
   intersection: string
   updatedAt: number
   activatedAt?: Date
+  estimatedDuration?: string
 }
 
 export const detourId = number()
@@ -34,6 +35,7 @@ export type SimpleDetourData = Infer<typeof SimpleDetourData>
 
 export const ActivatedDetourData = type({
   activated_at: coerce(date(), string(), (dateStr) => new Date(dateStr)),
+  estimated_duration: string(),
   details: SimpleDetourData,
 })
 
@@ -55,6 +57,7 @@ export const simpleDetourFromActivatedData = (
 ) => ({
   ...simpleDetourFromData(detourData.details),
   activatedAt: detourData.activated_at,
+  estimatedDuration: detourData.estimated_duration,
 })
 
 export interface GroupedSimpleDetours {

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -82,6 +82,11 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
             >
               On detour since
             </th>
+            <th
+              class="px-3 py-4 u-hide-for-mobile"
+            >
+              Est. Duration
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -123,6 +128,11 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
             >
               26 hours ago
             </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              2 hours
+            </td>
           </tr>
           <tr>
             <td
@@ -161,6 +171,11 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
               class="align-middle p-3 u-hide-for-mobile"
             >
               29 hours ago
+            </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              3 hours
             </td>
           </tr>
         </tbody>
@@ -453,6 +468,11 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
             >
               On detour since
             </th>
+            <th
+              class="px-3 py-4 u-hide-for-mobile"
+            >
+              Est. Duration
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -494,6 +514,11 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
             >
               26 hours ago
             </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              4 hours
+            </td>
           </tr>
           <tr>
             <td
@@ -532,6 +557,11 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
               class="align-middle p-3 u-hide-for-mobile"
             >
               29 hours ago
+            </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              Until end of service
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -85,6 +85,11 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
             >
               On detour since
             </th>
+            <th
+              class="px-3 py-4 u-hide-for-mobile"
+            >
+              Est. Duration
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -126,6 +131,11 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
             >
               Just now
             </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              2 hours
+            </td>
           </tr>
           <tr>
             <td
@@ -164,6 +174,11 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
               class="align-middle p-3 u-hide-for-mobile"
             >
               Just now
+            </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              2 hours
             </td>
           </tr>
         </tbody>
@@ -932,6 +947,11 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
             >
               On detour since
             </th>
+            <th
+              class="px-3 py-4 u-hide-for-mobile"
+            >
+              Est. Duration
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -973,6 +993,11 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
             >
               Just now
             </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              2 hours
+            </td>
           </tr>
           <tr>
             <td
@@ -1011,6 +1036,11 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
               class="align-middle p-3 u-hide-for-mobile"
             >
               Just now
+            </td>
+            <td
+              class="align-middle p-3 u-hide-for-mobile"
+            >
+              2 hours
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -42,6 +42,7 @@ describe("DetourListPage", () => {
             intersection: "Street A & Avenue B",
             updatedAt: 1724866392,
             activatedAt: new Date(1724866392000),
+            estimatedDuration: "2 hours",
           },
           {
             id: 8,
@@ -51,6 +52,7 @@ describe("DetourListPage", () => {
             intersection: "Street C & Avenue D",
             updatedAt: 1724856392,
             activatedAt: new Date(1724856392000),
+            estimatedDuration: "3 hours",
           },
         ],
         draft: undefined,
@@ -102,6 +104,7 @@ describe("DetourListPage", () => {
             intersection: "Street A & Avenue B",
             updatedAt: 1724866392,
             activatedAt: new Date(1724866392000),
+            estimatedDuration: "4 hours",
           },
           {
             id: 8,
@@ -111,6 +114,7 @@ describe("DetourListPage", () => {
             intersection: "Street C & Avenue D",
             updatedAt: 1724856392,
             activatedAt: new Date(1724856392000),
+            estimatedDuration: "Until end of service",
           },
         ],
         draft: undefined,

--- a/assets/tests/factories/detourListFactory.ts
+++ b/assets/tests/factories/detourListFactory.ts
@@ -39,5 +39,6 @@ export const activeDetourDataFactory = Factory.define<ActivatedDetourData>(
   () => ({
     details: simpleDetourDataFactory.build(),
     activated_at: new Date(),
+    estimated_duration: "2 hours",
   })
 )

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -74,6 +74,7 @@ defmodule Skate.Detours.Detour do
 
     @type t :: %__MODULE__{
             activated_at: DateTime.t(),
+            estimated_duration: String.t(),
             details: Detailed.t()
           }
 
@@ -81,6 +82,7 @@ defmodule Skate.Detours.Detour do
 
     defstruct [
       :activated_at,
+      :estimated_duration,
       :details
     ]
   end

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -91,13 +91,17 @@ defmodule Skate.Detours.Detours do
 
   def db_detour_to_detour(
         :active,
-        %Detour{activated_at: activated_at} = db_detour
+        %Detour{
+          activated_at: activated_at,
+          state: %{"context" => %{"selectedDuration" => estimated_duration}}
+        } = db_detour
       ) do
     details = DetailedDetour.from(:active, db_detour)
 
     details &&
       %ActivatedDetourDetails{
         activated_at: activated_at,
+        estimated_duration: estimated_duration,
         details: details
       }
   end

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -4,6 +4,7 @@ defmodule Skate.DetourFactory do
   `Skate.Detours`
   """
 
+  # credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
   defmacro __using__(_opts) do
     quote do
       def missed_stops_result_factory do
@@ -63,22 +64,37 @@ defmodule Skate.DetourFactory do
         with_id(detour, id)
       end
 
-      def activated(update_arg, activated_at \\ DateTime.utc_now())
+      def activated(
+            update_arg,
+            activated_at \\ DateTime.utc_now(),
+            estimated_duration \\ "1 hour"
+          )
 
-      def activated(%Skate.Detours.Db.Detour{} = detour, activated_at) do
+      def activated(%Skate.Detours.Db.Detour{} = detour, activated_at, estimated_duration) do
         activated_at = Skate.DetourFactory.browser_date(activated_at)
-        %{detour | state: activated(detour.state, activated_at), activated_at: activated_at}
+
+        %{
+          detour
+          | state: activated(detour.state, activated_at, estimated_duration),
+            activated_at: activated_at
+        }
       end
 
-      def activated(%{"value" => %{}, "context" => %{}} = state, activated_at) do
+      def activated(%{"value" => %{}, "context" => %{}} = state, activated_at, estimated_duration) do
         state =
           put_in(state["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
 
+        state =
+          put_in(
+            state["context"]["activatedAt"],
+            activated_at
+            |> Skate.DetourFactory.browser_date()
+            |> DateTime.to_iso8601()
+          )
+
         put_in(
-          state["context"]["activatedAt"],
-          activated_at
-          |> Skate.DetourFactory.browser_date()
-          |> DateTime.to_iso8601()
+          state["context"]["selectedDuration"],
+          estimated_duration
         )
       end
 


### PR DESCRIPTION
This adds the estimated duration info from the detour to the Activated Detour structure and returns that to the frontend to display in the activated detour table.

Asana Ticket: https://app.asana.com/0/0/1208989312907931/f
Depends on:
- #2911 
- #2910 