### PR TITLE
Fix: duplicate swiftly update

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -269,7 +269,6 @@ defmodule Skate.Detours.Detours do
     broadcast_detour(new_record, author_id)
     process_notifications(changeset, new_record)
     trigger_active_detour_s3_export_job(changeset, new_record)
-    update_swiftly(changeset, new_record)
   end
 
   @spec delete_draft_detour(Detour.t(), DbUser.id()) :: :ok


### PR DESCRIPTION
I noticed this while developing in another branch. It must have been an automatic merge conflict resolution.

`handle_detour_updated` no longer should send swiftly updates, because the `update_swiftly` has been moved to before the database insert so that the `swiftly_id` could be added there.

With it still in this side-effect helper, it sends again, and the ID would become out of sync.