### PR TITLE
feat: send frontend pagination filter options to backend

### DIFF
--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -22,6 +22,7 @@ import {
   usePastDetours,
 } from "../hooks/useDetours"
 import { SocketContext } from "../contexts/socketContext"
+import type { DetoursFilter } from "../models/detoursFilter"
 
 export const DetourListPage = () => {
   const routes = useContext(RoutesContext)
@@ -33,6 +34,7 @@ export const DetourListPage = () => {
 
   const { show: showDetourModal, fromCopy: showFromCopy } = showDetourModalProps
   const [routeId, setRouteId] = useState<string>("all")
+  const [detoursFilter, setDetoursFilter] = useState<DetoursFilter>({})
 
   // Wait for the detour channels to initialize
   const { socket } = useContext(SocketContext)
@@ -44,11 +46,11 @@ export const DetourListPage = () => {
   // turns on pagination to a reasonable page limit.
   const currentLimit = 10000
 
-  // For pagination, reset the page number to 1 when the routeId changes
+  // For pagination, reset the page number to 1 when the routeId or filter changes
   useEffect(() => {
     setPageNumber(1)
     setDetoursPagination(undefined)
-  }, [routeId])
+  }, [routeId, detoursFilter])
 
   const activeDetoursMap = useActiveDetours(socket)
   const draftDetoursMap = useDraftDetours(socket)
@@ -58,6 +60,7 @@ export const DetourListPage = () => {
     limit: currentLimit,
     pageNumber: pageNumber,
     onPaginate: setDetoursPagination,
+    detoursFilter: detoursFilter,
   })
 
   const activeDetours =
@@ -162,6 +165,8 @@ export const DetourListPage = () => {
                 setRouteId={setRouteId}
                 routes={routes}
                 classNames={["u-hide-for-mobile"]}
+                detoursFilter={detoursFilter}
+                setDetoursFilter={setDetoursFilter}
               />
               <PaginationBar
                 pageNumber={pageNumber}

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useMemo } from "react"
 import { Table, Form, Button } from "react-bootstrap"
 import { XSquare } from "../helpers/bsIcons"
 import { RoutePill } from "./routePill"
@@ -13,6 +13,7 @@ import {
   isUpdatedAfterActivated,
 } from "../util/dateTime"
 import { SimpleDetour } from "../models/detoursList"
+import type { DetoursFilter } from "../models/detoursFilter"
 import { EmptyDetourTableIcon } from "../helpers/skateIcons"
 import { joinClasses } from "../helpers/dom"
 import { Route } from "../schedule"
