### PR TITLE
Revert "fix:feat(ts/map): enable sat tiles up to level 20 (#3027)"

### DIFF
--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -128,7 +128,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
       >
         <TileLayer
           maxZoom={21}
-          maxNativeZoom={20}
+          maxNativeZoom={18}
           url={`${tilesetUrlForType(tileType)}`}
           attribution={
             tileType === "base"


### PR DESCRIPTION
This reverts commit ae558cf73201442349aa706306ddcb03837cdcec.

Asana Ticket: [Fix max zoom for default map layer](https://app.asana.com/1/15492006741476/project/1148853526253420/task/1210910206932699?focus=true)

This maxNativeZoom change applies to the map tiles and the sat tiles. 

Since the default map layer is the map tiles, revert the commit for now to prevent the default layer from looking like this when you zoom in:
<img width="720" height="521" alt="image" src="https://github.com/user-attachments/assets/6ed9b8df-3ca9-42e5-a062-c0c1243c6095" />

