### PR TITLE
feat: create detour expiration notification type

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -102,6 +102,7 @@ config :skate, SkateWeb.AuthManager,
   secret_key: nil
 
 config :skate, Skate.Repo,
+  types: Skate.PostgrexTypes,
   database: "skate_dev",
   username: System.get_env("POSTGRES_USERNAME", System.get_env("USER")),
   password: System.get_env("POSTGRES_PASSWORD", ""),

--- a/lib/notifications/db/detour_expiration.ex
+++ b/lib/notifications/db/detour_expiration.ex
@@ -1,0 +1,39 @@
+defmodule Notifications.Db.DetourExpiration do
+  @moduledoc """
+  Ecto Schema for Detour Expiration Notifications
+  """
+
+  use Skate.Schema
+  import Ecto.Changeset
+
+  @derive {Jason.Encoder,
+           only: [
+             :__struct__,
+             :detour_id,
+             :estimated_duration,
+             :expires_in
+           ]}
+
+  typed_schema "detour_expiration_notification" do
+    field(:estimated_duration, :string)
+    field(:expires_in, :duration)
+
+    belongs_to :detour, Skate.Detours.Db.Detour
+
+    has_one :notification, Notifications.Db.Notification
+  end
+
+  @doc """
+  Creates a new "Detour Expiration Notification"
+  """
+  def changeset(detour_expiration, attrs) do
+    detour_expiration
+    # A `%DetourExpiration{}` should always have a associated notification, so
+    # add a placeholder to the params in case `attrs` does not contain it.
+    |> cast(%{notification: %{}}, [])
+    |> cast(attrs, [:estimated_duration, :expires_in])
+    |> cast_assoc(:notification)
+    |> validate_required([:estimated_duration, :expires_in, :detour_id])
+    |> assoc_constraint(:detour)
+  end
+end

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -22,6 +22,7 @@ defmodule Notifications.Db.Notification do
     belongs_to(:block_waiver, DbBlockWaiver)
     belongs_to(:bridge_movement, DbBridgeMovement)
     belongs_to(:detour, Notifications.Db.Detour)
