### PR TITLE
fix: spacing on change duration modal [tiny]

### DIFF
--- a/assets/src/components/detours/changeDurationModal.tsx
+++ b/assets/src/components/detours/changeDurationModal.tsx
@@ -15,7 +15,10 @@ const ChangingDuration = ({
     <span className="mb-4">
       <span className="fw-bold">Previous time length</span>{" "}
       <span>(estimate)</span>
-      <p className="mt-2 mb-4" data-testid="change-detour-duration-previous-time">
+      <p
+        className="mt-2 mb-4"
+        data-testid="change-detour-duration-previous-time"
+      >
         {selectedDuration}
       </p>
     </span>


### PR DESCRIPTION
One line to fix the spacing on a separate modal from the other PR.

After: 
![Screenshot 2025-01-28 at 5 33 58 PM](https://github.com/user-attachments/assets/c7a22379-6a3f-488c-a9d2-e386f8fcea17)

Before:
![Screenshot 2025-01-28 at 5 34 17 PM](https://github.com/user-attachments/assets/76c2f5fc-7155-4deb-a334-30cd1087be77)
