### PR TITLE
refactor: move bridge movement de-duplicate logic into own module

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -167,6 +167,11 @@ config :skate, Skate.MqttConnection,
 
 config :skate, :swiftly, adjustments_module: Swiftly.API.ServiceAdjustments
 
+config :skate, Skate.BridgeStatus,
+  # 743 is SL3
+  bridge_route_ids: ~w[112 743],
+  blackout_period: Duration.new!(second: -120)
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/notifications/bridge.ex
+++ b/lib/notifications/bridge.ex
@@ -52,10 +52,15 @@ defmodule Notifications.Bridge do
           Application.get_env(
             :notifications,
             :notifications_server_bridge_movement_fn,
-            &Notifications.NotificationServer.bridge_movement/1
+            &Skate.BridgeStatus.maybe_record_bridge_status/1
           )
 
-        bridge_movement_fn.(new_state)
+        {status, lowering_time} = new_state
+
+        bridge_movement_fn.(%{
+          status: status,
+          lowering_time: lowering_time
+        })
       end
 
       {:noreply, new_state}

--- a/lib/notifications/db/bridge_movement.ex
+++ b/lib/notifications/db/bridge_movement.ex
@@ -19,12 +19,26 @@ defmodule Notifications.Db.BridgeMovement do
   typed_schema "bridge_movements" do
     field(:status, BridgeStatus)
     field(:lowering_time, :integer)
+
     timestamps()
+
+    has_one :notification, Notifications.Db.Notification
   end
 
   def changeset(bridge_movement, attrs \\ %{}) do
     bridge_movement
+    |> cast(%{notification: %{}}, [])
     |> cast(attrs, [:status, :lowering_time])
+    |> cast_assoc(:notification)
+    |> cast_timestamps_in_test(attrs)
     |> validate_required([:status])
+  end
+
+  if Mix.env() == :test do
+    def cast_timestamps_in_test(changeset, attrs) do
+      cast(changeset, attrs, [:inserted_at, :updated_at])
+    end
+  else
+    def cast_timestamps_in_test(changeset, _attrs), do: changeset
   end
 end

--- a/lib/notifications/db/bridge_movement.ex
+++ b/lib/notifications/db/bridge_movement.ex
@@ -25,20 +25,14 @@ defmodule Notifications.Db.BridgeMovement do
     has_one :notification, Notifications.Db.Notification
   end
 
+  @valid_test_options []
+  if Mix.env() == :test, do: @valid_test_options([:inserted_at, :updated_at])
+
   def changeset(bridge_movement, attrs \\ %{}) do
     bridge_movement
     |> cast(%{notification: %{}}, [])
-    |> cast(attrs, [:status, :lowering_time])
+    |> cast(attrs, [:status, :lowering_time | @valid_test_options])
     |> cast_assoc(:notification)
-    |> cast_timestamps_in_test(attrs)
     |> validate_required([:status])
-  end
-
-  if Mix.env() == :test do
-    def cast_timestamps_in_test(changeset, attrs) do
-      cast(changeset, attrs, [:inserted_at, :updated_at])
-    end
-  else
-    def cast_timestamps_in_test(changeset, _attrs), do: changeset
   end
 end

--- a/lib/notifications/db/bridge_movement.ex
+++ b/lib/notifications/db/bridge_movement.ex
@@ -28,11 +28,24 @@ defmodule Notifications.Db.BridgeMovement do
   @valid_test_options []
   if Mix.env() == :test, do: @valid_test_options([:inserted_at, :updated_at])
 
-  def changeset(bridge_movement, attrs \\ %{}) do
+  def changeset(bridge_movement, params \\ %{}) do
+    params = add_notification_params(params)
+
     bridge_movement
-    |> cast(%{notification: %{}}, [])
-    |> cast(attrs, [:status, :lowering_time | @valid_test_options])
+    |> cast(params, [:status, :lowering_time | @valid_test_options])
     |> cast_assoc(:notification)
     |> validate_required([:status])
+  end
+
+  defp add_notification_params(params) do
+    params
+    |> Map.put_new(:notification, %{})
+    |> Map.update!(:notification, fn notification ->
+      Map.put_new_lazy(notification, :users, fn ->
+        params
+        |> Map.get(:bridge_route_ids, [])
+        |> Skate.Settings.User.list_users_with_route_ids()
+      end)
+    end)
   end
 end

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -82,6 +82,17 @@ defmodule Notifications.Notification do
     |> from_db_notification()
   end
 
