### PR TITLE
fix(skate): Remove duplicate header for closed detours

### DIFF
--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -225,7 +225,7 @@ export const DetoursTable = ({
               </th>
               <th className="px-3 py-3 c-detours-table__col-sm">
                 <div>
-                  <label htmlFor="date-filter">Date</label>
+                  <label htmlFor="date-filter">Last Closed</label>
                   <DateTimePicker
                     className="mt-2"
                     value={dates}
@@ -239,21 +239,23 @@ export const DetoursTable = ({
               </th>
             </tr>
           )}
-          <tr>
-            <th className="px-3 py-4">Route and direction</th>
-            <th className="px-3 py-4 u-hide-for-mobile">
-              Starting Intersection
-            </th>
-            {hasReasonColumn(status) && (
-              <th className="px-3 py-4 u-hide-for-mobile">Reason</th>
-            )}
-            <th className="px-3 py-4 u-hide-for-mobile">
-              {timestampLabelFromStatus(status)}
-            </th>
-            {status === DetourStatus.Active && (
-              <th className="px-3 py-4 u-hide-for-mobile">Est. Duration</th>
-            )}
-          </tr>
+          {!hasFilters && (
+            <tr>
+              <th className="px-3 py-4">Route and direction</th>
+              <th className="px-3 py-4 u-hide-for-mobile">
+                Starting Intersection
+              </th>
+              {hasReasonColumn(status) && (
+                <th className="px-3 py-4 u-hide-for-mobile">Reason</th>
+              )}
+              <th className="px-3 py-4 u-hide-for-mobile">
+                {timestampLabelFromStatus(status)}
+              </th>
+              {status === DetourStatus.Active && (
+                <th className="px-3 py-4 u-hide-for-mobile">Est. Duration</th>
+              )}
+            </tr>
+          )}
         </thead>
         <tbody>
           {filteredData.length ? (

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -776,7 +776,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                 <label
                   for="date-filter"
                 >
-                  Date
+                  Last Closed
                 </label>
                 <div
                   class="input-group-filter display-editable mt-2"
@@ -823,28 +823,6 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
                   </div>
                 </div>
               </div>
-            </th>
-          </tr>
-          <tr>
-            <th
-              class="px-3 py-4"
-            >
-              Route and direction
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Starting Intersection
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Reason
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Last used
             </th>
           </tr>
         </thead>

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -550,7 +550,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                 <label
                   for="date-filter"
                 >
-                  Date
+                  Last Closed
                 </label>
                 <div
                   class="input-group-filter display-editable mt-2"
@@ -597,28 +597,6 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
                   </div>
                 </div>
               </div>
-            </th>
-          </tr>
-          <tr>
-            <th
-              class="px-3 py-4"
-            >
-              Route and direction
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Starting Intersection
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Reason
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Last used
             </th>
           </tr>
         </thead>
@@ -2466,7 +2444,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                 <label
                   for="date-filter"
                 >
-                  Date
+                  Last Closed
                 </label>
                 <div
                   class="input-group-filter display-editable mt-2"
@@ -2513,28 +2491,6 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
                   </div>
                 </div>
               </div>
-            </th>
-          </tr>
-          <tr>
-            <th
-              class="px-3 py-4"
-            >
-              Route and direction
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Starting Intersection
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Reason
-            </th>
-            <th
-              class="px-3 py-4 u-hide-for-mobile"
-            >
-              Last used
             </th>
           </tr>
         </thead>


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Update Filter Names](https://app.asana.com/1/15492006741476/project/1216434230851197/task/1216326666772047?focus=true)

If there are already filter headers, do not display a second row of repetitive titles (displayed as "Route and direction", etc)