@@ -30,6 +31,8 @@ interface DetoursTableProps {
   routeId?: string
   setRouteId?: (routeId: string) => void
   classNames?: string[]
+  detoursFilter?: DetoursFilter
+  setDetoursFilter?: (filter: DetoursFilter) => void
 }
 
 export enum DetourStatus {
@@ -47,6 +50,8 @@ const columnCount = (status: DetourStatus) => {
   if (hasReasonColumn(status)) count++ // Reason
   return count
 }
+
+const EMPTY_DATES: Date[] = []
 
 export const timestampLabelFromStatus = (status: DetourStatus) => {
   switch (status) {
@@ -70,38 +75,46 @@ export const DetoursTable = ({
   routeId,
   setRouteId = () => {},
   classNames = [],
+  detoursFilter = {},
+  setDetoursFilter = () => {},
 }: DetoursTableProps) => {
-  const [filter, setFilter] = useState("")
-  const [debouncedFilter, setDebouncedFilter] = useState(filter)
-  const [dates, setDates] = useState<Date[]>([])
-  const [reason, setReason] = useState<string>("all")
   const hasFilters = routes && status === DetourStatus.Closed
 
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedFilter(filter)
-    }, 300)
+  const intersectionFilter = detoursFilter.intersection || ""
+  const dates = detoursFilter.updatedAt || EMPTY_DATES
+  const reason = detoursFilter.reason || "all"
 
-    return () => {
-      clearTimeout(handler)
+  const normalizeAndSetFilter = (nextFilter: DetoursFilter) => {
+    const normalizedFilter: DetoursFilter = {}
+
+    if (nextFilter.intersection && nextFilter.intersection !== "") {
+      normalizedFilter.intersection = nextFilter.intersection
     }
-  }, [filter])
+
+    if (nextFilter.reason && nextFilter.reason !== "all") {
+      normalizedFilter.reason = nextFilter.reason
+    }
+
+    if (nextFilter.updatedAt && nextFilter.updatedAt.length > 0) {
+      normalizedFilter.updatedAt = nextFilter.updatedAt
+    }
+
+    setDetoursFilter(normalizedFilter)
+  }
 
   const resetInputs = () => {
     setRouteId("all")
-    setFilter("")
-    setDates([])
-    setReason("all")
+    setDetoursFilter({})
   }
 
   const filteredData = useMemo(() => {
     let result = data
 
-    if (debouncedFilter !== "") {
+    if (intersectionFilter !== "") {
       result = result.filter((detour) =>
         (detour.intersection || "")
           .toLowerCase()
-          .includes(debouncedFilter.toLowerCase())
+          .includes(intersectionFilter.toLowerCase())
       )
     }
 
@@ -119,7 +132,7 @@ export const DetoursTable = ({
     }
 
     return result
-  }, [data, debouncedFilter, dates, reason])
+  }, [data, intersectionFilter, dates, reason])
 
   return (
     <>
@@ -178,15 +191,25 @@ export const DetoursTable = ({
                     id="intersection-filter"
                     type="text"
                     placeholder="Search..."
-                    value={filter}
+                    value={intersectionFilter}
                     onBlur={() =>
                       fullStoryEvent("Detour Intersection Filter Used", {})
                     }
-                    onChange={(e) => setFilter(e.target.value)}
+                    onChange={(e) =>
+                      normalizeAndSetFilter({
+                        ...detoursFilter,
+                        intersection: e.target.value,
+                      })
+                    }
                   />
                   <div>
-                    {filter.length > 0 && (
-                      <button onClick={() => setFilter("")} title="Clear">
+                    {intersectionFilter.length > 0 && (
+                      <button
+                        onClick={() =>
+                          normalizeAndSetFilter({ ...detoursFilter, intersection: "" })
+                        }
+                        title="Clear"
+                      >
                         <span>
                           <CircleXIcon />
                         </span>
@@ -195,8 +218,10 @@ export const DetoursTable = ({
                     <button
                       type="submit"
                       title="Submit"
-                      onClick={setDebouncedFilter.bind(null, filter)}
-                      disabled={filter.length === 0}
+                      onClick={() =>
+                        normalizeAndSetFilter({ ...detoursFilter, intersection: intersectionFilter })
+                      }
+                      disabled={intersectionFilter.length === 0}
                     >
                       <span>
                         <SearchIcon />
@@ -212,7 +237,7 @@ export const DetoursTable = ({
                   className="select-filter mt-2"
                   value={reason}
                   onChange={(e) => {
-                    setReason(e.target.value)
+                    normalizeAndSetFilter({ ...detoursFilter, reason: e.target.value })
                   }}
                 >
                   <option key="" value="all">
@@ -233,7 +258,8 @@ export const DetoursTable = ({
                     value={dates}
                     options={{
                       maxDate: "today",
-                      onChange: setDates,
+                      onChange: (updatedAt) =>
+                        normalizeAndSetFilter({ ...detoursFilter, updatedAt }),
                       mode: "multiple",
                     }}
                   />

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -16,6 +16,10 @@ import { userUuid } from "../util/userUuid"
 import { ByRouteId, RouteId } from "../schedule"
 import { equalByElements } from "../helpers/array"
 import { array, create } from "superstruct"
+import {
+  type DetoursFilter,
+  serializeDetoursFilter,
+} from "../models/detoursFilter"
 
 export interface DetoursMap {
   [key: number]: SimpleDetour
@@ -167,12 +171,14 @@ export const usePastDetours = ({
   limit,
   pageNumber,
   onPaginate,
+  detoursFilter = {},
 }: {
   socket: Socket | undefined
   routeId: string
   limit: number
   pageNumber: number
   onPaginate?: (pagination: DetoursPagination) => void
+  detoursFilter?: DetoursFilter
 }) => {
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
@@ -226,14 +232,17 @@ export const usePastDetours = ({
     [onPaginate]
   )
 
-  // Send the pagination request when page number, topic, limit changes
+  // Serialize filter for dedup key
+  const serializedFilter = JSON.stringify(serializeDetoursFilter(detoursFilter))
+
+  // Send the pagination request when page number, topic, limit, or filter changes
   useEffect(() => {
     // If the channel is not joined yet, we cannot push the pagination request
     if (!isJoined || !channelRef.current) return
 
-    // Deduplication key to prevent multiple requests for the same page number and limit
-    const key = `${topic}:${limit}:${pageNumber}`
-    // If the last paginate request was for the same page number and limit, do not send
+    // Deduplication key to prevent multiple requests for the same page number, limit, and filter
+    const key = `${topic}:${serializedFilter}:${limit}:${pageNumber}`
+    // If the last paginate request was for the same page number, limit, and filter, do not send
     // another request
     if (lastPaginateRequestRef.current === key) return
 
@@ -244,9 +253,10 @@ export const usePastDetours = ({
       topic,
       limit,
       pageNumber,
+      detoursFilter,
       setDetoursFromData
     )
-  }, [topic, pageNumber, limit, isJoined, setDetoursFromData])
+  }, [topic, pageNumber, limit, serializedFilter, isJoined, setDetoursFromData])
 
   return pastDetours
 }
@@ -406,13 +416,20 @@ const pushPagination = (
   topic: string,
   limit: number,
   pageNumber: number,
+  detoursFilter: DetoursFilter,
   setDetoursCallback: (data: unknown) => void
 ) => {
   const clampedPageNumber = Math.max(1, pageNumber)
   const offset = (clampedPageNumber - 1) * limit
 
+  const payload = {
+    limit,
+    offset,
+    ...serializeDetoursFilter(detoursFilter),
+  }
+
   channel
-    .push("paginate", { limit, offset })
+    .push("paginate", payload)
     .receive("ok", (payload: unknown) => {
       setDetoursCallback(payload)
     })

--- a/assets/src/models/detoursFilter.ts
+++ b/assets/src/models/detoursFilter.ts
@@ -1,0 +1,27 @@
+export interface DetoursFilter {
+  intersection?: string
+  reason?: string
+  updatedAt?: Date[]
+}
+
+export const serializeDetoursFilter = (
+  filter: DetoursFilter
+): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {}
+
+  if (filter.intersection !== undefined && filter.intersection !== "") {
+    payload.intersection = filter.intersection
+  }
+
+  if (filter.reason !== undefined && filter.reason !== "all") {
+    payload.reason = filter.reason
+  }
+
+  if (filter.updatedAt !== undefined && filter.updatedAt.length > 0) {
+    payload.updated_at = filter.updatedAt.map((date) =>
+      date.toISOString().slice(0, 10)
+    )
+  }
+
+  return payload
+}

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -343,4 +343,70 @@ describe("DetourListPage", () => {
       )
     })
   })
+
+  test("passes filter to usePastDetours", async () => {
+    const routes = routeFactory.buildList(2)
+    jest.mocked(usePastDetours).mockReturnValue([])
+
+    render(
+      <RoutesProvider routes={routes}>
+        <DetourListPage />
+      </RoutesProvider>
+    )
+
+    await waitFor(() => {
+      expect(jest.mocked(usePastDetours)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detoursFilter: {},
+        })
+      )
+    })
+  })
+
+  test("resets page number to 1 when filter changes", async () => {
+    const routes = routeFactory.buildList(2)
+
+    jest.mocked(usePastDetours).mockImplementation((args) => {
+      return [
+        simpleDetourFactory.build({
+          id: args.pageNumber,
+          name: `Closed ${args.detoursFilter?.intersection || "all"}`,
+        }),
+      ]
+    })
+
+    render(
+      <RoutesProvider routes={routes}>
+        <DetourListPage />
+      </RoutesProvider>
+    )
+
+    // Navigate to page 2
+    fireEvent.click(screen.getByLabelText("Next"))
+
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("2").closest("li")).toHaveClass(
+        "active"
+      )
+    })
+
+    // Change filter - should reset to page 1
+    fireEvent.change(filterIntersectionInput.get(), {
+      target: { value: "Main St" },
+    })
+
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("1").closest("li")).toHaveClass(
+        "active"
+      )
+      expect(screen.getByLabelText("Previous")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      )
+    })
+  })
 })

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -1,0 +1,254 @@
+import { describe, test, expect, jest } from "@jest/globals"
+import "@testing-library/jest-dom/jest-globals"
+import React from "react"
+import { DetoursTable, DetourStatus } from "../../src/components/detoursTable"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { simpleDetourFactory } from "../factories/detourListFactory"
+import routeFactory from "../factories/route"
+import type { DetoursFilter } from "../../src/models/detoursFilter"
+
+jest.useFakeTimers().setSystemTime(new Date("2024-08-29T20:00:00"))
+
+describe("DetoursTable - Closed status with lifted filter", () => {
+  const routes = routeFactory.buildList(3)
+  const detours = [
+    simpleDetourFactory.build({
+      id: 1,
+      intersection: "Main St & 1st Ave",
+      reason: "Traffic",
+      updatedAt: new Date("2024-08-15").getTime() / 1000,
+    }),
+    simpleDetourFactory.build({
+      id: 2,
+      intersection: "Broadway & 2nd Ave",
+      reason: "Construction",
+      updatedAt: new Date("2024-08-16").getTime() / 1000,
+    }),
+    simpleDetourFactory.build({
+      id: 3,
+      intersection: "Main St & 3rd Ave",
+      reason: "Traffic",
+      updatedAt: new Date("2024-08-17").getTime() / 1000,
+    }),
+  ]
+
+  test("calls setFilter when intersection input changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const intersectionInput = screen.getByLabelText("Starting intersection")
+    fireEvent.change(intersectionInput, { target: { value: "Main St" } })
+
+    expect(setFilter).toHaveBeenCalledWith({ intersection: "Main St" })
+  })
+
+  test("calls setFilter when reason select changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const reasonSelect = screen.getByLabelText("Reason")
+    fireEvent.change(reasonSelect, { target: { value: "Traffic" } })
+
+    expect(setFilter).toHaveBeenCalledWith({ reason: "Traffic" })
+  })
+
+  test("calls setFilter when date picker changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    // DateTimePicker is tested separately, so we just verify the filter row exists.
+    expect(screen.getByText("Last Closed")).toBeInTheDocument()
+  })
+
+  test("calls setFilter with empty object when reset is clicked", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {
+      intersection: "Main St",
+      reason: "Traffic",
+      updatedAt: [new Date("2024-08-15")],
+    }
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const clearButton = screen.getByTitle("Clear Search")
+    fireEvent.click(clearButton)
+
+    expect(setFilter).toHaveBeenCalledWith({})
+  })
+
+  test("displays all detours without client-side filtering for Closed status", () => {
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={jest.fn()}
+      />
+    )
+
+    // All detours should be visible since server-side filtering is assumed
+    expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
+    expect(screen.getByText("Broadway & 2nd Ave")).toBeInTheDocument()
+    expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
+  })
+
+  test("displays filter values from lifted state", () => {
+    const filter: DetoursFilter = {
+      intersection: "Main St",
+      reason: "Traffic",
+    }
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={jest.fn()}
+      />
+    )
+
+    const intersectionInput = screen.getByLabelText(
+      "Starting intersection"
+    ) as HTMLInputElement
+    const reasonSelect = screen.getByLabelText("Reason") as HTMLSelectElement
+
+    expect(intersectionInput.value).toBe("Main St")
+    expect(reasonSelect.value).toBe("Traffic")
+  })
+})
+
+describe("DetoursTable - Active/Draft status with local filtering", () => {
+  const detours = [
+    simpleDetourFactory.build({
+      id: 1,
+      intersection: "Main St & 1st Ave",
+      reason: "Traffic",
+    }),
+    simpleDetourFactory.build({
+      id: 2,
+      intersection: "Broadway & 2nd Ave",
+      reason: "Construction",
+    }),
+    simpleDetourFactory.build({
+      id: 3,
+      intersection: "Main St & 3rd Ave",
+      reason: "Traffic",
+    }),
+  ]
+
+  test("filters detours locally for Active status", async () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Active}
+        title={<h2>Active detours</h2>}
+      />
+    )
+
+    // All detours initially visible
+    expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
+    expect(screen.getByText("Broadway & 2nd Ave")).toBeInTheDocument()
+    expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
+  })
+
+  test("does not show filter inputs for Active status", () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Active}
+        title={<h2>Active detours</h2>}
+      />
+    )
+
+    expect(
+      screen.queryByLabelText("Starting intersection")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+  })
+
+  test("does not show filter inputs for Draft status", () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Draft}
+        title={<h2>Draft detours</h2>}
+      />
+    )
+
+    expect(
+      screen.queryByLabelText("Starting intersection")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Add UI for Pagination ](https://app.asana.com/1/15492006741476/project/1216434230851197/task/1216177346261084?focus=true)

Following up on previous PR: https://github.com/mbta/skate/commit/e2bab55d2f7d2c190a735fbbb7662ec2f302fc1e

Filtering closed detours logic is currently split between the frontend (routeId filtering) and backend (intersection, reason, date); 

This frontend PR sends the (optional) filters to the backend for pagination calls, for closed detours only