### PR TITLE
fix: Updating the spacing on detour panel

### DIFF
--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -97,6 +97,11 @@
       display: none;
     }
   }
+
+  ol,
+  ul {
+    margin-top: unset;
+  }
 }
 
 .l-diversion-page-panel {
@@ -156,14 +161,15 @@
   font-weight: var(--font-weight-semi);
 }
 
-.c-diversion-panel__h2 {
+.c-diversion-panel__section-header {
   @include font-size($h4-font-size);
-  // font-size: 1.125rem; // h4 font size
-  // font-weight: var(--font-weight-semi);
+  font-weight: var(--font-weight-semi);
+  margin: 0 0 map-get($spacers, 2) 0;
 }
 
 .c-diversion-panel__help-text {
   line-height: 1.5;
+  margin-top: map-get($spacers, 2);
 }
 
 .c-active-detour__alert-icon {
@@ -188,6 +194,7 @@
 
   div {
     margin-bottom: map-get($spacers, 1);
+    line-height: 1.5rem;
   }
 
   // Remove leading margin from `<dd/>`'s

--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -157,8 +157,9 @@
 }
 
 .c-diversion-panel__h2 {
-  font-size: 1.125rem; // h4 font size
-  font-weight: var(--font-weight-semi);
+  @include font-size($h4-font-size);
+  // font-size: 1.125rem; // h4 font size
+  // font-weight: var(--font-weight-semi);
 }
 
 .c-diversion-panel__help-text {

--- a/assets/css/_diversion_page.scss
+++ b/assets/css/_diversion_page.scss
@@ -180,9 +180,13 @@
   }
 
   // But display each `<dt/>` on it's own line
-  dt::before {
+  dl > dt::before {
     content: "";
     display: block;
+  }
+
+  div {
+    margin-bottom: map-get($spacers, 1);
   }
 
   // Remove leading margin from `<dd/>`'s

--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -19,7 +19,7 @@ export const ConnectionPoints = ({
   connectionPoints: [connectionPointStart, connectionPointEnd],
 }: ConnectionPointsProps) => (
   <section className="mb-4">
-    <h2 className="c-diversion-panel__h2">Connection Points</h2>
+    <h2 className="c-diversion-panel__section-header">Connection Points</h2>
     <ListGroup as="ul">
       <ListGroup.Item>{connectionPointStart}</ListGroup.Item>
       <ListGroup.Item>{connectionPointEnd}</ListGroup.Item>
@@ -33,7 +33,7 @@ interface MissedStopsProps {
 
 export const MissedStops = ({ missedStops }: MissedStopsProps) => (
   <section className="mb-4">
-    <h2 className="c-diversion-panel__h2">
+    <h2 className="c-diversion-panel__section-header">
       Missed Stops
       <Badge pill bg="missed-stop" className="ms-2 fs-4">
         {missedStops.length}
@@ -60,8 +60,8 @@ export const AffectedRoute = ({
   routeOrigin,
   routeDirection,
 }: AffectedRouteProps) => (
-  <section className="mb-2">
-    <h2 className="c-diversion-panel__h2 c-detour-panel__subheader">
+  <section className="mt-2">
+    <h2 className="c-diversion-panel__section-header c-detour-panel__subheader">
       Affected route
     </h2>
     <div className="d-flex">
@@ -71,10 +71,10 @@ export const AffectedRoute = ({
         <p className="my-0 c-diversion-panel__description">
           {routeDescription}
         </p>
-        <p className="my-0 text-muted c-diversion-panel__origin py-1">
+        <p className="my-1 text-muted c-diversion-panel__origin">
           {routeOrigin}
         </p>
-        <p className="my-0 small c-diversion-panel__direction py-1">
+        <p className="my-1 small c-diversion-panel__direction">
           {routeDirection}
         </p>
       </div>

--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -18,7 +18,7 @@ interface ConnectionPointsProps {
 export const ConnectionPoints = ({
   connectionPoints: [connectionPointStart, connectionPointEnd],
 }: ConnectionPointsProps) => (
-  <section className="pb-3">
+  <section className="mb-4">
     <h2 className="c-diversion-panel__h2">Connection Points</h2>
     <ListGroup as="ul">
       <ListGroup.Item>{connectionPointStart}</ListGroup.Item>
@@ -32,7 +32,7 @@ interface MissedStopsProps {
 }
 
 export const MissedStops = ({ missedStops }: MissedStopsProps) => (
-  <section className="pb-3">
+  <section className="mb-4">
     <h2 className="c-diversion-panel__h2">
       Missed Stops
       <Badge pill bg="missed-stop" className="ms-2 fs-4">
@@ -60,7 +60,7 @@ export const AffectedRoute = ({
   routeOrigin,
   routeDirection,
 }: AffectedRouteProps) => (
-  <section className="pb-3">
+  <section className="mb-2">
     <h2 className="c-diversion-panel__h2 c-detour-panel__subheader">
       Affected route
     </h2>

--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -99,7 +99,7 @@ export const ActiveDetourPanel = ({
             routeDirection={routeDirection}
           />
 
-          <dl className="l-inline-dl m-0">
+          <dl className="l-inline-dl mt-2">
             <div>
               <dt id={dlReasonId} className="fw-bold me-2">
                 Reason
@@ -118,14 +118,16 @@ export const ActiveDetourPanel = ({
 
             <div>
               <dt id={dlDurationId} className="fw-bold me-2">
-                Est. Duration
+                Est. duration
               </dt>
               <dd aria-labelledby={dlDurationId}>{detourDuration}</dd>
             </div>
           </dl>
 
-          <section className="mb-4">
-            <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+          <section className="my-4">
+            <h2 className="c-diversion-panel__section-header">
+              Detour Directions
+            </h2>
             {directions ? (
               <ListGroup as="ol">
                 {directions.map((d) => (

--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -100,22 +100,28 @@ export const ActiveDetourPanel = ({
           />
 
           <dl className="l-inline-dl m-0">
-            <dt id={dlReasonId} className="fw-bold me-2">
-              Reason
-            </dt>
-            <dd aria-labelledby={dlReasonId}>{detourReason}</dd>
+            <div>
+              <dt id={dlReasonId} className="fw-bold me-2">
+                Reason
+              </dt>
+              <dd aria-labelledby={dlReasonId}>{detourReason}</dd>
+            </div>
 
-            <dt id={dlActiveSinceId} className="fw-bold me-2">
-              On detour since
-            </dt>
-            <dd aria-labelledby={dlActiveSinceId}>
-              {timeAgoLabelFromDate(activatedAt, currentTime)}
-            </dd>
+            <div>
+              <dt id={dlActiveSinceId} className="fw-bold me-2">
+                On detour since
+              </dt>
+              <dd aria-labelledby={dlActiveSinceId}>
+                {timeAgoLabelFromDate(activatedAt, currentTime)}
+              </dd>
+            </div>
 
-            <dt id={dlDurationId} className="fw-bold me-2">
-              Est. Duration
-            </dt>
-            <dd aria-labelledby={dlDurationId}>{detourDuration}</dd>
+            <div>
+              <dt id={dlDurationId} className="fw-bold me-2">
+                Est. Duration
+              </dt>
+              <dd aria-labelledby={dlDurationId}>{detourDuration}</dd>
+            </div>
           </dl>
 
           <section className="pb-3">

--- a/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/activeDetourPanel.tsx
@@ -124,7 +124,7 @@ export const ActiveDetourPanel = ({
             </div>
           </dl>
 
-          <section className="pb-3">
+          <section className="mb-4">
             <h2 className="c-diversion-panel__h2">Detour Directions</h2>
             {directions ? (
               <ListGroup as="ol">

--- a/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourFinishedPanel.tsx
@@ -52,29 +52,31 @@ export const DetourFinishedPanel = ({
 
         {affectedRoute}
 
-        <h2 className="c-diversion-panel__h2">Directions</h2>
-        {/*
-            We need a way to let the form area take up exactly the space of its content
-            (to avoid double scrollbars). We used this approach:
-            https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas
+        <section className="mt-4">
+          <h2 className="c-diversion-panel__section-header">Directions</h2>
+          {/*
+              We need a way to let the form area take up exactly the space of its content
+              (to avoid double scrollbars). We used this approach:
+              https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas
 
-            The result is that the Form.Control has an invisible twin that helps the
-            wrapper grow to the appropriate size, and then the Form.Control likewise
-            assumes that space. All styles that affect layout must be identical
-            (e.g., `border`, `padding`, `margin`, `font`) between the `<Form.Control/>`
-            and the `.c-autosized-textarea::after` pseudo-element.
-        */}
-        <div
-          className="c-autosized-textarea"
-          data-replicated-value={editableDirections}
-        >
-          <Form.Control
-            as="textarea"
-            value={editableDirections}
-            onChange={({ target: { value } }) => onChangeDetourText(value)}
-            data-fs-element="Detour Text"
-          />
-        </div>
+              The result is that the Form.Control has an invisible twin that helps the
+              wrapper grow to the appropriate size, and then the Form.Control likewise
+              assumes that space. All styles that affect layout must be identical
+              (e.g., `border`, `padding`, `margin`, `font`) between the `<Form.Control/>`
+              and the `.c-autosized-textarea::after` pseudo-element.
+          */}
+          <div
+            className="c-autosized-textarea mb-2"
+            data-replicated-value={editableDirections}
+          >
+            <Form.Control
+              as="textarea"
+              value={editableDirections}
+              onChange={({ target: { value } }) => onChangeDetourText(value)}
+              data-fs-element="Detour Text"
+            />
+          </div>
+        </section>
 
         {connectionPoints && (
           <ConnectionPoints connectionPoints={connectionPoints} />

--- a/assets/src/components/detours/detourPanels/detourRouteSelectionPanel.tsx
+++ b/assets/src/components/detours/detourPanels/detourRouteSelectionPanel.tsx
@@ -67,13 +67,13 @@ export const DetourRouteSelectionPanel = ({
 
       <Panel.Body className="d-flex flex-column">
         <Panel.Body.ScrollArea className="d-flex flex-column">
-          <section className="pb-3">
+          <section className="my-4">
             <Form
               // We're doing js validation, so disable HTML validation
               noValidate={true}
             >
               <Form.Group>
-                <h2 className="c-diversion-panel__h2" id={selectId}>
+                <h2 className="c-diversion-panel__section-header" id={selectId}>
                   Choose route
                 </h2>
                 <Form.Select
@@ -107,8 +107,10 @@ export const DetourRouteSelectionPanel = ({
             </Form>
           </section>
 
-          <section className="pb-3">
-            <h2 className="c-diversion-panel__h2">Choose direction</h2>
+          <section className="mb-4">
+            <h2 className="c-diversion-panel__section-header">
+              Choose direction
+            </h2>
             {selectedRouteInfo.selectedRoute ? (
               <div className="position-relative">
                 {selectedRouteInfo.routePatterns ? (
@@ -135,7 +137,7 @@ export const DetourRouteSelectionPanel = ({
                 )}
               </div>
             ) : (
-              <p className="fst-italic">
+              <p className="fst-italic my-2">
                 Select a route in order to choose a direction.
               </p>
             )}

--- a/assets/src/components/detours/detourPanels/drawDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/drawDetourPanel.tsx
@@ -60,8 +60,10 @@ export const DrawDetourPanel = ({
           routeDirection={routeDirection}
         />
 
-        <section className="pb-3">
-          <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+        <section className="my-4">
+          <h2 className="c-diversion-panel__section-header">
+            Detour Directions
+          </h2>
           {directions ? (
             <ListGroup as="ol">
               {directions.map((d) => (

--- a/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
@@ -65,8 +65,10 @@ export const PastDetourPanel = ({
           routeDirection={routeDirection}
         />
 
-        <section className="pb-3">
-          <h2 className="c-diversion-panel__h2">Detour Directions</h2>
+        <section className="my-4">
+          <h2 className="c-diversion-panel__section-header">
+            Detour Directions
+          </h2>
           {directions ? (
             <ListGroup as="ol">
               {directions.map((d) => (

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -472,10 +472,10 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                    Edit
                 </button>
                 <section
-                  class="pb-3"
+                  class="mt-2"
                 >
                   <h2
-                    class="c-diversion-panel__h2 c-detour-panel__subheader"
+                    class="c-diversion-panel__section-header c-detour-panel__subheader"
                   >
                     Affected route
                   </h2>
@@ -496,39 +496,43 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                         Headsign 2
                       </p>
                       <p
-                        class="my-0 text-muted c-diversion-panel__origin py-1"
+                        class="my-1 text-muted c-diversion-panel__origin"
                       >
                         Route pattern From A2 - To B2
                       </p>
                       <p
-                        class="my-0 small c-diversion-panel__direction py-1"
+                        class="my-1 small c-diversion-panel__direction"
                       >
                         Outbound
                       </p>
                     </div>
                   </div>
                 </section>
-                <h2
-                  class="c-diversion-panel__h2"
-                >
-                  Directions
-                </h2>
-                <div
-                  class="c-autosized-textarea"
-                  data-replicated-value="From null"
-                >
-                  <textarea
-                    class="form-control"
-                    data-fs-element="Detour Text"
-                  >
-                    From null
-                  </textarea>
-                </div>
                 <section
-                  class="pb-3"
+                  class="mt-4"
                 >
                   <h2
-                    class="c-diversion-panel__h2"
+                    class="c-diversion-panel__section-header"
+                  >
+                    Directions
+                  </h2>
+                  <div
+                    class="c-autosized-textarea mb-2"
+                    data-replicated-value="From null"
+                  >
+                    <textarea
+                      class="form-control"
+                      data-fs-element="Detour Text"
+                    >
+                      From null
+                    </textarea>
+                  </div>
+                </section>
+                <section
+                  class="mb-4"
+                >
+                  <h2
+                    class="c-diversion-panel__section-header"
                   >
                     Connection Points
                   </h2>
@@ -1338,10 +1342,10 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                  Edit
               </button>
               <section
-                class="pb-3"
+                class="mt-2"
               >
                 <h2
-                  class="c-diversion-panel__h2 c-detour-panel__subheader"
+                  class="c-diversion-panel__section-header c-detour-panel__subheader"
                 >
                   Affected route
                 </h2>
@@ -1362,39 +1366,43 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                       Headsign 1
                     </p>
                     <p
-                      class="my-0 text-muted c-diversion-panel__origin py-1"
+                      class="my-1 text-muted c-diversion-panel__origin"
                     >
                       Route pattern From A1 - To B1
                     </p>
                     <p
-                      class="my-0 small c-diversion-panel__direction py-1"
+                      class="my-1 small c-diversion-panel__direction"
                     >
                       Outbound
                     </p>
                   </div>
                 </div>
               </section>
-              <h2
-                class="c-diversion-panel__h2"
-              >
-                Directions
-              </h2>
-              <div
-                class="c-autosized-textarea"
-                data-replicated-value="From null"
-              >
-                <textarea
-                  class="form-control"
-                  data-fs-element="Detour Text"
-                >
-                  From null
-                </textarea>
-              </div>
               <section
-                class="pb-3"
+                class="mt-4"
               >
                 <h2
-                  class="c-diversion-panel__h2"
+                  class="c-diversion-panel__section-header"
+                >
+                  Directions
+                </h2>
+                <div
+                  class="c-autosized-textarea mb-2"
+                  data-replicated-value="From null"
+                >
+                  <textarea
+                    class="form-control"
+                    data-fs-element="Detour Text"
+                  >
+                    From null
+                  </textarea>
+                </div>
+              </section>
+              <section
+                class="mb-4"
+              >
+                <h2
+                  class="c-diversion-panel__section-header"
                 >
                   Connection Points
                 </h2>


### PR DESCRIPTION
Related to the UAT work [here](https://app.asana.com/0/1205385723132845/1209237355450159). Updates the spacing of items on the active detour panel, which had some overlap with other detour panels.

![Screenshot 2025-01-28 at 5 22 45 PM](https://github.com/user-attachments/assets/ad4cd856-db63-4a73-8943-fdc3a0d9f66a)
![Screenshot 2025-01-28 at 5 22 57 PM](https://github.com/user-attachments/assets/7631f936-e24f-45de-8feb-e7c0910355df)
![Screenshot 2025-01-28 at 5 23 06 PM](https://github.com/user-attachments/assets/d44ea535-e41d-4fff-a016-afd7a4bd9671)
![Screenshot 2025-01-28 at 5 23 21 PM](https://github.com/user-attachments/assets/9871b419-3df2-4adf-8ce2-21b723174cf0)
