### PR TITLE
fix: correct table update logic

### DIFF
--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -57,7 +57,7 @@ defmodule Skate.Detours.Db.Detour do
     |> cast(attrs, [:state, :activated_at])
     |> validate_activated_at()
     |> add_status()
-    |> prepare_changes(&populate_fields_from_state/1)
+    |> populate_fields_from_state()
     |> add_updated_at()
     |> validate_required([:state, :status])
     |> foreign_key_constraint(:author_id)
@@ -143,10 +143,13 @@ defmodule Skate.Detours.Db.Detour do
 
   defp put_change_from_state(changeset, field, path) do
     case {fetch_field(changeset, field), fetch_change(changeset, :state)} do
-      {{:data, _}, {:ok, state}} ->
-        case get_in(state, path) do
-          nil -> changeset
-          value -> put_change(changeset, field, value)
+      {{:data, table_value}, {:ok, state}} ->
+        context_value = get_in(state, path)
+
+        if table_value != context_value do
+          put_change(changeset, field, context_value)
+        else
+          changeset
         end
 
       _ ->

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -166,12 +166,15 @@ defmodule Skate.Detours.Detours do
     detour_changeset =
       Skate.Detours.SnapshotSerde.deserialize(author_id, snapshot)
 
+    changed_fields =
+      if detour_changeset.changes != %{}, do: Map.keys(detour_changeset.changes), else: [:state]
+
     detour_db_result =
       Skate.Repo.insert(
         detour_changeset,
         returning: true,
         conflict_target: [:id],
-        on_conflict: {:replace_all_except, [:inserted_at]}
+        on_conflict: {:replace, changed_fields}
       )
 
     case detour_db_result do

--- a/priv/repo/async_migrations/20260624200954_backfill_from_detour_state.exs
+++ b/priv/repo/async_migrations/20260624200954_backfill_from_detour_state.exs
@@ -1,0 +1,97 @@
+defmodule Skate.Repo.Migrations.BackfillFromDetourState.MigratingSchema do
+  use Skate.Schema
+
+  typed_schema "detours" do
+    field :state, :map, null: true
+    field :coordinates, {:array, :map}, null: true
+    field :nearest_intersection, :string, null: true
+    field :start_point, :map, null: true
+    field :end_point, :map, null: true
+    field :waypoints, {:array, :map}, null: true
+    field :reason, :string, null: true
+    field :estimated_duration, :string, null: true
+  end
+end
+
+defmodule Skate.Repo.Migrations.BackfillFromDetourState do
+  # https://fly.io/phoenix-files/backfilling-data/
+
+  import Ecto.Query
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+  @batch_size 100
+  @throttle_ms 100
+
+  def up do
+    throttle_change_in_batches(&page_query/1, &do_change/1)
+  end
+
+  def down, do: :ok
+
+  defp page_query(last_id) do
+    from(
+      r in Skate.Repo.Migrations.BackfillFromDetourState.MigratingSchema,
+      select: r.id,
+      where: r.id > ^last_id,
+      order_by: [asc: r.id],
+      limit: @batch_size
+    )
+  end
+
+  defp do_change(batch_of_ids) do
+    from(
+      r in Skate.Repo.Migrations.BackfillFromDetourState.MigratingSchema,
+      select: [:id, :state],
+      where: r.id in ^batch_of_ids
+    )
+    |> repo().all(log: :info)
+    |> Enum.map(fn %Skate.Repo.Migrations.BackfillFromDetourState.MigratingSchema{
+                     id: id,
+                     state: state
+                   } = detour ->
+      detour
+      |> Ecto.Changeset.change(map_fields(state))
+      |> repo().update()
+      |> case do
+        {:error, _changeset} -> raise "#{id} was not updated"
+        {:ok, %{id: changed_id}} -> changed_id
+      end
+    end)
+    |> (fn changed -> {:ok, changed} end).()
+  end
+
+  defp map_fields(state) do
+    %{
+      coordinates: get_in(state, ["context", "detourShape", "ok", "coordinates"]),
+      nearest_intersection: get_in(state, ["context", "nearestIntersection"]),
+      start_point: get_in(state, ["context", "startPoint"]),
+      end_point: get_in(state, ["context", "endPoint"]),
+      waypoints: get_in(state, ["context", "waypoints"]),
+      reason: get_in(state, ["context", "selectedReason"]),
+      estimated_duration: get_in(state, ["context", "selectedDuration"])
+    }
+  end
+
+  defp throttle_change_in_batches(query_fun, change_fun, last_pos \\ 0)
+  defp throttle_change_in_batches(_query_fun, _change_fun, nil), do: :ok
+
+  defp throttle_change_in_batches(query_fun, change_fun, last_pos) do
+    case repo().all(query_fun.(last_pos), log: :info, timeout: :infinity) do
+      [] ->
+        :ok
+
+      ids ->
+        case change_fun.(List.flatten(ids)) do
+          {:ok, results} ->
+            next_page = results |> Enum.reverse() |> List.first()
+            Process.sleep(@throttle_ms)
+            throttle_change_in_batches(query_fun, change_fun, next_page)
+
+          error ->
+            raise error
+        end
+    end
+  end
+end


### PR DESCRIPTION
Asana Ticket: [Edited tag is missing from edited active detours](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1215966396759436?focus=true)

Problem: Table values were copied from state fine the first time around, but edits were not recorded due to prepare_changes causing fetch_field to return {:changes, values}

Changes:
1. Remove `prepare_changes` which only executes the included function at upsert time - we need to know the contents of the changeset before the insert.
2. Now we get a ton of fields that aren't actually changing in the changeset, which makes our updated_at logic fire needlessly. Instead of including all not-nil state values in the changeset, compare them to the previous value before including them. (We could change the updated_at logic, but it seemed better to keep our updates targeted instead.)
3. Since not all fields are now supplied to the upsert, it would replace all fields that aren't supplied with nil. Instead, only replace specified fields.
4. Most importantly, we now probably have incorrect data in the table values. The async_migration repopulates table values from the state.