### PR TITLE
fix(ts/dateTime): compare dates in UTC

### DIFF
--- a/assets/src/util/dateTime.ts
+++ b/assets/src/util/dateTime.ts
@@ -117,5 +117,5 @@ export const timeAgoLabel = (
 
 export const timeAgoLabelFromDate = (start: Date, end: Date) => {
   const second = 1000
-  return timeAgoLabel(end.valueOf() / second, start.valueOf() / second)
+  return timeAgoLabel(end.getTime() / second, start.getTime() / second)
 }


### PR DESCRIPTION
turns out `valueOf()` doesn't do timezone conversions, so I've switched to `getTime()`
related to #2923 