### PR TITLE
refactor(ex/notifications): have `create_detour_expiration_notification` use `broadcast_notification`

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -218,17 +218,7 @@ defmodule Notifications.Notification do
     |> Notifications.Db.DetourExpiration.changeset(params)
     |> Skate.Repo.insert()
     |> log_notification()
-    |> case do
-      {:ok, %{notification: %{id: notification_id}}} = result ->
-        notification_id
-        |> get_domain_notification()
-        |> Notifications.NotificationServer.broadcast_notification(:all)
-
-        result
-
-      {:error, _} = error ->
-        error
-    end
+    |> broadcast_notification(:all)
   end
 
   @doc """


### PR DESCRIPTION
Cleaning up work related to https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210353029759134 that came out of refactoring.