### PR TITLE
fix: update aws cert file checksum since it updated again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache --update curl
 WORKDIR /root
 
 ADD \
-  --checksum=sha256:f6314d49b9750aa2a3b95b34c836d7af242628056db8aa6a2c8c70d12d6525aa \
+  --checksum=sha256:e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3 \
   https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
   aws-cert-bundle.pem
 


### PR DESCRIPTION
https://github.com/mbta/skate/actions/runs/16524261697/job/46733429405

```
$ curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  161k  100  161k    0     0   674k      0 --:--:-- --:--:-- --:--:--  675k
e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3  -
```