### PR TITLE
build: fix docker warning about FromAsCasing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mix local.hex --force && \
   mix local.rebar --force && \
   mix do deps.get --only prod
 
-FROM node:20.11.0-alpine3.19 as assets-builder
+FROM node:20.11.0-alpine3.19 AS assets-builder
 
 WORKDIR /root
 ADD . .
@@ -29,7 +29,7 @@ RUN apk add --no-cache --update python3 build-base
 RUN npm --prefix assets ci
 RUN npm --prefix assets run deploy
 
-FROM elixir-builder as app-builder
+FROM elixir-builder AS app-builder
 
 ENV LANG="C.UTF-8" MIX_ENV=prod
 


### PR DESCRIPTION
Asana Ticket: No ticket

Seen in a build:

```
 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 18)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 32)
ERROR: failed to build: failed to solve: digest mismatch sha256:f6314d49b9750aa2a3b95b34c836d7af242628056db8aa6a2c8c70d12d6525aa: sha256:5fa49cac7e6e9202ef85331c6f83377a71339d692d5644c9417a2d81406f0c03
Error: Process completed with exit code 1.
``` 
