### PR TITLE
chore: Add dependabot cooldown and increase allowed PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,18 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 1
+  open-pull-requests-limit: 2
+  cooldown:
+    default-days: 7
 - package-ecosystem: npm
   directory: "/assets"
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 1
+  open-pull-requests-limit: 2
   versioning-strategy: increase
+  cooldown:
+    default-days: 7
   ignore:
     - dependency-name: "phoenix"
     - dependency-name: "phoenix_html"


### PR DESCRIPTION
This came out of the monthly engineering meeting.