### PR TITLE
fix:test(ex/notifications): assert all users get a detour expiration notification

### DIFF
--- a/lib/notifications/db/detour_expiration.ex
+++ b/lib/notifications/db/detour_expiration.ex
@@ -37,11 +37,17 @@ defmodule Notifications.Db.DetourExpiration do
   Creates a new "Detour Expiration Notification"
   """
   def changeset(detour_expiration, attrs) do
+    params =
+      attrs
+      # A `%DetourExpiration{}` should always have a associated notification, so
+      # add a placeholder to the params in case `attrs` does not contain it.
+      |> Map.put_new(:notification, %{})
+      # All users are given a detour expiration notification at this time,
+      # so it is configured as default in the changeset
+      |> put_in([:notification, :users], Skate.Settings.User.get_all())
+
     detour_expiration
-    # A `%DetourExpiration{}` should always have a associated notification, so
-    # add a placeholder to the params in case `attrs` does not contain it.
-    |> cast(%{notification: %{}}, [])
-    |> cast(attrs, [:estimated_duration, :expires_in])
+    |> cast(params, [:estimated_duration, :expires_in])
     |> cast_assoc(:notification)
     |> validate_required([:estimated_duration, :expires_in, :detour_id])
     |> assoc_constraint(:detour)

--- a/lib/notifications/db/notification.ex
+++ b/lib/notifications/db/notification.ex
@@ -66,6 +66,7 @@ defmodule Notifications.Db.Notification do
     notification
     |> cast(attrs, [:created_at])
     |> put_default(:created_at, fn -> DateTime.to_unix(DateTime.utc_now()) end)
+    |> add_users_assoc(attrs)
     |> validate_required([:created_at])
   end
 
@@ -78,6 +79,18 @@ defmodule Notifications.Db.Notification do
       put_change(changeset, key, value)
     else
       changeset
+    end
+  end
+
+  defp add_users_assoc(changeset, attrs) do
+    # get `:users` from attrs directly so that we don't allow the string key
+    # "users" to be casted to an association
+    case attrs[:users] do
+      nil ->
+        changeset
+
+      users when is_list(users) ->
+        put_assoc(changeset, :users, users)
     end
   end
 

--- a/lib/notifications/db/notification_user.ex
+++ b/lib/notifications/db/notification_user.ex
@@ -14,7 +14,7 @@ defmodule Notifications.Db.NotificationUser do
   typed_schema "notifications_users" do
     belongs_to(:notification, DbNotification)
     belongs_to(:user, DbUser)
-    field(:state, NotificationState)
+    field(:state, NotificationState, default: :unread)
     timestamps()
   end
 end

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -520,7 +520,8 @@ defmodule Notifications.NotificationTest do
                  estimated_duration: "1 hour"
                })
 
-      assert ^users = notification |> Ecto.assoc(:users) |> Skate.Repo.all()
+      assert ^users =
+               notification |> Ecto.assoc(:users) |> Skate.Repo.all() |> Enum.sort_by(& &1.id)
     end
 
     test "logs info of notification creation" do

--- a/test/notifications/notification_test.exs
+++ b/test/notifications/notification_test.exs
@@ -509,6 +509,20 @@ defmodule Notifications.NotificationTest do
   describe "create_detour_expiration_notification/2" do
     # note: main tests in doctest
 
+    test "creates notifications for all users" do
+      users = insert_list(5, :user)
+
+      detour = insert(:detour, author: hd(users))
+
+      assert {:ok, %{notification: notification}} =
+               Notification.create_detour_expiration_notification(detour, %{
+                 expires_in: Duration.new!(minute: 30),
+                 estimated_duration: "1 hour"
+               })
+
+      assert ^users = notification |> Ecto.assoc(:users) |> Skate.Repo.all()
+    end
+
     test "logs info of notification creation" do
       Test.Support.Helpers.set_log_level(:info)
 


### PR DESCRIPTION
Asana Ticket: [Add Detour Expiration Notification Creation Interface](https://app.asana.com/1/15492006741476/task/1210594450484913)

Fixes the behavior added in #3009 to create notifications for all users and adds tests for this behavior.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210594450484913