### PR TITLE
tweak: add gtfs and hastus versions to Schedule.Fetcher logging

### DIFF
--- a/lib/schedule/fetcher.ex
+++ b/lib/schedule/fetcher.ex
@@ -163,7 +163,7 @@ defmodule Schedule.Fetcher do
 
     case fetch_remote_files(latest_gtfs_timestamp, latest_hastus_timestamp) do
       {:files, files, gtfs_timestamp, hastus_timestamp} ->
-        Logger.info("Updated schedule data found, parsing")
+        Logger.info("Updated schedule data found, parsing version=#{files.version}")
 
         try do
           data = Data.parse_files(files)


### PR DESCRIPTION
I noticed that we log the GTFS feed information and the last modified timestamp for the zip file. We don't log the hastus version information but there is an updated version of both returned from [fetch_remote_files](https://github.com/mbta/skate/blob/b8ae48a24306135c63d44962a87935152369df5c/lib/schedule/fetcher.ex#L231).

We could use the returned timestamps instead.

![image](https://github.com/user-attachments/assets/b396934d-d70f-41f0-bd01-d036034ff95c)
