### PR TITLE
Override default bootstrap color for pagination active state

### DIFF
--- a/assets/css/_nav.scss
+++ b/assets/css/_nav.scss
@@ -1,3 +1,5 @@
+@import "nav/pagination";
+
 .l-nav--wide {
   display: grid;
   gap: 0;

--- a/assets/css/nav/_pagination.scss
+++ b/assets/css/nav/_pagination.scss
@@ -1,0 +1,4 @@
+.pagination-primary {
+  --bs-pagination-active-bg: var(--bs-primary);
+  --bs-pagination-active-border-color: var(--bs-primary);
+}

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -19,9 +19,13 @@ export const PaginationBar = ({
   onNext,
   onSelectPage,
 }: PaginationBarProps) => {
+  const paginationStyle = {
+    "--bs-pagination-active-bg": "var(--bs-link-color)",
+    "--bs-pagination-active-border-color": "var(--bs-link-color);",
+  } as React.CSSProperties
   return (
     <div className="d-flex justify-content-end mb-4">
-      <Pagination className="mb-0">
+      <Pagination className="mb-0" style={paginationStyle}>
         <Pagination.Prev
           disabled={pageNumber <= 1}
           aria-disabled={pageNumber <= 1}

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -12,11 +12,6 @@ interface PaginationBarProps {
   style?: React.CSSProperties
 }
 
-const DEFAULT_PAGINATION_STYLE: React.CSSProperties & Record<string, string> = {
-  "--bs-pagination-active-bg": "var(--bs-primary)",
-  "--bs-pagination-active-border-color": "var(--bs-primary)",
-}
-
 export const PaginationBar = ({
   pageNumber,
   pageItems,
@@ -24,12 +19,10 @@ export const PaginationBar = ({
   onPrevious,
   onNext,
   onSelectPage,
-  style,
 }: PaginationBarProps) => {
-  const paginationStyle = { ...(style ?? DEFAULT_PAGINATION_STYLE) }
   return (
     <div className="d-flex justify-content-end mb-4">
-      <Pagination className="mb-0" style={paginationStyle}>
+      <Pagination className="mb-0 pagination-primary">
         <Pagination.Prev
           disabled={pageNumber <= 1}
           aria-disabled={pageNumber <= 1}

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -12,10 +12,10 @@ interface PaginationBarProps {
   style?: React.CSSProperties
 }
 
-const DEFAULT_PAGINATION_STYLE = {
-    "--bs-pagination-active-bg": "var(--bs-primary)",
-    "--bs-pagination-active-border-color": "var(--bs-primary);",
-} as React.CSSProperties
+const DEFAULT_PAGINATION_STYLE: React.CSSProperties & Record<string, string> = {
+  "--bs-pagination-active-bg": "var(--bs-primary)",
+  "--bs-pagination-active-border-color": "var(--bs-primary)",
+}
 
 export const PaginationBar = ({
   pageNumber,

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -20,8 +20,8 @@ export const PaginationBar = ({
   onSelectPage,
 }: PaginationBarProps) => {
   const paginationStyle = {
-    "--bs-pagination-active-bg": "var(--bs-link-color)",
-    "--bs-pagination-active-border-color": "var(--bs-link-color);",
+    "--bs-pagination-active-bg": "var(--bs-primary)",
+    "--bs-pagination-active-border-color": "var(--bs-primary);",
   } as React.CSSProperties
   return (
     <div className="d-flex justify-content-end mb-4">

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -9,7 +9,6 @@ interface PaginationBarProps {
   onPrevious: () => void
   onNext: () => void
   onSelectPage: (page: number) => void
-  style?: React.CSSProperties
 }
 
 export const PaginationBar = ({

--- a/assets/src/components/nav/paginationBar.tsx
+++ b/assets/src/components/nav/paginationBar.tsx
@@ -9,7 +9,13 @@ interface PaginationBarProps {
   onPrevious: () => void
   onNext: () => void
   onSelectPage: (page: number) => void
+  style?: React.CSSProperties
 }
+
+const DEFAULT_PAGINATION_STYLE = {
+    "--bs-pagination-active-bg": "var(--bs-primary)",
+    "--bs-pagination-active-border-color": "var(--bs-primary);",
+} as React.CSSProperties
 
 export const PaginationBar = ({
   pageNumber,
@@ -18,11 +24,9 @@ export const PaginationBar = ({
   onPrevious,
   onNext,
   onSelectPage,
+  style,
 }: PaginationBarProps) => {
-  const paginationStyle = {
-    "--bs-pagination-active-bg": "var(--bs-primary)",
-    "--bs-pagination-active-border-color": "var(--bs-primary);",
-  } as React.CSSProperties
+  const paginationStyle = { ...(style ?? DEFAULT_PAGINATION_STYLE) }
   return (
     <div className="d-flex justify-content-end mb-4">
       <Pagination className="mb-0" style={paginationStyle}>

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -876,6 +876,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
       >
         <ul
           class="mb-0 pagination"
+          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
         >
           <li
             class="page-item disabled"

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -875,8 +875,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
         class="d-flex justify-content-end mb-4"
       >
         <ul
-          class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
+          class="mb-0 pagination-primary pagination"
         >
           <li
             class="page-item disabled"

--- a/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detourListPage.test.tsx.snap
@@ -876,7 +876,7 @@ exports[`DetourListPage renders detour list page for dispatchers 1`] = `
       >
         <ul
           class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
+          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
         >
           <li
             class="page-item disabled"

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -650,7 +650,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
       >
         <ul
           class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
+          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
         >
           <li
             class="page-item disabled"
@@ -2606,7 +2606,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
       >
         <ul
           class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
+          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
         >
           <li
             class="page-item disabled"

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -649,8 +649,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
         class="d-flex justify-content-end mb-4"
       >
         <ul
-          class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
+          class="mb-0 pagination-primary pagination"
         >
           <li
             class="page-item disabled"
@@ -2605,8 +2604,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
         class="d-flex justify-content-end mb-4"
       >
         <ul
-          class="mb-0 pagination"
-          style="--bs-pagination-active-bg: var(--bs-primary); --bs-pagination-active-border-color: var(--bs-primary);;"
+          class="mb-0 pagination-primary pagination"
         >
           <li
             class="page-item disabled"

--- a/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
+++ b/assets/tests/components/detours/__snapshots__/detoursListPage.openDetour.test.tsx.snap
@@ -650,6 +650,7 @@ exports[`Detours Page: Open a Detour renders detour details in an open drawer on
       >
         <ul
           class="mb-0 pagination"
+          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
         >
           <li
             class="page-item disabled"
@@ -2605,6 +2606,7 @@ exports[`Detours Page: Open a Detour renders detour details modal to match mocke
       >
         <ul
           class="mb-0 pagination"
+          style="--bs-pagination-active-bg: var(--bs-link-color); --bs-pagination-active-border-color: var(--bs-link-color);;"
         >
           <li
             class="page-item disabled"


### PR DESCRIPTION
Asana Ticket: [QA Review: Pagination](https://app.asana.com/1/15492006741476/project/1148853526253420/task/1217493599510090?focus=true)

Later discussed with Brian: The purple for Detours button should match as well and both should be var(--Eggplant-500, #6D39AC);
