### PR TITLE
Feat: Closed detours pagination UI

### DIFF
--- a/assets/css/bootstrap.scss
+++ b/assets/css/bootstrap.scss
@@ -46,7 +46,7 @@
 @import "../node_modules/bootstrap/scss/nav";
 // @import "../node_modules/bootstrap/scss/navbar";
 // @import "../node_modules/bootstrap/scss/offcanvas";
-// @import "../node_modules/bootstrap/scss/pagination";
+@import "../node_modules/bootstrap/scss/pagination";
 // @import "../node_modules/bootstrap/scss/placeholders";
 @import "../node_modules/bootstrap/scss/popover";
 // @import "../node_modules/bootstrap/scss/progress";

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -1,14 +1,14 @@
-import React, { useContext, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { DetoursTable, DetourStatus } from "./detoursTable"
 import userInTestGroup, { TestGroups } from "../userInTestGroup"
-import { Button, Spinner } from "react-bootstrap"
+import { Button, Pagination, Spinner } from "react-bootstrap"
 import {
   GlobeAmericas,
   LockFill,
   PeopleFill,
   PlusSquare,
-  SvgProps,
 } from "../helpers/bsIcons"
+import type { SvgProps } from "../helpers/bsIcons"
 import RoutesContext from "../contexts/routesContext"
 import { DetourModal } from "./detours/detourModal"
 import { joinClasses } from "../helpers/dom"
@@ -33,10 +33,22 @@ export const DetourListPage = () => {
 
   // Wait for the detour channels to initialize
   const { socket } = useContext(SocketContext)
+  const [pageNumber, setPageNumber] = useState(1)
+  const currentLimit = 5
+
+  // For pagination, reset the page number to 1 when the routeId changes
+  useEffect(() => {
+    setPageNumber(1)
+  }, [routeId])
 
   const activeDetoursMap = useActiveDetours(socket)
   const draftDetoursMap = useDraftDetours(socket)
-  const pastDetoursMap = usePastDetours({ socket: socket, routeId: routeId })
+  const pastDetoursMap = usePastDetours({
+    socket: socket,
+    routeId: routeId,
+    limit: currentLimit,
+    offset: (pageNumber - 1) * currentLimit,
+  })
 
   const activeDetours =
     activeDetoursMap &&
@@ -130,6 +142,21 @@ export const DetourListPage = () => {
                 routes={routes}
                 classNames={["u-hide-for-mobile"]}
               />
+              <div className="d-flex justify-content-end mb-4">
+                <Pagination className="mb-0">
+                  <Pagination.Prev
+                    disabled={pageNumber <= 1}
+                    aria-label="Previous"
+                    onClick={() => setPageNumber((page) => Math.max(1, page - 1))}
+                  />
+                  <Pagination.Item active>{pageNumber}</Pagination.Item>
+                  <Pagination.Next
+                    disabled={!pastDetours || pastDetours.length < currentLimit}
+                    aria-label="Next"
+                    onClick={() => setPageNumber((page) => page + 1)}
+                  />
+                </Pagination>
+              </div>
             </>
           )}
         </>

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react"
 import { DetoursTable, DetourStatus } from "./detoursTable"
-import { buildPaginationItems, PaginationBar } from "./nav/paginationBar"
+import { PaginationBar } from "./nav/paginationBar"
 import userInTestGroup, { TestGroups } from "../userInTestGroup"
 import { Button, Spinner } from "react-bootstrap"
 import {
@@ -15,6 +15,7 @@ import { DetourModal } from "./detours/detourModal"
 import { joinClasses } from "../helpers/dom"
 import { useLoadDetour } from "../hooks/useLoadDetour"
 import type { DetoursPagination } from "../models/detoursPaginationData"
+import { buildPaginationItems } from "../models/detoursPaginationData"
 import {
   useActiveDetours,
   useDraftDetours,
@@ -39,7 +40,9 @@ export const DetourListPage = () => {
   const [detoursPagination, setDetoursPagination] = useState<
     DetoursPagination | undefined
   >()
-  const currentLimit = Number.MAX_SAFE_INTEGER
+  // Set arbitrarily high to see all detours (without pagination) until the next PR
+  // turns on pagination to a reasonable page limit.
+  const currentLimit = 10000
 
   // For pagination, reset the page number to 1 when the routeId changes
   useEffect(() => {

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -39,7 +39,7 @@ export const DetourListPage = () => {
   const [detoursPagination, setDetoursPagination] = useState<
     DetoursPagination | undefined
   >()
-  const currentLimit = 3
+  const currentLimit = Number.MAX_SAFE_INTEGER
 
   // For pagination, reset the page number to 1 when the routeId changes
   useEffect(() => {

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -1,7 +1,8 @@
 import React, { useContext, useEffect, useState } from "react"
 import { DetoursTable, DetourStatus } from "./detoursTable"
+import { buildPaginationItems, PaginationBar } from "./nav/paginationBar"
 import userInTestGroup, { TestGroups } from "../userInTestGroup"
-import { Button, Pagination, Spinner } from "react-bootstrap"
+import { Button, Spinner } from "react-bootstrap"
 import {
   GlobeAmericas,
   LockFill,
@@ -13,49 +14,13 @@ import RoutesContext from "../contexts/routesContext"
 import { DetourModal } from "./detours/detourModal"
 import { joinClasses } from "../helpers/dom"
 import { useLoadDetour } from "../hooks/useLoadDetour"
+import type { DetoursPagination } from "../models/detoursPaginationData"
 import {
-  type DetoursPagination,
   useActiveDetours,
   useDraftDetours,
   usePastDetours,
 } from "../hooks/useDetours"
 import { SocketContext } from "../contexts/socketContext"
-
-// Determine page numbers in the pagination component, with ellipses if there are too many pages to show
-export const buildPaginationItems = (
-  currentPage: number,
-  totalPages: number
-): Array<number | "ellipsis"> => {
-  if (totalPages <= 7) {
-    return Array.from({ length: totalPages }, (_, index) => index + 1)
-  }
-
-  const clampedCurrent = Math.min(Math.max(currentPage, 1), totalPages)
-  const pages = new Set<number>([1, totalPages])
-
-  // Show the page numbers before and after the current page
-  for (let page = clampedCurrent - 1; page <= clampedCurrent + 1; page += 1) {
-    if (page > 1 && page < totalPages) {
-      pages.add(page)
-    }
-  }
-
-  const orderedPages = Array.from(pages).sort((a, b) => a - b)
-  const items: Array<number | "ellipsis"> = []
-
-  // Add ellipses if there are gaps between the page numbers
-  orderedPages.forEach((page, index) => {
-    if (index > 0) {
-      const previousPage = orderedPages[index - 1]
-      if (page - previousPage > 1) {
-        items.push("ellipsis")
-      }
-    }
-    items.push(page)
-  })
-
-  return items
-}
 
 export const DetourListPage = () => {
   const routes = useContext(RoutesContext)
@@ -88,7 +53,7 @@ export const DetourListPage = () => {
     socket: socket,
     routeId: routeId,
     limit: currentLimit,
-    pageNumber,
+    pageNumber: pageNumber,
     onPaginate: setDetoursPagination,
   })
 
@@ -111,6 +76,7 @@ export const DetourListPage = () => {
     totalPages !== undefined
       ? pageNumber < totalPages
       : Boolean(pastDetours && pastDetours.length >= currentLimit)
+
   // --- End of detour channel initialization
 
   const { detour, isLoading: isLoadingDetour } = useLoadDetour(detourId)
@@ -194,33 +160,16 @@ export const DetourListPage = () => {
                 routes={routes}
                 classNames={["u-hide-for-mobile"]}
               />
-              <div className="d-flex justify-content-end mb-4">
-                <Pagination className="mb-0">
-                  <Pagination.Prev
-                    disabled={pageNumber <= 1}
-                    aria-label="Previous"
-                    onClick={() => setPageNumber((page) => Math.max(1, page - 1))}
-                  />
-                  {pageItems.map((page, index) =>
-                    typeof page === "number" ? (
-                      <Pagination.Item
-                        key={page}
-                        active={pageNumber === page}
-                        onClick={() => setPageNumber(page)}
-                      >
-                        {page}
-                      </Pagination.Item>
-                    ) : (
-                      <Pagination.Ellipsis key={`${page}-${index}`} disabled />
-                    )
-                  )}
-                  <Pagination.Next
-                    disabled={!canGoNext}
-                    aria-label="Next"
-                    onClick={() => setPageNumber((page) => page + 1)}
-                  />
-                </Pagination>
-              </div>
+              <PaginationBar
+                pageNumber={pageNumber}
+                pageItems={pageItems}
+                canGoNext={canGoNext}
+                onPrevious={() =>
+                  setPageNumber((page) => Math.max(1, page - 1))
+                }
+                onNext={() => setPageNumber((page) => page + 1)}
+                onSelectPage={setPageNumber}
+              />
             </>
           )}
         </>

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -75,7 +75,7 @@ export const DetourListPage = () => {
   const canGoNext =
     totalPages !== undefined
       ? pageNumber < totalPages
-      : Boolean(pastDetours && pastDetours.length >= currentLimit)
+      : (pastDetours !== null && pastDetours.length >= currentLimit)
 
   // --- End of detour channel initialization
 

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -75,7 +75,7 @@ export const DetourListPage = () => {
   const canGoNext =
     totalPages !== undefined
       ? pageNumber < totalPages
-      : (pastDetours !== null && pastDetours.length >= currentLimit)
+      : Boolean(pastDetours && pastDetours.length >= currentLimit)
 
   // --- End of detour channel initialization
 

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -14,11 +14,48 @@ import { DetourModal } from "./detours/detourModal"
 import { joinClasses } from "../helpers/dom"
 import { useLoadDetour } from "../hooks/useLoadDetour"
 import {
+  type DetoursPagination,
   useActiveDetours,
   useDraftDetours,
   usePastDetours,
 } from "../hooks/useDetours"
 import { SocketContext } from "../contexts/socketContext"
+
+// Determine page numbers in the pagination component, with ellipses if there are too many pages to show
+export const buildPaginationItems = (
+  currentPage: number,
+  totalPages: number
+): Array<number | "ellipsis"> => {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const clampedCurrent = Math.min(Math.max(currentPage, 1), totalPages)
+  const pages = new Set<number>([1, totalPages])
+
+  // Show the page numbers before and after the current page
+  for (let page = clampedCurrent - 1; page <= clampedCurrent + 1; page += 1) {
+    if (page > 1 && page < totalPages) {
+      pages.add(page)
+    }
+  }
+
+  const orderedPages = Array.from(pages).sort((a, b) => a - b)
+  const items: Array<number | "ellipsis"> = []
+
+  // Add ellipses if there are gaps between the page numbers
+  orderedPages.forEach((page, index) => {
+    if (index > 0) {
+      const previousPage = orderedPages[index - 1]
+      if (page - previousPage > 1) {
+        items.push("ellipsis")
+      }
+    }
+    items.push(page)
+  })
+
+  return items
+}
 
 export const DetourListPage = () => {
   const routes = useContext(RoutesContext)
@@ -34,11 +71,15 @@ export const DetourListPage = () => {
   // Wait for the detour channels to initialize
   const { socket } = useContext(SocketContext)
   const [pageNumber, setPageNumber] = useState(1)
-  const currentLimit = 5
+  const [detoursPagination, setDetoursPagination] = useState<
+    DetoursPagination | undefined
+  >()
+  const currentLimit = 3
 
   // For pagination, reset the page number to 1 when the routeId changes
   useEffect(() => {
     setPageNumber(1)
+    setDetoursPagination(undefined)
   }, [routeId])
 
   const activeDetoursMap = useActiveDetours(socket)
@@ -47,7 +88,8 @@ export const DetourListPage = () => {
     socket: socket,
     routeId: routeId,
     limit: currentLimit,
-    offset: (pageNumber - 1) * currentLimit,
+    pageNumber,
+    onPaginate: setDetoursPagination,
   })
 
   const activeDetours =
@@ -59,6 +101,16 @@ export const DetourListPage = () => {
   const pastDetours =
     pastDetoursMap &&
     Object.values(pastDetoursMap).sort((a, b) => b.updatedAt - a.updatedAt)
+
+  const totalPages = detoursPagination?.totalPages
+  const pageItems =
+    totalPages !== undefined
+      ? buildPaginationItems(pageNumber, totalPages)
+      : [pageNumber]
+  const canGoNext =
+    totalPages !== undefined
+      ? pageNumber < totalPages
+      : Boolean(pastDetours && pastDetours.length >= currentLimit)
   // --- End of detour channel initialization
 
   const { detour, isLoading: isLoadingDetour } = useLoadDetour(detourId)
@@ -149,9 +201,21 @@ export const DetourListPage = () => {
                     aria-label="Previous"
                     onClick={() => setPageNumber((page) => Math.max(1, page - 1))}
                   />
-                  <Pagination.Item active>{pageNumber}</Pagination.Item>
+                  {pageItems.map((page, index) =>
+                    typeof page === "number" ? (
+                      <Pagination.Item
+                        key={page}
+                        active={pageNumber === page}
+                        onClick={() => setPageNumber(page)}
+                      >
+                        {page}
+                      </Pagination.Item>
+                    ) : (
+                      <Pagination.Ellipsis key={`${page}-${index}`} disabled />
+                    )
+                  )}
                   <Pagination.Next
-                    disabled={!pastDetours || pastDetours.length < currentLimit}
+                    disabled={!canGoNext}
                     aria-label="Next"
                     onClick={() => setPageNumber((page) => page + 1)}
                   />

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -1,42 +1,7 @@
 import React from "react"
 import { Pagination } from "react-bootstrap"
+import { PaginationItem } from "../../models/detoursPaginationData"
 
-type PaginationItem = number | "ellipsis"
-
-export const buildPaginationItems = (
-  currentPage: number,
-  totalPages: number
-): PaginationItem[] => {
-  if (totalPages <= 7) {
-    return Array.from({ length: totalPages }, (_, index) => index + 1)
-  }
-
-  const clampedCurrent = Math.min(Math.max(currentPage, 1), totalPages)
-  const pages = new Set<number>([1, totalPages])
-
-  // Show the page numbers before and after the current page.
-  for (let page = clampedCurrent - 1; page <= clampedCurrent + 1; page += 1) {
-    if (page > 1 && page < totalPages) {
-      pages.add(page)
-    }
-  }
-
-  const orderedPages = Array.from(pages).sort((a, b) => a - b)
-  const items: PaginationItem[] = []
-
-  // Add ellipses if there are gaps between page numbers.
-  orderedPages.forEach((page, index) => {
-    if (index > 0) {
-      const previousPage = orderedPages[index - 1]
-      if (page - previousPage > 1) {
-        items.push("ellipsis")
-      }
-    }
-    items.push(page)
-  })
-
-  return items
-}
 
 interface PaginationBarProps {
   pageNumber: number

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import { Pagination } from "react-bootstrap"
 
+type PaginationItem = number | "ellipsis"
+
 export const buildPaginationItems = (
   currentPage: number,
   totalPages: number
-): Array<number | "ellipsis"> => {
+): PaginationItem[] => {
   if (totalPages <= 7) {
     return Array.from({ length: totalPages }, (_, index) => index + 1)
   }
@@ -20,7 +22,7 @@ export const buildPaginationItems = (
   }
 
   const orderedPages = Array.from(pages).sort((a, b) => a - b)
-  const items: Array<number | "ellipsis"> = []
+  const items: PaginationItem[] = []
 
   // Add ellipses if there are gaps between page numbers.
   orderedPages.forEach((page, index) => {
@@ -38,7 +40,7 @@ export const buildPaginationItems = (
 
 interface PaginationBarProps {
   pageNumber: number
-  pageItems: Array<number | "ellipsis">
+  pageItems: PaginationItem[]
   canGoNext: boolean
   onPrevious: () => void
   onNext: () => void

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { Pagination } from "react-bootstrap"
+
+export const buildPaginationItems = (
+  currentPage: number,
+  totalPages: number
+): Array<number | "ellipsis"> => {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const clampedCurrent = Math.min(Math.max(currentPage, 1), totalPages)
+  const pages = new Set<number>([1, totalPages])
+
+  // Show the page numbers before and after the current page.
+  for (let page = clampedCurrent - 1; page <= clampedCurrent + 1; page += 1) {
+    if (page > 1 && page < totalPages) {
+      pages.add(page)
+    }
+  }
+
+  const orderedPages = Array.from(pages).sort((a, b) => a - b)
+  const items: Array<number | "ellipsis"> = []
+
+  // Add ellipses if there are gaps between page numbers.
+  orderedPages.forEach((page, index) => {
+    if (index > 0) {
+      const previousPage = orderedPages[index - 1]
+      if (page - previousPage > 1) {
+        items.push("ellipsis")
+      }
+    }
+    items.push(page)
+  })
+
+  return items
+}
+
+interface PaginationBarProps {
+  pageNumber: number
+  pageItems: Array<number | "ellipsis">
+  canGoNext: boolean
+  onPrevious: () => void
+  onNext: () => void
+  onSelectPage: (page: number) => void
+}
+
+export const PaginationBar = ({
+  pageNumber,
+  pageItems,
+  canGoNext,
+  onPrevious,
+  onNext,
+  onSelectPage,
+}: PaginationBarProps) => {
+  return (
+    <div className="d-flex justify-content-end mb-4">
+      <Pagination className="mb-0">
+        <Pagination.Prev
+          disabled={pageNumber <= 1}
+          aria-disabled={pageNumber <= 1}
+          aria-label="Previous"
+          onClick={onPrevious}
+        />
+        {pageItems.map((page, index) =>
+          typeof page === "number" ? (
+            <Pagination.Item
+              key={page}
+              active={pageNumber === page}
+              onClick={() => onSelectPage(page)}
+            >
+              {page}
+            </Pagination.Item>
+          ) : (
+            <Pagination.Ellipsis key={`${page}-${index}`} disabled />
+          )
+        )}
+        <Pagination.Next
+          disabled={!canGoNext}
+          aria-disabled={!canGoNext}
+          aria-label="Next"
+          onClick={onNext}
+        />
+      </Pagination>
+    </div>
+  )
+}

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { Pagination } from "react-bootstrap"
 import { PaginationItem } from "../../models/detoursPaginationData"
 
-
 interface PaginationBarProps {
   pageNumber: number
   pageItems: PaginationItem[]

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -25,6 +25,7 @@ export const useDetour = (useDetourProps: UseDetourInput) => {
   const input =
     "snapshot" in useDetourProps
       ? {
+          input: {},
           snapshot: useDetourProps.snapshot,
         }
       : {

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -6,7 +6,7 @@ import {
   simpleDetourFromActiveData,
   simpleDetourFromData,
 } from "../models/detoursList"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { reload } from "../models/browser"
 import { userUuid } from "../util/userUuid"
 import { ByRouteId, RouteId } from "../schedule"
@@ -27,7 +27,8 @@ const subscribe = (
   handleActivated: ((data: SimpleDetour) => void) | undefined,
   handleDeactivated: ((data: SimpleDetour) => void) | undefined,
   handleDeleted: ((detourId: number) => void) | undefined,
-  initialMessageType: typeof SimpleDetourData | typeof SimpleActiveDetourData
+  initialMessageType: typeof SimpleDetourData | typeof SimpleActiveDetourData,
+  onJoined?: (channel: Channel) => void,
 ): Channel => {
   const channel = socket.channel(topic)
 
@@ -75,6 +76,9 @@ const subscribe = (
 
       const detoursMap = Object.fromEntries(data.map((v) => [v.id, v]))
       initializeChannel(detoursMap)
+      if (onJoined) {
+        onJoined(channel)
+      }
     })
 
     .receive("error", ({ reason }) => {
@@ -142,15 +146,25 @@ export const useActiveDetours = (
 export const usePastDetours = ({
   socket,
   routeId = "all",
+  limit = 5,
+  offset = 0,
 }: {
   socket: Socket | undefined
   routeId?: string
+  limit?: number
+  offset?: number
 }) => {
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
+  const channelRef = useRef<Channel | undefined>()
+  const joinedRef = useRef(false)
 
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
+  }
+  const setDetoursFromData = (data: unknown) => {
+    const detours = create(data, array(SimpleDetourData)).map(simpleDetourFromData)
+    setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
   }
 
   useEffect(() => {
@@ -164,7 +178,11 @@ export const usePastDetours = ({
         undefined,
         handleDeactivated,
         undefined,
-        SimpleDetourData
+        SimpleDetourData,
+        (channel) => {
+          channelRef.current = channel
+          joinedRef.current = true
+        }
       )
     }
 
@@ -172,9 +190,19 @@ export const usePastDetours = ({
       if (channel !== undefined) {
         channel.leave()
         channel = undefined
+        channelRef.current = undefined
+        joinedRef.current = false
       }
     }
   }, [socket, topic])
+
+  useEffect(() => {
+    const channel = channelRef.current
+    if (channel && joinedRef.current) {
+      pushPageNumber(channel, topic, limit, offset, setDetoursFromData)
+    }
+  }, [limit, offset])
+
   return pastDetours
 }
 
@@ -327,4 +355,22 @@ export const useActiveDetoursByRoute = (
   }, [socket, currentRouteIds])
 
   return activeDetoursByRoute
+}
+
+const pushPageNumber = (
+  channel: Channel,
+  topic: string,
+  limit: number,
+  offset: number,
+  setDetoursCallback: (data: unknown) => void
+) => {
+  channel
+    .push("paginate", { limit, offset })
+    .receive("ok", ({ data: unknownData }: { data: unknown }) => {
+      setDetoursCallback(unknownData)
+    })
+    .receive("error", ({ reason }) => {
+      // eslint-disable-next-line no-console
+      console.error(`paginate failed for topic ${topic}`, reason)
+    })
 }

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -8,7 +8,7 @@ import {
 } from "../models/detoursList"
 import {
   type DetoursPagination,
-  parsePaginatePayload,
+  parsePaginationPayload,
 } from "../models/detoursPaginationData"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { reload } from "../models/browser"
@@ -177,41 +177,12 @@ export const usePastDetours = ({
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
   const channelRef = useRef<Channel | undefined>()
-  const joinedRef = useRef(false)
+  const [isJoined, setIsJoined] = useState(false)
   const lastPaginateRequestRef = useRef<string | undefined>()
 
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
   }
-
-  const setDetoursFromData = useCallback(
-    (data: unknown) => {
-      const { detours, pagination } = parsePaginatePayload(data)
-      if (pagination) {
-        onPaginate?.(pagination)
-      }
-      setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
-    },
-    [onPaginate]
-  )
-
-  const pushPageNumberOncePerRequest = useCallback(
-    (channel: Channel) => {
-      const requestKey = `${topic}:${pageNumber}:${limit}`
-      if (lastPaginateRequestRef.current === requestKey) {
-        return
-      }
-      lastPaginateRequestRef.current = requestKey
-      pushPageNumber(channel, topic, limit, pageNumber, setDetoursFromData)
-    },
-    [limit, pageNumber, setDetoursFromData, topic]
-  )
-
-  const pushPageNumberOncePerRequestRef = useRef(pushPageNumberOncePerRequest)
-
-  useEffect(() => {
-    pushPageNumberOncePerRequestRef.current = pushPageNumberOncePerRequest
-  }, [pushPageNumberOncePerRequest])
 
   useEffect(() => {
     let channel: Channel | undefined
@@ -224,8 +195,7 @@ export const usePastDetours = ({
         initialMessageType: SimpleDetourData,
         onJoined: (channel) => {
           channelRef.current = channel
-          joinedRef.current = true
-          pushPageNumberOncePerRequestRef.current(channel)
+          setIsJoined(true)
         },
       })
     }
@@ -235,18 +205,46 @@ export const usePastDetours = ({
         channel.leave()
         channel = undefined
         channelRef.current = undefined
-        joinedRef.current = false
-        lastPaginateRequestRef.current = undefined
+        setIsJoined(false)
       }
     }
   }, [socket, topic])
 
+  // Cache the callback to set detours from data, so that the function reference doesn't
+  // change on every render. Also call the onPaginate callback to update the pagination
+  // state in the parent component
+  const setDetoursFromData = useCallback(
+    (data: unknown) => {
+      const { detours, pagination } = parsePaginationPayload(data)
+      if (pagination) {
+        onPaginate?.(pagination)
+      }
+      setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
+    },
+    [onPaginate]
+  )
+
+  // Send the pagination request when page number, topic, limit changes
   useEffect(() => {
-    const channel = channelRef.current
-    if (channel && joinedRef.current) {
-      pushPageNumberOncePerRequest(channel)
-    }
-  }, [pushPageNumberOncePerRequest])
+    // If the channel is not joined yet, we cannot push the pagination request
+    if (!isJoined || !channelRef.current) return
+
+    // Deduplication key to prevent multiple requests for the same page number and limit
+    const key = `${topic}:${pageNumber}:${limit}`
+    // If the last paginate request was for the same page number and limit, do not send
+    // another request
+    if (lastPaginateRequestRef.current === key) return
+
+    // Save the current request key
+    lastPaginateRequestRef.current = key
+    pushPagination(
+      channelRef.current,
+      topic,
+      limit,
+      pageNumber,
+      setDetoursFromData
+    )
+  }, [topic, pageNumber, limit, isJoined, setDetoursFromData])
 
   return pastDetours
 }
@@ -401,15 +399,15 @@ export const useActiveDetoursByRoute = (
   return activeDetoursByRoute
 }
 
-const pushPageNumber = (
+const pushPagination = (
   channel: Channel,
   topic: string,
   limit: number,
   pageNumber: number,
   setDetoursCallback: (data: unknown) => void
 ) => {
-  const safePageNumber = Math.max(1, pageNumber)
-  const offset = (safePageNumber - 1) * limit
+  const clampedPageNumber = Math.max(1, pageNumber)
+  const offset = (clampedPageNumber - 1) * limit
 
   channel
     .push("paginate", { limit, offset })

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -219,7 +219,9 @@ export const usePastDetours = ({
       if (pagination) {
         onPaginate?.(pagination)
       }
-      setPastDetours(Object.fromEntries(detours.map((detour) => [detour.id, detour])))
+      setPastDetours(
+        Object.fromEntries(detours.map((detour) => [detour.id, detour]))
+      )
     },
     [onPaginate]
   )

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -6,85 +6,37 @@ import {
   simpleDetourFromActiveData,
   simpleDetourFromData,
 } from "../models/detoursList"
-import { useEffect, useRef, useState } from "react"
+import {
+  type DetoursPagination,
+  parsePaginatePayload,
+} from "../models/detoursPaginationData"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { reload } from "../models/browser"
 import { userUuid } from "../util/userUuid"
 import { ByRouteId, RouteId } from "../schedule"
 import { equalByElements } from "../helpers/array"
-import { array, create, number, object } from "superstruct"
+import { array, create } from "superstruct"
 
 export interface DetoursMap {
   [key: number]: SimpleDetour
 }
 
-export interface DetoursPagination {
-  totalCount: number
-  totalPages: number
-  pageNumber: number
-  pageSize: number
-}
-
-const PaginatedDetoursData = object({
-  data: array(SimpleDetourData),
-  total_count: number(),
-  total_pages: number(),
-  page_number: number(),
-  page_size: number(),
-})
-
-type InitialMessageType = typeof SimpleDetourData | typeof SimpleActiveDetourData
+type InitialMessageType =
+  | typeof SimpleDetourData
+  | typeof SimpleActiveDetourData
 
 type SubscribeOptions = {
   socket: Socket
   topic: string
-  initializeChannel: React.Dispatch<React.SetStateAction<DetoursMap | undefined>>
+  initializeChannel: React.Dispatch<
+    React.SetStateAction<DetoursMap | undefined>
+  >
   initialMessageType: InitialMessageType
   onJoined?: (channel: Channel) => void
   handleDrafted?: (data: SimpleDetour) => void
   handleActivated?: (data: SimpleDetour) => void
   handleDeactivated?: (data: SimpleDetour) => void
   handleDeleted?: (detourId: number) => void
-}
-
-const hasKey = <K extends string>(
-  payload: unknown,
-  key: K
-): payload is Record<K, unknown> => {
-  return typeof payload === "object" && payload !== null && key in payload
-}
-
-const parsePaginatePayload = (payload: unknown): {
-  detours: SimpleDetour[]
-  pagination?: DetoursPagination
-} => {
-  const normalizedPayload = hasKey(payload, "data") && hasKey(payload.data, "total_count")
-    ? payload.data
-    : payload
-
-  if (Array.isArray(normalizedPayload)) {
-    const parsedData = create(normalizedPayload, array(SimpleDetourData))
-    return { detours: parsedData.map(simpleDetourFromData) }
-  }
-
-  if (hasKey(normalizedPayload, "total_count")) {
-    const parsedPagination = create(normalizedPayload, PaginatedDetoursData)
-    return {
-      detours: parsedPagination.data.map(simpleDetourFromData),
-      pagination: {
-        totalCount: parsedPagination.total_count,
-        totalPages: parsedPagination.total_pages,
-        pageNumber: parsedPagination.page_number,
-        pageSize: parsedPagination.page_size,
-      },
-    }
-  }
-
-  if (hasKey(normalizedPayload, "data")) {
-    const parsedData = create(normalizedPayload.data, array(SimpleDetourData))
-    return { detours: parsedData.map(simpleDetourFromData) }
-  }
-
-  return { detours: [] }
 }
 
 const subscribe = ({
@@ -212,32 +164,54 @@ export const useActiveDetours = (
 export const usePastDetours = ({
   socket,
   routeId = "all",
-  limit = 3,
-  pageNumber = 1,
+  limit,
+  pageNumber,
   onPaginate,
 }: {
   socket: Socket | undefined
-  routeId?: string
-  limit?: number
-  pageNumber?: number
+  routeId: string
+  limit: number
+  pageNumber: number
   onPaginate?: (pagination: DetoursPagination) => void
 }) => {
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
   const channelRef = useRef<Channel | undefined>()
   const joinedRef = useRef(false)
+  const lastPaginateRequestRef = useRef<string | undefined>()
 
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
   }
 
-  const setDetoursFromData = (data: unknown) => {
-    const { detours, pagination } = parsePaginatePayload(data)
-    if (pagination) {
-      onPaginate?.(pagination)
-    }
-    setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
-  }
+  const setDetoursFromData = useCallback(
+    (data: unknown) => {
+      const { detours, pagination } = parsePaginatePayload(data)
+      if (pagination) {
+        onPaginate?.(pagination)
+      }
+      setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
+    },
+    [onPaginate]
+  )
+
+  const pushPageNumberOncePerRequest = useCallback(
+    (channel: Channel) => {
+      const requestKey = `${topic}:${limit}:${pageNumber}`
+      if (lastPaginateRequestRef.current === requestKey) {
+        return
+      }
+      lastPaginateRequestRef.current = requestKey
+      pushPageNumber(channel, topic, limit, pageNumber, setDetoursFromData)
+    },
+    [limit, pageNumber, setDetoursFromData, topic]
+  )
+
+  const pushPageNumberOncePerRequestRef = useRef(pushPageNumberOncePerRequest)
+
+  useEffect(() => {
+    pushPageNumberOncePerRequestRef.current = pushPageNumberOncePerRequest
+  }, [pushPageNumberOncePerRequest])
 
   useEffect(() => {
     let channel: Channel | undefined
@@ -251,6 +225,7 @@ export const usePastDetours = ({
         onJoined: (channel) => {
           channelRef.current = channel
           joinedRef.current = true
+          pushPageNumberOncePerRequestRef.current(channel)
         },
       })
     }
@@ -261,6 +236,7 @@ export const usePastDetours = ({
         channel = undefined
         channelRef.current = undefined
         joinedRef.current = false
+        lastPaginateRequestRef.current = undefined
       }
     }
   }, [socket, topic])
@@ -268,9 +244,9 @@ export const usePastDetours = ({
   useEffect(() => {
     const channel = channelRef.current
     if (channel && joinedRef.current) {
-      pushPageNumber(channel, topic, limit, pageNumber, setDetoursFromData)
+      pushPageNumberOncePerRequest(channel)
     }
-  }, [limit, pageNumber, onPaginate, topic])
+  }, [pushPageNumberOncePerRequest])
 
   return pastDetours
 }

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -11,25 +11,93 @@ import { reload } from "../models/browser"
 import { userUuid } from "../util/userUuid"
 import { ByRouteId, RouteId } from "../schedule"
 import { equalByElements } from "../helpers/array"
-import { array, create } from "superstruct"
+import { array, create, number, object } from "superstruct"
 
 export interface DetoursMap {
   [key: number]: SimpleDetour
 }
 
-const subscribe = (
-  socket: Socket,
-  topic: string,
-  initializeChannel: React.Dispatch<
-    React.SetStateAction<DetoursMap | undefined>
-  >,
-  handleDrafted: ((data: SimpleDetour) => void) | undefined,
-  handleActivated: ((data: SimpleDetour) => void) | undefined,
-  handleDeactivated: ((data: SimpleDetour) => void) | undefined,
-  handleDeleted: ((detourId: number) => void) | undefined,
-  initialMessageType: typeof SimpleDetourData | typeof SimpleActiveDetourData,
-  onJoined?: (channel: Channel) => void,
-): Channel => {
+export interface DetoursPagination {
+  totalCount: number
+  totalPages: number
+  pageNumber: number
+  pageSize: number
+}
+
+const PaginatedDetoursData = object({
+  data: array(SimpleDetourData),
+  total_count: number(),
+  total_pages: number(),
+  page_number: number(),
+  page_size: number(),
+})
+
+type InitialMessageType = typeof SimpleDetourData | typeof SimpleActiveDetourData
+
+type SubscribeOptions = {
+  socket: Socket
+  topic: string
+  initializeChannel: React.Dispatch<React.SetStateAction<DetoursMap | undefined>>
+  initialMessageType: InitialMessageType
+  onJoined?: (channel: Channel) => void
+  handleDrafted?: (data: SimpleDetour) => void
+  handleActivated?: (data: SimpleDetour) => void
+  handleDeactivated?: (data: SimpleDetour) => void
+  handleDeleted?: (detourId: number) => void
+}
+
+const hasKey = <K extends string>(
+  payload: unknown,
+  key: K
+): payload is Record<K, unknown> => {
+  return typeof payload === "object" && payload !== null && key in payload
+}
+
+const parsePaginatePayload = (payload: unknown): {
+  detours: SimpleDetour[]
+  pagination?: DetoursPagination
+} => {
+  const normalizedPayload = hasKey(payload, "data") && hasKey(payload.data, "total_count")
+    ? payload.data
+    : payload
+
+  if (Array.isArray(normalizedPayload)) {
+    const parsedData = create(normalizedPayload, array(SimpleDetourData))
+    return { detours: parsedData.map(simpleDetourFromData) }
+  }
+
+  if (hasKey(normalizedPayload, "total_count")) {
+    const parsedPagination = create(normalizedPayload, PaginatedDetoursData)
+    return {
+      detours: parsedPagination.data.map(simpleDetourFromData),
+      pagination: {
+        totalCount: parsedPagination.total_count,
+        totalPages: parsedPagination.total_pages,
+        pageNumber: parsedPagination.page_number,
+        pageSize: parsedPagination.page_size,
+      },
+    }
+  }
+
+  if (hasKey(normalizedPayload, "data")) {
+    const parsedData = create(normalizedPayload.data, array(SimpleDetourData))
+    return { detours: parsedData.map(simpleDetourFromData) }
+  }
+
+  return { detours: [] }
+}
+
+const subscribe = ({
+  socket,
+  topic,
+  initializeChannel,
+  handleDrafted,
+  handleActivated,
+  handleDeactivated,
+  handleDeleted,
+  initialMessageType,
+  onJoined,
+}: SubscribeOptions): Channel => {
   const channel = socket.channel(topic)
 
   if (handleDrafted)
@@ -120,16 +188,14 @@ export const useActiveDetours = (
 
     let channel: Channel | undefined
     if (socket) {
-      channel = subscribe(
+      channel = subscribe({
         socket,
         topic,
-        setActiveDetours,
-        undefined,
-        handleActivated,
-        handleDeactivated,
-        undefined,
-        SimpleActiveDetourData
-      )
+        initializeChannel: setActiveDetours,
+        handleActivated: handleActivated,
+        handleDeactivated: handleDeactivated,
+        initialMessageType: SimpleActiveDetourData,
+      })
     }
 
     return () => {
@@ -146,13 +212,15 @@ export const useActiveDetours = (
 export const usePastDetours = ({
   socket,
   routeId = "all",
-  limit = 5,
-  offset = 0,
+  limit = 3,
+  pageNumber = 1,
+  onPaginate,
 }: {
   socket: Socket | undefined
   routeId?: string
   limit?: number
-  offset?: number
+  pageNumber?: number
+  onPaginate?: (pagination: DetoursPagination) => void
 }) => {
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
@@ -162,28 +230,29 @@ export const usePastDetours = ({
   const handleDeactivated = (data: SimpleDetour) => {
     setPastDetours((pastDetours) => ({ ...pastDetours, [data.id]: data }))
   }
+
   const setDetoursFromData = (data: unknown) => {
-    const detours = create(data, array(SimpleDetourData)).map(simpleDetourFromData)
+    const { detours, pagination } = parsePaginatePayload(data)
+    if (pagination) {
+      onPaginate?.(pagination)
+    }
     setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
   }
 
   useEffect(() => {
     let channel: Channel | undefined
     if (socket) {
-      channel = subscribe(
+      channel = subscribe({
         socket,
         topic,
-        setPastDetours,
-        undefined,
-        undefined,
-        handleDeactivated,
-        undefined,
-        SimpleDetourData,
-        (channel) => {
+        initializeChannel: setPastDetours,
+        handleDeactivated: handleDeactivated,
+        initialMessageType: SimpleDetourData,
+        onJoined: (channel) => {
           channelRef.current = channel
           joinedRef.current = true
-        }
-      )
+        },
+      })
     }
 
     return () => {
@@ -199,9 +268,9 @@ export const usePastDetours = ({
   useEffect(() => {
     const channel = channelRef.current
     if (channel && joinedRef.current) {
-      pushPageNumber(channel, topic, limit, offset, setDetoursFromData)
+      pushPageNumber(channel, topic, limit, pageNumber, setDetoursFromData)
     }
-  }, [limit, offset])
+  }, [limit, pageNumber, onPaginate, topic])
 
   return pastDetours
 }
@@ -232,16 +301,15 @@ export const useDraftDetours = (socket: Socket | undefined) => {
   useEffect(() => {
     let channel: Channel | undefined
     if (socket) {
-      channel = subscribe(
+      channel = subscribe({
         socket,
         topic,
-        setDraftDetours,
-        handleDrafted,
-        handleActivated,
-        undefined,
-        handleDeleted,
-        SimpleDetourData
-      )
+        initializeChannel: setDraftDetours,
+        handleDrafted: handleDrafted,
+        handleActivated: handleActivated,
+        handleDeleted: handleDeleted,
+        initialMessageType: SimpleDetourData,
+      })
     }
 
     return () => {
@@ -361,13 +429,16 @@ const pushPageNumber = (
   channel: Channel,
   topic: string,
   limit: number,
-  offset: number,
+  pageNumber: number,
   setDetoursCallback: (data: unknown) => void
 ) => {
+  const safePageNumber = Math.max(1, pageNumber)
+  const offset = (safePageNumber - 1) * limit
+
   channel
     .push("paginate", { limit, offset })
-    .receive("ok", ({ data: unknownData }: { data: unknown }) => {
-      setDetoursCallback(unknownData)
+    .receive("ok", (payload: unknown) => {
+      setDetoursCallback(payload)
     })
     .receive("error", ({ reason }) => {
       // eslint-disable-next-line no-console

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -219,7 +219,7 @@ export const usePastDetours = ({
       if (pagination) {
         onPaginate?.(pagination)
       }
-      setPastDetours(Object.fromEntries(detours.map((v) => [v.id, v])))
+      setPastDetours(Object.fromEntries(detours.map((detour) => [detour.id, detour])))
     },
     [onPaginate]
   )
@@ -230,7 +230,7 @@ export const usePastDetours = ({
     if (!isJoined || !channelRef.current) return
 
     // Deduplication key to prevent multiple requests for the same page number and limit
-    const key = `${topic}:${pageNumber}:${limit}`
+    const key = `${topic}:${limit}:${pageNumber}`
     // If the last paginate request was for the same page number and limit, do not send
     // another request
     if (lastPaginateRequestRef.current === key) return

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -96,7 +96,7 @@ const subscribe = ({
 
       const detoursMap = Object.fromEntries(data.map((v) => [v.id, v]))
       initializeChannel(detoursMap)
-      if (onJoined) {
+      if (typeof onJoined === "function") {
         onJoined(channel)
       }
     })
@@ -197,7 +197,7 @@ export const usePastDetours = ({
 
   const pushPageNumberOncePerRequest = useCallback(
     (channel: Channel) => {
-      const requestKey = `${topic}:${limit}:${pageNumber}`
+      const requestKey = `${topic}:${pageNumber}:${limit}`
       if (lastPaginateRequestRef.current === requestKey) {
         return
       }

--- a/assets/src/models/detoursPaginationData.ts
+++ b/assets/src/models/detoursPaginationData.ts
@@ -27,6 +27,43 @@ const hasKey = <K extends string>(
   return typeof payload === "object" && payload !== null && key in payload
 }
 
+export type PaginationItem = number | "ellipsis"
+
+export const buildPaginationItems = (
+  currentPage: number,
+  totalPages: number
+): PaginationItem[] => {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  const clampedCurrent = Math.min(Math.max(currentPage, 1), totalPages)
+  const pages = new Set<number>([1, totalPages])
+
+  // Show the page numbers before and after the current page.
+  for (let page = clampedCurrent - 1; page <= clampedCurrent + 1; page += 1) {
+    if (page > 1 && page < totalPages) {
+      pages.add(page)
+    }
+  }
+
+  const orderedPages = Array.from(pages).sort((a, b) => a - b)
+  const items: PaginationItem[] = []
+
+  // Add ellipses if there are gaps between page numbers.
+  orderedPages.forEach((page, index) => {
+    if (index > 0) {
+      const previousPage = orderedPages[index - 1]
+      if (page - previousPage > 1) {
+        items.push("ellipsis")
+      }
+    }
+    items.push(page)
+  })
+
+  return items
+}
+
 export const parsePaginationPayload = (
   payload: unknown
 ): {

--- a/assets/src/models/detoursPaginationData.ts
+++ b/assets/src/models/detoursPaginationData.ts
@@ -44,14 +44,14 @@ export const parsePaginatePayload = (
   }
 
   if (hasKey(normalizedPayload, "total_count")) {
-    const parsedPagination = create(normalizedPayload, PaginatedDetoursData)
+    const paginatedDetoursData = create(normalizedPayload, PaginatedDetoursData)
     return {
-      detours: parsedPagination.data.map(simpleDetourFromData),
+      detours: paginatedDetoursData.data.map(simpleDetourFromData),
       pagination: {
-        totalCount: parsedPagination.total_count,
-        totalPages: parsedPagination.total_pages,
-        pageNumber: parsedPagination.page_number,
-        pageSize: parsedPagination.page_size,
+        totalCount: paginatedDetoursData.total_count,
+        totalPages: paginatedDetoursData.total_pages,
+        pageNumber: paginatedDetoursData.page_number,
+        pageSize: paginatedDetoursData.page_size,
       },
     }
   }

--- a/assets/src/models/detoursPaginationData.ts
+++ b/assets/src/models/detoursPaginationData.ts
@@ -1,0 +1,65 @@
+import { array, create, number, object } from "superstruct"
+import {
+  SimpleDetour,
+  SimpleDetourData,
+  simpleDetourFromData,
+} from "./detoursList"
+
+export interface DetoursPagination {
+  totalCount: number
+  totalPages: number
+  pageNumber: number
+  pageSize: number
+}
+
+const PaginatedDetoursData = object({
+  data: array(SimpleDetourData),
+  total_count: number(),
+  total_pages: number(),
+  page_number: number(),
+  page_size: number(),
+})
+
+const hasKey = <K extends string>(
+  payload: unknown,
+  key: K
+): payload is Record<K, unknown> => {
+  return typeof payload === "object" && payload !== null && key in payload
+}
+
+export const parsePaginatePayload = (
+  payload: unknown
+): {
+  detours: SimpleDetour[]
+  pagination?: DetoursPagination
+} => {
+  const normalizedPayload =
+    hasKey(payload, "data") && hasKey(payload.data, "total_count")
+      ? payload.data
+      : payload
+
+  if (Array.isArray(normalizedPayload)) {
+    const parsedData = create(normalizedPayload, array(SimpleDetourData))
+    return { detours: parsedData.map(simpleDetourFromData) }
+  }
+
+  if (hasKey(normalizedPayload, "total_count")) {
+    const parsedPagination = create(normalizedPayload, PaginatedDetoursData)
+    return {
+      detours: parsedPagination.data.map(simpleDetourFromData),
+      pagination: {
+        totalCount: parsedPagination.total_count,
+        totalPages: parsedPagination.total_pages,
+        pageNumber: parsedPagination.page_number,
+        pageSize: parsedPagination.page_size,
+      },
+    }
+  }
+
+  if (hasKey(normalizedPayload, "data")) {
+    const parsedData = create(normalizedPayload.data, array(SimpleDetourData))
+    return { detours: parsedData.map(simpleDetourFromData) }
+  }
+
+  return { detours: [] }
+}

--- a/assets/src/models/detoursPaginationData.ts
+++ b/assets/src/models/detoursPaginationData.ts
@@ -27,7 +27,7 @@ const hasKey = <K extends string>(
   return typeof payload === "object" && payload !== null && key in payload
 }
 
-export const parsePaginatePayload = (
+export const parsePaginationPayload = (
   payload: unknown
 ): {
   detours: SimpleDetour[]
@@ -39,8 +39,8 @@ export const parsePaginatePayload = (
       : payload
 
   if (Array.isArray(normalizedPayload)) {
-    const parsedData = create(normalizedPayload, array(SimpleDetourData))
-    return { detours: parsedData.map(simpleDetourFromData) }
+    const simpleDetourData = create(normalizedPayload, array(SimpleDetourData))
+    return { detours: simpleDetourData.map(simpleDetourFromData) }
   }
 
   if (hasKey(normalizedPayload, "total_count")) {
@@ -57,8 +57,11 @@ export const parsePaginatePayload = (
   }
 
   if (hasKey(normalizedPayload, "data")) {
-    const parsedData = create(normalizedPayload.data, array(SimpleDetourData))
-    return { detours: parsedData.map(simpleDetourFromData) }
+    const simpleDetourData = create(
+      normalizedPayload.data,
+      array(SimpleDetourData)
+    )
+    return { detours: simpleDetourData.map(simpleDetourFromData) }
   }
 
   return { detours: [] }

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -871,6 +871,68 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
           </tr>
         </tbody>
       </table>
+      <div
+        class="d-flex justify-content-end mb-4"
+      >
+        <ul
+          class="mb-0 pagination"
+        >
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Previous"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ‹
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Previous
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item active"
+          >
+            <span
+              class="page-link"
+            >
+              1
+              <span
+                class="visually-hidden"
+              >
+                (current)
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Next"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ›
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Next
+              </span>
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -645,6 +645,68 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
           </tr>
         </tbody>
       </table>
+      <div
+        class="d-flex justify-content-end mb-4"
+      >
+        <ul
+          class="mb-0 pagination"
+        >
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Previous"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ‹
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Previous
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item active"
+          >
+            <span
+              class="page-link"
+            >
+              1
+              <span
+                class="visually-hidden"
+              >
+                (current)
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Next"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ›
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Next
+              </span>
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div
@@ -2539,6 +2601,68 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
           </tr>
         </tbody>
       </table>
+      <div
+        class="d-flex justify-content-end mb-4"
+      >
+        <ul
+          class="mb-0 pagination"
+        >
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Previous"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ‹
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Previous
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item active"
+          >
+            <span
+              class="page-link"
+            >
+              1
+              <span
+                class="visually-hidden"
+              >
+                (current)
+              </span>
+            </span>
+          </li>
+          <li
+            class="page-item disabled"
+          >
+            <span
+              aria-disabled="true"
+              aria-label="Next"
+              class="page-link"
+            >
+              <span
+                aria-hidden="true"
+              >
+                ›
+              </span>
+              <span
+                class="visually-hidden"
+              >
+                Next
+              </span>
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -195,4 +195,42 @@ describe("DetourListPage", () => {
       )
     })
   })
+
+  test("disables next when returned page has fewer than limit rows and enables prev only after page increment", async () => {
+    jest.mocked(useDraftDetours).mockReturnValue({})
+    jest.mocked(useActiveDetours).mockReturnValue({})
+    jest.mocked(usePastDetours).mockReturnValue([simpleDetourFactory.build()])
+
+    render(<DetourListPage />)
+
+    const prevButton = await screen.findByRole("button", { name: /Previous/i })
+    const nextButton = await screen.findByRole("button", { name: /Next/i })
+
+    expect(prevButton).toBeDisabled()
+    expect(nextButton).toBeDisabled()
+  })
+
+  test("resets page to 1 when route changes", async () => {
+    const routes = routeFactory.buildList(2)
+    jest.mocked(useDraftDetours).mockReturnValue({})
+    jest.mocked(useActiveDetours).mockReturnValue({})
+
+    const mockPastDetours = [simpleDetourFactory.build(), simpleDetourFactory.build()]
+    jest.mocked(usePastDetours).mockReturnValue(mockPastDetours)
+
+    render(
+      <RoutesProvider routes={routes}>
+        <DetourListPage />
+      </RoutesProvider>
+    )
+
+    const routeSelect = screen.getByLabelText("Route and direction") as HTMLSelectElement
+    const nextButton = await screen.findByRole("button", { name: /Next/i })
+
+    expect(nextButton).toBeDisabled()
+
+    fireEvent.change(routeSelect, { target: { value: routes[0].id } })
+
+    expect(screen.getByText("1")).toBeInTheDocument()
+  })
 })

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -2,8 +2,9 @@ import { describe, test, expect, jest, beforeEach } from "@jest/globals"
 import "@testing-library/jest-dom/jest-globals"
 import React from "react"
 import { DetourListPage } from "../../../src/components/detourListPage"
-import { buildPaginationItems } from "../../../src/components/nav/paginationBar"
+import { buildPaginationItems } from "../../../src/models/detoursPaginationData"
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -44,32 +45,43 @@ const filterIntersectionInput = byRole("textbox", {
 
 describe("buildPaginationItems", () => {
   test("returns all pages when the total page count is small", () => {
-    // arrange
     const currentPage = 3
     const totalPages = 7
 
-    // act
     const actual = buildPaginationItems(currentPage, totalPages)
 
-    // assert
     const expected = [1, 2, 3, 4, 5, 6, 7]
     expect(actual).toStrictEqual(expected)
   })
 
   test("builds a centered window with ellipses when there are many pages", () => {
-    expect(buildPaginationItems(5, 10)).toStrictEqual([
-      1,
-      "ellipsis",
-      4,
-      5,
-      6,
-      "ellipsis",
-      10,
-    ])
+    const currentPage = 5
+    const totalPages = 10
+
+    const actual = buildPaginationItems(currentPage, totalPages)
+
+    const expected = [1, "ellipsis", 4, 5, 6, "ellipsis", 10]
+    expect(actual).toStrictEqual(expected)
+  })
+
+  test("builds a window with ellipses when there are many pages", () => {
+    const currentPage = 4
+    const totalPages = 14
+
+    const actual = buildPaginationItems(currentPage, totalPages)
+
+    const expected = [1, "ellipsis", 3, 4, 5, "ellipsis", 14]
+    expect(actual).toStrictEqual(expected)
   })
 
   test("clamps the current page when it exceeds bounds", () => {
-    expect(buildPaginationItems(99, 10)).toStrictEqual([1, "ellipsis", 9, 10])
+    const currentPage = 99
+    const totalPages = 10
+
+    const actual = buildPaginationItems(currentPage, totalPages)
+
+    const expected = [1, "ellipsis", 9, 10]
+    expect(actual).toStrictEqual(expected)
   })
 })
 
@@ -236,14 +248,18 @@ describe("DetourListPage", () => {
 
   test("disables previous on first page and toggles next on last page", async () => {
     jest.mocked(usePastDetours).mockImplementation((args) => {
-      switch (args.pageNumber) {
-        case 1:
-          return simpleDetourFactory.buildList(3)
-        default:
-          return [
-            simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
-          ]
-      }
+      React.useEffect(() => {
+        args.onPaginate?.({
+          totalCount: 2,
+          totalPages: 2,
+          pageNumber: args.pageNumber,
+          pageSize: 1,
+        })
+      }, [args.pageNumber, args.onPaginate])
+
+      return [
+        simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
+      ]
     })
 
     render(<DetourListPage />)
@@ -251,15 +267,20 @@ describe("DetourListPage", () => {
     const previousButton = screen.getByLabelText("Previous")
     const nextButton = screen.getByLabelText("Next")
 
-    expect(previousButton).toHaveAttribute("aria-disabled", "true")
-    expect(nextButton).not.toHaveAttribute("aria-disabled", "true")
+    await waitFor(() => {
+      expect(previousButton).toHaveAttribute("aria-disabled", "true")
+      expect(nextButton).not.toHaveAttribute("aria-disabled", "true")
+    })
 
-    fireEvent.click(nextButton)
+    await act(async () => {
+      fireEvent.click(nextButton)
+    })
 
     await waitFor(() => {
       const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(pagination).not.toBeNull()
       expect(
-        within(pagination as HTMLElement)
+        within(pagination!)
           .getByText("2")
           .closest("li")
       ).toHaveClass("active")

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -248,18 +248,18 @@ describe("DetourListPage", () => {
 
   test("disables previous on first page and toggles next on last page", async () => {
     jest.mocked(usePastDetours).mockImplementation((args) => {
+      const { onPaginate, pageNumber } = args
+
       React.useEffect(() => {
-        args.onPaginate?.({
+        onPaginate?.({
           totalCount: 2,
           totalPages: 2,
-          pageNumber: args.pageNumber,
+          pageNumber,
           pageSize: 1,
         })
-      }, [args.pageNumber, args.onPaginate])
+      }, [onPaginate, pageNumber])
 
-      return [
-        simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
-      ]
+      return [simpleDetourFactory.build({ id: pageNumber, name: "Closed" })]
     })
 
     render(<DetourListPage />)
@@ -279,11 +279,9 @@ describe("DetourListPage", () => {
     await waitFor(() => {
       const pagination = screen.getByLabelText("Previous").closest("ul")
       expect(pagination).not.toBeNull()
-      expect(
-        within(pagination!)
-          .getByText("2")
-          .closest("li")
-      ).toHaveClass("active")
+      expect(within(pagination!).getByText("2").closest("li")).toHaveClass(
+        "active"
+      )
       expect(screen.getByLabelText("Previous")).not.toHaveAttribute(
         "aria-disabled",
         "true"
@@ -317,11 +315,10 @@ describe("DetourListPage", () => {
 
     await waitFor(() => {
       const pagination = screen.getByLabelText("Previous").closest("ul")
-      expect(
-        within(pagination as HTMLElement)
-          .getByText("2")
-          .closest("li")
-      ).toHaveClass("active")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("2").closest("li")).toHaveClass(
+        "active"
+      )
     })
 
     fireEvent.change(screen.getByLabelText("Route and direction"), {
@@ -330,11 +327,10 @@ describe("DetourListPage", () => {
 
     await waitFor(() => {
       const pagination = screen.getByLabelText("Previous").closest("ul")
-      expect(
-        within(pagination as HTMLElement)
-          .getByText("1")
-          .closest("li")
-      ).toHaveClass("active")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("1").closest("li")).toHaveClass(
+        "active"
+      )
       expect(screen.getByLabelText("Previous")).toHaveAttribute(
         "aria-disabled",
         "true"

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -236,14 +236,14 @@ describe("DetourListPage", () => {
 
   test("disables previous on first page and toggles next on last page", async () => {
     jest.mocked(usePastDetours).mockImplementation((args) => {
-    switch (args.pageNumber) {
-      case 1:
-        return simpleDetourFactory.buildList(3)
-      default:
-        return [
-          simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" })
-        ]
-    }
+      switch (args.pageNumber) {
+        case 1:
+          return simpleDetourFactory.buildList(3)
+        default:
+          return [
+            simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
+          ]
+      }
     })
 
     render(<DetourListPage />)

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -44,7 +44,16 @@ const filterIntersectionInput = byRole("textbox", {
 
 describe("buildPaginationItems", () => {
   test("returns all pages when the total page count is small", () => {
-    expect(buildPaginationItems(3, 7)).toStrictEqual([1, 2, 3, 4, 5, 6, 7])
+    // arrange
+    const currentPage = 3
+    const totalPages = 7
+
+    // act
+    const actual = buildPaginationItems(currentPage, totalPages)
+
+    // assert
+    const expected = [1, 2, 3, 4, 5, 6, 7]
+    expect(actual).toStrictEqual(expected)
   })
 
   test("builds a centered window with ellipses when there are many pages", () => {
@@ -227,13 +236,14 @@ describe("DetourListPage", () => {
 
   test("disables previous on first page and toggles next on last page", async () => {
     jest.mocked(usePastDetours).mockImplementation((args) => {
-      if (args.pageNumber === 1) {
+    switch (args.pageNumber) {
+      case 1:
         return simpleDetourFactory.buildList(3)
-      }
-
-      return [
-        simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
-      ]
+      default:
+        return [
+          simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" })
+        ]
+    }
     })
 
     render(<DetourListPage />)

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -2,7 +2,14 @@ import { describe, test, expect, jest, beforeEach } from "@jest/globals"
 import "@testing-library/jest-dom/jest-globals"
 import React from "react"
 import { DetourListPage } from "../../../src/components/detourListPage"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { buildPaginationItems } from "../../../src/components/nav/paginationBar"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import getTestGroups from "../../../src/userTestGroups"
 import { TestGroups } from "../../../src/userInTestGroup"
 import { byRole } from "testing-library-selector"
@@ -25,22 +32,6 @@ jest.mock("../../../src/hooks/useDetours")
 jest.mock("../../../src/userTestGroups")
 jest.mock("../../../src/helpers/fullStory")
 
-beforeEach(() => {
-  jest.mocked(useActiveDetours).mockReturnValue([
-    simpleActiveDetourFactory.build(),
-    simpleActiveDetourFactory.build({
-      name: "Headsign A",
-      direction: "Outbound",
-    }),
-  ])
-  jest.mocked(useDraftDetours).mockReturnValue([])
-  jest
-    .mocked(usePastDetours)
-    .mockReturnValue([simpleDetourFactory.build({ name: "Headsign Z" })])
-
-  jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursPilot])
-})
-
 const activeTableHeading = byRole("heading", { name: "Active detours" })
 const draftTableHeading = byRole("heading", { name: "Draft detours" })
 const closedTableHeading = byRole("heading", { name: "Closed detours" })
@@ -51,7 +42,45 @@ const filterIntersectionInput = byRole("textbox", {
   name: "Starting intersection",
 })
 
+describe("buildPaginationItems", () => {
+  test("returns all pages when the total page count is small", () => {
+    expect(buildPaginationItems(3, 7)).toStrictEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  test("builds a centered window with ellipses when there are many pages", () => {
+    expect(buildPaginationItems(5, 10)).toStrictEqual([
+      1,
+      "ellipsis",
+      4,
+      5,
+      6,
+      "ellipsis",
+      10,
+    ])
+  })
+
+  test("clamps the current page when it exceeds bounds", () => {
+    expect(buildPaginationItems(99, 10)).toStrictEqual([1, "ellipsis", 9, 10])
+  })
+})
+
 describe("DetourListPage", () => {
+  beforeEach(() => {
+    jest.mocked(useActiveDetours).mockReturnValue([
+      simpleActiveDetourFactory.build(),
+      simpleActiveDetourFactory.build({
+        name: "Headsign A",
+        direction: "Outbound",
+      }),
+    ])
+    jest.mocked(useDraftDetours).mockReturnValue([])
+    jest
+      .mocked(usePastDetours)
+      .mockReturnValue([simpleDetourFactory.build({ name: "Headsign Z" })])
+
+    jest.mocked(getTestGroups).mockReturnValue([TestGroups.DetoursPilot])
+  })
+
   test("renders detour list page for dispatchers", async () => {
     const routes = routeFactory.buildList(2)
     const { baseElement } = render(
@@ -196,27 +225,56 @@ describe("DetourListPage", () => {
     })
   })
 
-  test("disables next when returned page has fewer than limit rows and enables prev only after page increment", async () => {
-    jest.mocked(useDraftDetours).mockReturnValue({})
-    jest.mocked(useActiveDetours).mockReturnValue({})
-    jest.mocked(usePastDetours).mockReturnValue([simpleDetourFactory.build()])
+  test("disables previous on first page and toggles next on last page", async () => {
+    jest.mocked(usePastDetours).mockImplementation((args) => {
+      if (args.pageNumber === 1) {
+        return simpleDetourFactory.buildList(3)
+      }
+
+      return [
+        simpleDetourFactory.build({ id: args.pageNumber, name: "Closed" }),
+      ]
+    })
 
     render(<DetourListPage />)
 
-    const prevButton = await screen.findByRole("button", { name: /Previous/i })
-    const nextButton = await screen.findByRole("button", { name: /Next/i })
+    const previousButton = screen.getByLabelText("Previous")
+    const nextButton = screen.getByLabelText("Next")
 
-    expect(prevButton).toBeDisabled()
-    expect(nextButton).toBeDisabled()
+    expect(previousButton).toHaveAttribute("aria-disabled", "true")
+    expect(nextButton).not.toHaveAttribute("aria-disabled", "true")
+
+    fireEvent.click(nextButton)
+
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(
+        within(pagination as HTMLElement)
+          .getByText("2")
+          .closest("li")
+      ).toHaveClass("active")
+      expect(screen.getByLabelText("Previous")).not.toHaveAttribute(
+        "aria-disabled",
+        "true"
+      )
+      expect(screen.getByLabelText("Next")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      )
+    })
   })
 
-  test("resets page to 1 when route changes", async () => {
+  test("resets page number to 1 when the selected route changes", async () => {
     const routes = routeFactory.buildList(2)
-    jest.mocked(useDraftDetours).mockReturnValue({})
-    jest.mocked(useActiveDetours).mockReturnValue({})
 
-    const mockPastDetours = [simpleDetourFactory.build(), simpleDetourFactory.build()]
-    jest.mocked(usePastDetours).mockReturnValue(mockPastDetours)
+    jest.mocked(usePastDetours).mockImplementation((args) => {
+      return [
+        simpleDetourFactory.build({
+          id: args.pageNumber,
+          name: `Closed ${args.routeId}`,
+        }),
+      ]
+    })
 
     render(
       <RoutesProvider routes={routes}>
@@ -224,13 +282,38 @@ describe("DetourListPage", () => {
       </RoutesProvider>
     )
 
-    const routeSelect = screen.getByLabelText("Route and direction") as HTMLSelectElement
-    const nextButton = await screen.findByRole("button", { name: /Next/i })
+    fireEvent.click(screen.getByLabelText("Next"))
 
-    expect(nextButton).toBeDisabled()
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(
+        within(pagination as HTMLElement)
+          .getByText("2")
+          .closest("li")
+      ).toHaveClass("active")
+    })
 
-    fireEvent.change(routeSelect, { target: { value: routes[0].id } })
+    fireEvent.change(screen.getByLabelText("Route and direction"), {
+      target: { value: routes[0].id },
+    })
 
-    expect(screen.getByText("1")).toBeInTheDocument()
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(
+        within(pagination as HTMLElement)
+          .getByText("1")
+          .closest("li")
+      ).toHaveClass("active")
+      expect(screen.getByLabelText("Previous")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      )
+      expect(jest.mocked(usePastDetours)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          routeId: routes[0].id,
+          pageNumber: 1,
+        })
+      )
+    })
   })
 })

--- a/assets/tests/hooks/useDetours.test.ts
+++ b/assets/tests/hooks/useDetours.test.ts
@@ -176,6 +176,74 @@ describe("usePastDetours", () => {
     })
   })
 
+  test("pushes pagination on initial join with the provided limit and offset", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: detours })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    renderHook(() =>
+      usePastDetours({ socket: mockSocket, limit: 5, offset: 10 })
+    )
+
+    expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
+      limit: 5,
+      offset: 10,
+    })
+  })
+
+  test("pushes pagination again when offset changes", () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: detours })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    const { rerender } = renderHook(
+      ({ socket, offset }) => usePastDetours({ socket, limit: 5, offset }),
+      { initialProps: { socket: mockSocket, offset: 0 } }
+    )
+
+    expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
+      limit: 5,
+      offset: 0,
+    })
+
+    rerender({ socket: mockSocket, offset: 5 })
+
+    expect(mockChannel.push).toHaveBeenLastCalledWith("paginate", {
+      limit: 5,
+      offset: 5,
+    })
+  })
+
+  test("switches channels and paginates with offset 0 when route changes", () => {
+    const selectedRoute = parsedDetourA.route
+    const mockSocket = makeMockSocket()
+    const mockChannelA = makeMockChannel("ok", { data: detours })
+    const mockChannelB = makeMockChannel("ok", { data: [detourA] })
+
+    mockSocket.channel.mockImplementationOnce(() => mockChannelA)
+    mockSocket.channel.mockImplementationOnce(() => mockChannelB)
+
+    const { rerender } = renderHook(
+      ({ socket, routeId, offset }) =>
+        usePastDetours({ socket, routeId, limit: 5, offset }),
+      {
+        initialProps: { socket: mockSocket, routeId: "all", offset: 20 },
+      }
+    )
+
+    expect(mockChannelA.push).toHaveBeenCalledWith("paginate", {
+      limit: 5,
+      offset: 20,
+    })
+
+    rerender({ socket: mockSocket, routeId: selectedRoute, offset: 0 })
+
+    expect(mockChannelB.push).toHaveBeenCalledWith("paginate", {
+      limit: 5,
+      offset: 0,
+    })
+  })
+
   test("subscribes to a new channel by route when provided with a route", () => {
     const selectedRoute = parsedDetourA.route
     const mockSocket = makeMockSocket()

--- a/assets/tests/hooks/useDetours.test.ts
+++ b/assets/tests/hooks/useDetours.test.ts
@@ -176,13 +176,13 @@ describe("usePastDetours", () => {
     })
   })
 
-  test("pushes pagination on initial join with the provided limit and offset", () => {
+  test("pushes pagination on initial join with offset derived from page number", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok", { data: detours })
     mockSocket.channel.mockImplementation(() => mockChannel)
 
     renderHook(() =>
-      usePastDetours({ socket: mockSocket, limit: 5, offset: 10 })
+      usePastDetours({ socket: mockSocket, limit: 5, pageNumber: 3 })
     )
 
     expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
@@ -191,14 +191,39 @@ describe("usePastDetours", () => {
     })
   })
 
-  test("pushes pagination again when offset changes", () => {
+  test("emits pagination metadata from paginate responses", () => {
+    const onPaginate = jest.fn()
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", {
+      data: detours,
+      total_count: 20,
+      total_pages: 4,
+      page_number: 2,
+      page_size: 5,
+    })
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    renderHook(() =>
+      usePastDetours({ socket: mockSocket, limit: 5, pageNumber: 2, onPaginate })
+    )
+
+    expect(onPaginate).toHaveBeenCalledWith({
+      totalCount: 20,
+      totalPages: 4,
+      pageNumber: 2,
+      pageSize: 5,
+    })
+  })
+
+  test("pushes pagination again when pageNumber changes", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok", { data: detours })
     mockSocket.channel.mockImplementation(() => mockChannel)
 
     const { rerender } = renderHook(
-      ({ socket, offset }) => usePastDetours({ socket, limit: 5, offset }),
-      { initialProps: { socket: mockSocket, offset: 0 } }
+      ({ socket, pageNumber }) =>
+        usePastDetours({ socket, limit: 5, pageNumber }),
+      { initialProps: { socket: mockSocket, pageNumber: 1 } }
     )
 
     expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
@@ -206,7 +231,7 @@ describe("usePastDetours", () => {
       offset: 0,
     })
 
-    rerender({ socket: mockSocket, offset: 5 })
+    rerender({ socket: mockSocket, pageNumber: 2 })
 
     expect(mockChannel.push).toHaveBeenLastCalledWith("paginate", {
       limit: 5,
@@ -214,7 +239,7 @@ describe("usePastDetours", () => {
     })
   })
 
-  test("switches channels and paginates with offset 0 when route changes", () => {
+  test("switches channels and paginates with page 1 equivalent offset when route changes", () => {
     const selectedRoute = parsedDetourA.route
     const mockSocket = makeMockSocket()
     const mockChannelA = makeMockChannel("ok", { data: detours })
@@ -224,10 +249,10 @@ describe("usePastDetours", () => {
     mockSocket.channel.mockImplementationOnce(() => mockChannelB)
 
     const { rerender } = renderHook(
-      ({ socket, routeId, offset }) =>
-        usePastDetours({ socket, routeId, limit: 5, offset }),
+      ({ socket, routeId, pageNumber }) =>
+        usePastDetours({ socket, routeId, limit: 5, pageNumber }),
       {
-        initialProps: { socket: mockSocket, routeId: "all", offset: 20 },
+        initialProps: { socket: mockSocket, routeId: "all", pageNumber: 5 },
       }
     )
 
@@ -236,7 +261,7 @@ describe("usePastDetours", () => {
       offset: 20,
     })
 
-    rerender({ socket: mockSocket, routeId: selectedRoute, offset: 0 })
+    rerender({ socket: mockSocket, routeId: selectedRoute, pageNumber: 1 })
 
     expect(mockChannelB.push).toHaveBeenCalledWith("paginate", {
       limit: 5,

--- a/assets/tests/hooks/useDetours.test.ts
+++ b/assets/tests/hooks/useDetours.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "@jest/globals"
+import { describe, expect, jest, test } from "@jest/globals"
 import { makeMockChannel, makeMockSocket } from "../testHelpers/socketHelpers"
 import { renderHook } from "@testing-library/react"
 import { act } from "react"
@@ -122,7 +122,14 @@ describe("usePastDetours", () => {
     const mockSocket = makeMockSocket()
     const mockChannel = makeMockChannel("ok", { data: detours })
     mockSocket.channel.mockImplementation(() => mockChannel)
-    const { result } = renderHook(() => usePastDetours({ socket: mockSocket }))
+    const { result } = renderHook(() =>
+      usePastDetours({
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 1,
+      })
+    )
 
     expect(result.current).toStrictEqual({
       [detourA.id]: parsedDetourA,
@@ -148,7 +155,14 @@ describe("usePastDetours", () => {
 
     mockSocket.channel.mockImplementation(() => mockChannel)
 
-    const { result } = renderHook(() => usePastDetours({ socket: mockSocket }))
+    const { result } = renderHook(() =>
+      usePastDetours({
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 1,
+      })
+    )
 
     act(() => mockEvents["deactivated"]?.({ data: detourD }))
 
@@ -167,7 +181,12 @@ describe("usePastDetours", () => {
     const mockChannel = makeMockChannel("ok", { data: [detourA] })
     mockSocket.channel.mockImplementation(() => mockChannel)
     const { result } = renderHook(() =>
-      usePastDetours({ socket: mockSocket, routeId: selectedRoute })
+      usePastDetours({
+        socket: mockSocket,
+        routeId: selectedRoute,
+        limit: 5,
+        pageNumber: 1,
+      })
     )
 
     // Still sets a result when provided a route
@@ -182,7 +201,12 @@ describe("usePastDetours", () => {
     mockSocket.channel.mockImplementation(() => mockChannel)
 
     renderHook(() =>
-      usePastDetours({ socket: mockSocket, limit: 5, pageNumber: 3 })
+      usePastDetours({
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 3,
+      })
     )
 
     expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
@@ -204,7 +228,13 @@ describe("usePastDetours", () => {
     mockSocket.channel.mockImplementation(() => mockChannel)
 
     renderHook(() =>
-      usePastDetours({ socket: mockSocket, limit: 5, pageNumber: 2, onPaginate })
+      usePastDetours({
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 2,
+        onPaginate,
+      })
     )
 
     expect(onPaginate).toHaveBeenCalledWith({
@@ -222,7 +252,7 @@ describe("usePastDetours", () => {
 
     const { rerender } = renderHook(
       ({ socket, pageNumber }) =>
-        usePastDetours({ socket, limit: 5, pageNumber }),
+        usePastDetours({ socket, routeId: "all", limit: 5, pageNumber }),
       { initialProps: { socket: mockSocket, pageNumber: 1 } }
     )
 
@@ -289,7 +319,12 @@ describe("usePastDetours", () => {
     mockSocket.channel.mockImplementationOnce(() => mockChannel)
     mockSocket.channel.mockImplementation(() => mockChannelByRoute)
     const { result, rerender } = renderHook((props) => usePastDetours(props), {
-      initialProps: { socket: mockSocket, routeId: "all" },
+      initialProps: {
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 1,
+      },
     })
 
     act(() => mockEvents["deactivated"]?.({ data: detourD }))
@@ -301,7 +336,12 @@ describe("usePastDetours", () => {
       [detourD.id]: parsedDetourD,
     })
 
-    rerender({ socket: mockSocket, routeId: selectedRoute })
+    rerender({
+      socket: mockSocket,
+      routeId: selectedRoute,
+      limit: 5,
+      pageNumber: 1,
+    })
 
     const detourOnRoute = { ...detourD, route: detourA.route }
     act(() => mockEvents["deactivated"]?.({ data: detourOnRoute }))

--- a/assets/tests/hooks/useDetours.test.ts
+++ b/assets/tests/hooks/useDetours.test.ts
@@ -269,6 +269,40 @@ describe("usePastDetours", () => {
     })
   })
 
+  test("pushes pagination after an asynchronous join completes", async () => {
+    const mockSocket = makeMockSocket()
+    const mockChannel = makeMockChannel("ok", { data: detours })
+    const joinResult = {
+      receive: jest.fn((message: string, handler: (data?: unknown) => void) => {
+        if (message === "ok") {
+          setTimeout(() => handler({ data: detours }), 0)
+        }
+        return joinResult
+      }),
+    }
+
+    mockChannel.join.mockImplementation(() => joinResult as never)
+    mockSocket.channel.mockImplementation(() => mockChannel)
+
+    renderHook(() =>
+      usePastDetours({
+        socket: mockSocket,
+        routeId: "all",
+        limit: 5,
+        pageNumber: 1,
+      })
+    )
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mockChannel.push).toHaveBeenCalledWith("paginate", {
+      limit: 5,
+      offset: 0,
+    })
+  })
+
   test("switches channels and paginates with page 1 equivalent offset when route changes", () => {
     const selectedRoute = parsedDetourA.route
     const mockSocket = makeMockSocket()

--- a/test/skate_web/controllers/test_group_controller_test.exs
+++ b/test/skate_web/controllers/test_group_controller_test.exs
@@ -218,7 +218,7 @@ defmodule SkateWeb.TestGroupControllerTest do
 
       conn =
         post(conn, ~p"/test_groups/#{test_group.id}/add_user", %{
-          "user_id" => 123
+          "user_id" => 0
         })
 
       assert response(conn, 400) =~ "no user found"


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Add UI for Pagination ](https://app.asana.com/1/15492006741476/project/1216434230851197/task/1216177346261084?focus=true)

Building on the backend PR that's been approved and merged: https://github.com/mbta/skate/commit/f9fb49747a24659b82528d9ac6780087ab11171b

In addition to pagination UI, this PR changes the signature of the `subscribe` function from a long set of positional args (brittle) to a SocketOptions object with event handlers and optional pagination callbacks.

Note: I temporarily set the current "limit" of number of detours per page to 10,000 because I realized there needed to be more backend changes in a separate PR to enable filtering & paginating on "reason" "last closed" and/or "intersection" 
