### PR TITLE
feat: Populate detours list with channels

### DIFF
--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -18,7 +18,6 @@ import {
   usePastDetours,
 } from "../hooks/useDetours"
 import { SocketContext } from "../contexts/socketContext"
-import { SimpleDetour } from "../models/detoursList"
 
 export const DetourListPage = () => {
   const [showDetourModal, setShowDetourModal] = useState(false)
@@ -31,17 +30,17 @@ export const DetourListPage = () => {
   const draftDetoursMap = useDraftDetours(socket)
   const pastDetoursMap = usePastDetours(socket)
 
-  const activeDetours: SimpleDetour[] | null = activeDetoursMap
-    ? Object.values(activeDetoursMap).sort(
-        (a, b) => b.activatedAt - a.activatedAt
-      )
-    : null
-  const draftDetours: SimpleDetour[] | null = draftDetoursMap
-    ? Object.values(draftDetoursMap).sort((a, b) => b.updatedAt - a.updatedAt)
-    : null
-  const pastDetours: SimpleDetour[] | null = pastDetoursMap
-    ? Object.values(pastDetoursMap).sort((a, b) => b.updatedAt - a.updatedAt)
-    : null
+  const activeDetours =
+    activeDetoursMap &&
+    Object.values(activeDetoursMap).sort(
+      (a, b) => b.activatedAt - a.activatedAt
+    )
+  const draftDetours =
+    draftDetoursMap &&
+    Object.values(draftDetoursMap).sort((a, b) => b.updatedAt - a.updatedAt)
+  const pastDetours =
+    pastDetoursMap &&
+    Object.values(pastDetoursMap).sort((a, b) => b.updatedAt - a.updatedAt)
   // --- End of detour channel initialization
 
   const detour = useLoadDetour(detourId)

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -27,9 +27,9 @@ export const DetourListPage = () => {
   // Wait for the detour channels to initialize
   const { socket } = useContext(SocketContext)
 
-  let activeDetoursMap = useActiveDetours(socket)
-  let draftDetoursMap = useDraftDetours(socket)
-  let pastDetoursMap = usePastDetours(socket)
+  const activeDetoursMap = useActiveDetours(socket)
+  const draftDetoursMap = useDraftDetours(socket)
+  const pastDetoursMap = usePastDetours(socket)
 
   const activeDetours: SimpleDetour[] | null = activeDetoursMap
     ? Object.values(activeDetoursMap).sort(

--- a/assets/src/components/routeLadders.tsx
+++ b/assets/src/components/routeLadders.tsx
@@ -71,13 +71,15 @@ const RouteLadders = ({
     inTestGroup(TestGroups.DetoursOnLadder)
   )
 
-  const skateDetoursByRouteName = Object.values(allActiveSkateDetours).reduce(
-    (acc: ByRouteId<DetoursMap>, cur: SimpleDetour) => {
-      acc[cur.route] = { ...acc[cur.route], [cur.id]: cur }
-      return acc
-    },
-    {}
-  )
+  const skateDetoursByRouteName = allActiveSkateDetours
+    ? Object.values(allActiveSkateDetours).reduce(
+        (acc: ByRouteId<DetoursMap>, cur: SimpleDetour) => {
+          acc[cur.route] = { ...acc[cur.route], [cur.id]: cur }
+          return acc
+        },
+        {}
+      )
+    : {}
 
   for (const routeId in alerts) {
     if (alerts[routeId].length > 0) {

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -30,9 +30,8 @@ export const useDetour = (input: UseDetourInput) => {
       const persistedSnapshot = actorRef.getPersistedSnapshot()
       const serializedSnapshot = JSON.stringify(persistedSnapshot)
       localStorage.setItem("snapshot", serializedSnapshot)
-
       // check for no-save tag before
-      if (snap.hasTag("no-save")) {
+      if (snap.hasTag("no-save") || !snap.context.nearestIntersection) {
         return
       }
 

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -20,7 +20,7 @@ export interface DetoursMap {
 const subscribe = (
   socket: Socket,
   topic: string,
-  initializeChannel: React.Dispatch<React.SetStateAction<DetoursMap>>,
+  initializeChannel: React.Dispatch<React.SetStateAction<DetoursMap | null>>,
   handleDrafted: ((data: SimpleDetour) => void) | undefined,
   handleActivated: ((data: SimpleDetour) => void) | undefined,
   handleDeactivated: ((data: SimpleDetour) => void) | undefined,
@@ -94,7 +94,7 @@ export const useActiveDetours = (
   enable: boolean = true
 ) => {
   const topic = "detours:active"
-  const [activeDetours, setActiveDetours] = useState<DetoursMap>({})
+  const [activeDetours, setActiveDetours] = useState<DetoursMap | null>(null)
 
   const handleActivated = (data: SimpleDetour) => {
     setActiveDetours((activeDetours) => ({ ...activeDetours, [data.id]: data }))
@@ -102,7 +102,7 @@ export const useActiveDetours = (
 
   const handleDeactivated = (data: SimpleDetour) => {
     setActiveDetours((activeDetours) => {
-      delete activeDetours[data.id]
+      if (activeDetours) delete activeDetours[data.id]
       return activeDetours
     })
   }
@@ -139,7 +139,7 @@ export const useActiveDetours = (
 // This is to refresh the Detours List page, past detours section
 export const usePastDetours = (socket: Socket | undefined) => {
   const topic = "detours:past"
-  const [pastDetours, setPastDetours] = useState<DetoursMap>({})
+  const [pastDetours, setPastDetours] = useState<DetoursMap | null>(null)
 
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
@@ -173,7 +173,7 @@ export const usePastDetours = (socket: Socket | undefined) => {
 // This is to refresh the Detours List page, just the current user drafts
 export const useDraftDetours = (socket: Socket | undefined) => {
   const topic = "detours:draft:" + userUuid()
-  const [draftDetours, setDraftDetours] = useState<DetoursMap>({})
+  const [draftDetours, setDraftDetours] = useState<DetoursMap | null>(null)
 
   const handleDrafted = (data: SimpleDetour) => {
     setDraftDetours((draftDetours) => ({ ...draftDetours, [data.id]: data }))
@@ -181,14 +181,14 @@ export const useDraftDetours = (socket: Socket | undefined) => {
 
   const handleActivated = (data: SimpleDetour) => {
     setDraftDetours((draftDetours) => {
-      delete draftDetours[data.id]
+      if (draftDetours) delete draftDetours[data.id]
       return draftDetours
     })
   }
 
   const handleDeleted = (detourId: number) => {
     setDraftDetours((draftDetours) => {
-      delete draftDetours[detourId]
+      if (draftDetours) delete draftDetours[detourId]
       return draftDetours
     })
   }

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -20,7 +20,9 @@ export interface DetoursMap {
 const subscribe = (
   socket: Socket,
   topic: string,
-  initializeChannel: React.Dispatch<React.SetStateAction<DetoursMap | null>>,
+  initializeChannel: React.Dispatch<
+    React.SetStateAction<DetoursMap | undefined>
+  >,
   handleDrafted: ((data: SimpleDetour) => void) | undefined,
   handleActivated: ((data: SimpleDetour) => void) | undefined,
   handleDeactivated: ((data: SimpleDetour) => void) | undefined,
@@ -94,7 +96,7 @@ export const useActiveDetours = (
   enable: boolean = true
 ) => {
   const topic = "detours:active"
-  const [activeDetours, setActiveDetours] = useState<DetoursMap | null>(null)
+  const [activeDetours, setActiveDetours] = useState<DetoursMap | undefined>()
 
   const handleActivated = (data: SimpleDetour) => {
     setActiveDetours((activeDetours) => ({ ...activeDetours, [data.id]: data }))
@@ -139,7 +141,7 @@ export const useActiveDetours = (
 // This is to refresh the Detours List page, past detours section
 export const usePastDetours = (socket: Socket | undefined) => {
   const topic = "detours:past"
-  const [pastDetours, setPastDetours] = useState<DetoursMap | null>(null)
+  const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
 
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
@@ -173,7 +175,7 @@ export const usePastDetours = (socket: Socket | undefined) => {
 // This is to refresh the Detours List page, just the current user drafts
 export const useDraftDetours = (socket: Socket | undefined) => {
   const topic = "detours:draft:" + userUuid()
-  const [draftDetours, setDraftDetours] = useState<DetoursMap | null>(null)
+  const [draftDetours, setDraftDetours] = useState<DetoursMap | undefined>()
 
   const handleDrafted = (data: SimpleDetour) => {
     setDraftDetours((draftDetours) => ({ ...draftDetours, [data.id]: data }))

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  3
+                  15
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -81,7 +81,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign 3
+                    Headsign 15
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -94,18 +94,13 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street A3 & Avenue B3
+              Street A15 & Avenue B15
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
               23 hours ago
             </td>
-            <td
-              class="align-middle p-3 u-hide-for-mobile"
-            >
-              2 hours
-            </td>
           </tr>
           <tr>
             <td
@@ -117,7 +112,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  1
+                  13
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -125,7 +120,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign 1
+                    Headsign 13
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -138,18 +133,13 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street A1 & Avenue B1
+              Street A13 & Avenue B13
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
               54 hours ago
             </td>
-            <td
-              class="align-middle p-3 u-hide-for-mobile"
-            >
-              2 hours
-            </td>
           </tr>
           <tr>
             <td
@@ -161,7 +151,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  2
+                  14
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -169,7 +159,7 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign 2
+                    Headsign 14
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -182,17 +172,12 @@ exports[`DetourListPage orders active detour list by activatedAt value 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street A2 & Avenue B2
+              Street A14 & Avenue B14
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
               84 hours ago
-            </td>
-            <td
-              class="align-middle p-3 u-hide-for-mobile"
-            >
-              2 hours
             </td>
           </tr>
         </tbody>
@@ -310,7 +295,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign A
+                    Headsign 1
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -323,12 +308,12 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street A & Avenue B
+              Street A1 & Avenue B1
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
@@ -354,7 +339,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign B
+                    Headsign A
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -367,17 +352,17 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street C & Avenue D
+              Street A2 & Avenue B2
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              29 hours ago
+              Just now
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              3 hours
+              2 hours
             </td>
           </tr>
         </tbody>
@@ -540,46 +525,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  1
-                </div>
-                <div
-                  class="c-detours-table__route-info-text d-inline-block"
-                >
-                  <div
-                    class="pb-1 fs-4 fw-semibold"
-                  >
-                    Headsign A
-                  </div>
-                  <div
-                    class="c-detours-table__route-info-direction fs-6"
-                  >
-                    Inbound
-                  </div>
-                </div>
-              </div>
-            </td>
-            <td
-              class="align-middle p-3 u-hide-for-mobile"
-            >
-              Street E & Avenue F
-            </td>
-            <td
-              class="align-middle p-3 u-hide-for-mobile"
-            >
-              26 hours ago
-            </td>
-          </tr>
-          <tr>
-            <td
-              class="align-middle p-3"
-            >
-              <div
-                class="d-flex"
-              >
-                <div
-                  class="c-route-pill c-route-pill--bus"
-                >
-                  1
+                  3
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -592,7 +538,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                   <div
                     class="c-detours-table__route-info-direction fs-6"
                   >
-                    Outbound
+                    Inbound
                   </div>
                 </div>
               </div>
@@ -600,7 +546,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street C & Avenue D
+              Street A3 & Avenue B3
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
@@ -688,7 +634,7 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  1
+                  4
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -696,7 +642,7 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign A
+                    Headsign 4
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -709,17 +655,17 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street A & Avenue B
+              Street A4 & Avenue B4
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              26 hours ago
+              Just now
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              4 hours
+              2 hours
             </td>
           </tr>
           <tr>
@@ -732,7 +678,7 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
                 <div
                   class="c-route-pill c-route-pill--bus"
                 >
-                  2
+                  5
                 </div>
                 <div
                   class="c-detours-table__route-info-text d-inline-block"
@@ -740,7 +686,7 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
                   <div
                     class="pb-1 fs-4 fw-semibold"
                   >
-                    Headsign B
+                    Headsign A
                   </div>
                   <div
                     class="c-detours-table__route-info-direction fs-6"
@@ -753,17 +699,17 @@ exports[`DetourListPage renders limited detour list page for non-dispatchers 1`]
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Street C & Avenue D
+              Street A5 & Avenue B5
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              29 hours ago
+              Just now
             </td>
             <td
               class="align-middle p-3 u-hide-for-mobile"
             >
-              Until end of service
+              2 hours
             </td>
           </tr>
         </tbody>

--- a/assets/tests/components/detours/detoursListPage.addDetour.test.tsx
+++ b/assets/tests/components/detours/detoursListPage.addDetour.test.tsx
@@ -11,14 +11,12 @@ import { DetourListPage } from "../../../src/components/detourListPage"
 import { TestGroups } from "../../../src/userInTestGroup"
 import getTestGroups from "../../../src/userTestGroups"
 import { neverPromise } from "../../testHelpers/mockHelpers"
-import { fetchDetour, fetchDetours } from "../../../src/api"
+import { fetchDetour } from "../../../src/api"
 
 jest.mock("../../../src/userTestGroups")
-
 jest.mock("../../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetours).mockReturnValue(neverPromise())
   jest.mocked(fetchDetour).mockReturnValue(neverPromise())
 })
 

--- a/assets/tests/components/detours/diversionPage.delete.test.tsx
+++ b/assets/tests/components/detours/diversionPage.delete.test.tsx
@@ -8,12 +8,7 @@ import { render } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { DetourListPage } from "../../../src/components/detourListPage"
-import {
-  deleteDetour,
-  fetchDetour,
-  fetchDetours,
-  putDetourUpdate,
-} from "../../../src/api"
+import { deleteDetour, fetchDetour, putDetourUpdate } from "../../../src/api"
 import { Ok } from "../../../src/util/result"
 import { neverPromise } from "../../testHelpers/mockHelpers"
 import getTestGroups from "../../../src/userTestGroups"
@@ -25,17 +20,26 @@ import {
   deleteDetourButton,
 } from "../../testHelpers/selectors/components/detours/diversionPage"
 import { draftDetourFactory } from "../../factories/detourStateMachineFactory"
+import {
+  useActiveDetours,
+  useDraftDetours,
+  usePastDetours,
+} from "../../../src/hooks/useDetours"
 
 jest
   .useFakeTimers({ doNotFake: ["setTimeout"] })
   .setSystemTime(new Date("2024-08-29T20:00:00"))
 
 jest.mock("../../../src/userTestGroups")
-
+jest.mock("../../../src/hooks/useDetours")
 jest.mock("../../../src/api")
 
 beforeEach(() => {
-  jest.mocked(fetchDetours).mockReturnValue(neverPromise())
+  const detours = detourListFactoryWithDraft.build()
+  jest.mocked(useActiveDetours).mockReturnValue(detours.active)
+  jest.mocked(useDraftDetours).mockReturnValue(detours.draft)
+  jest.mocked(usePastDetours).mockReturnValue(detours.past)
+
   jest.mocked(fetchDetour).mockReturnValue(neverPromise())
   jest.mocked(putDetourUpdate).mockReturnValue(neverPromise())
   jest.mocked(deleteDetour).mockReturnValue(neverPromise())
@@ -50,10 +54,6 @@ beforeEach(() => {
 
 describe("Detours Page: Open a Detour", () => {
   test("calls API with correct detour ID", async () => {
-    jest
-      .mocked(fetchDetours)
-      .mockResolvedValue(Ok(detourListFactoryWithDraft.build()))
-
     render(<DetourListPage />)
 
     await userEvent.click(await screen.findByText("Draft Detour 123"))
@@ -61,9 +61,6 @@ describe("Detours Page: Open a Detour", () => {
   })
 
   test("renders detour details modal with delete draft button", async () => {
-    jest
-      .mocked(fetchDetours)
-      .mockResolvedValue(Ok(detourListFactoryWithDraft.build()))
     jest.mocked(fetchDetour).mockResolvedValue(Ok(draftDetourFactory.build()))
 
     render(<DetourListPage />)
@@ -74,9 +71,6 @@ describe("Detours Page: Open a Detour", () => {
   })
 
   test("delete draft detour confirmation modal displays when Delete Draft button clicked", async () => {
-    jest
-      .mocked(fetchDetours)
-      .mockResolvedValue(Ok(detourListFactoryWithDraft.build()))
     jest.mocked(fetchDetour).mockResolvedValue(Ok(draftDetourFactory.build()))
 
     render(<DetourListPage />)
@@ -90,9 +84,6 @@ describe("Detours Page: Open a Detour", () => {
   })
 
   test("Clicking the Delete Draft button on the Delete Draft Detour confirmation modal calls the deleteDetour api function", async () => {
-    jest
-      .mocked(fetchDetours)
-      .mockResolvedValue(Ok(detourListFactoryWithDraft.build()))
     jest.mocked(fetchDetour).mockResolvedValue(Ok(draftDetourFactory.build()))
 
     render(<DetourListPage />)
@@ -110,9 +101,6 @@ describe("Detours Page: Open a Detour", () => {
   })
 
   test("Clicking the Cancel button on the Delete Draft Detour confirmation modal closes the modal", async () => {
-    jest
-      .mocked(fetchDetours)
-      .mockResolvedValue(Ok(detourListFactoryWithDraft.build()))
     jest.mocked(fetchDetour).mockResolvedValue(Ok(draftDetourFactory.build()))
 
     render(<DetourListPage />)

--- a/assets/tests/components/detours/diversionPage.editDuration.test.tsx
+++ b/assets/tests/components/detours/diversionPage.editDuration.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event"
 import { screen } from "@testing-library/dom"
 import { render } from "@testing-library/react"
 import "@testing-library/jest-dom/jest-globals"
-import { fetchDetours, fetchDetour, putDetourUpdate } from "../../../src/api"
+import { fetchDetour, putDetourUpdate } from "../../../src/api"
 import { DetourListPage } from "../../../src/components/detourListPage"
 import { Ok } from "../../../src/util/result"
 import { detourListFactory } from "../../factories/detourListFactory"
@@ -21,12 +21,22 @@ import {
   DiversionPageProps,
 } from "../../../src/components/detours/diversionPage"
 import { byRole } from "testing-library-selector"
+import {
+  useActiveDetours,
+  useDraftDetours,
+  usePastDetours,
+} from "../../../src/hooks/useDetours"
 
 jest.mock("../../../src/api")
+jest.mock("../../../src/hooks/useDetours")
 jest.mock("../../../src/userTestGroups")
 
 beforeEach(() => {
-  jest.mocked(fetchDetours).mockReturnValue(neverPromise())
+  const detours = detourListFactory.build()
+  jest.mocked(useActiveDetours).mockReturnValue(detours.active)
+  jest.mocked(useDraftDetours).mockReturnValue(detours.draft)
+  jest.mocked(usePastDetours).mockReturnValue(detours.past)
+
   jest.mocked(fetchDetour).mockReturnValue(neverPromise())
   jest.mocked(putDetourUpdate).mockReturnValue(neverPromise())
 
@@ -56,7 +66,6 @@ const changeDurationHeading = byRole("heading", {
 describe("DiversionPage edit duration workflow", () => {
   describe("before change duration modal", () => {
     test("does not have a change duration button if not an active detour", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(Ok(detourInProgressFactory.build()))
@@ -69,7 +78,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("has a change duration button on the review details screen", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(Ok(activeDetourFactory.build()))
@@ -82,7 +90,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("does not show change duration modal before clicking the button", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(Ok(activeDetourFactory.build()))
@@ -95,7 +102,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("clicking change duration button shows the modal", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(Ok(activeDetourFactory.build()))
@@ -128,7 +134,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("changing duration and clicking cancel does not save the duration", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(
@@ -155,7 +160,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("changing the duration and clicking done saves the duration", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(
@@ -182,7 +186,6 @@ describe("DiversionPage edit duration workflow", () => {
     })
 
     test("not changing duration and clicking done doesn't change the duration", async () => {
-      jest.mocked(fetchDetours).mockResolvedValue(Ok(detourListFactory.build()))
       jest
         .mocked(fetchDetour)
         .mockResolvedValue(

--- a/assets/tests/components/detours/diversionPage.saveDetour.test.tsx
+++ b/assets/tests/components/detours/diversionPage.saveDetour.test.tsx
@@ -2,7 +2,11 @@ import { jest, describe, test, expect, beforeEach } from "@jest/globals"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import React from "react"
 import "@testing-library/jest-dom/jest-globals"
-import { fetchRoutePatterns, putDetourUpdate } from "../../../src/api"
+import {
+  fetchNearestIntersection,
+  fetchRoutePatterns,
+  putDetourUpdate,
+} from "../../../src/api"
 import {
   DiversionPage as DiversionPageDefault,
   DiversionPageProps,
@@ -34,6 +38,9 @@ jest.mock("../../../src/userTestGroups")
 beforeEach(() => {
   jest.mocked(fetchRoutePatterns).mockReturnValue(neverPromise())
   jest.mocked(getTestGroups).mockReturnValue([])
+  jest
+    .mocked(fetchNearestIntersection)
+    .mockResolvedValue("Returned Intersection")
   jest.mocked(putDetourUpdate).mockReturnValue(neverPromise())
 })
 
@@ -65,6 +72,10 @@ describe("DiversionPage autosave flow", () => {
 
     act(() => {
       fireEvent.click(container.querySelector(".c-vehicle-map")!)
+    })
+
+    await waitFor(() => {
+      expect(putDetourUpdate).toHaveBeenCalledTimes(1)
     })
 
     act(() => {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1205385723132845/1208390246838825

In terms of tests, I'm not sure what else to cover? Ideally, I'd like to verify some integration flow -- like activating a detour triggers the channel to be affected -- but I struggled with that.

Known issue: preventing a drafted detour from appearing in the channel and passing through the `handleDrafted` function before it has all it's returned values (like nearestIntersection). To be discussed in subsequent PR.

Also: have confirmed with Brian that the spinner is great! 