### PR TITLE
chore(deps) Remove UUID

### DIFF
--- a/assets/jest.config.ts
+++ b/assets/jest.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull)/)",
+    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull|uuid)/)",
   ],
   testRegex: "(src|tests)/.*\\.test\\.tsx?$",
   modulePaths: ["<rootDir>/src"],

--- a/assets/jest.config.ts
+++ b/assets/jest.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull|uuid)/)",
+    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull)/)",
   ],
   testRegex: "(src|tests)/.*\\.test\\.tsx?$",
   modulePaths: ["<rootDir>/src"],

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -32,7 +32,7 @@
         "react-router-dom": "^6.3.0",
         "react-transition-group": "^4.4.5",
         "superstruct": "^1.0.3",
-        "uuid": "^9.0.0",
+        "uuid": "^14.0.0",
         "whatwg-fetch": "^3.6.2",
         "xstate": "^5.13.0"
       },
@@ -5242,6 +5242,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -22768,11 +22782,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -14,7 +14,6 @@
         "@sentry/fullstory": "^2.0.0",
         "@sentry/react": "^7.15.0",
         "@tippyjs/react": "^4.2.6",
-        "@types/uuid": "^9.0.1",
         "@xstate/react": "^4.1.1",
         "bootstrap": "^5.3.2",
         "core-js": "^3.28.0",
@@ -99,20 +98,20 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.8.1",
+      "version": "1.8.5",
       "license": "MIT",
       "devDependencies": {
-        "@babel/cli": "7.28.3",
-        "@babel/core": "7.28.3",
-        "@babel/preset-env": "7.28.3",
-        "@eslint/js": "^9.28.0",
+        "@babel/cli": "7.28.6",
+        "@babel/core": "7.29.0",
+        "@babel/preset-env": "7.29.0",
+        "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.0.0",
         "documentation": "^14.0.3",
-        "eslint": "9.34.0",
-        "eslint-plugin-jest": "29.0.1",
+        "eslint": "10.0.2",
+        "eslint-plugin-jest": "29.15.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
-        "jsdom": "^26.1.0",
+        "jsdom": "^28.1.0",
         "mock-socket": "^9.3.1"
       }
     },
@@ -5244,6 +5243,13 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/addon-actions/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-actions/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -8742,11 +8748,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -31,7 +31,6 @@
         "react-router-dom": "^6.3.0",
         "react-transition-group": "^4.4.5",
         "superstruct": "^1.0.3",
-        "uuid": "^14.0.0",
         "whatwg-fetch": "^3.6.2",
         "xstate": "^5.13.0"
       },
@@ -22780,19 +22779,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -49,7 +49,7 @@
     "react-router-dom": "^6.3.0",
     "react-transition-group": "^4.4.5",
     "superstruct": "^1.0.3",
-    "uuid": "^9.0.0",
+    "uuid": "^14.0.0",
     "whatwg-fetch": "^3.6.2",
     "xstate": "^5.13.0"
   },

--- a/assets/package.json
+++ b/assets/package.json
@@ -48,7 +48,6 @@
     "react-router-dom": "^6.3.0",
     "react-transition-group": "^4.4.5",
     "superstruct": "^1.0.3",
-    "uuid": "^14.0.0",
     "whatwg-fetch": "^3.6.2",
     "xstate": "^5.13.0"
   },

--- a/assets/package.json
+++ b/assets/package.json
@@ -31,7 +31,6 @@
     "@sentry/fullstory": "^2.0.0",
     "@sentry/react": "^7.15.0",
     "@tippyjs/react": "^4.2.6",
-    "@types/uuid": "^9.0.1",
     "@xstate/react": "^4.1.1",
     "bootstrap": "^5.3.2",
     "core-js": "^3.28.0",

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -8,7 +8,6 @@ import {
   LadderCrowdingToggles,
   emptyLadderCrowdingTogglesByRouteId,
 } from "./ladderCrowdingToggle"
-import { v4 as uuidv4 } from "uuid"
 import { uniq, flatten } from "../helpers/array"
 import {
   array,
@@ -45,7 +44,7 @@ export const RouteTabData = type({
 export type RouteTabData = Infer<typeof RouteTabData>
 
 export const newRouteTab = (ordering: number): RouteTab => ({
-  uuid: uuidv4(),
+  uuid: crypto.randomUUID(),
   isCurrentTab: true,
   selectedRouteIds: [],
   ladderDirections: emptyLadderDirectionsByRouteId,
@@ -239,7 +238,7 @@ export const applyRouteTabEdit = (
   } else {
     const editedRouteTab = {
       ...updateFn(tabToEdit),
-      uuid: uuidv4(),
+      uuid: crypto.randomUUID(),
       saveChangesToTabUuid: tabToEdit.uuid,
     }
 

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,9 +1,8 @@
 import { Factory } from "fishery"
 import { RouteTab } from "../../src/models/routeTab"
-import { v4 as uuidv4 } from "uuid"
 
 const defaultRouteTabFactory = Factory.define<RouteTab>(({ sequence }) => ({
-  uuid: uuidv4(),
+  uuid: crypto.randomUUID(),
   isCurrentTab: false,
   ordering: sequence,
 

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,8 +1,9 @@
 import { Factory } from "fishery"
 import { RouteTab } from "../../src/models/routeTab"
+import { randomUUID } from "crypto"
 
 const defaultRouteTabFactory = Factory.define<RouteTab>(({ sequence }) => ({
-  uuid: crypto.randomUUID(),
+  uuid: randomUUID(),
   isCurrentTab: false,
   ordering: sequence,
 

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "@jest/globals"
+import { randomUUID } from "crypto"
 import {
   currentRouteTab,
   instantiatePresetByUUID,
@@ -75,7 +76,7 @@ describe("isPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: undefined,
-      saveChangesToTabUuid: crypto.randomUUID(),
+      saveChangesToTabUuid: randomUUID(),
     })
 
     expect(isPreset(routeTab)).toBeFalsy()
@@ -87,7 +88,7 @@ describe("isEditedPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: 0,
-      saveChangesToTabUuid: crypto.randomUUID(),
+      saveChangesToTabUuid: randomUUID(),
     })
 
     expect(isEditedPreset(routeTab)).toBeTruthy()

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -17,7 +17,6 @@ import {
   findFirstOpenTabWith,
   selectTabByUUID,
 } from "../../src/models/routeTab"
-import { v4 as uuidv4 } from "uuid"
 import routeTabFactory from "../factories/routeTab"
 
 describe("highestExistingOrdering", () => {
@@ -76,7 +75,7 @@ describe("isPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: undefined,
-      saveChangesToTabUuid: uuidv4(),
+      saveChangesToTabUuid: crypto.randomUUID(),
     })
 
     expect(isPreset(routeTab)).toBeFalsy()
@@ -88,7 +87,7 @@ describe("isEditedPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: 0,
-      saveChangesToTabUuid: uuidv4(),
+      saveChangesToTabUuid: crypto.randomUUID(),
     })
 
     expect(isEditedPreset(routeTab)).toBeTruthy()


### PR DESCRIPTION
After merging in [the dependabot PR](https://github.com/mbta/skate/pull/3177), I realized we shouldn't need UUID. There is a native method to generate v4 UUID in Javascript.

Browser support: https://caniuse.com/mdn-api_crypto_randomuuid