### PR TITLE
feat: broadcast detour expiration notification to users

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -54,6 +54,35 @@ defmodule Notifications.Notification do
   ]
 
   @doc """
+  Retrieves `Notifications.Db.Notification` and associated Notification Type
+  data for the given Notification ID.
+  """
+  def get_notification(id) do
+    import Notifications.Db.Notification.Queries
+
+    base()
+    |> select_bridge_movements()
+    |> select_block_waivers()
+    |> select_detour_info()
+    |> select_detour_expiration_notifications()
+    |> where(id: ^id)
+    |> Skate.Repo.one()
+  end
+
+  @doc """
+  Fetches a notification using `Notifications.Notification.get_notification/1`
+  and converts it to a `Notifications.Notification` struct.
+
+  Prefer `Notifications.Notification.get_notification/1` if you do not need to
+  send the returned notification to the frontend.
+  """
+  def get_domain_notification(id) do
+    id
+    |> get_notification()
+    |> from_db_notification()
+  end
+
+  @doc """
   Creates a new detour expiration notification
 
   ## Example

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -1,9 +1,70 @@
 defmodule Notifications.NotificationServer do
   @moduledoc """
-  GenServer which manages a realtime Notifications "PubSub".
+  `GenServer` which implements a "PubSub" to deliver `Notifications.Notification`'s.
 
-  It receives new messages via functions like `new_block_waivers/2` and manages
+  It receives new messages via `broadcast_notification/3` and manages
   new subscribers via `subscribe/2`.
