### PR TITLE
docs: add Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Asana Ticket: [TICKET_NAME](TICKET_LINK)


### PR DESCRIPTION
This adds the trigger phrase in the expected format for the Github -> Asana CI workflow to avoid issues with a missing or invalid trigger phrase. We could discuss adding more to this template in the future. 