### PR TITLE
fix: handle RAD/WAD activites in Timepoint Status

### DIFF
--- a/lib/realtime/timepoint_status.ex
+++ b/lib/realtime/timepoint_status.ex
@@ -157,33 +157,26 @@ defmodule Realtime.TimepointStatus do
 
     trip = Block.trip_at_time(block, now_time_of_day)
 
-    case trip do
-      nil ->
-        nil
+    with(
+      %{stop_times: stop_times} <- trip,
+      timepoints when is_list(timepoints) and length(timepoints) > 0 <-
+        Enum.filter(stop_times, &StopTime.timepoint?/1)
+    ) do
+      timepoint_status = scheduled_timepoint_status(timepoints, now_time_of_day)
 
-      _ ->
-        timepoints = Enum.filter(trip.stop_times, &StopTime.timepoint?/1)
-
-        case timepoints do
-          [] ->
-            nil
-
-          _ ->
-            timepoint_status = scheduled_timepoint_status(timepoints, now_time_of_day)
-
-            %{
-              route_id: trip.route_id,
-              route_pattern_id: trip.route_pattern_id,
-              direction_id: trip.direction_id,
-              trip_id: trip.id,
-              run_id: trip.run_id,
-              time_since_trip_start_time: now_time_of_day - trip.start_time,
-              headsign: trip.headsign,
-              via_variant:
-                trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id),
-              timepoint_status: timepoint_status
-            }
-        end
+      %{
+        route_id: trip.route_id,
+        route_pattern_id: trip.route_pattern_id,
+        direction_id: trip.direction_id,
+        trip_id: trip.id,
+        run_id: trip.run_id,
+        time_since_trip_start_time: now_time_of_day - trip.start_time,
+        headsign: trip.headsign,
+        via_variant: trip.route_pattern_id && RoutePattern.via_variant(trip.route_pattern_id),
+        timepoint_status: timepoint_status
+      }
+    else
+      _ -> nil
     end
   end
 

--- a/test/realtime/timepoint_status_test.exs
+++ b/test/realtime/timepoint_status_test.exs
@@ -416,5 +416,31 @@ defmodule Realtime.TimepointStatusTest do
       now = time0
       assert TimepointStatus.scheduled_location(nil, now) == nil
     end
+
+    test "returns nil if stop-times if active trip is as_directed" do
+      # 2019-01-01 12:00:00 EST
+      time0 = 1_546_362_000
+      time_of_day0 = Util.Time.parse_hhmmss("12:00:00")
+
+      block =
+        build(
+          :block,
+          start_time: time_of_day0 + 1,
+          end_time: time_of_day0 + 13,
+          pieces: [
+            build(:piece,
+              trips: [
+                build(:as_directed,
+                  kind: :rad,
+                  start_time: time_of_day0 + 3,
+                  end_time: time_of_day0 + 5
+                )
+              ]
+            )
+          ]
+        )
+
+      assert TimepointStatus.scheduled_location(block, time0) == nil
+    end
   end
 end


### PR DESCRIPTION
No ticket. 

Related to an issue we saw yesterday:

https://mbta.slack.com/archives/C047ZT8ACP5/p1747546808098849

```
key :stop_times not found in: %Schedule.AsDirected{
  kind: :rad,
  # redacted unnecessary info
}
```