### PR TITLE
tweak: pin earlier version step of getSentry action

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: getsentry/action-release@v1
+      - uses: getsentry/action-release@v1.10.2
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}


### PR DESCRIPTION
getSentry action updated to reference a new action, which isn't allowed in our github config. [See here](https://github.com/getsentry/action-release/pull/255#issuecomment-2647646773).