### PR TITLE
fix: Text only detours - UX review feedback

### DIFF
--- a/assets/css/bootstrap/_extra_bespoke.scss
+++ b/assets/css/bootstrap/_extra_bespoke.scss
@@ -49,6 +49,10 @@
   font-family: $font-family-monospace;
 }
 
+.c-autosized-textarea:not(.display-editable)::after {
+  font-family: $font-family-monospace;
+}
+
 .c-badge-pill {
   border-radius: 8px;
   background-color: new_tokens.$gray-200;

--- a/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
+++ b/assets/src/components/detours/detourPanels/pastDetourPanel.tsx
@@ -3,6 +3,7 @@ import { Panel } from "../diversionPage"
 import { DetourDirection, TypedDetour } from "../../../models/detour"
 import { Stop } from "../../../schedule"
 import { ArrowLeft, Copy } from "../../../helpers/bsIcons"
+import { TextOnlyAlert } from "../alerts/textOnlyAlert"
 import { Button } from "react-bootstrap"
 import {
   Directions,
@@ -69,7 +70,10 @@ export const PastDetourPanel = ({
         />
 
         {typedDetour ? (
-          <TypeDetourForm typedDetour={typedDetour} />
+          <div className="mt-3">
+            <TextOnlyAlert />
+            <TypeDetourForm typedDetour={typedDetour} />
+          </div>
         ) : (
           <>
             <Directions directions={directions} />

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -868,7 +868,6 @@ export const createDetourMachine = setup({
         },
 
         "Type Detour": {
-          tags: "no-save",
           on: {
             "detour.type.back": {
               target: "Editing",


### PR DESCRIPTION
Asana Ticket: [UX Review - View Past Detour Panel](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1216722774255341?focus=true)

[UX Review - Detour Table](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1216722671716555?focus=true)

--- 
1. The ::after text was Inter instead of monospace due to some bug with the way inherit works on readonly tags. Adds a css rule to overcome this.
2. Will now update the snapshots on typing.
3. Add a missing text-only alert in past detours.