### PR TITLE
tweak: pin to v1 major sentry action-release

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: getsentry/action-release@v1.10.2
+      - uses: getsentry/action-release@v1
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}


### PR DESCRIPTION
With [1.10.4](https://github.com/getsentry/action-release/releases/tag/v1.10.4) we replaced the unverified volta action with https://github.com/actions/setup-node which is a GitHub verified action.