### PR TITLE
Feat: Calculate number of pages for pagination

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -54,6 +54,19 @@ defmodule Skate.Detours.Detours do
     |> Enum.reject(&is_nil/1)
   end
 
+  def count_detours_for_route("all", status) do
+    Skate.Detours.Db.Detour.Queries.select_detour_list_info()
+    |> apply_status_filter(status)
+    |> Repo.aggregate(:count, :id)
+  end
+
+  def count_detours_for_route(route_id, status) do
+    Skate.Detours.Db.Detour.Queries.select_detour_list_info()
+    |> apply_status_filter(status)
+    |> apply_route_id_filter(route_id)
+    |> Repo.aggregate(:count, :id)
+  end
+
   defp apply_status_filter(query, status) do
     where(query, [detour: d], d.status == ^status)
   end
@@ -86,6 +99,12 @@ defmodule Skate.Detours.Detours do
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
+  end
+
+  def count_detours_for_user(user_id, status) do
+    Skate.Detours.Db.Detour.Queries.select_detour_list_info()
+    |> apply_user_and_status_filter(user_id, status)
+    |> Repo.aggregate(:count, :id)
   end
 
   defp apply_user_and_status_filter(query, user_id, :draft) do

--- a/lib/skate_web/channels/detours_channel.ex
+++ b/lib/skate_web/channels/detours_channel.ex
@@ -51,9 +51,21 @@ defmodule SkateWeb.DetoursChannel do
   @impl SkateWeb.AuthenticatedChannel
   def handle_in_authenticated("paginate", %{"limit" => limit, "offset" => offset}, socket) do
     with {:ok, limit} <- parse_integer(limit),
-         {:ok, offset} <- parse_integer(offset) do
-      detours = fetch_paginated_detours(socket, limit, offset)
-      {:reply, {:ok, %{data: detours}}, socket}
+         {:ok, offset} <- parse_integer(offset),
+         :ok <- validate_pagination(limit, offset) do
+      {detours, total_count} = fetch_paginated_detours_and_total_count(socket, limit, offset)
+      total_pages = calculate_total_pages(total_count, limit)
+      requested_page_number = div(offset, limit) + 1
+
+      {:reply,
+       {:ok,
+        %{
+          data: detours,
+          total_count: total_count,
+          total_pages: total_pages,
+          page_number: min(requested_page_number, total_pages),
+          page_size: limit
+        }}, socket}
     else
       _ ->
         {:reply, {:error, %{reason: :invalid_pagination}}, socket}
@@ -80,29 +92,60 @@ defmodule SkateWeb.DetoursChannel do
     end
   end
 
-  defp fetch_paginated_detours(%{topic: "detours:active"} = socket, limit, offset) do
+  defp validate_pagination(limit, offset) when is_integer(limit) and is_integer(offset) do
+    if limit > 0 and offset >= 0 do
+      :ok
+    else
+      :error
+    end
+  end
+
+  defp calculate_total_pages(total_count, page_size)
+       when is_integer(total_count) and is_integer(page_size) and page_size > 0 do
+    max(1, div(total_count + page_size - 1, page_size))
+  end
+
+  defp fetch_paginated_detours_and_total_count(socket, limit, offset) do
+    case pagination_scope(socket) do
+      {:user, user_id, status} ->
+        {Detours.detours_for_user(user_id, status, limit, offset),
+         Detours.count_detours_for_user(user_id, status)}
+
+      {:route, route_id, status} ->
+        {Detours.detours_for_route(route_id, status, limit, offset),
+         Detours.count_detours_for_route(route_id, status)}
+
+      :unknown ->
+        {[], 0}
+    end
+  end
+
+  defp pagination_scope(%{topic: "detours:active"} = socket) do
+    {:user, current_user_id(socket), :active}
+  end
+
+  defp pagination_scope(%{topic: "detours:active:" <> route_id}) do
+    {:route, route_id, :active}
+  end
+
+  defp pagination_scope(%{topic: "detours:past"}) do
+    {:route, "all", :past}
+  end
+
+  defp pagination_scope(%{topic: "detours:past:" <> route_id}) do
+    {:route, route_id, :past}
+  end
+
+  defp pagination_scope(%{topic: "detours:draft:" <> _author_uuid} = socket) do
+    {:user, current_user_id(socket), :draft}
+  end
+
+  defp pagination_scope(_socket), do: :unknown
+
+  defp current_user_id(socket) do
     %{id: user_id} = Guardian.Phoenix.Socket.current_resource(socket)
-    Detours.detours_for_user(user_id, :active, limit, offset)
+    user_id
   end
