### PR TITLE
fix(ts/detour_expiration): fix typo in `DetourExpiration` discriminator enum

### DIFF
--- a/assets/src/realtime.ts
+++ b/assets/src/realtime.ts
@@ -61,7 +61,7 @@ export enum NotificationType {
   BridgeMovement = "Elixir.Notifications.Db.BridgeMovement",
   BlockWaiver = "Elixir.Notifications.Db.BlockWaiver",
   Detour = "Elixir.Notifications.Db.Detour",
-  DetourExpiration = "Elixir.Notification.Db.DetourExpiration",
+  DetourExpiration = "Elixir.Notifications.Db.DetourExpiration",
 }
 export function isDetourNotification(
   notification: Notification


### PR DESCRIPTION
When testing locally, all notifications failed to load because the type string sent by the backend didn't match the enum on the frontend. This fixes the mismatch.

(Related to) Asana Ticket: [Parse Detour Expiration Notification on the frontend](https://app.asana.com/1/15492006741476/project/1148853526253420/task/1210675972767486?focus=true)
