### PR TITLE
fix(ts/createDetourMachine): create `activatedAt` date when invoked

### DIFF
--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -635,7 +635,7 @@ export const createDetourMachine = setup({
                       actions: assign({
                         // Record current time, should be done on the backend,
                         // but that requires a larger refactor of the state machine
-                        activatedAt: new Date(),
+                        activatedAt: () => new Date(),
                       }),
                     },
                   },


### PR DESCRIPTION
Currently, the date is being created when the machine starts, _not_ when the action is fired 🤣 😭 whoops.