### PR TITLE
tweak: Log on trip mod publication

### DIFF
--- a/lib/skate/detours/trip_modification_publisher.ex
+++ b/lib/skate/detours/trip_modification_publisher.ex
@@ -1,5 +1,7 @@
 defmodule Skate.Detours.TripModificationPublisher do
   @behaviour Skate.Detours.TripModificationPublisher
+  require Logger
+
   @moduledoc """
   Connects to the MQTT Broker, then allows sending `Realtime.TripModification`'s
   to the Broker.
@@ -152,9 +154,12 @@ defmodule Skate.Detours.TripModificationPublisher do
                # Send at least once
                qos: 1
              }) do
+        Logger.info(fn -> "publish_modification: message successfully sent" end)
         :ok
       else
-        res -> res
+        {:error, error} ->
+          Logger.warning(fn -> "publish_modification returned error: #{error}" end)
+          {:error, error}
       end
 
     {

--- a/lib/skate_web/controllers/detours_controller.ex
+++ b/lib/skate_web/controllers/detours_controller.ex
@@ -123,18 +123,7 @@ defmodule SkateWeb.DetoursController do
                shape_id: shape_id
              }) do
         try do
-          case trip_modification_publisher().publish_modification(modification, shape,
-                 is_draft?: true
-               ) do
-            {:ok, _} ->
-              Logger.info(fn -> "publish_modification: message successfully sent" end)
-
-            {{:error, error}, _} ->
-              Logger.warning(fn -> "publish_modification returned error: #{error}" end)
-
-            _ ->
-              nil
-          end
+          trip_modification_publisher().publish_modification(modification, shape, is_draft?: true)
         catch
           # May throw if the publishing server doesn't exist, which we can ignore.
           :exit, {:noproc, _} ->


### PR DESCRIPTION
Question: Is it valuable to log on trip mod publication success / failure? It seems that the skate-dev traffic to MQ is low or non-existent from infra's review, so I'd be curious to see logs to confirm messages are getting published properly. 