### PR TITLE
tweak: remove change-detour-duration feature flag

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -447,8 +447,7 @@ export const DiversionPage = ({
               : undefined
           }
           onOpenChangeDurationModal={
-            userInTestGroup(TestGroups.DetoursPilot) &&
-            userInTestGroup(TestGroups.ChangeDetourDuration)
+            userInTestGroup(TestGroups.DetoursPilot)
               ? () => {
                   send({ type: "detour.active.open-change-duration-modal" })
                 }

--- a/assets/src/userInTestGroup.ts
+++ b/assets/src/userInTestGroup.ts
@@ -10,7 +10,6 @@ export enum TestGroups {
   LateView = "late-view",
   CopyButton = "copy-button",
   DeleteDraftDetours = "delete-draft-detours",
-  ChangeDetourDuration = "change-detour-duration",
   DetoursOnLadder = "detours-on-ladder",
 }
 

--- a/assets/tests/components/detours/diversionPage.editDuration.test.tsx
+++ b/assets/tests/components/detours/diversionPage.editDuration.test.tsx
@@ -32,11 +32,7 @@ beforeEach(() => {
 
   jest
     .mocked(getTestGroups)
-    .mockReturnValue([
-      TestGroups.DetoursPilot,
-      TestGroups.DetoursList,
-      TestGroups.ChangeDetourDuration,
-    ])
+    .mockReturnValue([TestGroups.DetoursPilot, TestGroups.DetoursList])
 })
 
 const DiversionPage = (props: Partial<DiversionPageProps>) => {
@@ -59,22 +55,6 @@ const changeDurationHeading = byRole("heading", {
 
 describe("DiversionPage edit duration workflow", () => {
   describe("before change duration modal", () => {
-    test("does not have a change duration button if not in the ChangeDetourDuration group", async () => {
-      jest
-        .mocked(getTestGroups)
-        .mockReturnValue([TestGroups.DetoursList, TestGroups.DetoursPilot])
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
-      jest
-        .mocked(fetchDetour)
-        .mockResolvedValue(Ok(activeDetourFactory.build()))
-
-      render(<DetourListPage />)
-
-      await userEvent.click(await screen.findByText("Headsign A"))
-
-      expect(changeDurationButton.query()).not.toBeInTheDocument()
-    })
-
     test("does not have a change duration button if not an active detour", async () => {
       jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest


### PR DESCRIPTION
`change-detour-duration` feature flag is in override mode on prod, so we can remove the conditionals and delete the group