### PR TITLE
fix:feat(ts/map): enable sat tiles up to level 20

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -128,7 +128,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
       >
         <TileLayer
           maxZoom={21}
-          maxNativeZoom={18}
+          maxNativeZoom={20}
           url={`${tilesetUrlForType(tileType)}`}
           attribution={
             tileType === "base"


### PR DESCRIPTION
Turns out we had the tiles artificially capped at 18, when the source has up to level 20. This makes the tiles more defined and less pixelated at higher zoom levels.

Additionally, the new 2023 tiles also support level 20, which you can test with
```
SATELLITE_TILES_URL="https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/orthos2023/MapServer/tile/{z}/{y}/{x}" mix phx.server
```
So we're all set for the upgrade with this too.

here's more information:
- https://massgis.maps.arcgis.com/home/item.html?id=6c7009c789354573a42af7251fb768a4
- https://www.mass.gov/info-details/massgis-data-2023-aerial-imagery

