### PR TITLE
fix: restore logging for block waiver notifications

### DIFF
--- a/lib/notifications/notification.ex
+++ b/lib/notifications/notification.ex
@@ -155,6 +155,8 @@ defmodule Notifications.Notification do
          {:ok,
           %Notifications.Db.BlockWaiver{
             reason: reason,
+            block_id: block_id,
+            service_id: service_id,
             route_ids: route_ids,
             run_ids: run_ids,
             trip_ids: trip_ids,
@@ -168,6 +170,7 @@ defmodule Notifications.Notification do
            " type=BlockWaiver" <>
            " created_at=#{format_unix_timestamp(created_at)}" <>
            " reason=#{reason}" <>
+           " block_id=#{block_id} service_id=#{service_id}" <>
            " route_ids=#{inspect(route_ids)} run_ids=#{inspect(run_ids)} trip_ids=#{inspect(trip_ids)}" <>
            " start_time=#{format_unix_timestamp(start_time)} end_time=#{format_unix_timestamp(end_time)}"
 


### PR DESCRIPTION
Asana Ticket: [Add logging for block waiver notifications](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1210775001583863?focus=true)

I pulled this out of Kayla's work in progress branch for block waivers so we can unblock deploys to production.
