### PR TITLE
feat(ex/formatter): configure migrations formatter in directory

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,10 +2,5 @@
   import_deps: [:ecto, :ecto_sql, :phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
   subdirectories: ["priv/*/migrations"],
-  inputs: [
-    "*.{heex,ex,exs}",
-    "{config,lib,test}/**/*.{heex,ex,exs}",
-    "priv/*/seeds.exs",
-    "priv/repo/migrations/*.exs"
-  ]
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 [
   import_deps: [:ecto, :ecto_sql, :phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  subdirectories: ["priv/*/migrations"],
+  subdirectories: ["priv/repo/*migrations"],
   inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
 ]

--- a/priv/repo/async_migrations/.formatter.exs
+++ b/priv/repo/async_migrations/.formatter.exs
@@ -1,0 +1,9 @@
+[
+  import_deps: [
+    :ecto_sql,
+    # When adding a "Migrating Schema", such as described in https://fly.io/phoenix-files/backfilling-data/
+    # we need the `:ecto` formatter for formatting those schema files
+    :ecto
+  ],
+  inputs: ["*.exs"]
+]

--- a/priv/repo/async_migrations/20230830202227_first_async_migration.exs
+++ b/priv/repo/async_migrations/20230830202227_first_async_migration.exs
@@ -4,6 +4,5 @@ defmodule Skate.Repo.AsyncMigrations.FirstAsyncMigration do
 
   def change do
     Logger.info("first async migration")
-
   end
 end

--- a/priv/repo/async_migrations/20241218135700_backfill_detour_activated_at.exs
+++ b/priv/repo/async_migrations/20241218135700_backfill_detour_activated_at.exs
@@ -1,7 +1,6 @@
 defmodule Skate.Repo.Migrations.BackfillDetourActivatedAt do
   # https://fly.io/phoenix-files/backfilling-data/
 
-
   import Ecto.Query
   use Ecto.Migration
 
@@ -17,13 +16,14 @@ defmodule Skate.Repo.Migrations.BackfillDetourActivatedAt do
       from(
         r in Skate.Repo.Migrations.BackfillDetourActivatedAt.MigratingSchema,
         select: r.id,
-        where: not is_nil(r.state["value"]["Detour Drawing"]["Active"]) and is_nil(r.activated_at),
+        where:
+          not is_nil(r.state["value"]["Detour Drawing"]["Active"]) and is_nil(r.activated_at),
         update: [set: [activated_at: r.updated_at]]
       ),
       [],
       log: :info
     )
-   end
+  end
 
   def down, do: :ok
 end

--- a/priv/repo/migrations/.formatter.exs
+++ b/priv/repo/migrations/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  import_deps: [:ecto_sql],
+  inputs: ["*.exs"]
+]


### PR DESCRIPTION
This makes `.formatter.exs` match `phx.new` template, and moves formatter config for specific directories into local files in those directories, to match "new" phoenix conventions.make `.formatter.exs` match `phx.new` template

This also configures the async_migrations folder to be formatted, and formats those files.