### PR TITLE
fix: Allow manual deactivation of detours

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -281,10 +281,11 @@ defmodule Skate.Detours.Detours do
     })
   end
 
-  defp build_deactivation_changeset(detour) do
-    detour
-    |> put_in([:state, "value", "Detour Drawing"], "Past")
-    |> Detour.changeset(%{status: :past})
+  defp build_deactivation_changeset(detour) d
+    Detour.changeset(
+      detour,
+      %{state: put_in(detour.state, ["value", "Detour Drawing"], "Past"), status: :past}
+    )
   end
 
   def copy_to_draft_detour(detour, author_id) do

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -245,6 +245,12 @@ defmodule Skate.Detours.Detours do
     end
   end
 
+  def manual_deactivate_detour(detour_id) do
+    get_detour!(detour_id)
+    |> build_deactivation_changeset()
+    |> Repo.update!()
+  end
+
   defp fetch_detour_for_activation(detour_id, user_id) do
     case Repo.get(Detour, detour_id) do
       nil ->
@@ -272,6 +278,17 @@ defmodule Skate.Detours.Detours do
     Detour.changeset(detour, %{
       state: new_state,
       activated_at: DateTime.utc_now(:millisecond)
+    })
+  end
+
+  defp build_deactivation_changeset(detour) do
+    new_state =
+      detour.state
+      |> put_in(["value", "Detour Drawing"], "Past")
+
+    Detour.changeset(detour, %{
+      state: new_state,
+      status: :past
     })
   end
 

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -281,7 +281,7 @@ defmodule Skate.Detours.Detours do
     })
   end
 
-  defp build_deactivation_changeset(detour) d
+  defp build_deactivation_changeset(detour) do
     Detour.changeset(
       detour,
       %{state: put_in(detour.state, ["value", "Detour Drawing"], "Past"), status: :past}

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -282,14 +282,9 @@ defmodule Skate.Detours.Detours do
   end
 
   defp build_deactivation_changeset(detour) do
-    new_state =
-      detour.state
-      |> put_in(["value", "Detour Drawing"], "Past")
-
-    Detour.changeset(detour, %{
-      state: new_state,
-      status: :past
-    })
+    detour
+    |> put_in([:state, "value", "Detour Drawing"], "Past")
+    |> Detour.changeset(%{status: :past})
   end
 
   def copy_to_draft_detour(detour, author_id) do

--- a/lib/skate_web/controllers/detours_admin_controller.ex
+++ b/lib/skate_web/controllers/detours_admin_controller.ex
@@ -46,6 +46,14 @@ defmodule SkateWeb.DetoursAdminController do
     redirect(conn, to: ~p"/detours_admin")
   end
 
+  @spec manual_deactivate_detour(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def manual_deactivate_detour(conn, %{"id" => id}) do
+    Logger.info("begin manual deactivation for detour detour_id=#{inspect(id)}")
+    Detours.manual_deactivate_detour(id)
+    Logger.info("end manual deactivation for detour detour_id=#{inspect(id)}")
+    redirect(conn, to: ~p"/detours_admin/#{id}")
+  end
+
   @spec sync_swiftly(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def sync_swiftly(conn, _params) do
     Logger.info("begin manual sync detours with swiftly")

--- a/lib/skate_web/controllers/detours_admin_html/show.html.heex
+++ b/lib/skate_web/controllers/detours_admin_html/show.html.heex
@@ -70,10 +70,10 @@
   <summary>Manual Actions</summary>
   <.form
     for={@conn}
-    action={~p"/api/detours/#{detour_id}"}
-    method="DELETE"
+    action={~p"/detours_admin/#{detour_id}/manual_deactivate_detour"}
+    method="POST"
   >
-    {submit("Remove from Skate",
+    {submit("Deactivate in Skate",
       onclick: "return confirm('Are you sure?')"
     )}
   </.form>

--- a/lib/skate_web/router.ex
+++ b/lib/skate_web/router.ex
@@ -140,6 +140,10 @@ defmodule SkateWeb.Router do
            DetoursAdminController,
            :manual_remove_swiftly
 
+    post "/detours_admin/:id/manual_deactivate_detour",
+         DetoursAdminController,
+         :manual_deactivate_detour
+
     get "/reports", ReportController, :index
     get "/reports/:short_name", ReportController, :run
     get "/test_groups", TestGroupController, :index


### PR DESCRIPTION
Asana Ticket: [7/31/26 - Detour Unable to be Closed - ⚠️ Report an Issue submission](https://app.asana.com/1/15492006741476/project/1148853526253420/task/1217075170909625?focus=true)

Deleting ran into foreign key constraints - references to the detour_id become invalid (notifications & copied_from)

Plus the method I was using checks to see if the author is the one doing the deleting.

This is the smallest change I could think of to get the detour off of the list.