### PR TITLE
fix(amend/adr/5): use `Duration` where `DateTime` was accidentally used

### DIFF
--- a/documentation/adr/0005-detour-reminder-toasts-architecture.md
+++ b/documentation/adr/0005-detour-reminder-toasts-architecture.md
@@ -498,14 +498,14 @@ iex> Skate.Notifications.create_detour_expiration_notification(%{
 ...>   # store the _current_ estimated duration at this point in time
 ...>   estimated_duration: detour.estimated_duration,
 ...>   # 
-...>   expires_at: %DateTime{}
+...>   expires_at: %Duration{}
 ...> })
 
 %Skate.Notifications.Notification{
   detour_expiration: %Skate.Notifications.DetourExpiration{
     detour_id: ^detour.id,
     estimated_duration: ^detour.estimated_duration
-    expires_at: %DateTime{},
+    expires_at: %Duration{},
     # [...]
   },
   # [...]

--- a/documentation/adr/0005-detour-reminder-toasts-architecture.md
+++ b/documentation/adr/0005-detour-reminder-toasts-architecture.md
@@ -498,14 +498,14 @@ iex> Skate.Notifications.create_detour_expiration_notification(%{
 ...>   # store the _current_ estimated duration at this point in time
 ...>   estimated_duration: detour.estimated_duration,
 ...>   # 
-...>   expires_at: %Duration{}
+...>   expires_in: %Duration{}
 ...> })
 
 %Skate.Notifications.Notification{
   detour_expiration: %Skate.Notifications.DetourExpiration{
     detour_id: ^detour.id,
     estimated_duration: ^detour.estimated_duration
-    expires_at: %Duration{},
+    expires_in: %Duration{},
     # [...]
   },
   # [...]


### PR DESCRIPTION
I had intended when writing the ADR that `expires_at` would be a `Duration`, but it seems I missed that when originally writing this ADR.

The ticket for [Create New Notification Type on Backend](https://app.asana.com/1/15492006741476/project/1203014709808707/task/1209653841420226?focus=true) specifies `Duration`, and that's how I have currently implemented it, but if we need to discuss the path forward I understand, since I missed this.

Related-To: #3009 