### PR TITLE
chore(deps): Remove UUID dependency

### DIFF
--- a/assets/jest.config.ts
+++ b/assets/jest.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull|uuid)/)",
+    "/node_modules/(?!(@react-leaflet|react-leaflet|screenfull)/)",
   ],
   testRegex: "(src|tests)/.*\\.test\\.tsx?$",
   modulePaths: ["<rootDir>/src"],

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -31,7 +31,6 @@
         "react-router-dom": "^6.3.0",
         "react-transition-group": "^4.4.5",
         "superstruct": "^1.0.3",
-        "uuid": "^14.0.0",
         "whatwg-fetch": "^3.6.2",
         "xstate": "^5.13.0"
       },
@@ -22780,19 +22779,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -48,7 +48,6 @@
     "react-router-dom": "^6.3.0",
     "react-transition-group": "^4.4.5",
     "superstruct": "^1.0.3",
-    "uuid": "^14.0.0",
     "whatwg-fetch": "^3.6.2",
     "xstate": "^5.13.0"
   },

--- a/assets/src/models/routeTab.ts
+++ b/assets/src/models/routeTab.ts
@@ -8,7 +8,6 @@ import {
   LadderCrowdingToggles,
   emptyLadderCrowdingTogglesByRouteId,
 } from "./ladderCrowdingToggle"
-import { v4 as uuidv4 } from "uuid"
 import { uniq, flatten } from "../helpers/array"
 import {
   array,
@@ -45,7 +44,7 @@ export const RouteTabData = type({
 export type RouteTabData = Infer<typeof RouteTabData>
 
 export const newRouteTab = (ordering: number): RouteTab => ({
-  uuid: uuidv4(),
+  uuid: crypto.randomUUID(),
   isCurrentTab: true,
   selectedRouteIds: [],
   ladderDirections: emptyLadderDirectionsByRouteId,
@@ -239,7 +238,7 @@ export const applyRouteTabEdit = (
   } else {
     const editedRouteTab = {
       ...updateFn(tabToEdit),
-      uuid: uuidv4(),
+      uuid: crypto.randomUUID(),
       saveChangesToTabUuid: tabToEdit.uuid,
     }
 

--- a/assets/tests/factories/routeTab.ts
+++ b/assets/tests/factories/routeTab.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "crypto"
 import { Factory } from "fishery"
 import { RouteTab } from "../../src/models/routeTab"
-import { v4 as uuidv4 } from "uuid"
 
 const defaultRouteTabFactory = Factory.define<RouteTab>(({ sequence }) => ({
-  uuid: uuidv4(),
+  uuid: randomUUID(),
   isCurrentTab: false,
   ordering: sequence,
 

--- a/assets/tests/models/routeTab.test.ts
+++ b/assets/tests/models/routeTab.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto"
 import { describe, test, expect } from "@jest/globals"
 import {
   currentRouteTab,
@@ -17,7 +18,6 @@ import {
   findFirstOpenTabWith,
   selectTabByUUID,
 } from "../../src/models/routeTab"
-import { v4 as uuidv4 } from "uuid"
 import routeTabFactory from "../factories/routeTab"
 
 describe("highestExistingOrdering", () => {
@@ -76,7 +76,7 @@ describe("isPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: undefined,
-      saveChangesToTabUuid: uuidv4(),
+      saveChangesToTabUuid: randomUUID(),
     })
 
     expect(isPreset(routeTab)).toBeFalsy()
@@ -88,7 +88,7 @@ describe("isEditedPreset", () => {
     const routeTab = routeTabFactory.build({
       presetName: "My Preset",
       ordering: 0,
-      saveChangesToTabUuid: uuidv4(),
+      saveChangesToTabUuid: randomUUID(),
     })
 
     expect(isEditedPreset(routeTab)).toBeTruthy()

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import failOnConsole from "jest-fail-on-console"
 import React from "react"
+import { randomUUID } from "node:crypto"
 
 const ignoreList = [/.*components\/app\.test\.tsx/]
 const ignoreNameList = []
@@ -56,6 +57,14 @@ document.createElementNS = function (namespaceURI, qualifiedName) {
   }
   return element
 }
+
+Object.defineProperty(global, "crypto", {
+  value: {
+    randomUUID: randomUUID,
+  },
+  writable: true,
+  configurable: true,
+})
 
 beforeEach(() => {
   // eslint-disable-next-line jest/no-standalone-expect

--- a/assets/tests/setup.tsx
+++ b/assets/tests/setup.tsx
@@ -62,8 +62,6 @@ Object.defineProperty(global, "crypto", {
   value: {
     randomUUID: randomUUID,
   },
-  writable: true,
-  configurable: true,
 })
 
 beforeEach(() => {


### PR DESCRIPTION
After merging in https://github.com/mbta/skate/pull/3177, I realized we shouldn't need UUID. There is a native method to generate v4 UUID in Javascript.

Browser support: https://caniuse.com/mdn-api_crypto_randomuuid