### PR TITLE
feat: paginate detours with filters frontend

### DIFF
--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -42,9 +42,8 @@ export const DetourListPage = () => {
   const [detoursPagination, setDetoursPagination] = useState<
     DetoursPagination | undefined
   >()
-  // Set arbitrarily high to see all detours (without pagination) until the next PR
-  // turns on pagination to a reasonable page limit.
-  const currentLimit = 10000
+
+  const currentLimit = 10
 
   // For pagination, reset the page number to 1 when the routeId or filter changes
   useEffect(() => {

--- a/assets/src/components/detourListPage.tsx
+++ b/assets/src/components/detourListPage.tsx
@@ -22,6 +22,7 @@ import {
   usePastDetours,
 } from "../hooks/useDetours"
 import { SocketContext } from "../contexts/socketContext"
+import type { DetoursFilter } from "../models/detoursFilter"
 
 export const DetourListPage = () => {
   const routes = useContext(RoutesContext)
@@ -33,6 +34,7 @@ export const DetourListPage = () => {
 
   const { show: showDetourModal, fromCopy: showFromCopy } = showDetourModalProps
   const [routeId, setRouteId] = useState<string>("all")
+  const [detoursFilter, setDetoursFilter] = useState<DetoursFilter>({})
 
   // Wait for the detour channels to initialize
   const { socket } = useContext(SocketContext)
@@ -44,11 +46,11 @@ export const DetourListPage = () => {
   // turns on pagination to a reasonable page limit.
   const currentLimit = 10000
 
-  // For pagination, reset the page number to 1 when the routeId changes
+  // For pagination, reset the page number to 1 when the routeId or filter changes
   useEffect(() => {
     setPageNumber(1)
     setDetoursPagination(undefined)
-  }, [routeId])
+  }, [routeId, detoursFilter])
 
   const activeDetoursMap = useActiveDetours(socket)
   const draftDetoursMap = useDraftDetours(socket)
@@ -58,6 +60,7 @@ export const DetourListPage = () => {
     limit: currentLimit,
     pageNumber: pageNumber,
     onPaginate: setDetoursPagination,
+    detoursFilter: detoursFilter,
   })
 
   const activeDetours =
@@ -162,6 +165,8 @@ export const DetourListPage = () => {
                 setRouteId={setRouteId}
                 routes={routes}
                 classNames={["u-hide-for-mobile"]}
+                detoursFilter={detoursFilter}
+                setDetoursFilter={setDetoursFilter}
               />
               <PaginationBar
                 pageNumber={pageNumber}

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -51,7 +51,6 @@ const columnCount = (status: DetourStatus) => {
   return count
 }
 
-
 export const timestampLabelFromStatus = (status: DetourStatus) => {
   switch (status) {
     case DetourStatus.Draft:
@@ -80,7 +79,10 @@ export const DetoursTable = ({
   const hasFilters = routes && status === DetourStatus.Closed
 
   const intersectionFilter = detoursFilter.intersection || ""
-  const dates = detoursFilter.updatedAt || new Array<Date>()
+  const dates = useMemo(
+    () => detoursFilter.updatedAt || ([] as Date[]),
+    [detoursFilter.updatedAt]
+  )
   const reason = detoursFilter.reason || "all"
 
   const normalizeAndSetFilter = (nextFilter: DetoursFilter) => {

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useMemo } from "react"
 import { Table, Form, Button } from "react-bootstrap"
 import { XSquare } from "../helpers/bsIcons"
 import { RoutePill } from "./routePill"
@@ -13,6 +13,7 @@ import {
   isUpdatedAfterActivated,
 } from "../util/dateTime"
 import { SimpleDetour } from "../models/detoursList"
+import type { DetoursFilter } from "../models/detoursFilter"
 import { EmptyDetourTableIcon } from "../helpers/skateIcons"
 import { joinClasses } from "../helpers/dom"
 import { Route } from "../schedule"
@@ -30,6 +31,8 @@ interface DetoursTableProps {
   routeId?: string
   setRouteId?: (routeId: string) => void
   classNames?: string[]
+  detoursFilter?: DetoursFilter
+  setDetoursFilter?: (filter: DetoursFilter) => void
 }
 
 export enum DetourStatus {
@@ -47,6 +50,8 @@ const columnCount = (status: DetourStatus) => {
   if (hasReasonColumn(status)) count++ // Reason
   return count
 }
+
+const EMPTY_DATES: Date[] = []
 
 export const timestampLabelFromStatus = (status: DetourStatus) => {
   switch (status) {
@@ -70,38 +75,46 @@ export const DetoursTable = ({
   routeId,
   setRouteId = () => {},
   classNames = [],
+  detoursFilter = {},
+  setDetoursFilter = () => {},
 }: DetoursTableProps) => {
-  const [filter, setFilter] = useState("")
-  const [debouncedFilter, setDebouncedFilter] = useState(filter)
-  const [dates, setDates] = useState<Date[]>([])
-  const [reason, setReason] = useState<string>("all")
   const hasFilters = routes && status === DetourStatus.Closed
 
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedFilter(filter)
-    }, 300)
+  const intersectionFilter = detoursFilter.intersection || ""
+  const dates = detoursFilter.updatedAt || EMPTY_DATES
+  const reason = detoursFilter.reason || "all"
 
-    return () => {
-      clearTimeout(handler)
+  const normalizeAndSetFilter = (nextFilter: DetoursFilter) => {
+    const normalizedFilter: DetoursFilter = {}
+
+    if (nextFilter.intersection && nextFilter.intersection !== "") {
+      normalizedFilter.intersection = nextFilter.intersection
     }
-  }, [filter])
+
+    if (nextFilter.reason && nextFilter.reason !== "all") {
+      normalizedFilter.reason = nextFilter.reason
+    }
+
+    if (nextFilter.updatedAt && nextFilter.updatedAt.length > 0) {
+      normalizedFilter.updatedAt = nextFilter.updatedAt
+    }
+
+    setDetoursFilter(normalizedFilter)
+  }
 
   const resetInputs = () => {
     setRouteId("all")
-    setFilter("")
-    setDates([])
-    setReason("all")
+    setDetoursFilter({})
   }
 
   const filteredData = useMemo(() => {
     let result = data
 
-    if (debouncedFilter !== "") {
+    if (intersectionFilter !== "") {
       result = result.filter((detour) =>
         (detour.intersection || "")
           .toLowerCase()
-          .includes(debouncedFilter.toLowerCase())
+          .includes(intersectionFilter.toLowerCase())
       )
     }
 
@@ -119,7 +132,7 @@ export const DetoursTable = ({
     }
 
     return result
-  }, [data, debouncedFilter, dates, reason])
+  }, [data, intersectionFilter, dates, reason])
 
   return (
     <>
@@ -178,15 +191,25 @@ export const DetoursTable = ({
                     id="intersection-filter"
                     type="text"
                     placeholder="Search..."
-                    value={filter}
+                    value={intersectionFilter}
                     onBlur={() =>
                       fullStoryEvent("Detour Intersection Filter Used", {})
                     }
-                    onChange={(e) => setFilter(e.target.value)}
+                    onChange={(e) =>
+                      normalizeAndSetFilter({
+                        ...detoursFilter,
+                        intersection: e.target.value,
+                      })
+                    }
                   />
                   <div>
-                    {filter.length > 0 && (
-                      <button onClick={() => setFilter("")} title="Clear">
+                    {intersectionFilter.length > 0 && (
+                      <button
+                        onClick={() =>
+                          normalizeAndSetFilter({ ...detoursFilter, intersection: "" })
+                        }
+                        title="Clear"
+                      >
                         <span>
                           <CircleXIcon />
                         </span>
@@ -195,8 +218,10 @@ export const DetoursTable = ({
                     <button
                       type="submit"
                       title="Submit"
-                      onClick={setDebouncedFilter.bind(null, filter)}
-                      disabled={filter.length === 0}
+                      onClick={() =>
+                        normalizeAndSetFilter({ ...detoursFilter, intersection: intersectionFilter })
+                      }
+                      disabled={intersectionFilter.length === 0}
                     >
                       <span>
                         <SearchIcon />
@@ -212,7 +237,7 @@ export const DetoursTable = ({
                   className="select-filter mt-2"
                   value={reason}
                   onChange={(e) => {
-                    setReason(e.target.value)
+                    normalizeAndSetFilter({ ...detoursFilter, reason: e.target.value })
                   }}
                 >
                   <option key="" value="all">
@@ -233,7 +258,8 @@ export const DetoursTable = ({
                     value={dates}
                     options={{
                       maxDate: "today",
-                      onChange: setDates,
+                      onChange: (updatedAt) =>
+                        normalizeAndSetFilter({ ...detoursFilter, updatedAt }),
                       mode: "multiple",
                     }}
                   />

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -81,7 +81,7 @@ export const DetoursTable = ({
   const hasFilters = routes && status === DetourStatus.Closed
 
   const intersectionFilter = detoursFilter.intersection || ""
-  const dates = detoursFilter.updatedAt || EMPTY_DATES
+  const dates = detoursFilter.updatedAt || new Array<Date>()
   const reason = detoursFilter.reason || "all"
 
   const normalizeAndSetFilter = (nextFilter: DetoursFilter) => {

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -110,6 +110,11 @@ export const DetoursTable = ({
   const filteredData = useMemo(() => {
     let result = data
 
+    // Skip front-end filters for closed detours because it happens in the backend
+    if (status != DetourStatus.Closed) {
+      return result
+    }
+
     if (intersectionFilter !== "") {
       result = result.filter((detour) =>
         (detour.intersection || "")
@@ -132,7 +137,7 @@ export const DetoursTable = ({
     }
 
     return result
-  }, [data, intersectionFilter, dates, reason])
+  }, [data, status, intersectionFilter, dates, reason])
 
   return (
     <>

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -206,7 +206,10 @@ export const DetoursTable = ({
                     {intersectionFilter.length > 0 && (
                       <button
                         onClick={() =>
-                          normalizeAndSetFilter({ ...detoursFilter, intersection: "" })
+                          normalizeAndSetFilter({
+                            ...detoursFilter,
+                            intersection: "",
+                          })
                         }
                         title="Clear"
                       >
@@ -219,7 +222,10 @@ export const DetoursTable = ({
                       type="submit"
                       title="Submit"
                       onClick={() =>
-                        normalizeAndSetFilter({ ...detoursFilter, intersection: intersectionFilter })
+                        normalizeAndSetFilter({
+                          ...detoursFilter,
+                          intersection: intersectionFilter,
+                        })
                       }
                       disabled={intersectionFilter.length === 0}
                     >
@@ -237,7 +243,10 @@ export const DetoursTable = ({
                   className="select-filter mt-2"
                   value={reason}
                   onChange={(e) => {
-                    normalizeAndSetFilter({ ...detoursFilter, reason: e.target.value })
+                    normalizeAndSetFilter({
+                      ...detoursFilter,
+                      reason: e.target.value,
+                    })
                   }}
                 >
                   <option key="" value="all">

--- a/assets/src/components/detoursTable.tsx
+++ b/assets/src/components/detoursTable.tsx
@@ -51,7 +51,6 @@ const columnCount = (status: DetourStatus) => {
   return count
 }
 
-const EMPTY_DATES: Date[] = []
 
 export const timestampLabelFromStatus = (status: DetourStatus) => {
   switch (status) {

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -256,7 +256,15 @@ export const usePastDetours = ({
       detoursFilter,
       setDetoursFromData
     )
-  }, [topic, pageNumber, limit, serializedFilter, isJoined, setDetoursFromData])
+  }, [
+    topic,
+    pageNumber,
+    limit,
+    detoursFilter,
+    serializedFilter,
+    isJoined,
+    setDetoursFromData,
+  ])
 
   return pastDetours
 }

--- a/assets/src/hooks/useDetours.ts
+++ b/assets/src/hooks/useDetours.ts
@@ -16,6 +16,10 @@ import { userUuid } from "../util/userUuid"
 import { ByRouteId, RouteId } from "../schedule"
 import { equalByElements } from "../helpers/array"
 import { array, create } from "superstruct"
+import {
+  type DetoursFilter,
+  serializeDetoursFilter,
+} from "../models/detoursFilter"
 
 export interface DetoursMap {
   [key: number]: SimpleDetour
@@ -167,12 +171,14 @@ export const usePastDetours = ({
   limit,
   pageNumber,
   onPaginate,
+  detoursFilter = {},
 }: {
   socket: Socket | undefined
   routeId: string
   limit: number
   pageNumber: number
   onPaginate?: (pagination: DetoursPagination) => void
+  detoursFilter?: DetoursFilter
 }) => {
   const topic = routeId === "all" ? "detours:past" : `detours:past:${routeId}`
   const [pastDetours, setPastDetours] = useState<DetoursMap | undefined>()
@@ -226,14 +232,17 @@ export const usePastDetours = ({
     [onPaginate]
   )
 
-  // Send the pagination request when page number, topic, limit changes
+  // Serialize filter for dedup key
+  const serializedFilter = JSON.stringify(serializeDetoursFilter(detoursFilter))
+
+  // Send the pagination request when page number, topic, limit, or filter changes
   useEffect(() => {
     // If the channel is not joined yet, we cannot push the pagination request
     if (!isJoined || !channelRef.current) return
 
-    // Deduplication key to prevent multiple requests for the same page number and limit
-    const key = `${topic}:${limit}:${pageNumber}`
-    // If the last paginate request was for the same page number and limit, do not send
+    // Deduplication key to prevent multiple requests for the same page number, limit, and filter
+    const key = `${topic}:${serializedFilter}:${limit}:${pageNumber}`
+    // If the last paginate request was for the same page number, limit, and filter, do not send
     // another request
     if (lastPaginateRequestRef.current === key) return
 
@@ -244,9 +253,10 @@ export const usePastDetours = ({
       topic,
       limit,
       pageNumber,
+      detoursFilter,
       setDetoursFromData
     )
-  }, [topic, pageNumber, limit, isJoined, setDetoursFromData])
+  }, [topic, pageNumber, limit, serializedFilter, isJoined, setDetoursFromData])
 
   return pastDetours
 }
@@ -406,13 +416,20 @@ const pushPagination = (
   topic: string,
   limit: number,
   pageNumber: number,
+  detoursFilter: DetoursFilter,
   setDetoursCallback: (data: unknown) => void
 ) => {
   const clampedPageNumber = Math.max(1, pageNumber)
   const offset = (clampedPageNumber - 1) * limit
 
+  const payload = {
+    limit,
+    offset,
+    ...serializeDetoursFilter(detoursFilter),
+  }
+
   channel
-    .push("paginate", { limit, offset })
+    .push("paginate", payload)
     .receive("ok", (payload: unknown) => {
       setDetoursCallback(payload)
     })

--- a/assets/src/models/detoursFilter.ts
+++ b/assets/src/models/detoursFilter.ts
@@ -1,0 +1,27 @@
+export interface DetoursFilter {
+  intersection?: string
+  reason?: string
+  updatedAt?: Date[]
+}
+
+export const serializeDetoursFilter = (
+  filter: DetoursFilter
+): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {}
+
+  if (filter.intersection !== undefined && filter.intersection !== "") {
+    payload.intersection = filter.intersection
+  }
+
+  if (filter.reason !== undefined && filter.reason !== "all") {
+    payload.reason = filter.reason
+  }
+
+  if (filter.updatedAt !== undefined && filter.updatedAt.length > 0) {
+    payload.updated_at = filter.updatedAt.map((date) =>
+      date.toISOString().slice(0, 10)
+    )
+  }
+
+  return payload
+}

--- a/assets/tests/components/detours/detourListPage.test.tsx
+++ b/assets/tests/components/detours/detourListPage.test.tsx
@@ -343,4 +343,70 @@ describe("DetourListPage", () => {
       )
     })
   })
+
+  test("passes filter to usePastDetours", async () => {
+    const routes = routeFactory.buildList(2)
+    jest.mocked(usePastDetours).mockReturnValue([])
+
+    render(
+      <RoutesProvider routes={routes}>
+        <DetourListPage />
+      </RoutesProvider>
+    )
+
+    await waitFor(() => {
+      expect(jest.mocked(usePastDetours)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detoursFilter: {},
+        })
+      )
+    })
+  })
+
+  test("resets page number to 1 when filter changes", async () => {
+    const routes = routeFactory.buildList(2)
+
+    jest.mocked(usePastDetours).mockImplementation((args) => {
+      return [
+        simpleDetourFactory.build({
+          id: args.pageNumber,
+          name: `Closed ${args.detoursFilter?.intersection || "all"}`,
+        }),
+      ]
+    })
+
+    render(
+      <RoutesProvider routes={routes}>
+        <DetourListPage />
+      </RoutesProvider>
+    )
+
+    // Navigate to page 2
+    fireEvent.click(screen.getByLabelText("Next"))
+
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("2").closest("li")).toHaveClass(
+        "active"
+      )
+    })
+
+    // Change filter - should reset to page 1
+    fireEvent.change(filterIntersectionInput.get(), {
+      target: { value: "Main St" },
+    })
+
+    await waitFor(() => {
+      const pagination = screen.getByLabelText("Previous").closest("ul")
+      expect(pagination).not.toBeNull()
+      expect(within(pagination!).getByText("1").closest("li")).toHaveClass(
+        "active"
+      )
+      expect(screen.getByLabelText("Previous")).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      )
+    })
+  })
 })

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -232,7 +232,9 @@ describe("DetoursTable - Active/Draft status with local filtering", () => {
       screen.queryByLabelText("Starting intersection")
     ).not.toBeInTheDocument()
     expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
   })
 
   test("does not show filter inputs for Draft status", () => {
@@ -249,6 +251,8 @@ describe("DetoursTable - Active/Draft status with local filtering", () => {
       screen.queryByLabelText("Starting intersection")
     ).not.toBeInTheDocument()
     expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
   })
 })

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -7,10 +7,30 @@ import { simpleDetourFactory } from "../factories/detourListFactory"
 import routeFactory from "../factories/route"
 import type { DetoursFilter } from "../../src/models/detoursFilter"
 
-jest.useFakeTimers().setSystemTime(new Date("2024-08-29T20:00:00"))
+const GLOBAL_DATE = new Date("2024-08-29T20:00:00")
 
-describe("DetoursTable - Closed status with lifted filter", () => {
+jest.mock("../../src/components/dateTimePicker", () => ({
+  DateTimePicker: ({
+    options,
+  }: {
+    options: { onChange?: (dates: Date[]) => void }
+  }) => (
+    <button
+      aria-label="Mock date picker"
+      onClick={() =>
+        options.onChange?.([GLOBAL_DATE])
+      }
+    >
+      Pick date
+    </button>
+  ),
+}))
+
+jest.useFakeTimers().setSystemTime(GLOBAL_DATE)
+
+describe("DetoursTable - Closed", () => {
   const routes = routeFactory.buildList(3)
+  const expectedDate = GLOBAL_DATE
   const detours = [
     simpleDetourFactory.build({
       id: 1,
@@ -32,10 +52,13 @@ describe("DetoursTable - Closed status with lifted filter", () => {
     }),
   ]
 
-  test("calls setFilter when intersection input changes", async () => {
-    const setFilter = jest.fn()
-    const filter: DetoursFilter = {}
-
+  const renderClosedTable = ({
+    detoursFilter = {},
+    setDetoursFilter = jest.fn(),
+  }: {
+    detoursFilter?: DetoursFilter
+    setDetoursFilter?: jest.Mock
+  } = {}) =>
     render(
       <DetoursTable
         data={detours}
@@ -45,107 +68,65 @@ describe("DetoursTable - Closed status with lifted filter", () => {
         routes={routes}
         routeId="all"
         setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={setFilter}
+        detoursFilter={detoursFilter}
+        setDetoursFilter={setDetoursFilter}
       />
     )
 
-    const intersectionInput = screen.getByLabelText("Starting intersection")
-    fireEvent.change(intersectionInput, { target: { value: "Main St" } })
-
-    expect(setFilter).toHaveBeenCalledWith({ intersection: "Main St" })
-  })
-
-  test("calls setFilter when reason select changes", async () => {
+  test.each([
+    {
+      name: "intersection input changes",
+      detoursFilter: {} as DetoursFilter,
+      interact: () => {
+        const intersectionInput = screen.getByLabelText("Starting intersection")
+        fireEvent.change(intersectionInput, { target: { value: "Main St" } })
+      },
+      expected: { intersection: "Main St" },
+    },
+    {
+      name: "reason select changes",
+      detoursFilter: {} as DetoursFilter,
+      interact: () => {
+        const reasonSelect = screen.getByLabelText("Reason")
+        fireEvent.change(reasonSelect, { target: { value: "Traffic" } })
+      },
+      expected: { reason: "Traffic" },
+    },
+    {
+      name: "date picker changes",
+      detoursFilter: {} as DetoursFilter,
+      interact: () => {
+        fireEvent.click(screen.getByLabelText("Mock date picker"))
+      },
+      expected: { updatedAt: [expectedDate] },
+    },
+    {
+      name: "reset is clicked",
+      detoursFilter: {
+        intersection: "Main St",
+        reason: "Traffic",
+        updatedAt: [new Date("2024-08-15")],
+      },
+      interact: () => {
+        const clearButton = screen.getByTitle("Clear Search")
+        fireEvent.click(clearButton)
+      },
+      expected: {},
+    },
+  ])("calls setFilter when $name", ({ detoursFilter, interact, expected }) => {
     const setFilter = jest.fn()
-    const filter: DetoursFilter = {}
 
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Closed}
-        title={<h2>Closed detours</h2>}
-        routes={routes}
-        routeId="all"
-        setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={setFilter}
-      />
-    )
+    renderClosedTable({ detoursFilter, setDetoursFilter: setFilter })
 
-    const reasonSelect = screen.getByLabelText("Reason")
-    fireEvent.change(reasonSelect, { target: { value: "Traffic" } })
+    interact()
 
-    expect(setFilter).toHaveBeenCalledWith({ reason: "Traffic" })
-  })
-
-  test("calls setFilter when date picker changes", async () => {
-    const setFilter = jest.fn()
-    const filter: DetoursFilter = {}
-
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Closed}
-        title={<h2>Closed detours</h2>}
-        routes={routes}
-        routeId="all"
-        setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={setFilter}
-      />
-    )
-
-    // DateTimePicker is tested separately, so we just verify the filter row exists.
-    expect(screen.getByText("Last Closed")).toBeInTheDocument()
-  })
-
-  test("calls setFilter with empty object when reset is clicked", async () => {
-    const setFilter = jest.fn()
-    const filter: DetoursFilter = {
-      intersection: "Main St",
-      reason: "Traffic",
-      updatedAt: [new Date("2024-08-15")],
-    }
-
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Closed}
-        title={<h2>Closed detours</h2>}
-        routes={routes}
-        routeId="all"
-        setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={setFilter}
-      />
-    )
-
-    const clearButton = screen.getByTitle("Clear Search")
-    fireEvent.click(clearButton)
-
-    expect(setFilter).toHaveBeenCalledWith({})
+    expect(setFilter).toHaveBeenCalledWith(expected)
   })
 
   test("displays all detours without client-side filtering for Closed status", () => {
     const filter: DetoursFilter = {}
 
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Closed}
-        title={<h2>Closed detours</h2>}
-        routes={routes}
-        routeId="all"
-        setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={jest.fn()}
-      />
-    )
+    renderClosedTable({ detoursFilter: filter, setDetoursFilter: jest.fn() })
 
     // All detours should be visible since server-side filtering is assumed
     expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
@@ -153,25 +134,13 @@ describe("DetoursTable - Closed status with lifted filter", () => {
     expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
   })
 
-  test("displays filter values from lifted state", () => {
+  test("displays filter values from filter state", () => {
     const filter: DetoursFilter = {
       intersection: "Main St",
       reason: "Traffic",
     }
 
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Closed}
-        title={<h2>Closed detours</h2>}
-        routes={routes}
-        routeId="all"
-        setRouteId={jest.fn()}
-        detoursFilter={filter}
-        setDetoursFilter={jest.fn()}
-      />
-    )
+    renderClosedTable({ detoursFilter: filter, setDetoursFilter: jest.fn() })
 
     const intersectionInput = screen.getByLabelText<HTMLInputElement>("Starting intersection")!
     const reasonSelect = screen.getByLabelText("Reason") as HTMLSelectElement
@@ -185,63 +154,46 @@ describe("DetoursTable - Active/Draft status with local filtering", () => {
   const detours = [
     simpleDetourFactory.build({
       id: 1,
+      status: "active",
       intersection: "Main St & 1st Ave",
       reason: "Traffic",
     }),
     simpleDetourFactory.build({
       id: 2,
+      status: "active",
       intersection: "Broadway & 2nd Ave",
       reason: "Construction",
     }),
     simpleDetourFactory.build({
       id: 3,
+      status: "active",
       intersection: "Main St & 3rd Ave",
+      reason: "Traffic",
+    }),
+    simpleDetourFactory.build({
+      id: 4,
+      status: "draft",
+      intersection: "Main St & 4th Ave",
       reason: "Traffic",
     }),
   ]
 
-  test("filters detours locally for Active status", async () => {
+  test.each([
+    {
+      status: DetourStatus.Active,
+      title: "Active detours",
+    },
+    {
+      status: DetourStatus.Draft,
+      title: "Draft detours",
+    },
+  ])("does not show filter inputs for $status status", ({ status, title }) => {
     render(
       <DetoursTable
         data={detours}
         onOpenDetour={jest.fn()}
-        status={DetourStatus.Active}
-        title={<h2>Active detours</h2>}
-      />
-    )
-
-    // All detours initially visible
-    expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
-    expect(screen.getByText("Broadway & 2nd Ave")).toBeInTheDocument()
-    expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
-  })
-
-  test("does not show filter inputs for Active status", () => {
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Active}
-        title={<h2>Active detours</h2>}
-      />
-    )
-
-    expect(
-      screen.queryByLabelText("Starting intersection")
-    ).not.toBeInTheDocument()
-    expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: "Clear" })
-    ).not.toBeInTheDocument()
-  })
-
-  test("does not show filter inputs for Draft status", () => {
-    render(
-      <DetoursTable
-        data={detours}
-        onOpenDetour={jest.fn()}
-        status={DetourStatus.Draft}
-        title={<h2>Draft detours</h2>}
+        status={status}
+        title={<h2>{title}</h2>}
       />
     )
 

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -1,0 +1,254 @@
+import { describe, test, expect, jest } from "@jest/globals"
+import "@testing-library/jest-dom/jest-globals"
+import React from "react"
+import { DetoursTable, DetourStatus } from "../../src/components/detoursTable"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { simpleDetourFactory } from "../factories/detourListFactory"
+import routeFactory from "../factories/route"
+import type { DetoursFilter } from "../../src/models/detoursFilter"
+
+jest.useFakeTimers().setSystemTime(new Date("2024-08-29T20:00:00"))
+
+describe("DetoursTable - Closed status with lifted filter", () => {
+  const routes = routeFactory.buildList(3)
+  const detours = [
+    simpleDetourFactory.build({
+      id: 1,
+      intersection: "Main St & 1st Ave",
+      reason: "Traffic",
+      updatedAt: new Date("2024-08-15").getTime() / 1000,
+    }),
+    simpleDetourFactory.build({
+      id: 2,
+      intersection: "Broadway & 2nd Ave",
+      reason: "Construction",
+      updatedAt: new Date("2024-08-16").getTime() / 1000,
+    }),
+    simpleDetourFactory.build({
+      id: 3,
+      intersection: "Main St & 3rd Ave",
+      reason: "Traffic",
+      updatedAt: new Date("2024-08-17").getTime() / 1000,
+    }),
+  ]
+
+  test("calls setFilter when intersection input changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const intersectionInput = screen.getByLabelText("Starting intersection")
+    fireEvent.change(intersectionInput, { target: { value: "Main St" } })
+
+    expect(setFilter).toHaveBeenCalledWith({ intersection: "Main St" })
+  })
+
+  test("calls setFilter when reason select changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const reasonSelect = screen.getByLabelText("Reason")
+    fireEvent.change(reasonSelect, { target: { value: "Traffic" } })
+
+    expect(setFilter).toHaveBeenCalledWith({ reason: "Traffic" })
+  })
+
+  test("calls setFilter when date picker changes", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    // DateTimePicker is tested separately, so we just verify the filter row exists.
+    expect(screen.getByText("Last Closed")).toBeInTheDocument()
+  })
+
+  test("calls setFilter with empty object when reset is clicked", async () => {
+    const setFilter = jest.fn()
+    const filter: DetoursFilter = {
+      intersection: "Main St",
+      reason: "Traffic",
+      updatedAt: [new Date("2024-08-15")],
+    }
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={setFilter}
+      />
+    )
+
+    const clearButton = screen.getByTitle("Clear Search")
+    fireEvent.click(clearButton)
+
+    expect(setFilter).toHaveBeenCalledWith({})
+  })
+
+  test("displays all detours without client-side filtering for Closed status", () => {
+    const filter: DetoursFilter = {}
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={jest.fn()}
+      />
+    )
+
+    // All detours should be visible since server-side filtering is assumed
+    expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
+    expect(screen.getByText("Broadway & 2nd Ave")).toBeInTheDocument()
+    expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
+  })
+
+  test("displays filter values from lifted state", () => {
+    const filter: DetoursFilter = {
+      intersection: "Main St",
+      reason: "Traffic",
+    }
+
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Closed}
+        title={<h2>Closed detours</h2>}
+        routes={routes}
+        routeId="all"
+        setRouteId={jest.fn()}
+        detoursFilter={filter}
+        setDetoursFilter={jest.fn()}
+      />
+    )
+
+    const intersectionInput = screen.getByLabelText(
+      "Starting intersection"
+    ) as HTMLInputElement
+    const reasonSelect = screen.getByLabelText("Reason") as HTMLSelectElement
+
+    expect(intersectionInput.value).toBe("Main St")
+    expect(reasonSelect.value).toBe("Traffic")
+  })
+})
+
+describe("DetoursTable - Active/Draft status with local filtering", () => {
+  const detours = [
+    simpleDetourFactory.build({
+      id: 1,
+      intersection: "Main St & 1st Ave",
+      reason: "Traffic",
+    }),
+    simpleDetourFactory.build({
+      id: 2,
+      intersection: "Broadway & 2nd Ave",
+      reason: "Construction",
+    }),
+    simpleDetourFactory.build({
+      id: 3,
+      intersection: "Main St & 3rd Ave",
+      reason: "Traffic",
+    }),
+  ]
+
+  test("filters detours locally for Active status", async () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Active}
+        title={<h2>Active detours</h2>}
+      />
+    )
+
+    // All detours initially visible
+    expect(screen.getByText("Main St & 1st Ave")).toBeInTheDocument()
+    expect(screen.getByText("Broadway & 2nd Ave")).toBeInTheDocument()
+    expect(screen.getByText("Main St & 3rd Ave")).toBeInTheDocument()
+  })
+
+  test("does not show filter inputs for Active status", () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Active}
+        title={<h2>Active detours</h2>}
+      />
+    )
+
+    expect(
+      screen.queryByLabelText("Starting intersection")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+  })
+
+  test("does not show filter inputs for Draft status", () => {
+    render(
+      <DetoursTable
+        data={detours}
+        onOpenDetour={jest.fn()}
+        status={DetourStatus.Draft}
+        title={<h2>Draft detours</h2>}
+      />
+    )
+
+    expect(
+      screen.queryByLabelText("Starting intersection")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Reason")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument()
+  })
+})

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -17,9 +17,7 @@ jest.mock("../../src/components/dateTimePicker", () => ({
   }) => (
     <button
       aria-label="Mock date picker"
-      onClick={() =>
-        options.onChange?.([GLOBAL_DATE])
-      }
+      onClick={() => options.onChange?.([GLOBAL_DATE])}
     >
       Pick date
     </button>
@@ -142,7 +140,9 @@ describe("DetoursTable - Closed", () => {
 
     renderClosedTable({ detoursFilter: filter, setDetoursFilter: jest.fn() })
 
-    const intersectionInput = screen.getByLabelText<HTMLInputElement>("Starting intersection")!
+    const intersectionInput = screen.getByLabelText<HTMLInputElement>(
+      "Starting intersection"
+    )!
     const reasonSelect = screen.getByLabelText("Reason") as HTMLSelectElement
 
     expect(intersectionInput.value).toBe("Main St")

--- a/assets/tests/components/detoursTable.test.tsx
+++ b/assets/tests/components/detoursTable.test.tsx
@@ -173,9 +173,7 @@ describe("DetoursTable - Closed status with lifted filter", () => {
       />
     )
 
-    const intersectionInput = screen.getByLabelText(
-      "Starting intersection"
-    ) as HTMLInputElement
+    const intersectionInput = screen.getByLabelText<HTMLInputElement>("Starting intersection")!
     const reasonSelect = screen.getByLabelText("Reason") as HTMLSelectElement
 
     expect(intersectionInput.value).toBe("Main St")

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -33,37 +33,43 @@ defmodule Skate.Detours.Detours do
     |> Repo.all()
   end
 
-  def detours_for_route(route_id, status, limit \\ nil, offset \\ nil)
+  def detours_for_route(route_id, status, limit \\ nil, offset \\ nil, filters \\ %{})
 
-  def detours_for_route("all", status, limit, offset) do
+  def detours_for_route("all", status, limit, offset, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def detours_for_route(route_id, status, limit, offset) do
+  def detours_for_route(route_id, status, limit, offset, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
     |> apply_route_id_filter(route_id)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def count_detours_for_route("all", status) do
+  def count_detours_for_route(route_id, status, filters \\ %{})
+
+  def count_detours_for_route("all", status, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 
-  def count_detours_for_route(route_id, status) do
+  def count_detours_for_route(route_id, status, filters) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_status_filter(status)
     |> apply_route_id_filter(route_id)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 
@@ -73,6 +79,33 @@ defmodule Skate.Detours.Detours do
 
   defp apply_route_id_filter(query, route_id) do
     where(query, [detour: d], d.route_id == ^route_id)
+  end
+
+  defp apply_filters(query, filters) when is_map(filters) do
+    query
+    |> apply_intersection_filter(Map.get(filters, :intersection))
+    |> apply_reason_filter(Map.get(filters, :reason))
+    |> apply_updated_at_filter(Map.get(filters, :updated_at))
+  end
+
+  defp apply_filters(query, _), do: query
+
+  defp apply_intersection_filter(query, nil), do: query
+  defp apply_intersection_filter(query, ""), do: query
+
+  defp apply_intersection_filter(query, text) do
+    where(query, [detour: d], ilike(d.nearest_intersection, ^"%#{text}%"))
+  end
+
+  defp apply_reason_filter(query, nil), do: query
+  defp apply_reason_filter(query, ""), do: query
+  defp apply_reason_filter(query, reason), do: where(query, [detour: d], d.reason == ^reason)
+
+  defp apply_updated_at_filter(query, nil), do: query
+  defp apply_updated_at_filter(query, []), do: query
+
+  defp apply_updated_at_filter(query, dates) when is_list(dates) do
+    where(query, [detour: d], fragment("?::date", d.updated_at) in ^dates)
   end
 
   # Fetches a certain range of detours, determined by limit and offset
@@ -92,18 +125,20 @@ defmodule Skate.Detours.Detours do
     |> limit(^limit)
   end
 
-  def detours_for_user(user_id, status, limit \\ nil, offset \\ nil) do
+  def detours_for_user(user_id, status, limit \\ nil, offset \\ nil, filters \\ %{}) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_user_and_status_filter(user_id, status)
+    |> apply_filters(filters)
     |> apply_pagination(limit, offset)
     |> Repo.all()
     |> Enum.map(&db_detour_to_detour/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  def count_detours_for_user(user_id, status) do
+  def count_detours_for_user(user_id, status, filters \\ %{}) do
     Skate.Detours.Db.Detour.Queries.select_detour_list_info()
     |> apply_user_and_status_filter(user_id, status)
+    |> apply_filters(filters)
     |> Repo.aggregate(:count, :id)
   end
 

--- a/lib/skate_web/channels/detours_channel.ex
+++ b/lib/skate_web/channels/detours_channel.ex
@@ -49,11 +49,18 @@ defmodule SkateWeb.DetoursChannel do
 
   # Return a certain range of detours, determined by limit and offset
   @impl SkateWeb.AuthenticatedChannel
-  def handle_in_authenticated("paginate", %{"limit" => limit, "offset" => offset}, socket) do
+  def handle_in_authenticated(
+        "paginate",
+        %{"limit" => limit, "offset" => offset} = payload,
+        socket
+      ) do
     with {:ok, limit} <- parse_integer(limit),
          {:ok, offset} <- parse_integer(offset),
-         :ok <- validate_pagination(limit, offset) do
-      {detours, total_count} = fetch_paginated_detours_and_total_count(socket, limit, offset)
+         :ok <- validate_pagination(limit, offset),
+         {:ok, filters} <- build_filters(payload) do
+      {detours, total_count} =
+        fetch_paginated_detours_and_total_count(socket, limit, offset, filters)
+
       total_pages = calculate_total_pages(total_count, limit)
       requested_page_number = div(offset, limit) + 1
 
@@ -105,20 +112,57 @@ defmodule SkateWeb.DetoursChannel do
     max(1, div(total_count + page_size - 1, page_size))
   end
 
-  defp fetch_paginated_detours_and_total_count(socket, limit, offset) do
+  defp fetch_paginated_detours_and_total_count(socket, limit, offset, filters) do
     case pagination_scope(socket) do
       {:user, user_id, status} ->
-        {Detours.detours_for_user(user_id, status, limit, offset),
-         Detours.count_detours_for_user(user_id, status)}
+        {Detours.detours_for_user(user_id, status, limit, offset, filters),
+         Detours.count_detours_for_user(user_id, status, filters)}
 
       {:route, route_id, status} ->
-        {Detours.detours_for_route(route_id, status, limit, offset),
-         Detours.count_detours_for_route(route_id, status)}
+        {Detours.detours_for_route(route_id, status, limit, offset, filters),
+         Detours.count_detours_for_route(route_id, status, filters)}
 
       :unknown ->
         {[], 0}
     end
   end
+
+  defp build_filters(payload) do
+    with {:ok, intersection} <- parse_optional_string(Map.get(payload, "intersection")),
+         {:ok, reason} <- parse_optional_string(Map.get(payload, "reason")),
+         {:ok, updated_at} <- parse_updated_at_dates(Map.get(payload, "updated_at")) do
+      {:ok, %{intersection: intersection, reason: reason, updated_at: updated_at}}
+    end
+  end
+
+  defp parse_optional_string(nil), do: {:ok, nil}
+  defp parse_optional_string(value) when is_binary(value), do: {:ok, value}
+  defp parse_optional_string(_value), do: :error
+
+  defp parse_updated_at_dates(nil), do: {:ok, nil}
+  defp parse_updated_at_dates([]), do: {:ok, []}
+
+  defp parse_updated_at_dates(values) when is_list(values) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case value do
+        date_string when is_binary(date_string) ->
+          case Date.from_iso8601(date_string) do
+            {:ok, date} -> {:cont, {:ok, [date | acc]}}
+            _ -> {:halt, :error}
+          end
+
+        _ ->
+          {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, dates} -> {:ok, Enum.reverse(dates)}
+      :error -> :error
+    end
+  end
+
+  defp parse_updated_at_dates(_values), do: :error
 
   defp pagination_scope(%{topic: "detours:active"} = socket) do
     {:user, current_user_id(socket), :active}

--- a/test/skate/detours/detours_test.exs
+++ b/test/skate/detours/detours_test.exs
@@ -161,6 +161,90 @@ defmodule Skate.Detours.DetoursTest do
     end
   end
 
+  describe "detour list filtering" do
+    test "filters past detours by route, intersection, reason, and updated_at dates" do
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(101)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Parade")
+      |> deactivated()
+      |> with_id(102)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Broadway & 2nd Ave")
+      |> with_updated_at(~U[2026-08-03 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(103)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-05 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> activated()
+      |> with_id(104)
+      |> with_route(%{name: "66", id: "66"})
+      |> with_nearest_intersection("Main St & 4th Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      filters = %{
+        intersection: "Main",
+        reason: "Construction",
+        updated_at: [~D[2026-08-01], ~D[2026-08-03]]
+      }
+
+      detours = Detours.detours_for_route("66", :past, nil, nil, filters)
+
+      assert Enum.map(detours, & &1.id) == [101]
+      assert Detours.count_detours_for_route("66", :past, filters) == 1
+    end
+
+    test "filters draft detours by user and intersection" do
+      author = insert(:user)
+      other_author = insert(:user)
+
+      :detour
+      |> build(author: author)
+      |> with_id(201)
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 12:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(author: author)
+      |> with_id(202)
+      |> with_nearest_intersection("Broadway & 2nd Ave")
+      |> with_updated_at(~U[2026-08-01 12:01:00Z])
+      |> insert()
+
+      :detour
+      |> build(author: other_author)
+      |> with_id(203)
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-01 12:02:00Z])
+      |> insert()
+
+      filters = %{intersection: "Main"}
+
+      detours = Detours.detours_for_user(author.id, :draft, nil, nil, filters)
+
+      assert Enum.map(detours, & &1.id) == [201]
+      assert Detours.count_detours_for_user(author.id, :draft, filters) == 1
+    end
+  end
+
   describe "calculate_expiration_timestamp" do
     @activated_at ~U[2026-01-05 15:00:00.000000Z]
 

--- a/test/skate_web/channels/detours_channel_test.exs
+++ b/test/skate_web/channels/detours_channel_test.exs
@@ -227,6 +227,70 @@ defmodule SkateWeb.DetoursChannelTest do
     end
 
     @tag :authenticated
+    test "paginates past detours with intersection reason and updated_at filters", %{
+      socket: socket
+    } do
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(1)
+      |> with_nearest_intersection("Main St & 1st Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Construction")
+      |> deactivated()
+      |> with_id(2)
+      |> with_nearest_intersection("Main St & 2nd Ave")
+      |> with_updated_at(~U[2026-08-05 14:00:00Z])
+      |> insert()
+
+      :detour
+      |> build(reason: "Parade")
+      |> deactivated()
+      |> with_id(3)
+      |> with_nearest_intersection("Main St & 3rd Ave")
+      |> with_updated_at(~U[2026-08-01 14:00:00Z])
+      |> insert()
+
+      {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:past")
+
+      ref =
+        Phoenix.ChannelTest.push(socket, "paginate", %{
+          "limit" => "10",
+          "offset" => "0",
+          "intersection" => "Main",
+          "reason" => "Construction",
+          "updated_at" => ["2026-08-01", "2026-08-03"]
+        })
+
+      assert_reply(ref, :ok, %{
+        data: [%Skate.Detours.Detour.Simple{id: 1}],
+        total_count: 1,
+        total_pages: 1,
+        page_number: 1,
+        page_size: 10
+      })
+    end
+
+    @tag :authenticated
+    test "returns invalid_pagination when updated_at date filter is invalid", %{socket: socket} do
+      :detour |> build() |> deactivated() |> with_id(1) |> insert()
+
+      {:ok, _, socket} = subscribe_and_join(socket, DetoursChannel, "detours:past")
+
+      ref =
+        Phoenix.ChannelTest.push(socket, "paginate", %{
+          "limit" => "10",
+          "offset" => "0",
+          "updated_at" => ["not-a-date"]
+        })
+
+      assert_reply(ref, :error, %{reason: :invalid_pagination})
+    end
+
+    @tag :authenticated
     test "paginates active detours with limit 10 and offset 10", %{socket: socket} do
       now = DateTime.utc_now()
 


### PR DESCRIPTION
Asana Ticket: [Closed Detours Table | Add UI for Pagination](https://app.asana.com/1/15492006741476/project/1216434230851197/task/1216177346261084?focus=true)

Following up on previous PR: https://github.com/mbta/skate/commit/e2bab55d2f7d2c190a735fbbb7662ec2f302fc1e
Relevant backend PR: https://github.com/mbta/skate/pull/3251

## Previously:
Filtering closed detours logic was split between the frontend (routeId filtering) and backend (intersection, reason, date)

## The change
This frontend PR sends the (optional) filters to the backend for pagination calls, for closed detours only. Lifting the filters state up to the parent component

## Overall logic flow:
The parent component DetourListPage tracks state
-> pageNumber and detoursFilter (any user interaction will change that state)

then passes that state to the useDetours.ts usePastDetours function
-> usePastDetours subscribes to the filter changes and pageNumber changes and sends the updated filters and page numbers to the socket (pushPagination), and when it gets the reply it refreshes the list of closed Detours. 

Closed detours are the only type of detours that 1. have filters 2. show in paginated view