### PR TITLE
feat(ex/notifcations): return expiration notifications from `unexpired_notifications_for_user`

### DIFF
--- a/lib/notifications/db/detour_expiration.ex
+++ b/lib/notifications/db/detour_expiration.ex
@@ -11,7 +11,11 @@ defmodule Notifications.Db.DetourExpiration do
              :__struct__,
              :detour_id,
              :estimated_duration,
-             :expires_in
+             :expires_in,
+             :headsign,
+             :route,
+             :direction,
+             :origin
            ]}
 
   typed_schema "detour_expiration_notification" do
@@ -21,6 +25,12 @@ defmodule Notifications.Db.DetourExpiration do
     belongs_to :detour, Skate.Detours.Db.Detour
 
     has_one :notification, Notifications.Db.Notification
+
+    # Derived from the associated detour
+    field :headsign, :any, virtual: true
+    field :route, :any, virtual: true
+    field :direction, :any, virtual: true
+    field :origin, :any, virtual: true
   end
 
   @doc """

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -215,6 +215,116 @@ defmodule Notifications.Db.Notification do
     end
 
     @doc """
+    Joins associated `Notifications.Db.DetourExpiration`'s on
+    `Notifications.Db.Notification`'s and retrieves the Detour's
+    associated info.
+
+    ## Examples
+
+    Using this query returns the associated information from the linked detour
+        iex> :detour
+        ...> |> build()
+        ...> |> with_route_name("17")
+        ...> |> with_direction(:outbound)
+        ...> |> with_headsign("17 Outbound")
+        ...> |> insert()
+        ...> |> Notifications.Notification.create_detour_expiration_notification(%{
+        ...>   estimated_duration: "1 hour",
+        ...>   expires_in: Duration.new!(minute: 30)
+        ...> })
+        ...>
+        ...> all_detour_notifications =
+        ...>   Notifications.Db.Notification.Queries.select_detour_expiration_notifications()
+        ...>   |> Skate.Repo.all()
+        ...>
+        ...> [
+        ...>   %Notifications.Db.Notification{
+        ...>     detour_expiration: %Notifications.Db.DetourExpiration{
+        ...>       estimated_duration: "1 hour",
+        ...>       expires_in: %Duration{second: 1800},
+        ...>       headsign: "17 Outbound",
+        ...>       direction: "Outbound",
+        ...>       route: "17"
+        ...>     }
+        ...>   }
+        ...> ] = all_detour_notifications
+
+    ### The `query` parameter and `base`
+    There is a `base` query struct that can be provided at the
+    beginning of a query:
+
+        iex> :detour
+        ...> |> insert()
+        ...> |> Notifications.Notification.create_detour_expiration_notification(%{
+        ...>   estimated_duration: "1 hour",
+        ...>   expires_in: Duration.new!(minute: 30)
+        ...> })
+        ...>
+        ...> all_detour_notifications =
+        ...>   Notifications.Db.Notification.Queries.base()
+        ...>   |> Notifications.Db.Notification.Queries.select_detour_expiration_notifications()
+        ...>   |> Skate.Repo.all()
+        ...>
+        ...> [
+        ...>   %Notifications.Db.Notification{
+        ...>     detour_expiration: %Notifications.Db.DetourExpiration{
+        ...>       estimated_duration: "1 hour",
+        ...>       expires_in: %Duration{second: 1800}
+        ...>     }
+        ...>   }
+        ...> ] = all_detour_notifications
+
+    If `base` is omitted, then it's inferred:
+
+        iex> :detour
+        ...> |> insert()
+        ...> |> Notifications.Notification.create_detour_expiration_notification(%{
+        ...>   estimated_duration: "1 hour",
+        ...>   expires_in: Duration.new!(minute: 30)
+        ...> })
+        ...>
+        ...> all_detour_notifications =
+        ...>   Notifications.Db.Notification.Queries.select_detour_expiration_notifications()
+        ...>   |> Skate.Repo.all()
+        ...>
+        ...> [
+        ...>   %Notifications.Db.Notification{
+        ...>     detour_expiration: %Notifications.Db.DetourExpiration{
+        ...>       estimated_duration: "1 hour",
+        ...>       expires_in: %Duration{second: 1800}
+        ...>     }
+        ...>   }
+        ...> ] = all_detour_notifications
+    """
+    def select_detour_expiration_notifications(query \\ base()) do
+      query
+      |> with_named_binding(:detour_expiration, fn query, binding ->
+        from(
+          [notification: n] in query,
+          left_join:
+            de in subquery(
+              from(
+                de in Notifications.Db.DetourExpiration,
+                as: ^binding,
+                left_join: assoc(de, :detour),
+                as: :detour
+              )
+              |> Skate.Detours.Db.Detour.Queries.select_route_name(:route)
+              |> Skate.Detours.Db.Detour.Queries.select_route_pattern_name(:origin)
+              |> Skate.Detours.Db.Detour.Queries.select_route_pattern_headsign(:headsign)
+              |> Skate.Detours.Db.Detour.Queries.select_direction(:direction)
+            ),
+          on: n.detour_expiration_id == de.id,
+          as: ^binding
+        )
+      end)
+      |> select_merge(
+        [detour_expiration: d],
+        %{detour_expiration: d}
+      )
+    end
+
+    @doc """
     Joins associated `Notifications.Db.BridgeMovement`'s on
     `Notifications.Db.Notification`'s
     """

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -296,6 +296,7 @@ defmodule Notifications.Notification do
     |> select_bridge_movements()
     |> select_block_waivers()
     |> select_detour_info()
+    |> select_detour_expiration_notifications()
     |> where([notification: n], n.created_at > ^cutoff_time)
     |> order_by([notification: n], desc: n.created_at)
     |> Skate.Repo.all()


### PR DESCRIPTION
Asana Ticket: [Create New Notification Type on Backend](https://app.asana.com/1/15492006741476/task/1210468388234802)

Small PR which adds the query to return Expiration Notifications and the associated data from the Detour.

> [!WARNING]
> This should not be merged until the corresponding SuperStruct definitions are added in https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210353029759135 