### PR TITLE
refactor(ex/skate/detours): use changeset to check change to `status` in `send_notification`

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -143,6 +143,27 @@ defmodule Skate.Detours.Detours do
   def get_detour!(id), do: Repo.get!(Detour, id)
 
   @doc """
+  Gets a single detour.
+
+  Returns `nil` if the Detour does not exist.
+
+  Raises `ArgumentError` if `id` is `nil`
+
+  ## Examples
+
+      iex> get_detour(123)
+      %Detour{}
+
+      iex> get_detour(456)
+      nil
+
+      iex> get_detour(nil)
+      ** (ArgumentError)
+
+  """
+  def get_detour(id), do: Repo.get(Detour, id)
+
+  @doc """
   Gets a single detour authored by the provided user_id.
 
   Raises `Ecto.NoResultsError` if the Detour does not exist.

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -14,12 +14,12 @@ defmodule Skate.Detours.SnapshotSerde do
   def deserialize(user_id, %{} = snapshot) do
     {activated_at, snapshot} = pop_in(snapshot, ["context", "activatedAt"])
 
+    id = id_from_snapshot(snapshot)
+
+    detour = (id && Skate.Detours.Detours.get_detour(id)) || %Detour{id: id, author_id: user_id}
+
     Skate.Detours.Db.Detour.changeset(
-      %Skate.Detours.Db.Detour{
-        # `id` is `nil` by default, so a `nil` `id` should be fine
-        id: id_from_snapshot(snapshot),
-        author_id: user_id
-      },
+      detour,
       %{
         # Save Snapshot to DB until we've fully transitioned to serializing
         # snapshots from DB data


### PR DESCRIPTION
Currently, `Skate.Detours.SnapshotSerde.deserialize` "clobbers" anything in the database because the created changeset isn't doing any real change tracking because the detour object isn't pulled from the database first.

This starts tracking changes appropriately, and then uses the created changeset to check if `:status` is changed and uses _that_ change to trigger sending & creation of notifications.