+    belongs_to(:detour_expiration, Notifications.Db.DetourExpiration)
   end
 
   @doc """

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -24,6 +24,59 @@ defmodule Notifications.Db.Notification do
     belongs_to(:detour, Notifications.Db.Detour)
   end
 
+  @doc """
+  Creates a new `Notifications.Db.Notification`.
+
+  Using this function directly is not recommended, instead you should consider
+  using changesets functions from the intended "Notification Type" to construct
+  notifications.
+
+  This function exists mainly to be used by `cast_assoc` from
+  "Notification Type" changeset functions.
+
+  If `:created_at` is not provided, it will default to the current
+  time.
+
+  ## Examples
+  ### Create Notification with a backdated `created_at` timestamp
+      iex> current_time = DateTime.utc_now()
+      ...> |> DateTime.shift(minute: -30)
+      ...> |> DateTime.to_unix()
+      ...>
+      iex> %{created_at: ^current_time} = %Notifications.Db.Notification{}
+      ...> |> Notifications.Db.Notification.changeset(%{created_at: current_time})
+      ...> |> Ecto.Changeset.apply_action!(:insert)
+
+  ### Create Notification and default the current time to now
+      iex> current_time = DateTime.utc_now() |> DateTime.to_unix()
+      ...>
+      iex> %{created_at: created_at} = %Notifications.Db.Notification{}
+      ...> |> Notifications.Db.Notification.changeset(%{})
+      ...> |> Ecto.Changeset.apply_action!(:insert)
+      ...>
+      iex> current_time <= created_at
+      true
+
+  """
+  def changeset(notification, attrs) do
+    notification
+    |> cast(attrs, [:created_at])
+    |> put_default(:created_at, fn -> DateTime.to_unix(DateTime.utc_now()) end)
+    |> validate_required([:created_at])
+  end
+
+  defp put_default(changeset, key, value_fn) when is_function(value_fn, 0) do
+    put_default(changeset, key, value_fn.())
+  end
+
+  defp put_default(changeset, key, value) do
+    if field_missing?(changeset, key) do
+      put_change(changeset, key, value)
+    else
+      changeset
+    end
+  end
+
   def block_waiver_changeset(notification, attrs \\ %{}) do
     block_waiver_values =
       notification

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -321,4 +321,10 @@ defmodule Notifications.Notification do
        }) do
     detour
   end
+
+  defp content_from_db_notification(%DbNotification{
+         detour_expiration: %Notifications.Db.DetourExpiration{} = detour_expiration
+       }) do
+    detour_expiration
+  end
 end

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -42,6 +42,8 @@ defmodule Skate.Detours.Db.Detour do
     field :estimated_duration, :string, virtual: true
 
     # -------------------------------------------------------
+
+    has_many :detour_expiration_notifications, Notifications.Db.DetourExpiration
   end
 
   def changeset(detour, attrs) do

--- a/lib/skate/postgrex_types.ex
+++ b/lib/skate/postgrex_types.ex
@@ -1,0 +1,5 @@
+Postgrex.Types.define(
+  Skate.PostgrexTypes,
+  Ecto.Adapters.Postgres.extensions(),
+  interval_decode_type: Duration
+)

--- a/priv/repo/migrations/20250522165450_create_detour_expiration_notifications.exs
+++ b/priv/repo/migrations/20250522165450_create_detour_expiration_notifications.exs
@@ -1,0 +1,16 @@
+defmodule Skate.Repo.Migrations.CreateDetourExpirationNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:detour_expiration_notification) do
+      add :estimated_duration, :string, null: false
+      add :expires_in, :duration, null: false
+
+      add(
+        :detour_id,
+        references(:detours, on_delete: :delete_all, on_update: :update_all),
+        null: false
+      )
+    end
+  end
+end

--- a/priv/repo/migrations/20250522204236_fkey_notifications_detour_expiration_notification.exs
+++ b/priv/repo/migrations/20250522204236_fkey_notifications_detour_expiration_notification.exs
@@ -1,0 +1,15 @@
+defmodule Skate.Repo.Migrations.FkeyNotificationsDetourExpirationNotification do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notifications) do
+      add(
+        :detour_expiration_id,
+        references(:detour_expiration_notification,
+          on_delete: :delete_all,
+          on_update: :update_all
+        )
+      )
+    end
+  end
+end

--- a/test/notifications/db/notification_test.exs
+++ b/test/notifications/db/notification_test.exs
@@ -3,5 +3,6 @@ defmodule Notifications.Db.NotificationTest do
 
   import Skate.Factory
 
+  doctest Notifications.Db.Notification
   doctest Notifications.Db.Notification.Queries
 end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -1,5 +1,8 @@
 defmodule Notifications.NotificationTest do
   use Skate.DataCase
+
+  doctest Notifications.Notification
+
   import Skate.Factory
 
   alias Notifications.Notification


### PR DESCRIPTION
Asana Ticket: [Create New Notification Type on Backend](https://app.asana.com/1/15492006741476/task/1210418717846181)

# Summary
This does just about everything to setup the database side of notifications, except for returning the new notifications from `unexpired_notifications_for_user`. 

If a `DetourExpiration` notification is returned to the frontend before the Superstruct definition is completed on the frontend, then all notifications will fail to work, so that has been left out of this to unblock this from being merged or needing any sort of rollback.

## Usage of `%Duration{}` in Schema

This also configures `PostgrexTypes` per the documentation, so that we can use `%Duration{}`(as per the ideas in the ADR[^adr-mistake]).

[^adr-mistake]: turns out, I also had a bit of a "typo" in the original ADR, which I've opened a [PR to correct the mistake](https://github.com/mbta/skate/pull/3008), but if we need to reconsider usage of `%Duration{}` since it wasn't originally in the ADR that would be understandable.

I believe this is the _correct_ type to use for this, but I'm not sure if it'll currently be the most _ergonomic_ type, because Postgres stores limited info in it's `interval` type (<a href="https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-OUTPUT"><q>PostgreSQL stores interval values as months, days, and microseconds</q></a>) and due to this postgrex converts the fields in a duration into this limited set and fails to reconstruct it as the original units.

So for example, when a Duration is created with 30 minutes, it comes out of the database as 1800 seconds on retrieval. 
```elixir
iex> Duration.new!(minute: 30)
%Duration{minute: 30}

# becomes
iex> ExampleDatabase.get()
%Duration{second: 1800, microsecond: {0, 6}}
```


I had assumed that the `Duration` API would have functions for converting between units or ["balancing"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration#duration_balancing) the duration, but that doesn't seem to exist, like it does in [C#'s `TimeSpan`](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.totalminutes?view=net-9.0), or [Temporal's `round()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/round).

I expect that it would be easy[^2] to implement "balancing" as needed[^1], but it's disappointing to realize that this doesn't exist _now_. But, at the risk of speculating too much, I think it's still worth using the `Duration` type, as those functions could be either:
1. added in future Elixir versions
2. implemented as a Library
3. or done well enough with our own implementation ad-hoc.[^postgrex-reference-implementation]

[^postgrex-reference-implementation]: Here's some examples from Postgrex of what implementing this would _maybe_ look like:
	1. https://github.com/elixir-ecto/postgrex/blob/412b55567b6f0f3feb587e38466fcab047581c0f/lib/postgrex/extensions/interval.ex#L80-L82
	2. https://github.com/elixir-ecto/postgrex/blob/412b55567b6f0f3feb587e38466fcab047581c0f/lib/postgrex/extensions/interval.ex#L68-L76
	3. https://github.com/elixir-ecto/postgrex/blob/412b55567b6f0f3feb587e38466fcab047581c0f/lib/postgrex/extensions/interval.ex#L31-L44

[^1]: i.e., convert 1800 seconds to 30 minutes, or instead change implementations to check for 1800 seconds instead of 30 minutes

[^2]: in our _limited_ use case, which is 30 minutes or 0, the problem set is not "easy", as mentioned in the [Temporal docs on Duration Balancing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration#duration_balancing)

<details>
<summary>Enabling Duration Type Docs</summary>


1. > For the `:duration` type, you may need to enable [Duration](https://hexdocs.pm/elixir/Duration.html) support in your adapter. For information on how to enable it in Postgrex, see their [HexDocs page](https://hexdocs.pm/postgrex/readme.html#data-representation).
	> &mdash; https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types
1. https://hexdocs.pm/postgrex/Postgrex.Types.html#define/3

</details>