### PR TITLE
[low priority] tweak: Tiny changes to detour modal buttons

### DIFF
--- a/assets/src/components/detours/deleteDetourModal.tsx
+++ b/assets/src/components/detours/deleteDetourModal.tsx
@@ -29,7 +29,7 @@ export const DeleteDetourModal = ({
           className="text-white"
           data-fs-element="Confirm Delete Draft"
         >
-          Delete Draft
+          Delete draft
         </Button>
       </Modal.Footer>
     </Modal>

--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -85,23 +85,23 @@ export const DetourFinishedPanel = ({
       <Panel.Body.Footer className="d-flex flex-column">
         {onDeleteDetour && (
           <Button
-            className="m-3 mb-0 flex-grow-1 icon-link justify-content-center"
+            className="m-3 mb-0 flex-grow-1 icon-link"
             variant="outline-ui-alert"
             onClick={onDeleteDetour}
             data-fs-element="Delete Detour Draft"
           >
             <BsIcons.Trash />
-            Delete Draft
+            Delete draft
           </Button>
         )}
         {onActivateDetour && (
           <Button
-            className="m-3 flex-grow-1 icon-link justify-content-center"
+            className="m-3 flex-grow-1 icon-link"
             onClick={onActivateDetour}
             data-fs-element="Begin Activate Detour"
           >
             <BsIcons.Power />
-            Start Detour
+            Start detour
           </Button>
         )}
       </Panel.Body.Footer>

--- a/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
+++ b/assets/tests/testHelpers/selectors/components/detours/diversionPage.tsx
@@ -3,7 +3,7 @@ import { byRole } from "testing-library-selector"
 
 export const reviewDetourButton = byRole("button", { name: "Review" })
 export const activateDetourButton = byRole("button", {
-  name: "Start Detour",
+  name: "Start detour",
 })
 export const editDetourButton = byRole("button", { name: "Edit" })
 


### PR DESCRIPTION
Case changes, left alignment. Will not merge before https://github.com/mbta/skate/pull/2925

https://www.figma.com/design/XGmmwVROXdOvnWtJeUFC50/Unplanned-Detours-%7C-Handoff?node-id=6062-9423&t=1PzWYK3bawIcqFfx-4

before
![Screenshot 2025-01-24 at 10 53 25 AM](https://github.com/user-attachments/assets/f0507bc9-3ce9-433d-99a3-d1129f504072)

after
![Screenshot 2025-01-24 at 10 52 26 AM](https://github.com/user-attachments/assets/bcb620cd-64b9-4391-9e39-39f5bf3edb1a)