+  defp broadcast_notification(
+         {:ok, %{notification: %Notifications.Db.Notification{id: id}}} = input,
+         users
+       ) do
+    broadcast_notification_by_id(id, users)
+
+    input
+  end
+
+  defp broadcast_notification(input, _), do: input
+
   defp broadcast_notification_by_id(id, users) do
     id
     |> get_domain_notification()

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -82,6 +82,12 @@ defmodule Notifications.Notification do
     |> from_db_notification()
   end
 
+  defp broadcast_notification_by_id(id, users) do
+    id
+    |> get_domain_notification()
+    |> Notifications.NotificationServer.broadcast_notification(users)
+  end
+
   defp notification_log_message(
          {:ok,
           %Notifications.Db.DetourExpiration{

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -124,6 +124,21 @@ defmodule Notifications.Notification do
            " expires_in=#{Duration.to_iso8601(expires_in)}" <>
            " estimated_duration=#{inspect(estimated_duration)}"
 
+  defp notification_log_message(
+         {:ok,
+          %Notifications.Db.BridgeMovement{
+            status: status,
+            lowering_time: lowering_time,
+            notification: %{created_at: created_at}
+          }}
+       ),
+       do:
+         "result=notification_created" <>
+           " type=BridgeMovement" <>
+           " created_at=#{created_at |> DateTime.from_unix!() |> DateTime.to_iso8601()}" <>
+           " status=#{status}" <>
+           " lowering_time=#{if is_integer(lowering_time), do: lowering_time |> DateTime.from_unix!() |> DateTime.to_iso8601(), else: "nil"}"
+
   defp notification_log_message({:error, error}),
     do: "result=error error=#{inspect(error)}"
 
@@ -145,6 +160,7 @@ defmodule Notifications.Notification do
     %Notifications.Db.BridgeMovement{}
     |> Notifications.Db.BridgeMovement.changeset(attrs)
     |> Skate.Repo.insert()
+    |> log_notification()
     |> broadcast_notification(:users_from_notification)
   end
 

--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -82,6 +82,16 @@ defmodule Notifications.Notification do
     |> from_db_notification()
   end
 
+  def get_notification_user_ids(id) do
+    Skate.Repo.all(
+      from(n in Notifications.Db.Notification,
+        where: [id: ^id],
+        join: user in assoc(n, :users),
+        select: user.id
+      )
+    )
+  end
+
   defp broadcast_notification(
          {:ok, %{notification: %Notifications.Db.Notification{id: id}}} = input,
          users
@@ -92,6 +102,9 @@ defmodule Notifications.Notification do
   end
 
   defp broadcast_notification(input, _), do: input
+
+  defp broadcast_notification_by_id(id, :users_from_notification),
+    do: broadcast_notification_by_id(id, get_notification_user_ids(id))
 
   defp broadcast_notification_by_id(id, users) do
     id

--- a/lib/skate/bridge_status.ex
+++ b/lib/skate/bridge_status.ex
@@ -1,0 +1,110 @@
+defmodule Skate.BridgeStatus do
+  @moduledoc """
+  Context for recording and deduplicating Bridge status changes reported from
+  `Notifications.Bridge` and creating notifications from those reports.
+
+  ## Options
+  This module sources additional configuration from the `:skate` application
+  environment under the `Skate.BridgeStatus` key, this expects a `Keyword` list.
+  """
+
+  import Ecto.Query
+
+  @doc """
+  Accepts a bridge status change event and creates a
+  `Notifications.Db.BridgeMovement` notification.
+
+  If a `Notifications.Db.BridgeMovement` with the same `:status` has an
+  `:inserted_at` timestamp newer than the current time shifted by the
+  `:blackout_period` option, then a notification **will not** be created, and
+  will return the following error.
+
+  ```elixir
+  {:error, {:bridge_movement_already_exists, "Bridge Movement Already Exists"}}
+  ```
+
+  ## Options
+  | Option             | Purpose                                                                                                              |
+  |--------------------|----------------------------------------------------------------------------------------------------------------------|
+  | `bridge_route_ids` | Describes the `Schedule.Gtfs.Route.id()` affected by the bridge for determining which users to send notifications to |
+  | `blackout_period`  | Intended to be 2 times the `@fetch_ms` config from `Notifications.Bridge`                                            |
+
+  See the [Options](#module-options) documentation for more info.
+  """
+  def maybe_record_bridge_status(attrs, opts \\ []) do
+    opts = add_config_opts(opts)
+
+    attrs = add_users_to_notification_params(attrs, opts)
+
+    Ecto.Multi.new()
+    |> lock_bridge_movements_table()
+    |> assert_bridge_movement_nonexistent(attrs, opts)
+    |> Ecto.Multi.run(:bridge_movement_notification, fn _repo, _multi ->
+      Notifications.Notification.create_bridge_movement_notification(attrs)
+    end)
+    |> Skate.Repo.transaction()
+    |> case do
+      {:ok, %{bridge_movement_notification: out}} -> {:ok, out}
+      {:error, name, message, _multi_map} -> {:error, {name, message}}
+    end
+  end
+
+  # Sources configuration for options from config in addition to
+  # parameters to allow callers to leave options up to configuration
+  # values
+  defp add_config_opts(opts) do
+    opts ++ Application.get_env(:skate, __MODULE__, [])
+  end
+
+  defp lock_bridge_movements_table(multi) do
+    Ecto.Multi.run(multi, :lock_bridge_movements_table, fn repo, _ ->
+      repo.query("LOCK TABLE bridge_movements")
+    end)
+  end
+
+  defp assert_bridge_movement_nonexistent(multi, %{status: status}, opts) do
+    cutoff_time = cutoff_time(opts)
+
+    multi
+    |> Ecto.Multi.exists?(
+      :bridge_movement_exists?,
+      from(bm in Notifications.Db.BridgeMovement,
+        where: bm.status == ^status,
+        where: bm.inserted_at > ^cutoff_time
+      )
+    )
+    |> Ecto.Multi.run(:bridge_movement_already_exists, fn
+      _, %{bridge_movement_exists?: true} -> {:error, "Bridge Movement Already Exists"}
+      _, %{bridge_movement_exists?: false} -> {:ok, false}
+    end)
+  end
+
+  defp cutoff_time(opts) do
+    # The bridge API doesn't have anything like an "updated at" timestamp
+    # so we assume that, if we see two bridge movements within a blackout
+    # period, they are actually the same movement and what's happening is
+    # that we have multiple servers trying to insert a movement at once.
+    blackout_period = Keyword.fetch!(opts, :blackout_period)
+    now = current_time(opts)
+
+    DateTime.shift(now, blackout_period)
+  end
+
+  if Mix.env() != :test do
+    defp current_time(_opts), do: DateTime.utc_now()
+  else
+    # if we're testing, allow setting the time via `opts`
+    defp current_time(opts), do: Keyword.get_lazy(opts, :test_time, &DateTime.utc_now/0)
+  end
+
+  defp add_users_to_notification_params(attrs, opts) do
+    bridge_route_ids = Keyword.fetch!(opts, :bridge_route_ids)
+
+    users = Skate.Settings.User.list_users_with_route_ids(bridge_route_ids)
+
+    Map.merge(attrs, %{notification: %{users: users}}, fn
+      :notification, attr_val, merge_val -> Map.merge(attr_val, merge_val)
+      _, attr_val, _ -> attr_val
+    end)
+  end
+end

--- a/lib/skate/bridge_status.ex
+++ b/lib/skate/bridge_status.ex
@@ -34,7 +34,7 @@ defmodule Skate.BridgeStatus do
   def maybe_record_bridge_status(attrs, opts \\ []) do
     opts = get_config(opts)
 
-    attrs = add_users_to_notification_params(attrs, opts)
+    attrs = add_affected_route_ids(attrs, opts)
 
     Ecto.Multi.new()
     |> lock_bridge_movements_table()
@@ -99,14 +99,9 @@ defmodule Skate.BridgeStatus do
     DateTime.shift(now, blackout_period)
   end
 
-  defp add_users_to_notification_params(attrs, opts) do
-    bridge_route_ids = Keyword.fetch!(opts, :bridge_route_ids)
-
-    users = Skate.Settings.User.list_users_with_route_ids(bridge_route_ids)
-
-    Map.merge(attrs, %{notification: %{users: users}}, fn
-      :notification, attr_val, merge_val -> Map.merge(attr_val, merge_val)
-      _, attr_val, _ -> attr_val
+  defp add_affected_route_ids(attrs, opts) do
+    Map.put_new_lazy(attrs, :bridge_route_ids, fn ->
+      Keyword.fetch!(opts, :bridge_route_ids)
     end)
   end
 end

--- a/lib/skate/settings/user.ex
+++ b/lib/skate/settings/user.ex
@@ -70,6 +70,10 @@ defmodule Skate.Settings.User do
     end
   end
 
+  def list_users_with_route_ids(route_ids) do
+    Skate.Repo.all(from(u in users_for_route_ids_query(route_ids), select: [:id]))
+  end
+
   @spec user_ids_for_route_ids([String.t()]) :: [DbUser.id()]
   def user_ids_for_route_ids(route_ids) do
     Skate.Repo.all(from(u in users_for_route_ids_query(route_ids), select: u.id))

--- a/test/notifications/bridge_test.exs
+++ b/test/notifications/bridge_test.exs
@@ -174,13 +174,13 @@ defmodule Notifications.BridgeTest do
       reassign_env(:skate, :bridge_url, "http://localhost:#{bypass.port}/raise")
       {:noreply, raised_state} = handle_info(:update, nil)
       {:noreply, ^raised_state} = handle_info(:update, raised_state)
-      refute_received({:raised, _})
+      refute_received(%{status: :raised})
 
       # But transitioning to the lowered state ought to send a message
 
       reassign_env(:skate, :bridge_url, "http://localhost:#{bypass.port}/lower")
       {:noreply, _lowered_state} = handle_info(:update, raised_state)
-      assert_received({:lowered, nil})
+      assert_received(%{status: :lowered, lowering_time: nil})
     end
 
     test "Logs warning on bad message" do

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -503,14 +503,20 @@ defmodule Notifications.NotificationTest do
         })
     end
 
-    test "creates unread notifications for specified users" do
-      users = insert_list(3, :user)
+    test "creates unread notifications for users with affected route ids" do
+      test_users =
+        insert_list(3, :user,
+          route_tabs: fn -> build_list(1, :db_route_tab, selected_route_ids: ["1"]) end
+        )
 
-      {:ok, %{notification: %{users: ^users}}} =
-        Notifications.Notification.create_bridge_movement_notification(%{
-          status: :lowered,
-          notification: %{users: users}
-        })
+      assert {:ok, %{notification: %{users: users}}} =
+               Notifications.Notification.create_bridge_movement_notification(%{
+                 status: :lowered,
+                 bridge_route_ids: ["1"]
+               })
+
+      assert Enum.map(test_users, & &1.id) ==
+               users |> Enum.map(& &1.id) |> Enum.sort(:asc)
     end
 
     test "logs info of notification creation" do

--- a/test/skate/bridge_status_test.exs
+++ b/test/skate/bridge_status_test.exs
@@ -1,0 +1,136 @@
+defmodule Skate.BridgeStatusTest do
+  use Skate.DataCase
+
+  alias Skate.BridgeStatus
+
+  doctest Skate.BridgeStatus
+
+  describe "get_latest_bridge_status/0" do
+  end
+
+  describe "maybe_record_bridge_status/2" do
+    test "creates bridge movement record" do
+      assert {:ok, %Notifications.Db.BridgeMovement{id: id}} =
+               BridgeStatus.maybe_record_bridge_status(%{status: :lowered}, [])
+
+      assert %{status: :lowered} = Repo.get(Notifications.Db.BridgeMovement, id)
+    end
+
+    test "returns :error if another record exists in the cutoff period" do
+      Test.Support.Helpers.config(
+        :skate,
+        BridgeStatus,
+        blackout_period: Duration.new!(second: -30)
+      )
+
+      now = DateTime.utc_now()
+
+      assert {:ok, _} =
+               BridgeStatus.maybe_record_bridge_status(
+                 %{
+                   status: :lowered,
+                   inserted_at: now
+                 },
+                 test_time: now
+               )
+
+      for seconds <- [0, 1, 10, 29] do
+        assert {:error, {:bridge_movement_already_exists, _}} =
+                 BridgeStatus.maybe_record_bridge_status(
+                   %{
+                     status: :lowered
+                   },
+                   test_time: DateTime.shift(now, second: seconds)
+                 )
+      end
+
+      assert {:ok, _} =
+               BridgeStatus.maybe_record_bridge_status(
+                 %{
+                   status: :lowered
+                 },
+                 test_time: DateTime.shift(now, second: 30)
+               )
+    end
+
+    test "returns :ok if status changes within cutoff period" do
+      Test.Support.Helpers.config(
+        :skate,
+        BridgeStatus,
+        blackout_period: Duration.new!(second: -30)
+      )
+
+      now = start = DateTime.utc_now()
+
+      assert {:ok, _} =
+               BridgeStatus.maybe_record_bridge_status(
+                 %{
+                   status: :lowered,
+                   inserted_at: now
+                 },
+                 test_time: now
+               )
+
+      now = DateTime.shift(start, second: 1)
+
+      assert {:ok, _} =
+               BridgeStatus.maybe_record_bridge_status(
+                 %{
+                   status: :raised,
+                   lowering_time: DateTime.to_unix(now),
+                   inserted_at: now
+                 },
+                 test_time: now
+               )
+    end
+
+    test "creates notifications for users looking at routes affected by the chelsea drawbridge" do
+      [%{id: user_id_1}, %{id: user_id_2}, _user_3] =
+        for route_id <- ["1", "2", "3"] do
+          Skate.Factory.insert(:user,
+            route_tabs: [
+              Map.from_struct(Skate.Factory.build(:route_tab, selected_route_ids: [route_id]))
+            ]
+          )
+        end
+
+      Test.Support.Helpers.config(
+        :skate,
+        BridgeStatus,
+        bridge_route_ids: ["1", "2"]
+      )
+
+      {:ok, %{notification: %{id: notification_id}}} =
+        BridgeStatus.maybe_record_bridge_status(%{
+          status: :lowered
+        })
+
+      assert [%{id: ^user_id_1}, %{id: ^user_id_2}] =
+               Skate.Repo.all(
+                 from(
+                   n in Notifications.Db.Notification,
+                   where: [id: ^notification_id],
+                   join: users in assoc(n, :users),
+                   order_by: users.id,
+                   select: users
+                 )
+               )
+
+      {:ok, %{notification: %{id: notification_id}}} =
+        BridgeStatus.maybe_record_bridge_status(%{
+          status: :raised
+        })
+
+      assert [%{id: ^user_id_1}, %{id: ^user_id_2}] =
+               Skate.Repo.all(
+                 from(
+                   n in Notifications.Db.Notification,
+                   where: [id: ^notification_id],
+                   join: users in assoc(n, :users),
+                   order_by: users.id,
+                   select: users
+                 )
+               )
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -87,6 +87,19 @@ defmodule Skate.Factory do
     }
   end
 
+  def db_route_tab_factory do
+    %Skate.Settings.Db.RouteTab{
+      uuid: Ecto.UUID.generate(),
+      preset_name: "preset",
+      selected_route_ids: [],
+      ladder_directions: %{},
+      ladder_crowding_toggles: %{},
+      ordering: sequence(:route_tab_ordering, & &1),
+      is_current_tab: false,
+      save_changes_to_tab_uuid: nil
+    }
+  end
+
   def amazon_location_place_factory(attrs) do
     address_number = Map.get(attrs, :address_number, sequence(:address_number, &to_string/1))
     street = Map.get(attrs, :street, "Test St")

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -16,6 +16,31 @@ defmodule Test.Support.Helpers do
     end
   end
 
+  @doc """
+  Utility to merge configuration options into the application env for tests.
+
+  Functions similar to `Config.config` and merges any new options with existing
+  options configured via `config/` files.
+
+  Automatically resets configuration back to the previous configuration
+  `on_exit`
+  """
+  def config(application, key, opts) do
+    existing_config = get_config!(application)
+    ExUnit.Callbacks.on_exit(fn -> put_config(existing_config, application) end)
+
+    merge_config(application, key, opts)
+  end
+
+  defp merge_config(application, key, opts) do
+    get_config!(application)
+    |> Config.__merge__([{key, opts}])
+    |> put_config(application)
+  end
+
+  defp get_config!(application), do: Application.get_all_env(application)
+  defp put_config(config, application), do: Application.put_all_env([{application, config}])
+
   defmacro set_log_level(log_level) do
     quote do
       old_log_level = Logger.level()


### PR DESCRIPTION
Asana Ticket: [Refactor: Move Bridge Movement and Block Waiver logic into own modules](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210323017373160?focus=true)


This relies on commitsfunctionality also in PR https://github.com/mbta/skate/pull/3016

---

~Putting this up for review of the approach. Mainly I'm not sure where the interface should live.~

~This current implementation has two places that could create bridge notifications, `Notifications.Notification.new_bridge_movement_notification/2` and `Skate.BridgeStatus.maybe_record_bridge_status/2`~

~But another implementation could look like `new_bridge_movement_notification` being the only interface and having `new_bridge_movement_notification` call a module with the functionality in `maybe_record_bridge_status`.~ 

~I'm not sure what would be the better approach here, but whatever we do, I'd like to also follow for Block Waivers.~

---

Upon thinking about this some more, I think it's best that the logic that solely pertains to how `Notifications.Bridge` acts in a deployment with multiple instances lives in it's own module and that module calls `Notifications.Notifications`, as I have it [set up as of now at commit `8903eaf5cb0dccbe767d282c40ee3fd9eeed4729`](https://github.com/mbta/skate/commit/8903eaf5cb0dccbe767d282c40ee3fd9eeed4729).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210650673850512
  - https://app.asana.com/0/0/1210675409294975