### PR TITLE
fix(ex/notifications): log `detour_expiration_notification` repo operations

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -94,7 +94,7 @@ defmodule Notifications.Notification do
        do:
          "result=notification_created" <>
            " type=DetourExpiration" <>
-           " created_at=#{created_at}" <>
+           " created_at=#{created_at |> DateTime.from_unix!() |> DateTime.to_iso8601()}" <>
            " detour_id=#{detour_id}" <>
            " expires_in=#{Duration.to_iso8601(expires_in)}" <>
            " estimated_duration=#{inspect(estimated_duration)}"

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -529,7 +529,7 @@ defmodule Notifications.NotificationTest do
       # Result of operation
       assert log_30m =~ " result=notification_created"
       # Notification information
-      assert log_30m =~ " created_at=123456000"
+      assert log_30m =~ " created_at=1973-11-29T21:20:00Z"
       # Type of notification created
       assert log_30m =~ " type=DetourExpiration"
       # Detour Expiration specific information
@@ -550,7 +550,7 @@ defmodule Notifications.NotificationTest do
       # Result of operation
       assert log_0m =~ " result=notification_created"
       # Notification information
-      assert log_0m =~ " created_at=123456000"
+      assert log_0m =~ " created_at=1973-11-29T21:20:00Z"
       # Type of notification created
       assert log_0m =~ " type=DetourExpiration"
       # Detour Expiration specific information


### PR DESCRIPTION
Asana Ticket: [Add Detour Expiration Notification Creation Interface](https://app.asana.com/1/15492006741476/task/1210629674369600)

Little bit of missing functionality from the implementation in #3009

This module has historically logged notification creation but this refactors `log_creation` into a macro so that `mfa` is accurate to the caller and adds extra metadata so that it can be filtered/charted in splunk.

This follows the same pattern for logging notifications as #3018 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210629674369600