-
-  defp fetch_paginated_detours(%{topic: "detours:active:" <> route_id}, limit, offset) do
-    Detours.detours_for_route(route_id, :active, limit, offset)
-  end
-
-  defp fetch_paginated_detours(%{topic: "detours:past"}, limit, offset) do
-    Detours.detours_for_route("all", :past, limit, offset)
-  end
-
-  defp fetch_paginated_detours(%{topic: "detours:past:" <> route_id}, limit, offset) do
-    Detours.detours_for_route(route_id, :past, limit, offset)
-  end
-
-  defp fetch_paginated_detours(%{topic: "detours:draft:" <> _author_uuid} = socket, limit, offset) do
-    %{id: user_id} = Guardian.Phoenix.Socket.current_resource(socket)
-    Detours.detours_for_user(user_id, :draft, limit, offset)
-  end
-
-  defp fetch_paginated_detours(_socket, _limit, _offset), do: []
 
   @impl SkateWeb.AuthenticatedChannel
   def handle_info_authenticated(

--- a/test/skate_web/channels/detours_channel_test.exs
+++ b/test/skate_web/channels/detours_channel_test.exs
@@ -188,7 +188,14 @@ defmodule SkateWeb.DetoursChannelTest do
       {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:active")
 
       ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "1", "offset" => "0"})
-      assert_reply(ref, :ok, %{data: [%Skate.Detours.Detour.Simple{id: 3}]})
+
+      assert_reply(ref, :ok, %{
+        data: [%Skate.Detours.Detour.Simple{id: 3}],
+        total_count: 3,
+        total_pages: 3,
+        page_number: 1,
+        page_size: 1
+      })
     end
 
     @tag :authenticated
@@ -208,7 +215,14 @@ defmodule SkateWeb.DetoursChannelTest do
 
       ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "10", "offset" => "1"})
 
-      assert_reply(ref, :ok, %{data: data})
+      assert_reply(ref, :ok, %{
+        data: data,
+        total_count: 12,
+        total_pages: 2,
+        page_number: 1,
+        page_size: 10
+      })
+
       assert Enum.map(data, & &1.id) == Enum.to_list(2..11)
     end
 
@@ -228,8 +242,56 @@ defmodule SkateWeb.DetoursChannelTest do
 
       ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "10", "offset" => "10"})
 
-      assert_reply(ref, :ok, %{data: data})
+      assert_reply(ref, :ok, %{
+        data: data,
+        total_count: 20,
+        total_pages: 2,
+        page_number: 2,
+        page_size: 10
+      })
+
       assert Enum.map(data, & &1.id) == Enum.to_list(11..20)
+    end
+
+    @tag :authenticated
+    test "paginates active detours by route with limit and offset", %{socket: socket} do
+      now = DateTime.utc_now()
+
+      :detour
+      |> build()
+      |> activated
+      |> with_id(1)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_updated_at(now)
+      |> insert()
+
+      :detour
+      |> build()
+      |> activated
+      |> with_id(2)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_updated_at(DateTime.add(now, -1, :minute))
+      |> insert()
+
+      :detour
+      |> build()
+      |> activated
+      |> with_id(3)
+      |> with_route(%{name: "57", id: "57"})
+      |> with_updated_at(DateTime.add(now, -2, :minute))
+      |> insert()
+
+      {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:active:66")
+
+      ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "1", "offset" => "0"})
+
+      assert_reply(ref, :ok, %{
+        data: [%Skate.Detours.Detour.Simple{id: 1}],
+        total_count: 2,
+        total_pages: 2,
+        page_number: 1,
+        page_size: 1
+      })
     end
 
     @tag :authenticated
@@ -247,7 +309,14 @@ defmodule SkateWeb.DetoursChannelTest do
       {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:active")
 
       ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "10", "offset" => "10"})
-      assert_reply(ref, :ok, %{data: []})
+
+      assert_reply(ref, :ok, %{
+        data: [],
+        total_count: 5,
+        total_pages: 1,
+        page_number: 1,
+        page_size: 10
+      })
     end
 
     @tag :authenticated
@@ -277,7 +346,14 @@ defmodule SkateWeb.DetoursChannelTest do
       {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:past:66")
 
       ref = Phoenix.ChannelTest.push(socket, "paginate", %{"limit" => "1", "offset" => "0"})
-      assert_reply(ref, :ok, %{data: [%Skate.Detours.Detour.Simple{id: 2}]})
+
+      assert_reply(ref, :ok, %{
+        data: [%Skate.Detours.Detour.Simple{id: 2}],
+        total_count: 2,
+        total_pages: 2,
+        page_number: 1,
+        page_size: 1
+      })
     end
 
     @tag :authenticated


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Backend Pagination Improvements](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1216326666772054?focus=true)

Iterating on the previous PR https://github.com/mbta/skate/pull/3240

We need to know the # of pages in order to display the page range to the user. For example, if there are 140 detours and each page displays 10 detours, the user sees a range of page numbers they can click on: 1...14 (with some options in the middle)