### PR TITLE
docs: Update new dev environment instructions in README

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -27,6 +27,10 @@ export SECRET_KEY_BASE=$(openssl rand -base64 48)
 ## * Request your personal API key from [MBTA Realtime API](https://api-v3.mbta.com/)
 # export API_KEY=
 
+## Needed for drawing detours: Open Route Service (API URL will usually be https://api.openrouteservice.org/; you can get your API Key from the ORS console once you create an account)
+# export OPEN_ROUTE_SERVICE_API_URL=
+# export OPEN_ROUTE_SERVICE_API_KEY=
+
 ### The following variables are imported by 1Password in `.env.1p.skate`
 
 ## API key from [Swiftly Transitime API](https://swiftly-inc.stoplight.io/docs/realtime-standalone/YXBpOjI4NDM2MDU3-swiftly-api-reference)
@@ -72,10 +76,6 @@ export SECRET_KEY_BASE=$(openssl rand -base64 48)
 ## Credentials for the API that gets drawbridge status
 # export BRIDGE_API_USERNAME
 # export BRIDGE_API_PASSWORD
-
-## Open Route Service (API URL will usually be https://api.openrouteservice.org/; you can your API Key from the ORS console once you create an account)
-# export OPEN_ROUTE_SERVICE_API_URL=
-# export OPEN_ROUTE_SERVICE_API_KEY=
 
 ### The following variables are imported by 1Password in `.env.1p.skate`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The MBTA Customer Technology Department supports a shared Slack channel that tra
 > ```shell
 > brew install openssl asdf direnv
 > echo 'eval "$(direnv hook zsh)"' >> ~/.zprofile
+> echo 'export PATH=~/.asdf/shims:$PATH' >> ~/.zprofile
 > ```
 Doing development on Skate requires Elixir, Erlang, and node, as described in [.tool-versions](https://github.com/mbta/skate/blob/main/.tool-versions). Most developers use [asdf](https://asdf-vm.com/) to help manage the required versions, but that isn't required.
 
@@ -50,13 +51,9 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 First, install the project dependencies:
 
 ```shell
-asdf plugin add elixir
-asdf plugin add erlang
-asdf plugin add nodejs
-asdf plugin add adr-tools
+asdf plugin add elixir erlang nodejs adr-tools
 asdf install
 asdf reshim
-echo 'export PATH=~/.asdf/shims:$PATH' >> ~/.zprofile
 ```
 
 Next, initialize the project: 
@@ -100,6 +97,17 @@ mix phx.server
 ```
 
 View the application in your browser at [`https://localhost:4000`](https://localhost:4000).
+
+### Enabling Detours
+
+In order to draw detours on your local environment, you'll need to go to ['https://127.0.0.1:4000/test_groups'](https://127.0.0.1:4000/test_groups) and create the following groups:
+
+```shell
+detours-list
+detours-pilot
+edit-active-detours
+text-only-detours
+```
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 First, install the project dependencies:
 
 ```shell
-asdf plugin add elixir erlang nodejs adr-tools
+asdf plugin add elixir
+asdf plugin add erlang
+asdf plugin add nodejs
+asdf plpugin add adr-tools
 asdf install
 asdf reshim
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ The MBTA Customer Technology Department supports a shared Slack channel that tra
 
 ### Prerequisites
 
-If you're using a package manager like HomeBrew, here are installation recommendations:
-- brew install openssl
-- brew install asdf
-- brew install direnv
-- echo 'eval "$(direnv hook zsh)"' >> ~/.zprofile
-
+> [!TIP]
+> If you're using a package manager like Homebrew, here are installation recommendations:
+>
+> ```shell
+> brew install openssl asdf direnv
+> echo 'eval "$(direnv hook zsh)"' >> ~/.zprofile
+> ```
 Doing development on Skate requires Elixir, Erlang, and node, as described in [.tool-versions](https://github.com/mbta/skate/blob/main/.tool-versions). Most developers use [asdf](https://asdf-vm.com/) to help manage the required versions, but that isn't required.
 
 Skate also requires Postgres. If you don't already have Postgres installed, and you're on a Mac, [Postgres.app](https://postgresapp.com/downloads.html) is an easy way to get started. However, any Postgres instance to which you can connect and in which you have sufficient privileges should work.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The MBTA Customer Technology Department supports a shared Slack channel that tra
 
 ### Prerequisites
 
+If you're using a package manager like HomeBrew, here are installation recommendations:
+- brew install openssl
+- brew install asdf
+- brew install direnv
+- echo 'eval "$(direnv hook zsh)"' >> ~/.zprofile
+
 Doing development on Skate requires Elixir, Erlang, and node, as described in [.tool-versions](https://github.com/mbta/skate/blob/main/.tool-versions). Most developers use [asdf](https://asdf-vm.com/) to help manage the required versions, but that isn't required.
 
 Skate also requires Postgres. If you don't already have Postgres installed, and you're on a Mac, [Postgres.app](https://postgresapp.com/downloads.html) is an easy way to get started. However, any Postgres instance to which you can connect and in which you have sufficient privileges should work.
@@ -43,7 +49,13 @@ Here are the values you'll need to be prepared to update to run Skate locally:
 First, install the project dependencies:
 
 ```shell
+asdf plugin add elixir
+asdf plugin add erlang
+asdf plugin add nodejs
+asdf plugin add adr-tools
 asdf install
+asdf reshim
+echo 'export PATH=~/.asdf/shims:$PATH' >> ~/.zprofile
 ```
 
 Next, initialize the project: 


### PR DESCRIPTION
No Asana Ticket; this is an engineering onboarding task in [Notion](https://app.notion.com/p/mbta-downtown-crossing/Engineer-Onboarding-351f5d8d11ea809db0acd1333b95ff55)

Added in some instructions for installing prerequisite packages and ensuring that `direnv` and `asdf` work properly. During environment setup, those two packages would run but do nothing if they're not hooked into the shell properly.


