### PR TITLE
feat: add filter functionality to backend pagination

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -33,37 +33,43 @@ defmodule Skate.Detours.Detours do
     |> Repo.all()
   end
 
-  def detours_for_route(route_id, status, limit \\ nil, offset \\ nil)
+  def detours_for_route(route_id, status, limit \\ nil, offset \\ nil, filters \\ %{})
 
-  def detours_for_route("all", status, limit, offset) do
+  def detours_for_route("all", status, limit, offset, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def detours_for_route(route_id, status, limit, offset) do
+  def detours_for_route(route_id, status, limit, offset, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
     |> apply_route_id_filter(route_id)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def count_detours_for_route("all", status) do
+  def count_detours_for_route(route_id, status, filters \\ %{})
+
+  def count_detours_for_route("all", status, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 
-  def count_detours_for_route(route_id, status) do
+  def count_detours_for_route(route_id, status, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
     |> apply_route_id_filter(route_id)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 
@@ -73,6 +79,33 @@ defmodule Skate.Detours.Detours do
 
   defp apply_route_id_filter(query, route_id) do
     where(query, [detour: d], d.route_id == ^route_id)
+  end
+
+  defp apply_filters(query, filters) when is_map(filters) do
+    query
+    |> apply_intersection_filter(Map.get(filters, :intersection))
+    |> apply_reason_filter(Map.get(filters, :reason))
+    |> apply_updated_at_filter(Map.get(filters, :updated_at))
+  end
+
+  defp apply_filters(query, _), do: query
+
+  defp apply_intersection_filter(query, nil), do: query
+  defp apply_intersection_filter(query, ""), do: query
+
+  defp apply_intersection_filter(query, text) do
+    where(query, [detour: d], ilike(d.nearest_intersection, ^"%#{text}%"))
+  end
+
+  defp apply_reason_filter(query, nil), do: query
+  defp apply_reason_filter(query, ""), do: query
+  defp apply_reason_filter(query, reason), do: where(query, [detour: d], d.reason == ^reason)
+
+  defp apply_updated_at_filter(query, nil), do: query
+  defp apply_updated_at_filter(query, []), do: query
+
+  defp apply_updated_at_filter(query, dates) when is_list(dates) do
+    where(query, [detour: d], fragment("?::date", d.updated_at) in ^dates)
   end
 
   # Fetches a certain range of detours, determined by limit and offset
@@ -92,18 +125,20 @@ defmodule Skate.Detours.Detours do
     |> limit(^limit)
   end
 
-  def detours_for_user(user_id, status, limit \\ nil, offset \\ nil) do
+  def detours_for_user(user_id, status, limit \\ nil, offset \\ nil, filters \\ %{}) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_user_and_status_filter(user_id, status)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def count_detours_for_user(user_id, status) do
+  def count_detours_for_user(user_id, status, filters \\ %{}) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_user_and_status_filter(user_id, status)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 

--- a/lib/skate_web/channels/detours_channel.ex
+++ b/lib/skate_web/channels/detours_channel.ex
@@ -49,11 +49,18 @@ defmodule SkateWeb.DetoursChannel do
 
   # Return a certain range of detours, determined by limit and offset
   @impl SkateWeb.AuthenticatedChannel
-  def handle_in_authenticated("paginate", %{"limit" => limit, "offset" => offset}, socket) do
+  def handle_in_authenticated(
+        "paginate",
+        %{"limit" => limit, "offset" => offset} = payload,
+        socket
+      ) do
     with {:ok, limit} <- parse_integer(limit),
          {:ok, offset} <- parse_integer(offset),
-         :ok <- validate_pagination(limit, offset) do
-      {detours, total_count} = fetch_paginated_detours_and_total_count(socket, limit, offset)
+         :ok <- validate_pagination(limit, offset),
+         {:ok, filters} <- build_filters(payload) do
+      {detours, total_count} =
+        fetch_paginated_detours_and_total_count(socket, limit, offset, filters)
+
       total_pages = calculate_total_pages(total_count, limit)
       requested_page_number = div(offset, limit) + 1
 
@@ -105,20 +112,57 @@ defmodule SkateWeb.DetoursChannel do
     max(1, div(total_count + page_size - 1, page_size))
   end
 
-  defp fetch_paginated_detours_and_total_count(socket, limit, offset) do
+  defp fetch_paginated_detours_and_total_count(socket, limit, offset, filters) do
     case pagination_scope(socket) do
       {:user, user_id, status} ->
-        {Detours.detours_for_user(user_id, status, limit, offset),
-         Detours.count_detours_for_user(user_id, status)}
+        {Detours.detours_for_user(user_id, status, limit, offset, filters),
+         Detours.count_detours_for_user(user_id, status, filters)}
 
       {:route, route_id, status} ->
-        {Detours.detours_for_route(route_id, status, limit, offset),
-         Detours.count_detours_for_route(route_id, status)}
+        {Detours.detours_for_route(route_id, status, limit, offset, filters),
+         Detours.count_detours_for_route(route_id, status, filters)}
 
       :unknown ->
         {[], 0}
     end
   end
+
+  defp build_filters(payload) do
+    with {:ok, intersection} <- parse_optional_string(Map.get(payload, "intersection")),
+         {:ok, reason} <- parse_optional_string(Map.get(payload, "reason")),
+         {:ok, updated_at} <- parse_updated_at_dates(Map.get(payload, "updated_at")) do
+      {:ok, %{intersection: intersection, reason: reason, updated_at: updated_at}}
+    end
+  end
+
+  defp parse_optional_string(nil), do: {:ok, nil}
+  defp parse_optional_string(value) when is_binary(value), do: {:ok, value}
+  defp parse_optional_string(_value), do: :error
+
+  defp parse_updated_at_dates(nil), do: {:ok, nil}
+  defp parse_updated_at_dates([]), do: {:ok, []}
+
+  defp parse_updated_at_dates(values) when is_list(values) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case value do
+        date_string when is_binary(date_string) ->
+          case Date.from_iso8601(date_string) do
+            {:ok, date} -> {:cont, {:ok, [date | acc]}}
+            _ -> {:halt, :error}
+          end
+
+        _ ->
+          {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, dates} -> {:ok, Enum.reverse(dates)}
+      :error -> :error
+    end
+  end
+
+  defp parse_updated_at_dates(_values), do: :error
 
   defp pagination_scope(%{topic: "detours:active"} = socket) do
     {:user, current_user_id(socket), :active}

--- a/test/skate/detours/detours_test.exs
+++ b/test/skate/detours/detours_test.exs
@@ -161,6 +161,90 @@ defmodule Skate.Detours.DetoursTest do
     end
   end
 
+  describe "detour list filtering" do
+    test "filters past detours by route, intersection, reason, and updated_at dates" do
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(101)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Parade")
+      |> deactivated()
+      |> with_id(102)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Broadway & 2nd Ave")
+      |> with_updated_at(~U[2026-08-03 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(103)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-05 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> activated()
+      |> with_id(104)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 4th Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      filters = %{
+        intersection: "Main",
+        reason: "Construction",
+        updated_at: [~D[2026-08-01], ~D[2026-08-03]]
+      }
+
+      detours = Detours.detours_for_route("66", :past, nil, nil, filters)
+
+      assert Enum.map(detours, & &1.id) == [101]
+      assert Detours.count_detours_for_route("66", :past, filters) == 1
+    end
+
+    test "filters draft detours by user and intersection" do
+      author = insert(:user)
+      other_author = insert(:user)
+
+      :detour
+      |> build(author: author)
+      |> with_id(201)
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 12:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(author: author)
+      |> with_id(202)
+      |> with_nearest_intersection("Broadway & 2nd Ave")
+      |> with_updated_at(~U[2026-08-01 12:01:00Z])
+      |> insert()
+
+      :detour
+      |> build(author: other_author)
+      |> with_id(203)
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-01 12:02:00Z])
+      |> insert()
+
+      filters = %{intersection: "Main"}
+
+      detours = Detours.detours_for_user(author.id, :draft, nil, nil, filters)
+
+      assert Enum.map(detours, & &1.id) == [201]
+      assert Detours.count_detours_for_user(author.id, :draft, filters) == 1
+    end
+  end
+
   describe "calculate_expiration_timestamp" do
     @activated_at ~U[2026-01-05 15:00:00.000000Z]
 

--- a/test/skate_web/channels/detours_channel_test.exs
+++ b/test/skate_web/channels/detours_channel_test.exs
@@ -227,6 +227,70 @@ defmodule SkateWeb.DetoursChannelTest do
     end
 
     @tag :authenticated
+    test "paginates past detours with intersection reason and updated_at filters", %{
+      socket: socket
+    } do
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(1)
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(2)
+      |> with_nearest_intersection("Main St & 2nd Ave")
+      |> with_updated_at(~U[2026-08-05 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Parade")
+      |> deactivated()
+      |> with_id(3)
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:past")
+
+      ref =
+        Phoenix.ChannelTest.push(socket, "paginate", %{
+          "limit" => "10",
+          "offset" => "0",
+          "intersection" => "Main",
+          "reason" => "Construction",
+          "updated_at" => ["2026-08-01", "2026-08-03"]
+        })
+
+      assert_reply(ref, :ok, %{
+        data: [%Skate.Detours.Detour.Simple{id: 1}],
+        total_count: 1,
+        total_pages: 1,
+        page_number: 1,
+        page_size: 10
+      })
+    end
+
+    @tag :authenticated
+    test "returns invalid_pagination when updated_at date filter is invalid", %{socket: socket} do
+      :detour |> build() |> deactivated() |> with_id(1) |> insert()
+
+      {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:past")
+
+      ref =
+        Phoenix.ChannelTest.push(socket, "paginate", %{
+          "limit" => "10",
+          "offset" => "0",
+          "updated_at" => ["not-a-date"]
+        })
+
+      assert_reply(ref, :error, %{reason: :invalid_pagination})
+    end
+
+    @tag :authenticated
     test "paginates active detours with limit 10 and offset 10", %{socket: socket} do
       now = DateTime.utc_now()
 


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Backend Pagination Improvements ](https://app.asana.com/1/15492006741476/project/1216434230851197/task/1216326666772054?focus=true)

Following up on previous PR: https://github.com/mbta/skate/commit/e2bab55d2f7d2c190a735fbbb7662ec2f302fc1e
Relevant frontend PR: https://github.com/mbta/skate/pull/3254

Filtering closed detours logic is currently split between the frontend (routeId filtering) and backend (intersection, reason, date);

This backend PR allows the (optional) filters to be passed into the backend for pagination calls

Note: some failing checks earlier today because I cancelled the run. But the re-run passes