### PR TITLE
fix(ts/activeDetourPanel): fix time ago label

### DIFF
--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -106,7 +106,7 @@ export const ActiveDetourPanel = ({
               On detour since
             </dt>
             <dd aria-labelledby={dlActiveSinceId}>
-              {timeAgoLabelFromDate(currentTime, activatedAt)}
+              {timeAgoLabelFromDate(activatedAt, currentTime)}
             </dd>
 
             <dt id={dlDurationId} className="fw-bold me-2">


### PR DESCRIPTION
The arguments were reversed 🙃 
related to #2923 