+
+  ## How it works
+  `Notifications.NotificationServer` implements a "PubSub" server across a
+  Distributed Erlang cluster using `GenServer` and `Registry`.
+
+  All entries in the `Registry` are stored under the "key" composed of
+  `Notifications.NotificationServer`'s GenServer `pid`.
+
+  The `Registry` is configured in `Notifications.Supervisor`.
+
+  ## Subscribing
+  When a process calls `subscribe/2`, that process is associated with
+  a `Skate.Settings.Db.User`'s ID for filtering when using `Registry`
+  as a PubSub via `Registry.dispatch/3`.
+
+
+  ## Publishing
+  When `broadcast_notification/3` is called with a notification, a
+  `:broadcast_to_cluster` message is sent to the `Notifications.NotificationServer`
+  on that local instance.
+
+  > #### `:broadcast_to_cluster` note
+  > {: .info}
+  > This first message provides an opportunity for the `Notifications.NotificationServer`
+  > to do any necessary pre-processing work, in it's own process from the
+  > caller, before proceeding with distributed work across the cluster.
+
+  The `Notifications.NotificationServer` then informs the entire cluster
+  to broadcast the provided notification to subscribers. When each
+  `Notifications.NotificationServer` instance receives a message, it
+  proceeds to `send/2` `{:notification, %Notifications.Notification{}}`
+  messages to every process.
+
+
+  ## Contradictions
+  While the above describes how `broadcast_notification/3` works, and
+  broadly how the PubSub is implemented `Notifications.NotificationServer`
+  has other functions such as
+
+    - `new_block_waivers/2`
+    - `bridge_movement/2`
+    - `detour_deactivated/2`
+    - `detour_activated/2`
+
+  These functions are being deprecated and moved into `Notifications.Notification`
+  because they blur the line of what `Notifications.NotificationServer`
+  is responsible for. These functions currently manage _creating_
+  notifications by calling corresponding functions in `Notifications.Notification`
+  **and** then broadcasting the created notification.
+
+  In context of the original implementation, this made sense at the
+  time because a Distributed Erlang cluster was not configured at the
+  time, and block waivers and bridge movement notifications needed
+  to be broadcasted to all users when the instance became aware of it,
+  so informing the `Notifications.NotificationServer` was the correct
+  choice.
+
+  This reasoning _**does not**_ apply to detour status notifications,
+  the `detour_deactivated/2` and `detour_activated/2` functions exist
+  here because they were following the precedent set by block waivers
+  and bridge movements.
   """
 
   use GenServer
@@ -18,7 +79,6 @@ defmodule Notifications.NotificationServer do
   alias Skate.Settings.User
 
   # Client
-
   @spec default_name() :: GenServer.name()
   def default_name(), do: Notifications.NotificationServer
 
@@ -28,6 +88,38 @@ defmodule Notifications.NotificationServer do
     GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
+  @doc """
+  Broadcasts the argument `notification` to all processes that have subscribed
+  via `subscribe/2`.
+
+  If argument `users` is `:all`, broadcasts to all subscribers.
+
+  If argument `users` is a list of `Skate.Settings.Db.User` ID's, subscribers
+  with `user_id`'s contained in `users` are notified.
+  """
+  def broadcast_notification(
+        %Notifications.Notification{} = notification,
+        users,
+        server \\ default_name()
+      ) do
+    GenServer.cast(server, {:broadcast_to_cluster, notification, users})
+
+    :ok
+  end
+
+  @doc """
+  Records the calling process as associated with the `user_id` argument to
+  subscribe to future notifications.
+  """
+  def subscribe(user_id, server \\ default_name()) do
+    registry_key = GenServer.call(server, :subscribe)
+
+    Registry.register(Notifications.Supervisor.registry_name(), registry_key, user_id)
+    :ok
+  end
+
+  ## Deprecated Interface
+  # -----------------------------------------------------------------------------
   @spec new_block_waivers(BlockWaiver.block_waivers_by_block_key(), GenServer.server()) :: :ok
   def new_block_waivers(new_waivers_by_block_key, server \\ default_name()) do
     GenServer.cast(server, {:new_block_waivers, new_waivers_by_block_key})
@@ -84,22 +176,23 @@ defmodule Notifications.NotificationServer do
     GenServer.cast(server, {:detour_deactivated, detour, notify_finished})
   end
 
-  def subscribe(user_id, server \\ default_name()) do
-    registry_key = GenServer.call(server, :subscribe)
-
-    Registry.register(Notifications.Supervisor.registry_name(), registry_key, user_id)
-    :ok
-  end
-
   # Server
-
   @enforce_keys [:name]
   defstruct [:name]
+
   @impl GenServer
   def init(opts \\ []) do
     {:ok, struct(__MODULE__, opts)}
   end
 
+  @impl GenServer
+  def handle_call(:subscribe, _from, state) do
+    registry_key = self()
+    {:reply, registry_key, state}
+  end
+
+  ## Deprecated Functionality
+  # -----------------------------------------------------------------------------
   @impl true
   def handle_cast({:new_block_waivers, new_block_waivers_by_block_key}, state) do
     new_block_waivers_by_block_key
@@ -177,6 +270,88 @@ defmodule Notifications.NotificationServer do
 
     {:noreply, state}
   end
+
+  ## New Implementation
+  # -----------------------------------------------------------------------------
+  @impl GenServer
+  def handle_cast(
+        {:broadcast_to_cluster, %Notifications.Notification{} = notification, users},
+        state
+      ) do
+    broadcast_to_cluster(notification, users, state.name)
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_cast(
+        {:broadcast_to_subscribers, %Notifications.Notification{} = notification, users},
+        state
+      ) do
+    broadcast_to_subscribers(notification, users, self())
+
+    {:noreply, state}
+  end
+
+  defp broadcast_to_cluster(%Notifications.Notification{} = notification, users, server_name) do
+    # Currently, we've implemented our own "PubSub" for notifications and we
+    # are not using the provided `Phoenix.PubSub` that comes with Phoenix
+    # channels. This means we don't benefit from Phoenix PubSub's ability to
+    # send messages using distributed Elixir, and that we need to implement
+    # this ourselves at this current time.
+    # Ideally, Notifications would be delivered using
+    # `Phoenix.Channel.broadcast` instead of our custom `broadcast` function
+    #  in `NotificationServer`. To do this, we'd need to implement the same
+    # filtering mechanism that this module has implemented. For now, we'll
+    # send messages to other Skate instances letting them know about new
+    # Notifications.
+
+    # Skate instances currently do not "specialize", and therefore we need to
+    # send the notification to all instances
+    nodes = [Node.self()] ++ Node.list()
+
+    Logger.info(
+      "broadcasting notification to distributed instances notification_id=#{notification.id} nodes=#{inspect(nodes)}"
+    )
+
+    GenServer.abcast(nodes, server_name, {:broadcast_to_subscribers, notification, users})
+  end
+
+  defp broadcast_to_subscribers(
+         %Notifications.Notification{} = notification,
+         user_ids,
+         registry_key
+       ) do
+    # Frontend expects the :status not to be `nil`, and when broadcasting, the
+    # broadcasted notification is new and therefore unread.
+    payload = {:notification, default_unread(notification)}
+
+    Registry.dispatch(
+      Notifications.Supervisor.registry_name(),
+      registry_key,
+      &(&1
+        |> filter_entities(user_ids)
+        |> Enum.each(fn {pid, _user_id} -> send(pid, payload) end))
+    )
+  end
+
+  defp filter_entities(enumerable, :all) do
+    enumerable
+  end
+
+  defp filter_entities(_enumerable, [] = _user_ids) do
+    []
+  end
+
+  defp filter_entities(enumerable, user_ids) when is_list(user_ids) do
+    Enum.filter(enumerable, fn {_pid, user_id} -> Enum.member?(user_ids, user_id) end)
+  end
+
+  defp default_unread(%Notifications.Notification{state: nil} = notification),
+    do: %{notification | state: :unread}
+
+  defp default_unread(%Notifications.Notification{} = notification),
+    do: notification
 
   # Tell the caller when a notification is created
   # Mainly useful for writing tests so that they don't require
@@ -394,17 +569,5 @@ defmodule Notifications.NotificationServer do
         )
       end
     )
-  end
-
-  defp default_unread(%Notifications.Notification{state: nil} = notification),
-    do: %{notification | state: :unread}
-
-  defp default_unread(%Notifications.Notification{} = notification),
-    do: notification
-
-  @impl true
-  def handle_call(:subscribe, _from, state) do
-    registry_key = self()
-    {:reply, registry_key, state}
   end
 end

--- a/lib/notifications/notification_server.ex
+++ b/lib/notifications/notification_server.ex
@@ -40,7 +40,7 @@ defmodule Notifications.NotificationServer do
 
   ## Contradictions
   While the above describes how `broadcast_notification/3` works, and
-  broadly how the PubSub is implemented `Notifications.NotificationServer`
+  broadly how the PubSub is implemented, `Notifications.NotificationServer`
   has other functions such as
 
     - `new_block_waivers/2`

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -681,6 +681,8 @@ defmodule Notifications.NotificationServerTest do
     end
 
     test "saves to database", %{server: server} do
+      NotificationServer.subscribe(0, server)
+
       notification_count = 3
       # create new notification
       for _ <- 1..notification_count do
@@ -688,9 +690,9 @@ defmodule Notifications.NotificationServerTest do
           detour =
           insert(:detour)
 
-        NotificationServer.detour_activated(detour, notify_finished: self(), server: server)
+        NotificationServer.detour_activated(detour, server: server)
 
-        assert_receive {:new_notification, detour: ^id}
+        assert_receive {:notification, %{content: %{detour_id: ^id}}}
       end
 
       # assert database contains notification
@@ -698,6 +700,8 @@ defmodule Notifications.NotificationServerTest do
     end
 
     test "broadcasts to all connected users", %{server: server} do
+      NotificationServer.subscribe(0, server)
+
       notification_count = 3
       # connect users to channel
       for id <- 1..notification_count do
@@ -709,15 +713,13 @@ defmodule Notifications.NotificationServerTest do
         detour =
         insert(:detour)
 
-      NotificationServer.detour_activated(detour, notify_finished: self(), server: server)
-
-      assert_receive {:new_notification, detour: ^id}
+      NotificationServer.detour_activated(detour, server: server)
 
       # assert channel sends notifications to each user
       for _ <- 1..notification_count do
         assert_receive {:notification,
                         %Notification{
-                          content: %Notifications.Db.Detour{status: :activated}
+                          content: %Notifications.Db.Detour{status: :activated, detour_id: ^id}
                         }}
       end
     end
@@ -731,6 +733,8 @@ defmodule Notifications.NotificationServerTest do
     end
 
     test "saves to database", %{server: server} do
+      NotificationServer.subscribe(0, server)
+
       notification_count = 3
       # create new notification
       for _ <- 1..notification_count do
@@ -738,9 +742,9 @@ defmodule Notifications.NotificationServerTest do
           detour =
           insert(:detour)
 
-        NotificationServer.detour_deactivated(detour, notify_finished: self(), server: server)
+        NotificationServer.detour_deactivated(detour, server: server)
 
-        assert_receive {:new_notification, detour: ^id}
+        assert_receive {:notification, %{content: %{detour_id: ^id}}}
       end
 
       # assert database contains notification
@@ -748,6 +752,8 @@ defmodule Notifications.NotificationServerTest do
     end
 
     test "broadcasts to all connected users", %{server: server} do
+      NotificationServer.subscribe(0, server)
+
       notification_count = 3
       # connect users to channel
       for id <- 1..notification_count do
@@ -759,15 +765,13 @@ defmodule Notifications.NotificationServerTest do
         detour =
         insert(:detour)
 
-      NotificationServer.detour_deactivated(detour, notify_finished: self(), server: server)
-
-      assert_receive {:new_notification, detour: ^id}
+      NotificationServer.detour_deactivated(detour, server: server)
 
       # assert channel sends notifications to each user
       for _ <- 1..notification_count do
         assert_receive {:notification,
                         %Notification{
-                          content: %Notifications.Db.Detour{status: :deactivated}
+                          content: %Notifications.Db.Detour{status: :deactivated, detour_id: ^id}
                         }}
       end
     end

--- a/test/notifications/notification_server_test.exs
+++ b/test/notifications/notification_server_test.exs
@@ -270,6 +270,65 @@ defmodule Notifications.NotificationServerTest do
     end
   end
 
+  describe "broadcast_notification/3" do
+    setup do
+      {:ok, server} = setup_server()
+
+      %{server: server}
+    end
+
+    test "broadcasts to all subscribers if the provided user specification is :all", %{
+      server: server
+    } do
+      Notifications.NotificationServer.subscribe(0, server)
+      Notifications.NotificationServer.subscribe(1, server)
+      Notifications.NotificationServer.subscribe(2, server)
+
+      id = 1
+
+      Notifications.NotificationServer.broadcast_notification(
+        %Notifications.Notification{
+          id: id,
+          created_at: nil,
+          state: nil,
+          content: nil
+        },
+        :all,
+        server
+      )
+
+      assert_receive {:notification, %Notifications.Notification{id: ^id}}
+      assert_receive {:notification, %Notifications.Notification{id: ^id}}
+      assert_receive {:notification, %Notifications.Notification{id: ^id}}
+
+      refute_receive {:notification, %Notifications.Notification{id: ^id}}
+    end
+
+    test "broadcasts to all subscribers in the provided users list", %{server: server} do
+      Notifications.NotificationServer.subscribe(0, server)
+      Notifications.NotificationServer.subscribe(1, server)
+      Notifications.NotificationServer.subscribe(2, server)
+
+      id = 1
+
+      Notifications.NotificationServer.broadcast_notification(
+        %Notifications.Notification{
+          id: id,
+          created_at: nil,
+          state: nil,
+          content: nil
+        },
+        [0, 1],
+        server
+      )
+
+      assert_receive {:notification, %Notifications.Notification{id: ^id}}
+      assert_receive {:notification, %Notifications.Notification{id: ^id}}
+
+      refute_receive {:notification, %Notifications.Notification{id: ^id}}
+    end
+  end
+
   describe "new_block_waivers/2" do
     setup do
       reassign_env(:realtime, :block_fn, fn _, _ -> @block end)


### PR DESCRIPTION
Asana Ticket: [Add Detour Expiration Notification Creation Interface](https://app.asana.com/1/15492006741476/project/1203014709808707/task/1210353029759134?focus=true)

Depends-on:
- #3011 

---

# Summary
This implements broadcasting Detour Expiration Notifications to the frontend.

This is a few things wrapped up together, but the work should make sense when viewed by commit

1. Implements a interface to get notifications[^ac-1]
1. Implements a interface to get database notifications as `Notifications.Notification{}` structs (expected to be removed with [Refactor: Move "Notifications Database Object => Notifications Frontend Object" conversion into own module](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210323017373166?focus=true)) [^ac-1]
1. Broadcasts notifications when a expiration notification is created [^ac-2]
1. Makes the `NotificationServer` able to "generically" broadcast a notification, rather than require specific functions for creating & broadcasting notifications [^ac-2-support]
1. Removes `:notify_finished` test utility from `NotificationServer` and relies on `subscribe/2` instead[^refactor]
1. Refactors `detour_activated/2` and `detour_deactivated/2` to use the new `broadcast_notification/3` function instead of implementing distributed broadcast specifically for detour state change notifications[^refactor]

[^ac-1]: Related to AC 1: "Add CR(UD) API for detour expiration notifications" in [Add Detour Expiration Notification Creation Interface](https://app.asana.com/1/15492006741476/project/1203014709808707/task/1210353029759134?focus=true)

[^ac-2]: Related to AC 2: "Send Notification to users when expiration notification is created" in [Add Detour Expiration Notification Creation Interface](https://app.asana.com/1/15492006741476/project/1203014709808707/task/1210353029759134?focus=true)

[^ac-2-support]: Supports AC 2: "Send Notification to users when expiration notification is created" and partially addresses [Refactor: Move notification creation logic from `Notifications.NotificationServer` to `Notifications`](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210323017373161)

[^refactor]: This is split into it's own commit well enough that it could be done as it's own PR

## Todo
1. [x] Figure out if `logs broadcast_to_subscribers call` test is too flaky to merge
	- This was working fine locally, but on github actions it was failing, I tried forcing that all notifications are accounted for before it exits the `capture_log` call, but I haven't confirmed 100% that it solved the issue yet.
3. [ ] Write test for asserting that `create_detour_expiration_notification/2` broadcasts to users
	- Mostly done, trying to figure out where it should live. Considering either adding it in `notification_server_test.exs` because it requires the NotificationServer to be running, or if it should live in `notifications_test.exs` because that's where the function is.