### PR TITLE
fix(ex/snapshot_serde): fix "activatedAt" not present in old snapshots at serialize time

### DIFF
--- a/test/skate_web/controllers/detours_controller_test.exs
+++ b/test/skate_web/controllers/detours_controller_test.exs
@@ -309,6 +309,41 @@ defmodule SkateWeb.DetoursControllerTest do
     end
 
     @tag :authenticated
+    @tag :bug
+    test "defers to `activated_at` column when serialized detour doesn't match saved snapshot", %{
+      conn: conn
+    } do
+      activated_at = Skate.DetourFactory.browser_date()
+
+      %{id: id, state: snapshot} =
+        detour =
+        :detour
+        |> build()
+        |> activated(activated_at)
+        |> insert()
+
+      # Make ID match snapshot
+      snapshot = with_id(snapshot, id)
+      # Old snapshots will not have this key populated
+      {_value, snapshot} = pop_in(snapshot["context"]["activatedAt"])
+
+      detour
+      |> Skate.Detours.Detours.change_detour(%{state: snapshot})
+      |> Skate.Repo.update!()
+
+      {conn, log} =
+        CaptureLog.with_log(fn ->
+          get(conn, "/api/detours/#{id}")
+        end)
+
+      assert log =~
+               "Serialized detour doesn't match saved snapshot. Falling back to snapshot for detour_id=#{id}"
+
+      assert DateTime.to_iso8601(activated_at) ==
+               json_response(conn, 200)["data"]["state"]["context"]["activatedAt"]
+    end
+
+    @tag :authenticated
     test "log an error if the serialized detour does not match db state", %{conn: conn} do
       detour_id = 4
 


### PR DESCRIPTION
I don't think this is a full solution, but I think this addresses the bug well enough that we can ship other things by tomorrow.