### PR TITLE
fix(ex/notifications/bridge): remove comma in log

### DIFF
--- a/lib/notifications/bridge.ex
+++ b/lib/notifications/bridge.ex
@@ -119,7 +119,7 @@ defmodule Notifications.Bridge do
       |> do_get_datetime()
 
     Logger.info(
-      "bridge_response status=#{inspect(raw_status)}, lowering_time=#{inspect(lowering_time)}"
+      "bridge_response status=#{inspect(raw_status)} lowering_time=#{inspect(lowering_time)}"
     )
 
     status =


### PR DESCRIPTION
In Splunk, the logfmt parser they have doesn't really handle this comma very well, and logfmt formatted logs should be key=value pairs with spaces between.

---

No Ticket.