### PR TITLE
tweak: replace use of classname with use of tag

### DIFF
--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -25,6 +25,10 @@
     }
   }
 
+  h4 {
+    font-weight: var(--font-weight-semi);
+  }
+
   &--mobile,
   &--mobile_landscape_tablet_portrait {
     grid-template:
@@ -153,11 +157,6 @@
 
 .c-diversion-panel__h1 {
   font-size: 1.25rem; // h3 font size
-  font-weight: var(--font-weight-semi);
-}
-
-.c-diversion-panel__h2 {
-  font-size: 1.125rem; // h4 font size
   font-weight: var(--font-weight-semi);
 }
 

--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -19,7 +19,7 @@ export const ConnectionPoints = ({
   connectionPoints: [connectionPointStart, connectionPointEnd],
 }: ConnectionPointsProps) => (
   <section className="pb-3">
-    <h2 className="c-diversion-panel__h2">Connection Points</h2>
+    <h4>Connection Points</h4>
     <ListGroup as="ul">
       <ListGroup.Item>{connectionPointStart}</ListGroup.Item>
       <ListGroup.Item>{connectionPointEnd}</ListGroup.Item>
@@ -33,12 +33,12 @@ interface MissedStopsProps {
 
 export const MissedStops = ({ missedStops }: MissedStopsProps) => (
   <section className="pb-3">
-    <h2 className="c-diversion-panel__h2">
+    <h4>
       Missed Stops
       <Badge pill bg="missed-stop" className="ms-2 fs-4">
         {missedStops.length}
       </Badge>
-    </h2>
+    </h4>
     <ListGroup as="ul">
       {uniqBy(missedStops, (stop) => stop.id).map((missedStop) => (
         <ListGroup.Item key={missedStop.id}>{missedStop.name}</ListGroup.Item>
@@ -61,9 +61,7 @@ export const AffectedRoute = ({
   routeDirection,
 }: AffectedRouteProps) => (
   <section className="pb-3">
-    <h2 className="c-diversion-panel__h2 c-detour-panel__subheader">
-      Affected route
-    </h2>
+    <h4 className="c-detour-panel__subheader">Affected route</h4>
     <div className="d-flex">
       <RoutePill className="me-2 align-top" routeName={routeName} />
 

--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -119,7 +119,7 @@ export const ActiveDetourPanel = ({
           </dl>
 
           <section className="pb-3">
-            <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+            <h4>Detour Directions</h4>
             {directions ? (
               <ListGroup as="ol">
                 {directions.map((d) => (

--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -52,7 +52,7 @@ export const DetourFinishedPanel = ({
 
         {affectedRoute}
 
-        <h2 className="c-diversion-panel__h2">Directions</h2>
+        <h4>Directions</h4>
         {/*
             We need a way to let the form area take up exactly the space of its content
             (to avoid double scrollbars). We used this approach:

--- a/assets/src/components/detours/detourPanels/detourRouteSelectionPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourRouteSelectionPanel.tsx
@@ -73,9 +73,7 @@ export const DetourRouteSelectionPanel = ({
               noValidate={true}
             >
               <Form.Group>
-                <h2 className="c-diversion-panel__h2" id={selectId}>
-                  Choose route
-                </h2>
+                <h4 id={selectId}>Choose route</h4>
                 <Form.Select
                   // Never show the "valid" style
                   isValid={false}
@@ -108,7 +106,7 @@ export const DetourRouteSelectionPanel = ({
           </section>
 
           <section className="pb-3">
-            <h2 className="c-diversion-panel__h2">Choose direction</h2>
+            <h4>Choose direction</h4>
             {selectedRouteInfo.selectedRoute ? (
               <div className="position-relative">
                 {selectedRouteInfo.routePatterns ? (

--- a/assets/src/components/detours/detourPanels/drawDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/drawDetourPanel.tsx
@@ -61,7 +61,7 @@ export const DrawDetourPanel = ({
         />
 
         <section className="pb-3">
-          <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+          <h4>Detour Directions</h4>
           {directions ? (
             <ListGroup as="ol">
               {directions.map((d) => (

--- a/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
@@ -66,7 +66,7 @@ export const PastDetourPanel = ({
         />
 
         <section className="pb-3">
-          <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+          <h4>Detour Directions</h4>
           {directions ? (
             <ListGroup as="ol">
               {directions.map((d) => (

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -474,11 +474,11 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                 <section
                   class="pb-3"
                 >
-                  <h2
-                    class="c-diversion-panel__h2 c-detour-panel__subheader"
+                  <h4
+                    class="c-detour-panel__subheader"
                   >
                     Affected route
-                  </h2>
+                  </h4>
                   <div
                     class="d-flex"
                   >
@@ -508,11 +508,9 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                     </div>
                   </div>
                 </section>
-                <h2
-                  class="c-diversion-panel__h2"
-                >
+                <h4>
                   Directions
-                </h2>
+                </h4>
                 <div
                   class="c-autosized-textarea"
                   data-replicated-value="From null"
@@ -527,11 +525,9 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                 <section
                   class="pb-3"
                 >
-                  <h2
-                    class="c-diversion-panel__h2"
-                  >
+                  <h4>
                     Connection Points
-                  </h2>
+                  </h4>
                   <ul
                     class="list-group"
                   >
@@ -1340,11 +1336,11 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
               <section
                 class="pb-3"
               >
-                <h2
-                  class="c-diversion-panel__h2 c-detour-panel__subheader"
+                <h4
+                  class="c-detour-panel__subheader"
                 >
                   Affected route
-                </h2>
+                </h4>
                 <div
                   class="d-flex"
                 >
@@ -1374,11 +1370,9 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   </div>
                 </div>
               </section>
-              <h2
-                class="c-diversion-panel__h2"
-              >
+              <h4>
                 Directions
-              </h2>
+              </h4>
               <div
                 class="c-autosized-textarea"
                 data-replicated-value="From null"
@@ -1393,11 +1387,9 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
               <section
                 class="pb-3"
               >
-                <h2
-                  class="c-diversion-panel__h2"
-                >
+                <h4>
                   Connection Points
-                </h2>
+                </h4>
                 <ul
                   class="list-group"
                 >


### PR DESCRIPTION
Kind of a silly thing, but noticed while picking up Kayla's styling work. She had to fix something with the `.c-diversion-panel__h2` class that made me realize I previously made the mistake of using the h2 header tag and overwriting the font-size in css. (why??) So figured I should fix that.

Although... maybe I need context here, because I see this classname existed before I started making side panels, so maybe it predates me.