### PR TITLE
disable active detours on ladder

### DIFF
--- a/assets/src/components/routeLadders.tsx
+++ b/assets/src/components/routeLadders.tsx
@@ -11,6 +11,7 @@ import { SocketContext } from "../contexts/socketContext"
 import useAlerts from "../hooks/useAlerts"
 import { DetoursMap, useActiveDetours } from "../hooks/useDetours"
 import { DetourId, SimpleDetour } from "../models/detoursList"
+import inTestGroup, { TestGroups } from "../userInTestGroup"
 
 export const findRouteById = (
   routes: Route[] | null,
@@ -65,7 +66,10 @@ const RouteLadders = ({
 
   // TODO: once DB is optimized for querying by route and status, we can open individual channels for each route ladder
   // const skateDetours = useActiveDetoursByRoute(socket, selectedRouteIds)
-  const allActiveSkateDetours = useActiveDetours(socket)
+  const allActiveSkateDetours = useActiveDetours(
+    socket,
+    inTestGroup(TestGroups.DetoursOnLadder)
+  )
 
   const skateDetoursByRouteName = Object.values(allActiveSkateDetours).reduce(
     (acc: ByRouteId<DetoursMap>, cur: SimpleDetour) => {

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -89,7 +89,10 @@ const subscribe = (
 }
 
 // This is to refresh the Detours List page. We need all active detours
-export const useActiveDetours = (socket: Socket | undefined) => {
+export const useActiveDetours = (
+  socket: Socket | undefined,
+  enable: boolean = true
+) => {
   const topic = "detours:active"
   const [activeDetours, setActiveDetours] = useState<DetoursMap>({})
 
@@ -105,6 +108,10 @@ export const useActiveDetours = (socket: Socket | undefined) => {
   }
 
   useEffect(() => {
+    if (enable === false) {
+      return
+    }
+
     let channel: Channel | undefined
     if (socket) {
       channel = subscribe(
@@ -125,7 +132,7 @@ export const useActiveDetours = (socket: Socket | undefined) => {
         channel = undefined
       }
     }
-  }, [socket])
+  }, [socket, enable])
   return activeDetours
 }
 

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -11,6 +11,7 @@ export enum TestGroups {
   CopyButton = "copy-button",
   DeleteDraftDetours = "delete-draft-detours",
   ChangeDetourDuration = "change-detour-duration",
+  DetoursOnLadder = "detours-on-ladder",
 }
 
 const inTestGroup = (key: TestGroups): boolean => {


### PR DESCRIPTION
Production issue is possibly due to DB overload from every route ladder making a 6s+ query.

This makes it so it doesn't fire by default.