### PR TITLE
test: clicking a notification card marks it as read

### DIFF
--- a/assets/stories/skate-components/notifications/detourNotificationCard.stories.tsx
+++ b/assets/stories/skate-components/notifications/detourNotificationCard.stories.tsx
@@ -58,7 +58,6 @@ const detourDeactivatedNotification = {
 
 const detourExpirationNotificationContent = {
   $type: NotificationType.DetourExpiration,
-  status: DetourNotificationStatus.Activated,
   detourId: 3,
   headsign: "Headsign",
   route: "66",

--- a/assets/tests/components/notificationCard.test.tsx
+++ b/assets/tests/components/notificationCard.test.tsx
@@ -16,6 +16,7 @@ import {
   detourActivatedNotificationFactory,
   detourDeactivatedNotificationFactory,
   detourExpirationNotificationFactory,
+  detourExpirationWarningNotificationFactory,
 } from "../factories/notification"
 import routeFactory from "../factories/route"
 import userEvent from "@testing-library/user-event"
@@ -443,6 +444,7 @@ describe("NotificationCard", () => {
   test.each<{
     notification: Notification
     text: RegExp
+    mocks?: () => void
   }>([
     {
       notification: blockWaiverNotificationFactory.build({
@@ -462,11 +464,19 @@ describe("NotificationCard", () => {
     },
     {
       notification: detourExpirationNotificationFactory.build(),
-      text: /Detour/,
+      text: /Detour duration/,
+      mocks: () =>
+        jest
+          .mocked(getTestGroups)
+          .mockReturnValue([TestGroups.DetourExpirationNotifications]),
     },
     {
       notification: detourExpirationWarningNotificationFactory.build(),
-      text: /Detour/,
+      text: /Detour duration/,
+      mocks: () =>
+        jest
+          .mocked(getTestGroups)
+          .mockReturnValue([TestGroups.DetourExpirationNotifications]),
     },
     {
       notification: bridgeRaisedNotificationFactory.build(),
@@ -478,7 +488,11 @@ describe("NotificationCard", () => {
     },
   ])(
     "clicking $text notification should call onRead",
-    async ({ notification, text }) => {
+    async ({ notification, text, mocks }) => {
+      if (mocks) {
+        mocks()
+      }
+
       const currentTime = new Date()
       const onRead = jest.fn()
 

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -88,7 +88,7 @@ export const bridgeLoweredNotificationFactory = Factory.define<
   content: bridgeLoweredNotificationContentFactory.build(),
 }))
 
-const detourActivatedNotificationContentFactory =
+export const detourActivatedNotificationContentFactory =
   Factory.define<DetourNotification>(({ sequence }) => ({
     $type: NotificationType.Detour,
     status: DetourNotificationStatus.Activated,

--- a/assets/tests/factories/notification.ts
+++ b/assets/tests/factories/notification.ts
@@ -134,6 +134,15 @@ export const detourExpirationNotificationContentFactory =
     origin: "origin",
   }))
 
+export const detourExpirationWarningNotificationFactory = Factory.define<
+  Notification<DetourExpirationNotification>
+>(({ sequence }) => ({
+  id: sequence.toString(),
+  createdAt: new Date(),
+  state: "unread",
+  content: detourExpirationNotificationContentFactory.build({ expiresIn: 0 }),
+}))
+
 export const detourExpirationNotificationFactory = Factory.define<
   Notification<DetourExpirationNotification>
 >(({ sequence }) => ({


### PR DESCRIPTION
Asana Ticket: [Mark Notification as Read when Clicked](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210353029759140?focus=true)

I looked briefly at changing the role of these readable Cards to something other than button, like dialog (while keeping the buttons as buttons). That change affected a lot of other code paths and tests though, so I didn't pursue it further.