### PR TITLE
fix: delete draft text only detour

### DIFF
--- a/assets/src/components/detours/diversionPage.tsx
+++ b/assets/src/components/detours/diversionPage.tsx
@@ -388,7 +388,28 @@ export const DiversionPage = ({
             })
           }}
           isActiveDetour={detourStatus === DetourStatus.Active}
-        />
+        >
+          {snapshot.matches({
+            "Detour Drawing": {
+              "Type Detour": "Deleting",
+            },
+          }) ? (
+            <DeleteDetourModal
+              onDelete={deleteDetourCallback}
+              onCancel={() =>
+                send({ type: "detour.delete.delete-modal.cancel" })
+              }
+              affectedRoute={
+                <AffectedRoute
+                  routeName={routeName ?? "??"}
+                  routeDescription={routeDescription ?? "??"}
+                  routeOrigin={routeOrigin ?? "??"}
+                  routeDirection={routeDirection ?? "??"}
+                />
+              }
+            />
+          ) : null}
+        </TypeDetourPanel>
       )
     } else if (
       snapshot.matches({ "Detour Drawing": "Share Detour" }) &&

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -868,6 +868,7 @@ export const createDetourMachine = setup({
         },
 
         "Type Detour": {
+          initial: "Typing",
           on: {
             "detour.type.back": {
               target: "Editing",
@@ -892,6 +893,23 @@ export const createDetourMachine = setup({
             },
             "detour.type.done": {
               target: "Share Detour.Activating",
+            },
+            "detour.delete.open-delete-modal": {
+              target: ".Deleting",
+            },
+          },
+          states: {
+            Typing: {},
+            Deleting: {
+              on: {
+                "detour.delete.delete-modal.cancel": {
+                  target: "Typing",
+                },
+                "detour.delete.delete-modal.delete-draft": {
+                  tags: "no-save",
+                  target: "#Deleted",
+                },
+              },
             },
           },
         },

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -874,32 +874,35 @@ export const createDetourMachine = setup({
               target: "Editing",
               actions: assign({ isTextOnly: false, typedDetour: undefined }),
             },
-            "detour.type.edit-typed-detour": {
-              target: "Type Detour",
-              actions: assign({
-                typedDetour: ({ context: { typedDetour }, event }) => {
-                  const current = typedDetour || {
-                    directions: "",
-                    missedStops: "",
-                    connectionPoints: "",
-                  }
-
-                  return {
-                    ...current,
-                    ...event.typedDetour,
-                  }
-                },
-              }),
-            },
-            "detour.type.done": {
-              target: "Share Detour.Activating",
-            },
-            "detour.delete.open-delete-modal": {
-              target: ".Deleting",
-            },
           },
           states: {
-            Typing: {},
+            Typing: {
+              on: {
+                "detour.type.edit-typed-detour": {
+                  target: "Typing",
+                  actions: assign({
+                    typedDetour: ({ context: { typedDetour }, event }) => {
+                      const current = typedDetour || {
+                        directions: "",
+                        missedStops: "",
+                        connectionPoints: "",
+                      }
+
+                      return {
+                        ...current,
+                        ...event.typedDetour,
+                      }
+                    },
+                  }),
+                },
+                "detour.delete.open-delete-modal": {
+                  target: "Deleting",
+                },
+                "detour.type.done": {
+                  target: "Done",
+                },
+              },
+            },
             Deleting: {
               on: {
                 "detour.delete.delete-modal.cancel": {
@@ -911,6 +914,12 @@ export const createDetourMachine = setup({
                 },
               },
             },
+            Done: {
+              type: "final",
+            },
+          },
+          onDone: {
+            target: "Share Detour.Activating",
           },
         },
 


### PR DESCRIPTION
Asana Ticket: [UX Review - Type Detour Panel](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1216722774255339?focus=true)

note: the button will not appear unless the test_group `delete-draft-detours` is enabled