### PR TITLE
fix: Text only detours - style updates

### DIFF
--- a/assets/css/_alert.scss
+++ b/assets/css/_alert.scss
@@ -4,6 +4,11 @@
   @include media-breakpoint-up(md) {
     min-width: 400px;
   }
+
+  &.c-alert__in-sidebar {
+    min-width: unset;
+    width: 100%;
+  }
 }
 
 .c-alert__close-button {

--- a/assets/css/_alert.scss
+++ b/assets/css/_alert.scss
@@ -9,6 +9,8 @@
     min-width: unset;
     width: 100%;
   }
+
+  font-size: var(--font-size-m);
 }
 
 .c-alert__close-button {

--- a/assets/css/_autosized_textarea.scss
+++ b/assets/css/_autosized_textarea.scss
@@ -22,7 +22,6 @@
     border: 1px solid $primary;
     padding: 0.5rem;
     font: inherit;
-    margin-bottom: 1rem;
     line-height: 1.5rem;
   }
 }

--- a/assets/css/_leaflet.scss
+++ b/assets/css/_leaflet.scss
@@ -4,6 +4,7 @@ $max-leaflet-z-index: 1000;
 .leaflet-container {
   width: 100%;
   height: 100%;
+  font-family: $font-family;
 }
 
 .c-vehicle-map-state--street-view-enabled + .leaflet-container {

--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -19,8 +19,7 @@
 .c-detour_map--text-only {
   .c-text-only-alert {
     z-index: 1001; // max leaflet + 1
-    width: 100%;
-    padding-right: 240px; // space for top right form controls
+    width: calc(100% - 240px); // space for top right form controls
     top: 0;
 
     .c-alert {

--- a/assets/css/detours/_detour_map.scss
+++ b/assets/css/detours/_detour_map.scss
@@ -29,7 +29,16 @@
 
   .c-detour_map--original-route-shape-core {
     stroke: tokens.$gray-900;
-    stroke-dasharray: 10;
+
+    &.zoom-far {
+      stroke-dasharray: 5 10;
+    }
+    &.zoom-mid {
+      stroke-dasharray: 10;
+    }
+    &.zoom-close {
+      stroke-dasharray: 10 15;
+    }
   }
 }
 

--- a/assets/src/components/alerts/baseAlert.tsx
+++ b/assets/src/components/alerts/baseAlert.tsx
@@ -1,8 +1,12 @@
 import React from "react"
 import { Alert, AlertProps } from "react-bootstrap"
+import { joinClasses } from "../../helpers/dom"
 
 const BaseAlert = ({ className, children, ...props }: AlertProps) => (
-  <Alert className={`c-alert icon-link ${className || ""}`} {...props}>
+  <Alert
+    className={joinClasses(["c-alert", "icon-link", className || ""])}
+    {...props}
+  >
     {children}
   </Alert>
 )

--- a/assets/src/components/alerts/baseAlert.tsx
+++ b/assets/src/components/alerts/baseAlert.tsx
@@ -1,20 +1,10 @@
-import React, { PropsWithChildren } from "react"
-import { Alert } from "react-bootstrap"
-import { Variant } from "react-bootstrap/esm/types"
+import React from "react"
+import { Alert, AlertProps } from "react-bootstrap"
 
-const BaseAlert = ({
-  variant: variant,
-  show: show,
-  children,
-}: PropsWithChildren<{
-  variant: Variant
-  show: boolean
-}>): React.ReactElement => {
-  return (
-    <Alert className="c-alert icon-link" variant={variant} show={show}>
-      {children}
-    </Alert>
-  )
-}
+const BaseAlert = ({ className, children, ...props }: AlertProps) => (
+  <Alert className={`c-alert icon-link ${className || ""}`} {...props}>
+    {children}
+  </Alert>
+)
 
 export default BaseAlert

--- a/assets/src/components/detours/alerts/textOnlyAlert.tsx
+++ b/assets/src/components/detours/alerts/textOnlyAlert.tsx
@@ -3,7 +3,7 @@ import { ExclamationCircle } from "../../../helpers/bsIcons"
 import BaseAlert from "../../alerts/baseAlert"
 
 export const TextOnlyAlert = (): React.ReactElement => (
-  <BaseAlert variant="warning" show={true}>
+  <BaseAlert variant="warning" show={true} className="c-alert__in-sidebar">
     <ExclamationCircle aria-hidden={true} className="c-alert__icon" />
     <span className="d-flex flex-column">
       <strong className="c-alert__header pb-2">Text Only</strong>

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -3,7 +3,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
@@ -182,8 +181,6 @@ export const DetourMap = ({
   editing,
   isTextOnly,
 }: DetourMapProps) => {
-  const id = useId()
-
   const [
     {
       mapLayers: {

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -371,29 +371,26 @@ export const DetourMap = ({
               onClickOriginalShape(latLngLiteralToShapePoint(e.latlng))
             }}
           />
-        ) : (
-          <OriginalRouteShape
-            positions={originalShape.map(shapePointToLatLngLiteral)}
-            key={`detour-map-original-route-shape-${id}-${
-              startPoint === undefined
-            }`}
-            interactive={canDraw}
-            classNames={
-              startPoint === undefined
-                ? ["c-detour_map--original-route-shape__unstarted"]
-                : ["c-detour_map--original-route-shape__unfinished"]
-            }
-            onClick={(e) => {
-              onClickOriginalShape(latLngLiteralToShapePoint(e.latlng))
-            }}
-          >
-            {!startPoint && <MapTooltip>Click to start detour</MapTooltip>}
-          </OriginalRouteShape>
-        )}
+        ) : null}
 
         <ZoomLevelWrapper>
           {(zoomLevel: number) => (
             <>
+              {!routeSegments && !unfinishedRouteSegments && (
+                <OriginalRouteShape
+                  zoomLevel={zoomLevel}
+                  started={!!startPoint}
+                  positions={originalShape.map(shapePointToLatLngLiteral)}
+                  interactive={canDraw}
+                  onClick={(e) => {
+                    onClickOriginalShape(latLngLiteralToShapePoint(e.latlng))
+                  }}
+                >
+                  {!startPoint && (
+                    <MapTooltip>Click to start detour</MapTooltip>
+                  )}
+                </OriginalRouteShape>
+              )}
               {uniqBy(stops, (stop) => stop.id).map((stop) => (
                 <StopMarkerWithStopCard
                   key={stop.id}
@@ -665,44 +662,55 @@ export const WaypointIcon = () => (
 )
 
 interface OriginalRouteShapeProps extends PropsWithChildren {
+  started: boolean
+  zoomLevel: number
   positions: LatLngLiteral[]
-  classNames: string[]
   onClick: (e: LeafletMouseEvent) => void
   interactive: boolean
 }
 
 const OriginalRouteShape = ({
+  started,
+  zoomLevel,
   positions,
   children,
-  classNames,
   onClick,
   interactive,
-}: OriginalRouteShapeProps) => (
-  <>
-    <Polyline
-      interactive={false}
-      weight={6}
-      positions={positions}
-      className="c-detour_map--original-route-shape-core"
-    />
-    {interactive && (
+}: OriginalRouteShapeProps) => {
+  const zoomClass =
+    zoomLevel < 15 ? "zoom-far" : zoomLevel < 18 ? "zoom-mid" : "zoom-close"
+
+  return (
+    <React.Fragment
+      key={`detour-map-original-route-shape-${started}-${zoomClass}`}
+    >
       <Polyline
+        interactive={false}
+        weight={6}
         positions={positions}
-        weight={16}
-        className={joinClasses([
-          "c-detour_map--original-route-shape",
-          ...classNames,
-        ])}
-        bubblingMouseEvents={false}
-        eventHandlers={{
-          click: onClick,
-        }}
-      >
-        {children}
-      </Polyline>
-    )}
-  </>
-)
+        className={`c-detour_map--original-route-shape-core ${zoomClass}`}
+      />
+      {interactive && (
+        <Polyline
+          positions={positions}
+          weight={16}
+          className={joinClasses([
+            "c-detour_map--original-route-shape",
+            `c-detour_map--original-route-shape__${
+              started ? "unstarted" : "unfinished"
+            }`,
+          ])}
+          bubblingMouseEvents={false}
+          eventHandlers={{
+            click: onClick,
+          }}
+        >
+          {children}
+        </Polyline>
+      )}
+    </React.Fragment>
+  )
+}
 
 interface UnfinishedDiversionRouteShapeProps {
   interactive: boolean

--- a/assets/src/components/detours/detourMap.tsx
+++ b/assets/src/components/detours/detourMap.tsx
@@ -694,7 +694,7 @@ const OriginalRouteShape = ({
           className={joinClasses([
             "c-detour_map--original-route-shape",
             `c-detour_map--original-route-shape__${
-              started ? "unstarted" : "unfinished"
+              started ? "unfinished" : "unstarted"
             }`,
           ])}
           bubblingMouseEvents={false}

--- a/assets/src/components/detours/detourPanelComponents.tsx
+++ b/assets/src/components/detours/detourPanelComponents.tsx
@@ -169,10 +169,10 @@ export const TypeDetourForm = ({
               aria-describedby="form-directions-character-count form-directions-feedback"
               readOnly={isReadOnly}
             />
+            <Form.Control.Feedback id="form-directions-feedback" type="invalid">
+              Directions are required
+            </Form.Control.Feedback>
           </div>
-          <Form.Control.Feedback id="form-directions-feedback" type="invalid">
-            Directions are required
-          </Form.Control.Feedback>
           {!isReadOnly && (
             <Form.Text
               muted

--- a/assets/src/components/map.tsx
+++ b/assets/src/components/map.tsx
@@ -123,6 +123,7 @@ const Map = (props: Props): ReactElement<HTMLDivElement> => {
         zoomControl={false}
         center={props.center ?? defaultCenter}
         zoom={props.zoom ?? defaultZoom}
+        minZoom={10}
         ref={mapRef}
         attributionControl={false}
       >

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -1489,7 +1489,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                         stroke-width="6"
                       />
                       <path
-                        class="c-detour_map--original-route-shape-core"
+                        class="c-detour_map--original-route-shape-core zoom-far"
                         d="M0 0"
                         fill="none"
                         stroke="#3388ff"
@@ -1664,7 +1664,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                     aria-hidden="true"
                     aria-label=""
                     class="c-street-view-switch__label"
-                    for="street-view-toggle-:ra:"
+                    for="street-view-toggle-:r8:"
                     role="presentation"
                   >
                     <span
@@ -1675,7 +1675,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                   </label>
                   <label
                     class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
-                    for="street-view-toggle-:ra:"
+                    for="street-view-toggle-:r8:"
                   >
                     Street View
                   </label>
@@ -1684,7 +1684,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                   >
                     <input
                       class="form-check-input"
-                      id="street-view-toggle-:ra:"
+                      id="street-view-toggle-:r8:"
                       role="switch"
                       type="checkbox"
                     />
@@ -1758,14 +1758,14 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                             class="list-group"
                           >
                             <li
-                              aria-labelledby="tile-layer-control-label-:rb:"
+                              aria-labelledby="tile-layer-control-label-:r9:"
                               class="list-group-item"
                             >
                               <div
                                 class="c-layers-control__tile_layer_control"
                               >
                                 <h2
-                                  id="tile-layer-control-label-:rb:"
+                                  id="tile-layer-control-label-:r9:"
                                 >
                                   Base Map
                                 </h2>
@@ -1775,14 +1775,14 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                                   <input
                                     checked=""
                                     class="form-check-input"
-                                    id="base-layer-radio-:rd:"
-                                    name="layers-control-tile-type-:rf:"
+                                    id="base-layer-radio-:rb:"
+                                    name="layers-control-tile-type-:rd:"
                                     type="radio"
                                     value=""
                                   />
                                   <label
                                     class="stretched-link form-check-label"
-                                    for="base-layer-radio-:rd:"
+                                    for="base-layer-radio-:rb:"
                                   >
                                     Map (default)
                                   </label>
@@ -1792,14 +1792,14 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                                 >
                                   <input
                                     class="form-check-input"
-                                    id="satellite-layer-radio-:re:"
-                                    name="layers-control-tile-type-:rf:"
+                                    id="satellite-layer-radio-:rc:"
+                                    name="layers-control-tile-type-:rd:"
                                     type="radio"
                                     value=""
                                   />
                                   <label
                                     class="stretched-link form-check-label"
-                                    for="satellite-layer-radio-:re:"
+                                    for="satellite-layer-radio-:rc:"
                                   >
                                     Satellite
                                   </label>
@@ -3340,7 +3340,25 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                         alt=""
                         class="leaflet-tile"
                         src="undefined"
-                        style="width: 256px; height: 256px; left: -4px; top: -239px;"
+                        style="width: 256px; height: 256px; left: -256px; top: -256px;"
+                      />
+                      <img
+                        alt=""
+                        class="leaflet-tile"
+                        src="undefined"
+                        style="width: 256px; height: 256px; left: 0px; top: -256px;"
+                      />
+                      <img
+                        alt=""
+                        class="leaflet-tile"
+                        src="undefined"
+                        style="width: 256px; height: 256px; left: -256px; top: 0px;"
+                      />
+                      <img
+                        alt=""
+                        class="leaflet-tile"
+                        src="undefined"
+                        style="width: 256px; height: 256px; left: 0px; top: 0px;"
                       />
                     </div>
                   </div>
@@ -3387,7 +3405,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                         stroke-width="6"
                       />
                       <path
-                        class="c-detour_map--original-route-shape-core"
+                        class="c-detour_map--original-route-shape-core zoom-far"
                         d="M0 0"
                         fill="none"
                         stroke="#3388ff"
@@ -3420,7 +3438,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   <div
                     class="leaflet-marker-icon leaflet-zoom-hide"
                     role="button"
-                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: 0px; top: 0px; z-index: 0;"
+                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: -413948px; top: -272913px; z-index: -272913; z-index: -272913;"
                     tabindex="0"
                     title="detour start"
                   >
@@ -3456,7 +3474,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   <div
                     class="leaflet-marker-icon leaflet-zoom-hide"
                     role="button"
-                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: 0px; top: 0px; z-index: 0;"
+                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: -413948px; top: -272913px; z-index: -272913; z-index: -272913;"
                     tabindex="0"
                   >
                     <svg
@@ -3481,7 +3499,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   <div
                     class="leaflet-marker-icon leaflet-zoom-hide"
                     role="button"
-                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: 0px; top: -1px; z-index: -1;"
+                    style="margin-left: -20px; margin-top: -20px; width: 40px; height: 40px; left: -413948px; top: -272914px; z-index: -272914;"
                     tabindex="0"
                     title="detour end"
                   >
@@ -3517,7 +3535,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   <div
                     class="leaflet-marker-icon c-stop-icon-container c-vehicle-map__stop leaflet-zoom-hide leaflet-interactive"
                     role="button"
-                    style="margin-left: -7px; margin-top: -7px; width: 14px; height: 14px; left: 0px; top: 0px; z-index: 0;"
+                    style="margin-left: -7px; margin-top: -7px; width: 14px; height: 14px; left: -413948px; top: -272913px; z-index: -272913; z-index: -272913;"
                     tabindex="0"
                   >
                     <svg
@@ -3555,6 +3573,39 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
               <div
                 class="leaflet-control-container"
               >
+                <div
+                  class="leaflet-control leaflet-bar c-street-view-switch position-absolute"
+                >
+                  <label
+                    aria-hidden="true"
+                    aria-label=""
+                    class="c-street-view-switch__label"
+                    for="street-view-toggle-:r1:"
+                    role="presentation"
+                  >
+                    <span
+                      class="c-street-view-switch__label-icon"
+                    >
+                      <svg />
+                    </span>
+                  </label>
+                  <label
+                    class="c-street-view-switch__label c-street-view-switch__label-text stretched-link"
+                    for="street-view-toggle-:r1:"
+                  >
+                    Street View
+                  </label>
+                  <div
+                    class="c-street-view-switch__input form-switch"
+                  >
+                    <input
+                      class="form-check-input"
+                      id="street-view-toggle-:r1:"
+                      role="switch"
+                      type="checkbox"
+                    />
+                  </div>
+                </div>
                 <div
                   class="leaflet-top leaflet-left"
                 />
@@ -3594,6 +3645,89 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                     </a>
                   </div>
                   <div
+                    class="leaflet-control"
+                  >
+                    <div
+                      class="c-layers-control"
+                    >
+                      <button
+                        class="c-layers-control__button leaflet-bar"
+                        title="Layers"
+                      >
+                        <span>
+                          <svg />
+                        </span>
+                      </button>
+                      <div
+                        class="c-layers-control__pill"
+                        hidden=""
+                      >
+                        1
+                      </div>
+                      <div
+                        hidden=""
+                      >
+                        <div
+                          class="c-layers-control__content"
+                        >
+                          <ul
+                            class="list-group"
+                          >
+                            <li
+                              aria-labelledby="tile-layer-control-label-:r2:"
+                              class="list-group-item"
+                            >
+                              <div
+                                class="c-layers-control__tile_layer_control"
+                              >
+                                <h2
+                                  id="tile-layer-control-label-:r2:"
+                                >
+                                  Base Map
+                                </h2>
+                                <div
+                                  class="position-relative form-check"
+                                >
+                                  <input
+                                    checked=""
+                                    class="form-check-input"
+                                    id="base-layer-radio-:r4:"
+                                    name="layers-control-tile-type-:r6:"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  <label
+                                    class="stretched-link form-check-label"
+                                    for="base-layer-radio-:r4:"
+                                  >
+                                    Map (default)
+                                  </label>
+                                </div>
+                                <div
+                                  class="position-relative form-check"
+                                >
+                                  <input
+                                    class="form-check-input"
+                                    id="satellite-layer-radio-:r5:"
+                                    name="layers-control-tile-type-:r6:"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  <label
+                                    class="stretched-link form-check-label"
+                                    for="satellite-layer-radio-:r5:"
+                                  >
+                                    Satellite
+                                  </label>
+                                </div>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
                     class="leaflet-bar leaflet-control"
                   >
                     <a
@@ -3607,7 +3741,72 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                 </div>
                 <div
                   class="leaflet-bottom leaflet-left"
-                />
+                >
+                  <div
+                    class="leaflet-control leaflet-bar"
+                  >
+                    <button
+                      class="border-box inherit-box border-0 d-flex flex-column justify-content-center align-items-center c-map-button c-map-button--lg btn btn-outline-primary btn-lg"
+                      data-fs-element="Undo"
+                      disabled=""
+                      title="Undo"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="bi bi-arrow-left-square"
+                        fill="currentColor"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm11.5 5.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                      <span
+                        class="mt-1"
+                      >
+                        Undo
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="leaflet-control leaflet-bar"
+                  >
+                    <button
+                      class="border-box inherit-box border-0 d-flex flex-column justify-content-center align-items-center c-map-button c-map-button--lg btn btn-outline-primary btn-lg"
+                      data-fs-element="Clear"
+                      disabled=""
+                      title="Clear"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="bi bi-x-square"
+                        fill="currentColor"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"
+                        />
+                        <path
+                          d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"
+                        />
+                      </svg>
+                      <span
+                        class="mt-1"
+                      >
+                        Clear
+                      </span>
+                    </button>
+                  </div>
+                </div>
                 <div
                   class="leaflet-bottom leaflet-right"
                 >

--- a/assets/tests/components/detours/detoursListPage.openDetour.test.tsx
+++ b/assets/tests/components/detours/detoursListPage.openDetour.test.tsx
@@ -68,8 +68,8 @@ describe("Detours Page: Open a Detour", () => {
     // Click an arbitrary detour from the list
     await userEvent.click(await screen.findByText("Headsign Z"))
     await screen.findByText("Base Map")
-    // Render modal based on mocked value, which is a detour-in-progress
 
+    // Render modal based on mocked value, which is a detour-in-progress
     expect(viewDraftDetourHeading.get()).toBeVisible()
 
     // Finally, check snapshot

--- a/assets/tests/components/detours/detoursListPage.openDetour.test.tsx
+++ b/assets/tests/components/detours/detoursListPage.openDetour.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, jest, test } from "@jest/globals"
 
 import React from "react"
 
-import { screen, waitFor } from "@testing-library/dom"
+import { screen } from "@testing-library/dom"
 import "@testing-library/jest-dom/jest-globals"
 import { render } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -67,12 +67,13 @@ describe("Detours Page: Open a Detour", () => {
 
     // Click an arbitrary detour from the list
     await userEvent.click(await screen.findByText("Headsign Z"))
-
+    await screen.findByText("Base Map")
     // Render modal based on mocked value, which is a detour-in-progress
+
     expect(viewDraftDetourHeading.get()).toBeVisible()
 
     // Finally, check snapshot
-    await waitFor(() => expect(baseElement).toMatchSnapshot())
+    expect(baseElement).toMatchSnapshot()
   })
 
   test("renders detour details in an open drawer on mobile", async () => {


### PR DESCRIPTION
Asana Ticket: [Text Only Detours | Type Detour Panel](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1214013307977452?focus=true)

https://mbta.slack.com/archives/C09RWAP5ZHP/p1783538654278689
2- Text only banner breaks the side panel (alerts are too wide by default)
3- Showing regular route alert has tiny text (regular font size missing in leaflet container)
4- can we had a hair more space between the black dashes? (updated dash-array)
5- The warning banner should be Inter first like the other things/banners. (updated leaflet-container to be inter by default)
6- It seems to be missing the hint text and has weird spacing under the input fields.(Feedback must be a sibling of Control + autosized field had extraneous margin-bottom)

* Black border around the whole frame on focus (pre-existing bug, not fixed)