### PR TITLE
fix: remove Logger.error call from a non-error state

### DIFF
--- a/lib/skate/settings/test_group.ex
+++ b/lib/skate/settings/test_group.ex
@@ -91,9 +91,7 @@ defmodule Skate.Settings.TestGroup do
     test_group = DbTestGroup |> Skate.Repo.get_by(name: name) |> Skate.Repo.preload(:users)
 
     if test_group do
-      t = convert_from_db_test_group(test_group)
-      Logger.error(inspect(t))
-      t
+      convert_from_db_test_group(test_group)
     else
       nil
     end


### PR DESCRIPTION
Asana Ticket: No ticket

I saw these errors in Splunk while looking at something else. I'm assuming it's code leftover from debugging during development, I don't see a reason to log it in production as an error.

