### PR TITLE
fix: update dialyzer action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           POSTGRES_PASSWORD: ${{env.DATABASE_PASSWORD}}
           POSTGRES_HOSTNAME: ${{env.DATABASE_HOST}}
           GUARDIAN_SECRET_KEY: ${{env.GUARDIAN_SECRET_KEY}}
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2
 
   build_typescript:
     name: Build and test TypeScript


### PR DESCRIPTION
## Context
> it looks like mbta/actions/dialyzer is being affected by the scheduled brownout of the deprecated cache service today, meaning it will permanently stop working one week from today (April 15th) when the service is decommissioned for good. although it seems like only attempts to restore the cache are being affected, so re-running the relevant job once it fails does work, since the action does not attempt to restore the cache on re-runs.
> -- https://mbta.slack.com/archives/GP5QJM98A/p1744134926110489

> https://github.com/mbta/actions/pull/64