### PR TITLE
fix: Prevent unremovable detour

### DIFF
--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -194,61 +194,60 @@ defmodule Skate.Detours.Db.Detour do
     end
   end
 
-  defp put_change_from_state(changeset, field, path) do
-    case {fetch_field(changeset, field), fetch_change(changeset, :state)} do
-      {{:data, table_value}, {:ok, state}} ->
-        context_value = get_in(state, path)
+  @state_fields %{
+    state_value: ["value"],
+    snapshot_children: ["children"],
+    undo_stack: ["context", "undoStack"],
+    estimated_duration: ["context", "selectedDuration"],
+    route_patterns: ["context", "routePatterns"],
+    garages: ["context", "route", "garages"],
+    reason: ["context", "selectedReason"],
+    direction_names: ["context", "route", "directionNames"],
+    edited_directions: ["context", "editedDirections"],
+    detour_shape: ["context", "detourShape"],
+    route_name: ["context", "route", "name"],
+    route_pattern_id: ["context", "routePattern", "id"],
+    route_pattern_name: ["context", "routePattern", "name"],
+    headsign: ["context", "routePattern", "headsign"],
+    is_text_only: ["context", "isTextOnly"],
+    route_id: ["context", "route", "id"]
+  }
 
-        if table_value != context_value and not is_nil(context_value) do
-          put_change(changeset, field, context_value)
-        else
-          changeset
-        end
+  @nullable_state_fields %{
+    nearest_intersection: ["context", "nearestIntersection"],
+    route_segments: ["context", "finishedDetour", "routeSegments"],
+    connection_points: ["context", "finishedDetour", "connectionPoint"],
+    missed_stops: ["context", "finishedDetour", "missedStops"],
+    start_point: ["context", "startPoint"],
+    end_point: ["context", "endPoint"],
+    waypoints: ["context", "waypoints"],
+    typed_detour: ["context", "typedDetour"],
+    coordinates: ["context", "detourShape", "ok", "coordinates"]
+  }
 
-      _ ->
-        changeset
+  defp put_change_from_state(changeset, field, path, allow_nil?) do
+    with {:data, table_value} <- fetch_field(changeset, field),
+         {:ok, state} <- fetch_change(changeset, :state),
+         context_value <- get_in(state, path),
+         true <- table_value != context_value,
+         true <- allow_nil? or not is_nil(context_value) do
+      put_change(changeset, field, context_value)
+    else
+      _ -> changeset
     end
+  end
+
+  defp put_changes_from_state(changeset, fields, allow_nil?) do
+    Enum.reduce(fields, changeset, fn {field, path}, acc ->
+      put_change_from_state(acc, field, path, allow_nil?)
+    end)
   end
 
   defp populate_fields_from_state(changeset) do
     changeset
-    |> put_change_from_state(:state_value, ["value"])
-    |> put_change_from_state(:snapshot_children, ["children"])
-    |> put_change_from_state(:undo_stack, ["context", "undoStack"])
-    |> put_change_from_state(:estimated_duration, ["context", "selectedDuration"])
-    |> put_change_from_state(:reason, ["context", "selectedReason"])
-    |> put_change_from_state(:nearest_intersection, ["context", "nearestIntersection"])
-    |> put_change_from_state(:route_patterns, ["context", "routePatterns"])
-    |> put_change_from_state(:garages, ["context", "route", "garages"])
-    |> put_change_from_state(:direction_names, ["context", "route", "directionNames"])
-    |> put_change_from_state(:edited_directions, ["context", "editedDirections"])
-    |> put_change_from_state(:detour_shape, ["context", "detourShape"])
-    |> put_change_from_state(:route_segments, ["context", "finishedDetour", "routeSegments"])
-    |> put_change_from_state(:connection_points, ["context", "finishedDetour", "connectionPoint"])
-    |> put_change_from_state(:missed_stops, ["context", "finishedDetour", "missedStops"])
-    |> put_change_from_state(:start_point, ["context", "startPoint"])
-    |> put_change_from_state(:end_point, ["context", "endPoint"])
-    |> put_change_from_state(:waypoints, ["context", "waypoints"])
-    |> put_change_from_state(:route_id, ["context", "route", "id"])
-    |> put_change_from_state(:route_name, ["context", "route", "name"])
-    |> put_change_from_state(:route_pattern_id, ["context", "routePattern", "id"])
-    |> put_change_from_state(:route_pattern_name, ["context", "routePattern", "name"])
-    |> put_change_from_state(:headsign, ["context", "routePattern", "headsign"])
-    |> put_change_from_state(:is_text_only, ["context", "isTextOnly"])
-    |> put_change_from_state(:typed_detour, ["context", "typedDetour"])
-    |> populate_coordinates_from_state()
+    |> put_changes_from_state(@state_fields, false)
+    |> put_changes_from_state(@nullable_state_fields, true)
     |> populate_direction_from_state()
-  end
-
-  defp populate_coordinates_from_state(changeset) do
-    case {fetch_field(changeset, :coordinates), fetch_change(changeset, :state)} do
-      {{:data, _},
-       {:ok, %{"context" => %{"detourShape" => %{"ok" => %{"coordinates" => coordinates}}}}}} ->
-        put_change(changeset, :coordinates, coordinates)
-
-      _ ->
-        changeset
-    end
   end
 
   defp populate_direction_from_state(changeset) do

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -46,8 +46,7 @@ defmodule Skate.Detours.Db.Detour do
     field :route_pattern_name, :string
     field :headsign, :string
     field :direction, :string
-    field :direction_id, :integer, virtual: true
-    field :route_pattern, :map, virtual: true
+    field :direction_id, :integer
 
     # Detour shape properties
     field :nearest_intersection, :string
@@ -203,6 +202,7 @@ defmodule Skate.Detours.Db.Detour do
     garages: ["context", "route", "garages"],
     reason: ["context", "selectedReason"],
     direction_names: ["context", "route", "directionNames"],
+    direction_id: ["context", "routePattern", "directionId"],
     edited_directions: ["context", "editedDirections"],
     detour_shape: ["context", "detourShape"],
     route_name: ["context", "route", "name"],
@@ -266,29 +266,6 @@ defmodule Skate.Detours.Db.Detour do
         changeset
     end
   end
-
-  def with_virtual_fields(detour) do
-    detour
-    |> put_route_pattern()
-    |> put_direction_id()
-  end
-
-  defp put_route_pattern(%{route_patterns: route_patterns, route_pattern_id: id} = detour)
-       when is_list(route_patterns) do
-    route_pattern =
-      Enum.find(route_patterns, &(&1["id"] == id))
-
-    %{detour | route_pattern: route_pattern}
-  end
-
-  defp put_route_pattern(detour), do: detour
-
-  defp put_direction_id(%{route_pattern: route_pattern} = detour) when is_map(route_pattern) do
-    direction_id = route_pattern["directionId"]
-    %{detour | direction_id: direction_id}
-  end
-
-  defp put_direction_id(detour), do: detour
 
   defmodule Queries do
     @moduledoc """

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -143,11 +143,11 @@ defmodule Skate.Detours.Db.Detour do
   end
 
   defp add_status(changeset) do
-    case {fetch_field(changeset, :status), fetch_change(changeset, :state_value)} do
-      {{:data, :active}, {:ok, %{"Detour Drawing" => "Past"}}} ->
+    case {fetch_field(changeset, :status), fetch_change(changeset, :state)} do
+      {{:data, :active}, {:ok, %{"value" => %{"Detour Drawing" => "Past"}}}} ->
         put_change(changeset, :status, :past)
 
-      {{:data, :draft}, {:ok, %{"Detour Drawing" => %{"Active" => _}}}} ->
+      {{:data, :draft}, {:ok, %{"value" => %{"Detour Drawing" => %{"Active" => _}}}}} ->
         put_change(changeset, :status, :active)
 
       {{:data, nil}, {:ok, _state}} ->
@@ -224,7 +224,7 @@ defmodule Skate.Detours.Db.Detour do
     |> put_change_from_state(:edited_directions, ["context", "editedDirections"])
     |> put_change_from_state(:detour_shape, ["context", "detourShape"])
     |> put_change_from_state(:route_segments, ["context", "finishedDetour", "routeSegments"])
-    |> put_change_from_state(:connection_points, ["context", "finishedDetour", "connectionPoints"])
+    |> put_change_from_state(:connection_points, ["context", "finishedDetour", "connectionPoint"])
     |> put_change_from_state(:missed_stops, ["context", "finishedDetour", "missedStops"])
     |> put_change_from_state(:start_point, ["context", "startPoint"])
     |> put_change_from_state(:end_point, ["context", "endPoint"])

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -98,7 +98,7 @@ defmodule Skate.Detours.Db.Detour do
       |> Map.merge(%{
         status: :draft,
         state: copy_to_draft_state(source.state),
-        state_value: %{SaveState: "Saved", "Detour Drawing": "Share Detour"}
+        state_value: %{"SaveState" => "Saved", "Detour Drawing" => "Share Detour"}
       })
 
     change(new_detour, copied_fields)
@@ -143,11 +143,11 @@ defmodule Skate.Detours.Db.Detour do
   end
 
   defp add_status(changeset) do
-    case {fetch_field(changeset, :status), fetch_change(changeset, :state)} do
-      {{:data, :active}, {:ok, %{"value" => %{"Detour Drawing" => "Past"}}}} ->
+    case {fetch_field(changeset, :status), fetch_change(changeset, :state_value)} do
+      {{:data, :active}, {:ok, %{"Detour Drawing" => "Past"}}} ->
         put_change(changeset, :status, :past)
 
-      {{:data, :draft}, {:ok, %{"value" => %{"Detour Drawing" => %{"Active" => _}}}}} ->
+      {{:data, :draft}, {:ok, %{"Detour Drawing" => %{"Active" => _}}}} ->
         put_change(changeset, :status, :active)
 
       {{:data, nil}, {:ok, _state}} ->
@@ -281,10 +281,14 @@ defmodule Skate.Detours.Db.Detour do
     %{detour | route_pattern: route_pattern}
   end
 
+  defp put_route_pattern(detour), do: detour
+
   defp put_direction_id(%{route_pattern: route_pattern} = detour) do
     direction_id = route_pattern["directionId"]
     %{detour | direction_id: direction_id}
   end
+
+  defp put_direction_id(detour), do: detour
 
   defmodule Queries do
     @moduledoc """

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -212,9 +212,20 @@ defmodule Skate.Detours.Db.Detour do
 
   defp populate_fields_from_state(changeset) do
     changeset
+    |> put_change_from_state(:state_value, ["value"])
+    |> put_change_from_state(:snapshot_children, ["children"])
+    |> put_change_from_state(:undo_stack, ["context", "undoStack"])
     |> put_change_from_state(:estimated_duration, ["context", "selectedDuration"])
     |> put_change_from_state(:reason, ["context", "selectedReason"])
     |> put_change_from_state(:nearest_intersection, ["context", "nearestIntersection"])
+    |> put_change_from_state(:route_patterns, ["context", "routePatterns"])
+    |> put_change_from_state(:garages, ["context", "route", "garages"])
+    |> put_change_from_state(:direction_names, ["context", "route", "directionNames"])
+    |> put_change_from_state(:edited_directions, ["context", "editedDirections"])
+    |> put_change_from_state(:detour_shape, ["context", "detourShape"])
+    |> put_change_from_state(:route_segments, ["context", "finishedDetour", "routeSegments"])
+    |> put_change_from_state(:connection_points, ["context", "finishedDetour", "connectionPoints"])
+    |> put_change_from_state(:missed_stops, ["context", "finishedDetour", "missedStops"])
     |> put_change_from_state(:start_point, ["context", "startPoint"])
     |> put_change_from_state(:end_point, ["context", "endPoint"])
     |> put_change_from_state(:waypoints, ["context", "waypoints"])

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -273,7 +273,8 @@ defmodule Skate.Detours.Db.Detour do
     |> put_direction_id()
   end
 
-  defp put_route_pattern(%{route_patterns: route_patterns, route_pattern_id: id} = detour) do
+  defp put_route_pattern(%{route_patterns: route_patterns, route_pattern_id: id} = detour)
+       when is_list(route_patterns) do
     route_pattern =
       Enum.find(route_patterns, &(&1["id"] == id))
 
@@ -282,7 +283,7 @@ defmodule Skate.Detours.Db.Detour do
 
   defp put_route_pattern(detour), do: detour
 
-  defp put_direction_id(%{route_pattern: route_pattern} = detour) do
+  defp put_direction_id(%{route_pattern: route_pattern} = detour) when is_map(route_pattern) do
     direction_id = route_pattern["directionId"]
     %{detour | direction_id: direction_id}
   end

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -12,26 +12,24 @@ defmodule Skate.Detours.Db.Detour do
   @type status :: :active | :draft | :past
 
   typed_schema "detours" do
-    field :state, :map
-
-    field(:status, Ecto.Enum, values: [:draft, :active, :past]) :: status()
-
     belongs_to :author, User
-
     belongs_to :copied_from, __MODULE__, foreign_key: :copied_from_id
 
-    # When this detour was activated
+    # State properties
+    field :state, :map
+    field(:status, Ecto.Enum, values: [:draft, :active, :past]) :: status()
     field :activated_at, :utc_datetime_usec
-
     timestamps()
+    field :is_text_only, :boolean, default: false
+    field :undo_stack, {:array, :map}
+    field :snapshot_children, :map
+    field :state_value, :map
 
-    # -------------------------------------------------------
-    # Activated properties
+    # Activation properties
     field :estimated_duration, :string
     field :reason, :string
     field :swiftly_id, :string
 
-    # -------------------------------------------------------
     # Map point properties
     field :start_point, :map
     field :end_point, :map
@@ -41,15 +39,22 @@ defmodule Skate.Detours.Db.Detour do
     # Route properties
     field :route_id, :string
     field :route_name, :string
+    field :garages, {:array, :string}
+    field :direction_names, :map
+    field :route_patterns, {:array, :map}
     field :route_pattern_id, :string
     field :route_pattern_name, :string
     field :headsign, :string
     field :direction, :string
-    field :is_text_only, :boolean, default: false
-    field :typed_detour, :map
 
-    # Default detour properties
+    # Detour shape properties
     field :nearest_intersection, :string
+    field :missed_stops, {:array, :map}
+    field :connection_points, :map
+    field :route_segments, :map
+    field :typed_detour, :map
+    field :detour_shape, :map
+    field :edited_directions, :string
 
     has_many :detour_status_notifications, Notifications.Db.Detour
     has_many :detour_expiration_notifications, Notifications.Db.DetourExpiration
@@ -295,8 +300,8 @@ defmodule Skate.Detours.Db.Detour do
         estimated_duration: d.estimated_duration,
         reason: d.reason,
         nearest_intersection: d.nearest_intersection,
-        route_id: d.route_id,
-        route_name: d.route_name,
+        route_id: fragment("?->>?", d.route, "id"),
+        route_name: fragment("?->>?", d.route, "name"),
         route_pattern_id: d.route_pattern_id,
         route_pattern_name: d.route_pattern_name,
         headsign: d.headsign,

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -75,6 +75,8 @@ defmodule Skate.Detours.Db.Detour do
 
   # TODO use db fields
   def update_copied_detour_state_changeset(detour) do
+    dbg(detour)
+
     new_state =
       detour.state
       |> Map.put(
@@ -230,6 +232,24 @@ defmodule Skate.Detours.Db.Detour do
     end
   end
 
+  def with_virtual_fields(detour) do
+    detour
+    |> put_route_pattern()
+    |> put_direction_id()
+  end
+
+  defp put_route_pattern(%{route_patterns: route_patterns, route_pattern_id: id} = detour) do
+    route_pattern =
+      Enum.find(route_patterns, &(&1["id"] == id))
+
+    %{detour | route_pattern: route_pattern}
+  end
+
+  defp put_direction_id(%{route_pattern: route_pattern} = detour) do
+    direction_id = route_pattern["directionId"]
+    %{detour | direction_id: direction_id}
+  end
+
   defmodule Queries do
     @moduledoc """
     Defines composable queries for retrieving `Skate.Detours.Db.Detour`
@@ -289,25 +309,6 @@ defmodule Skate.Detours.Db.Detour do
       from([detour: d] in query,
         join: a in assoc(d, :author)
       )
-    end
-
-    def with_virtual_fields(query \\ base()) do
-      query
-      |> select_route_pattern()
-      |> select_direction_id()
-    end
-
-    defp select_route_pattern(query \\ base()) do
-      select_merge(query, [detour: d], %{
-        :route_pattern =>
-          Enum.find(d.route_patterns, fn routePattern -> routePattern.id == d.route_pattern_id end)
-      })
-    end
-
-    defp select_direction_id(query \\ base()) do
-      select_merge(query, [detour: d], %{
-        :direction_id => get_in(d.route_pattern, ["directionId"])
-      })
     end
 
     def select_detour_list_info(query \\ from(Skate.Detours.Db.Detour, as: :detour)) do

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -73,26 +73,51 @@ defmodule Skate.Detours.Db.Detour do
     |> foreign_key_constraint(:author_id)
   end
 
-  # TODO use db fields
-  def update_copied_detour_state_changeset(detour) do
-    dbg(detour)
-
-    new_state =
-      detour.state
-      |> Map.put(
-        "context",
-        detour.state["context"]
-        |> Map.merge(%{"uuid" => detour.id, "status" => "draft"})
-        |> Map.drop(["selectedReason", "selectedDuration", "activatedAt"])
-      )
-      |> Map.put("value", %{
-        SaveState: "Saved",
-        "Detour Drawing": "Share Detour"
+  def copy_to_draft_changeset(new_detour, source) do
+    copied_fields =
+      source
+      |> Map.from_struct()
+      |> Map.drop([
+        # clear detour specific properties
+        :__meta__,
+        :id,
+        :inserted_at,
+        :updated_at,
+        :copied_from,
+        :copied_from_id,
+        :author,
+        :author_id,
+        :detour_status_notifications,
+        :detour_expiration_notifications,
+        # "deactivate" detour
+        :activated_at,
+        :estimated_duration,
+        :reason,
+        :swiftly_id
+      ])
+      |> Map.merge(%{
+        status: :draft,
+        state: copy_to_draft_state(source.state),
+        state_value: %{SaveState: "Saved", "Detour Drawing": "Share Detour"}
       })
 
-    detour
-    |> change(%{activated_at: nil, estimated_duration: nil, reason: nil, swiftly_id: nil})
-    |> change(%{state: new_state})
+    change(new_detour, copied_fields)
+  end
+
+  defp copy_to_draft_state(state) do
+    state
+    |> Map.put(
+      "context",
+      state["context"]
+      |> Map.merge(%{"status" => "draft"})
+      |> Map.drop(["selectedReason", "selectedDuration", "activatedAt"])
+    )
+    |> Map.put("value", %{SaveState: "Saved", "Detour Drawing": "Share Detour"})
+  end
+
+  def set_state_uuid_changeset(detour) do
+    new_state = put_in(detour.state, ["context", "uuid"], detour.id)
+    change(detour, %{state: new_state})
   end
 
   # Add or update swiftly_id

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -111,7 +111,7 @@ defmodule Skate.Detours.Db.Detour do
       |> Map.merge(%{"status" => "draft"})
       |> Map.drop(["selectedReason", "selectedDuration", "activatedAt"])
     )
-    |> Map.put("value", %{SaveState: "Saved", "Detour Drawing": "Share Detour"})
+    |> Map.put("value", %{"SaveState" => "Saved", "Detour Drawing" => "Share Detour"})
   end
 
   def set_state_uuid_changeset(detour) do

--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -46,6 +46,8 @@ defmodule Skate.Detours.Db.Detour do
     field :route_pattern_name, :string
     field :headsign, :string
     field :direction, :string
+    field :direction_id, :integer, virtual: true
+    field :route_pattern, :map, virtual: true
 
     # Detour shape properties
     field :nearest_intersection, :string
@@ -71,6 +73,7 @@ defmodule Skate.Detours.Db.Detour do
     |> foreign_key_constraint(:author_id)
   end
 
+  # TODO use db fields
   def update_copied_detour_state_changeset(detour) do
     new_state =
       detour.state
@@ -288,6 +291,25 @@ defmodule Skate.Detours.Db.Detour do
       )
     end
 
+    def with_virtual_fields(query \\ base()) do
+      query
+      |> select_route_pattern()
+      |> select_direction_id()
+    end
+
+    defp select_route_pattern(query \\ base()) do
+      select_merge(query, [detour: d], %{
+        :route_pattern =>
+          Enum.find(d.route_patterns, fn routePattern -> routePattern.id == d.route_pattern_id end)
+      })
+    end
+
+    defp select_direction_id(query \\ base()) do
+      select_merge(query, [detour: d], %{
+        :direction_id => get_in(d.route_pattern, ["directionId"])
+      })
+    end
+
     def select_detour_list_info(query \\ from(Skate.Detours.Db.Detour, as: :detour)) do
       query
       |> with_author()
@@ -300,8 +322,8 @@ defmodule Skate.Detours.Db.Detour do
         estimated_duration: d.estimated_duration,
         reason: d.reason,
         nearest_intersection: d.nearest_intersection,
-        route_id: fragment("?->>?", d.route, "id"),
-        route_name: fragment("?->>?", d.route, "name"),
+        route_id: d.route_id,
+        route_name: d.route_name,
         route_pattern_id: d.route_pattern_id,
         route_pattern_name: d.route_pattern_name,
         headsign: d.headsign,

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -88,8 +88,7 @@ defmodule Skate.Detours.Detour do
            reason: reason,
            status: status,
            is_text_only: is_text_only
-         })
-         when not is_nil(headsign) and not is_nil(direction) and not is_nil(route_name) do
+         }) do
       %__MODULE__{
         id: id,
         route: route_name,
@@ -126,6 +125,7 @@ defmodule Skate.Detours.Detour do
            } = db_detour
          ) do
       direction = Map.get(direction_names, Integer.to_string(direction_id))
+      Logger.warning("detour_missing_info using_context id=#{db_detour.id}")
 
       %__MODULE__{
         id: id,
@@ -229,18 +229,17 @@ defmodule Skate.Detours.Detour do
     def from!(%Detour{is_text_only: true} = detour) do
       %{
         base_report(detour)
-        | missed_stops_text_only: get_in(detour.state, ["context", "typedDetour", "missedStops"]),
-          connection_points_text_only:
-            get_in(detour.state, ["context", "typedDetour", "connectionPoints"])
+        | missed_stops_text_only: get_in(detour, ["typedDetour", "missedStops"]),
+          connection_points_text_only: get_in(detour, ["typedDetour", "connectionPoints"])
       }
     end
 
     def from!(%Detour{is_text_only: false} = detour) do
       %{
         base_report(detour)
-        | missed_stops: missed_stops!(detour),
-          connection_points: connection_points!(detour),
-          route_segments: route_segments(detour)
+        | missed_stops: detour.missed_stops,
+          connection_points: detour.connection_points,
+          route_segments: detour.route_segments
       }
     end
 
@@ -248,7 +247,7 @@ defmodule Skate.Detours.Detour do
       %__MODULE__{
         id: detour.id,
         route_id: detour.route_id,
-        direction_id: get_in(detour.state, ["context", "routePattern", "directionId"]),
+        direction_id: detour.direction_id,
         reason: detour.reason,
         nearest_intersection: detour.nearest_intersection,
         estimated_duration: detour.estimated_duration,
@@ -263,45 +262,13 @@ defmodule Skate.Detours.Detour do
       |> DateTime.to_unix()
     end
 
-    defp missed_stops!(%Detour{} = detour) do
-      case get_in(detour.state, ["context", "finishedDetour", "missedStops"]) do
-        missed_stops when is_list(missed_stops) ->
-          missed_stops
-          |> Enum.map(&get_in(&1, ["id"]))
-          |> Enum.reject(&is_nil/1)
-
-        _ ->
-          Logger.warning("detour #{detour.id} has invalid missed stops")
-          raise ArgumentError
-      end
-    end
-
-    defp connection_points!(%Detour{} = detour) do
-      case get_in(detour.state, ["context", "finishedDetour", "connectionPoint"]) do
-        connection_points when is_map(connection_points) ->
-          ["start", "end"]
-          |> Enum.map(&get_in(connection_points, [&1, "id"]))
-          |> Enum.reject(&is_nil/1)
-
-        _ ->
-          Logger.warning("detour #{detour.id} has invalid connection points")
-          raise ArgumentError
-      end
-    end
-
     defp route_segments(%Detour{
-           state: %{
-             "context" => %{
-               "finishedDetour" => %{
-                 "routeSegments" => %{
-                   "beforeDetour" => before_detour,
-                   "afterDetour" => after_detour,
-                   "detour" => detour_segment
-                 },
-                 "detourShape" => %{"coordinates" => bypassed_segment}
-               }
-             }
-           }
+           routeSegments: %{
+             "beforeDetour" => before_detour,
+             "afterDetour" => after_detour,
+             "detour" => detour_segment
+           },
+           detourShape: {"ok", %{"coordinates" => bypassed_segment}}
          }) do
       %{
         before_detour: before_detour,

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -88,7 +88,8 @@ defmodule Skate.Detours.Detour do
            reason: reason,
            status: status,
            is_text_only: is_text_only
-         }) do
+         })
+         when not is_nil(route_name) and not is_nil(headsign) and not is_nil(direction) do
       %__MODULE__{
         id: id,
         route: route_name,

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -230,8 +230,8 @@ defmodule Skate.Detours.Detour do
     def from!(%Detour{is_text_only: true} = detour) do
       %{
         base_report(detour)
-        | missed_stops_text_only: get_in(detour, ["typedDetour", "missedStops"]),
-          connection_points_text_only: get_in(detour, ["typedDetour", "connectionPoints"])
+        | missed_stops_text_only: detour.typed_detour["missedStops"],
+          connection_points_text_only: detour.typed_detour["connectionPoints"]
       }
     end
 

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -239,7 +239,7 @@ defmodule Skate.Detours.Detour do
         base_report(detour)
         | missed_stops: detour.missed_stops,
           connection_points: detour.connection_points,
-          route_segments: detour.route_segments
+          route_segments: route_segments(detour)
       }
     end
 
@@ -263,12 +263,12 @@ defmodule Skate.Detours.Detour do
     end
 
     defp route_segments(%Detour{
-           routeSegments: %{
+           route_segments: %{
              "beforeDetour" => before_detour,
              "afterDetour" => after_detour,
              "detour" => detour_segment
            },
-           detourShape: {"ok", %{"coordinates" => bypassed_segment}}
+           detour_shape: {"ok", %{"coordinates" => bypassed_segment}}
          }) do
       %{
         before_detour: before_detour,

--- a/lib/skate/detours/detour.ex
+++ b/lib/skate/detours/detour.ex
@@ -268,7 +268,7 @@ defmodule Skate.Detours.Detour do
              "afterDetour" => after_detour,
              "detour" => detour_segment
            },
-           detour_shape: {"ok", %{"coordinates" => bypassed_segment}}
+           detour_shape: %{"ok" => %{"coordinates" => bypassed_segment}}
          }) do
       %{
         before_detour: before_detour,

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -350,30 +350,21 @@ defmodule Skate.Detours.Detours do
     )
   end
 
-  def copy_to_draft_detour(detour, author_id) do
-    if detour.status == :past do
-      new_detour_attrs =
-        detour
-        |> Map.from_struct()
-        |> Map.take([:state])
-        |> Map.put(:status, :draft)
-
-      {:ok, new_draft_detour} =
-        %Detour{author_id: author_id, copied_from: detour}
-        |> Detour.changeset(new_detour_attrs)
-        |> Repo.insert()
-
-      {:ok, updated_state_detour} =
-        new_draft_detour
-        |> Detour.update_copied_detour_state_changeset()
-        |> Repo.update()
-
+  def copy_to_draft_detour(%{status: :past} = detour, author_id) do
+    with {:ok, new_draft_detour} <-
+           %Detour{author_id: author_id, copied_from: detour}
+           |> Detour.copy_to_draft_changeset(detour)
+           |> Repo.insert(),
+         {:ok, updated_state_detour} <-
+           new_draft_detour
+           |> Detour.set_state_uuid_changeset()
+           |> Repo.update() do
       broadcast_detour(updated_state_detour, author_id)
       {:ok, updated_state_detour}
-    else
-      {:error, :not_a_past_detour}
     end
   end
+
+  def copy_to_draft_detour(_detour, _author_id), do: {:error, :not_a_past_detour}
 
   @spec broadcast_detour(Detour.t(), DbUser.id()) :: :ok
   defp broadcast_detour(%Detour{status: :draft} = detour, author_id) do

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -228,7 +228,6 @@ defmodule Skate.Detours.Detours do
       (detour in Skate.Detours.Db.Detour)
       |> from(where: detour.id == ^id, preload: [:author])
       |> Repo.one!()
-      |> Skate.Detours.Db.Detour.with_virtual_fields()
 
     %DetourWithState{
       state: SnapshotSerde.serialize(detour),
@@ -317,7 +316,7 @@ defmodule Skate.Detours.Detours do
         {:error, :not_found}
 
       %Detour{author_id: ^user_id} = detour ->
-        {:ok, Detour.with_virtual_fields(detour)}
+        {:ok, detour}
 
       %Detour{} ->
         {:error, :unauthorized}

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -494,7 +494,6 @@ defmodule Skate.Detours.Detours do
 
   defp process_notifications(_, _), do: nil
 
-  # TODO references context
   @spec trigger_active_detour_s3_export_job(
           Ecto.Changeset.t(),
           Detour.t()
@@ -520,7 +519,7 @@ defmodule Skate.Detours.Detours do
                 "active detour #{detour.id} estimated duration changed"
 
               # ...or when saving changes...
-              is_map(get_in(detour.state, ["context", "savedContext"])) ->
+              !is_nil(Ecto.Changeset.get_change(changeset, :activated_at)) ->
                 "active detour #{detour.id} changed"
 
               # ...ignore otherwise

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -228,6 +228,7 @@ defmodule Skate.Detours.Detours do
       (detour in Skate.Detours.Db.Detour)
       |> from(where: detour.id == ^id, preload: [:author])
       |> Repo.one!()
+      |> Skate.Detours.Db.Detour.with_virtual_fields()
 
     %DetourWithState{
       state: SnapshotSerde.serialize(detour),
@@ -327,6 +328,7 @@ defmodule Skate.Detours.Detours do
   defp validate_detour_status(%Detour{status: :draft}), do: :ok
   defp validate_detour_status(_), do: {:error, :invalid_status}
 
+  # TODO manipulate fields?
   defp build_activation_changeset(detour, selected_duration, selected_reason) do
     new_state =
       detour.state
@@ -340,6 +342,7 @@ defmodule Skate.Detours.Detours do
     })
   end
 
+  # TODO manipulate fields?
   defp build_deactivation_changeset(detour) do
     Detour.changeset(
       detour,
@@ -457,6 +460,7 @@ defmodule Skate.Detours.Detours do
     Skate.Detours.NotificationScheduler.detour_deactivated(detour)
   end
 
+  # TODO uses context
   defp process_notifications(
          %Ecto.Changeset{
            changes:
@@ -487,6 +491,7 @@ defmodule Skate.Detours.Detours do
 
   defp process_notifications(_, _), do: nil
 
+  # TODO references context
   @spec trigger_active_detour_s3_export_job(
           Ecto.Changeset.t(),
           Detour.t()

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -264,7 +264,6 @@ defmodule Skate.Detours.Detours do
       conflict_target: [:id],
       on_conflict: {:replace, changed_fields}
     )
-    |> dbg()
   end
 
   defp handle_detour_updated(changeset, new_record, author_id) do

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -516,8 +516,8 @@ defmodule Skate.Detours.Detours do
               !is_nil(Ecto.Changeset.get_change(changeset, :estimated_duration)) ->
                 "active detour #{detour.id} estimated duration changed"
 
-              # ...or when saving changes...
-              !is_nil(Ecto.Changeset.get_change(changeset, :activated_at)) ->
+              # ...or when saving active detour edits (via updated_at changes)...
+              !is_nil(Ecto.Changeset.get_change(changeset, :updated_at)) ->
                 "active detour #{detour.id} changed"
 
               # ...ignore otherwise

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -328,25 +328,28 @@ defmodule Skate.Detours.Detours do
   defp validate_detour_status(%Detour{status: :draft}), do: :ok
   defp validate_detour_status(_), do: {:error, :invalid_status}
 
-  # TODO manipulate fields?
   defp build_activation_changeset(detour, selected_duration, selected_reason) do
     new_state =
       detour.state
       |> put_in(["context", "selectedDuration"], selected_duration)
       |> put_in(["context", "selectedReason"], selected_reason)
-      |> put_in(["value", "Detour Drawing"], %{"Active" => "Reviewing"})
+      |> put_in(["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
 
     Detour.changeset(detour, %{
       state: new_state,
+      state_value: %{"Detour Drawing" => %{"Active" => "Reviewing"}},
+      estimated_duration: selected_duration,
+      reason: selected_reason,
       activated_at: DateTime.utc_now(:millisecond)
     })
   end
 
-  # TODO manipulate fields?
   defp build_deactivation_changeset(detour) do
+    new_state = put_in(detour.state, ["value"], %{"Detour Drawing" => "Past"})
+
     Detour.changeset(
       detour,
-      %{state: put_in(detour.state, ["value", "Detour Drawing"], "Past"), status: :past}
+      %{state: new_state, state_value: %{"Detour Drawing" => "Past"}, status: :past}
     )
   end
 
@@ -451,32 +454,41 @@ defmodule Skate.Detours.Detours do
     Skate.Detours.NotificationScheduler.detour_deactivated(detour)
   end
 
-  # TODO uses context
   defp process_notifications(
          %Ecto.Changeset{
-           changes:
-             %{
-               updated_at: _,
-               state: %{"context" => %{"selectedDuration" => selected_duration}}
-             } = changes,
+           changes: %{estimated_duration: selected_duration} = changes,
            data: %Detour{
              status: :active,
-             state: %{"context" => %{"selectedDuration" => previous_duration}}
+             estimated_duration: previous_duration
            }
          },
          %Detour{} = detour
        ) do
-    if is_map_key(changes, :end_point) or
-         is_map_key(changes, :start_point) or
-         is_map_key(changes, :waypoints) do
-      Notifications.Notification.create_updated_detour_notification_from_detour(detour)
-    end
+    maybe_notify_detour_updated(changes, detour)
 
     if previous_duration != selected_duration do
       %SimpleDetour{estimated_duration: estimated_duration} = db_detour_to_detour(detour)
       expires_at = calculate_expiration_timestamp(detour, estimated_duration)
 
       Skate.Detours.NotificationScheduler.detour_duration_changed(detour, expires_at)
+    end
+  end
+
+  defp process_notifications(
+         %Ecto.Changeset{
+           changes: changes,
+           data: %Detour{status: :active}
+         },
+         %Detour{} = detour
+       ) do
+    maybe_notify_detour_updated(changes, detour)
+  end
+
+  defp maybe_notify_detour_updated(changes, detour) do
+    if is_map_key(changes, :end_point) or
+         is_map_key(changes, :start_point) or
+         is_map_key(changes, :waypoints) do
+      Notifications.Notification.create_updated_detour_notification_from_detour(detour)
     end
   end
 

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -327,15 +327,17 @@ defmodule Skate.Detours.Detours do
   defp validate_detour_status(_), do: {:error, :invalid_status}
 
   defp build_activation_changeset(detour, selected_duration, selected_reason) do
+    state_value = %{"SaveState" => "Saved", "Detour Drawing" => %{"Active" => "Reviewing"}}
+
     new_state =
       detour.state
       |> put_in(["context", "selectedDuration"], selected_duration)
       |> put_in(["context", "selectedReason"], selected_reason)
-      |> put_in(["value"], %{"Detour Drawing" => %{"Active" => "Reviewing"}})
+      |> put_in(["value"], state_value)
 
     Detour.changeset(detour, %{
       state: new_state,
-      state_value: %{"Detour Drawing" => %{"Active" => "Reviewing"}},
+      state_value: state_value,
       estimated_duration: selected_duration,
       reason: selected_reason,
       activated_at: DateTime.utc_now(:millisecond)
@@ -343,11 +345,12 @@ defmodule Skate.Detours.Detours do
   end
 
   defp build_deactivation_changeset(detour) do
-    new_state = put_in(detour.state, ["value"], %{"Detour Drawing" => "Past"})
+    state_value = %{"SaveState" => "Saved", "Detour Drawing" => "Past"}
+    new_state = put_in(detour.state, ["value"], state_value)
 
     Detour.changeset(
       detour,
-      %{state: new_state, state_value: %{"Detour Drawing" => "Past"}, status: :past}
+      %{state: new_state, state_value: state_value, status: :past}
     )
   end
 

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -264,6 +264,7 @@ defmodule Skate.Detours.Detours do
       conflict_target: [:id],
       on_conflict: {:replace, changed_fields}
     )
+    |> dbg()
   end
 
   defp handle_detour_updated(changeset, new_record, author_id) do
@@ -316,12 +317,11 @@ defmodule Skate.Detours.Detours do
       nil ->
         {:error, :not_found}
 
-      detour ->
-        if detour.author_id == user_id do
-          {:ok, detour}
-        else
-          {:error, :unauthorized}
-        end
+      %Detour{author_id: ^user_id} = detour ->
+        {:ok, Detour.with_virtual_fields(detour)}
+
+      %Detour{} ->
+        {:error, :unauthorized}
     end
   end
 
@@ -484,6 +484,8 @@ defmodule Skate.Detours.Detours do
     maybe_notify_detour_updated(changes, detour)
   end
 
+  defp process_notifications(_, _), do: nil
+
   defp maybe_notify_detour_updated(changes, detour) do
     if is_map_key(changes, :end_point) or
          is_map_key(changes, :start_point) or
@@ -491,8 +493,6 @@ defmodule Skate.Detours.Detours do
       Notifications.Notification.create_updated_detour_notification_from_detour(detour)
     end
   end
-
-  defp process_notifications(_, _), do: nil
 
   @spec trigger_active_detour_s3_export_job(
           Ecto.Changeset.t(),

--- a/lib/skate/detours/notification_scheduler.ex
+++ b/lib/skate/detours/notification_scheduler.ex
@@ -126,7 +126,7 @@ defmodule Skate.Detours.NotificationScheduler do
 
     Notifications.Notification.create_detour_expiration_notification(detour, %{
       expires_in: Duration.new!(minute: offset_minutes),
-      estimated_duration: detour.state["context"]["selectedDuration"],
+      estimated_duration: detour.estimated_duration,
       notification: %{created_at: created_at_notification_offset}
     })
   end

--- a/lib/skate/detours/s3_exporter.ex
+++ b/lib/skate/detours/s3_exporter.ex
@@ -38,8 +38,8 @@ defmodule Skate.Detours.S3Exporter do
       Detour
       |> Ecto.Query.where(status: ^status)
       |> Ecto.Query.order_by(^order_by)
-      |> Detour.Queries.with_virtual_fields()
       |> Skate.Repo.all()
+      |> Enum.map(&Skate.Detours.Db.Detour.with_virtual_fields/1)
 
     converted =
       selected

--- a/lib/skate/detours/s3_exporter.ex
+++ b/lib/skate/detours/s3_exporter.ex
@@ -38,6 +38,7 @@ defmodule Skate.Detours.S3Exporter do
       Detour
       |> Ecto.Query.where(status: ^status)
       |> Ecto.Query.order_by(^order_by)
+      |> Detour.Queries.with_virtual_fields()
       |> Skate.Repo.all()
 
     converted =

--- a/lib/skate/detours/s3_exporter.ex
+++ b/lib/skate/detours/s3_exporter.ex
@@ -39,7 +39,6 @@ defmodule Skate.Detours.S3Exporter do
       |> Ecto.Query.where(status: ^status)
       |> Ecto.Query.order_by(^order_by)
       |> Skate.Repo.all()
-      |> Enum.map(&Skate.Detours.Db.Detour.with_virtual_fields/1)
 
     converted =
       selected

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -152,7 +152,8 @@ defmodule Skate.Detours.SnapshotSerde do
     end
   end
 
-  # defp state_from_detour(%Detour{detour_state: state}), do: state
+  defp state_from_detour(%Detour{state_value: state}), do: state
+
   defp state_from_detour(%Detour{
          state: %{
            "value" => state

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -173,10 +173,10 @@ defmodule Skate.Detours.SnapshotSerde do
          direction_names: direction_names
        }) do
     %{
-      id: route_id,
-      name: route_name,
-      garages: garages,
-      direction_names: direction_names
+      "id" => route_id,
+      "name" => route_name,
+      "garages" => garages,
+      "directionNames" => direction_names
     }
   end
 
@@ -193,12 +193,7 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp route_from_detour(_), do: nil
 
-  defp routepattern_from_detour(%Detour{
-         route_patterns: route_patterns,
-         route_pattern_id: route_pattern_id
-       }) do
-    Enum.find(route_patterns, fn route_pattern -> route_pattern.id == route_pattern_id end)
-  end
+  defp routepattern_from_detour(%Detour{route_pattern: route_pattern}), do: route_pattern
 
   defp routepattern_from_detour(%Detour{
          state: %{
@@ -298,10 +293,10 @@ defmodule Skate.Detours.SnapshotSerde do
          route_segments: route_segments
        }) do
     %{
-      detourShape: detour_shape,
-      connectionPoint: connection_points,
-      missedStops: missed_stops,
-      routeSegments: route_segments
+      "detourShape" => detour_shape,
+      "connectionPoint" => connection_points,
+      "missedStops" => missed_stops,
+      "routeSegments" => route_segments
     }
   end
 

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -171,7 +171,9 @@ defmodule Skate.Detours.SnapshotSerde do
          route_name: route_name,
          garages: garages,
          direction_names: direction_names
-       }) do
+       })
+       when not is_nil(route_id) and not is_nil(route_name) and not is_nil(garages) and
+              not is_nil(direction_names) do
     %{
       "id" => route_id,
       "name" => route_name,

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -215,7 +215,9 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp routepattern_from_detour(_), do: nil
 
-  defp routepatterns_from_detour(%Detour{route_patterns: route_patterns}), do: route_patterns
+  defp routepatterns_from_detour(%Detour{route_patterns: route_patterns})
+       when not is_nil(route_patterns),
+       do: route_patterns
 
   defp routepatterns_from_detour(%Detour{
          state: %{
@@ -278,7 +280,8 @@ defmodule Skate.Detours.SnapshotSerde do
   defp nearestintersection_from_detour(%Detour{nearest_intersection: nearest_intersection}),
     do: nearest_intersection
 
-  defp detourshape_from_detour(%Detour{detour_shape: detour_shape}), do: detour_shape
+  defp detourshape_from_detour(%Detour{detour_shape: detour_shape}) when not is_nil(detour_shape),
+    do: detour_shape
 
   defp detourshape_from_detour(%Detour{
          state: %{
@@ -439,8 +442,7 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp activated_at_from_detour(%Detour{activated_at: nil}), do: nil
 
-  defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}),
-    do: snapshot_children
+  defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}) when not is_nil(snapshot_children), do: snapshot_children
 
   defp snapshot_children_from_detour(%Detour{
          state: %{

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -128,8 +128,8 @@ defmodule Skate.Detours.SnapshotSerde do
     :maps.filter(fn _, v -> v != nil end, %{
       "uuid" => uuid_from_detour(detour),
       "route" => route_from_detour(detour),
-      "routePattern" => routepattern_from_detour(detour),
       "routePatterns" => routepatterns_from_detour(detour),
+      "routePattern" => routepattern_from_detour(detour),
       "startPoint" => startpoint_from_detour(detour),
       "endPoint" => endpoint_from_detour(detour),
       "waypoints" => waypoints_from_detour(detour),
@@ -193,9 +193,13 @@ defmodule Skate.Detours.SnapshotSerde do
     route
   end
 
-  defp route_from_detour(_), do: nil
-
-  defp routepattern_from_detour(%Detour{route_pattern: route_pattern}), do: route_pattern
+  defp routepattern_from_detour(%Detour{
+         route_patterns: route_patterns,
+         route_pattern_id: route_pattern_id
+       })
+       when is_list(route_patterns) do
+    Enum.find(route_patterns, &(&1["id"] == route_pattern_id))
+  end
 
   defp routepattern_from_detour(%Detour{
          state: %{

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -152,7 +152,7 @@ defmodule Skate.Detours.SnapshotSerde do
     end
   end
 
-  defp state_from_detour(%Detour{state_value: state}), do: state
+  defp state_from_detour(%Detour{state_value: state}) when not is_nil(state), do: state
 
   defp state_from_detour(%Detour{
          state: %{

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -442,7 +442,9 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp activated_at_from_detour(%Detour{activated_at: nil}), do: nil
 
-  defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}) when not is_nil(snapshot_children), do: snapshot_children
+  defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children})
+       when not is_nil(snapshot_children),
+       do: snapshot_children
 
   defp snapshot_children_from_detour(%Detour{
          state: %{

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -166,7 +166,20 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp uuid_from_detour(%Detour{id: id}), do: id
 
-  # defp route_from_detour(%Detour{route: route}), do: route
+  defp route_from_detour(%Detour{
+         route_id: route_id,
+         route_name: route_name,
+         garages: garages,
+         direction_names: direction_names
+       }) do
+    %{
+      id: route_id,
+      name: route_name,
+      garages: garages,
+      direction_names: direction_names
+    }
+  end
+
   defp route_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -180,7 +193,13 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp route_from_detour(_), do: nil
 
-  # defp routepattern_from_detour(%Detour{route_pattern: route_pattern}), do: route_pattern
+  defp routepattern_from_detour(%Detour{
+         route_patterns: route_patterns,
+         route_pattern_id: route_pattern_id
+       }) do
+    Enum.find(route_patterns, fn route_pattern -> route_pattern.id == route_pattern_id end)
+  end
+
   defp routepattern_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -194,7 +213,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp routepattern_from_detour(_), do: nil
 
-  # defp routepatterns_from_detour(%Detour{route_patterns: route_patterns}), do: route_patterns
+  defp routepatterns_from_detour(%Detour{route_patterns: route_patterns}), do: route_patterns
+
   defp routepatterns_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -208,7 +228,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp routepatterns_from_detour(_), do: nil
 
-  # defp startpoint_from_detour(%Detour{start_point: start_point}), do: start_point
+  defp startpoint_from_detour(%Detour{start_point: start_point}), do: start_point
+
   defp startpoint_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -222,7 +243,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp startpoint_from_detour(_), do: nil
 
-  # defp endpoint_from_detour(%Detour{end_point: end_point}), do: end_point
+  defp endpoint_from_detour(%Detour{end_point: end_point}), do: end_point
+
   defp endpoint_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -236,7 +258,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp endpoint_from_detour(_), do: nil
 
-  # defp waypoints_from_detour(%Detour{waypoints: waypoints}), do: waypoints
+  defp waypoints_from_detour(%Detour{waypoints: waypoints}), do: waypoints
+
   defp waypoints_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -253,7 +276,8 @@ defmodule Skate.Detours.SnapshotSerde do
   defp nearestintersection_from_detour(%Detour{nearest_intersection: nearest_intersection}),
     do: nearest_intersection
 
-  # defp detourshape_from_detour(%Detour{detour_shape: detour_shape}), do: detour_shape
+  defp detourshape_from_detour(%Detour{detour_shape: detour_shape}), do: detour_shape
+
   defp detourshape_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -267,7 +291,20 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp detourshape_from_detour(_), do: nil
 
-  # defp finisheddetour_from_detour(%Detour{finished_detour: finished_detour}), do: finished_detour
+  defp finisheddetour_from_detour(%Detour{
+         detour_shape: %{ok: detour_shape},
+         connection_points: connection_points,
+         missed_stops: missed_stops,
+         route_segments: route_segments
+       }) do
+    %{
+      detourShape: detour_shape,
+      connectionPoint: connection_points,
+      missedStops: missed_stops,
+      routeSegments: route_segments
+    }
+  end
+
   defp finisheddetour_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -281,7 +318,9 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp finisheddetour_from_detour(_), do: nil
 
-  # defp editeddirections_from_detour(%Detour{edited_directions: edited_directions}), do: edited_directions
+  defp editeddirections_from_detour(%Detour{edited_directions: edited_directions}),
+    do: edited_directions
+
   defp editeddirections_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -295,7 +334,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp editeddirections_from_detour(_), do: nil
 
-  # defp undostack_from_detour(%Detour{undo_stack: undo_stack}), do: undo_stack
+  defp undostack_from_detour(%Detour{undo_stack: undo_stack}), do: undo_stack
+
   defp undostack_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -309,7 +349,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp undostack_from_detour(_), do: nil
 
-  # defp istextonly_from_detour(%Detour{is_text_only: is_text_only}), do: is_text_only
+  defp istextonly_from_detour(%Detour{is_text_only: is_text_only}), do: is_text_only
+
   defp istextonly_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -322,6 +363,8 @@ defmodule Skate.Detours.SnapshotSerde do
   end
 
   defp istextonly_from_detour(_), do: nil
+
+  defp typeddetour_from_detour(%Detour{typed_detour: typed_detour}), do: typed_detour
 
   defp typeddetour_from_detour(%Detour{
          state: %{
@@ -336,7 +379,9 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp typeddetour_from_detour(_), do: nil
 
-  # defp selectedduration_from_detour(%Detour{snapshot_children: snapshot_children}), do: snapshot_children
+  defp selectedduration_from_detour(%Detour{estimated_duration: estimated_duration}),
+    do: estimated_duration
+
   defp selectedduration_from_detour(
          %Detour{
            state: state
@@ -358,7 +403,8 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp selectedduration_from_detour(_), do: nil
 
-  # defp selectedreason_from_detour(%Detour{snapshot_children: snapshot_children}), do: snapshot_children
+  defp selectedreason_from_detour(%Detour{reason: reason}), do: reason
+
   defp selectedreason_from_detour(%Detour{
          state: %{
            "context" => %{
@@ -391,7 +437,9 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp activated_at_from_detour(%Detour{activated_at: nil}), do: nil
 
-  # defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}), do: snapshot_children
+  defp snapshot_children_from_detour(%Detour{snapshot_children: snapshot_children}),
+    do: snapshot_children
+
   defp snapshot_children_from_detour(%Detour{
          state: %{
            "children" => snapshot_children

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -287,7 +287,7 @@ defmodule Skate.Detours.SnapshotSerde do
   defp detourshape_from_detour(_), do: nil
 
   defp finisheddetour_from_detour(%Detour{
-         detour_shape: %{ok: detour_shape},
+         detour_shape: %{"ok" => detour_shape},
          connection_points: connection_points,
          missed_stops: missed_stops,
          route_segments: route_segments

--- a/lib/skate/notifications/notification.ex
+++ b/lib/skate/notifications/notification.ex
@@ -258,7 +258,7 @@ defmodule Skate.Notifications.Notification do
   end
 
   def create_detour_expiration_notification(%Skate.Detours.Db.Detour{} = detour, params) do
-    params = Map.put_new(params, :route_id, detour.state["context"]["route"]["id"])
+    params = Map.put_new(params, :route_id, detour.route_id)
 
     detour
     |> Ecto.build_assoc(:detour_expiration_notifications)
@@ -276,7 +276,7 @@ defmodule Skate.Notifications.Notification do
     |> Ecto.build_assoc(:detour_status_notifications)
     |> Notifications.Db.Detour.changeset(%{
       status: :deactivated,
-      route_id: detour.state["context"]["route"]["id"]
+      route_id: detour.route_id
     })
     |> Skate.Repo.insert()
     |> log_notification()
@@ -291,7 +291,7 @@ defmodule Skate.Notifications.Notification do
     |> Ecto.build_assoc(:detour_status_notifications)
     |> Notifications.Db.Detour.changeset(%{
       status: :activated,
-      route_id: detour.state["context"]["route"]["id"]
+      route_id: detour.route_id
     })
     |> Skate.Repo.insert()
     |> log_notification()
@@ -306,7 +306,7 @@ defmodule Skate.Notifications.Notification do
     |> Ecto.build_assoc(:detour_status_notifications)
     |> Notifications.Db.Detour.changeset(%{
       status: :updated,
-      route_id: detour.state["context"]["route"]["id"]
+      route_id: detour.route_id
     })
     |> Skate.Repo.insert()
     |> log_notification()

--- a/lib/swiftly/api/requests.ex
+++ b/lib/swiftly/api/requests.ex
@@ -59,6 +59,12 @@ defmodule Swiftly.API.Requests do
   end
 
   defp map_skipped_stops(%Detour{
+         missed_stops: [_ | _] = missed_stops
+       }) do
+    Enum.map(missed_stops, fn missed_stop -> Map.get(missed_stop, "id") end)
+  end
+
+  defp map_skipped_stops(%Detour{
          state: %{"context" => %{"finishedDetour" => %{"missedStops" => [_ | _] = missed_stops}}}
        }) do
     Enum.map(missed_stops, fn missed_stop -> Map.get(missed_stop, "id") end)

--- a/lib/swiftly/api/requests.ex
+++ b/lib/swiftly/api/requests.ex
@@ -24,7 +24,7 @@ defmodule Swiftly.API.Requests do
          detourRouteDirectionDetails: [
            %DetourRouteDirectionCreationDetails{
              routeShortName: detour.route_name,
-             direction: Integer.to_string(detour.direction_id),
+             direction: parse_direction(detour),
              shape: parse_shape(detour),
              skippedStops: map_skipped_stops(detour)
            }
@@ -40,6 +40,17 @@ defmodule Swiftly.API.Requests do
   end
 
   defp parse_begin_time(_), do: nil
+
+  defp parse_direction(%Detour{direction_id: direction_id}) when is_integer(direction_id) do
+    Integer.to_string(direction_id)
+  end
+
+  defp parse_direction(%Detour{
+         state: %{"context" => %{"routePattern" => %{"directionId" => direction_id}}}
+       })
+       when is_integer(direction_id) do
+    Integer.to_string(direction_id)
+  end
 
   defp parse_shape(%Detour{coordinates: coordinates}) when not is_nil(coordinates) do
     map_coordinates(coordinates)

--- a/lib/swiftly/api/requests.ex
+++ b/lib/swiftly/api/requests.ex
@@ -23,8 +23,8 @@ defmodule Swiftly.API.Requests do
          beginTime: parse_begin_time(detour),
          detourRouteDirectionDetails: [
            %DetourRouteDirectionCreationDetails{
-             routeShortName: detour.state["context"]["route"]["name"],
-             direction: Integer.to_string(detour.state["context"]["routePattern"]["directionId"]),
+             routeShortName: detour.route_name,
+             direction: Integer.to_string(detour.direction_id),
              shape: parse_shape(detour),
              skippedStops: map_skipped_stops(detour)
            }

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -1,0 +1,111 @@
+defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema do
+  @moduledoc """
+  Detours database table schema frozen at this point in time.
+  """
+
+  use Skate.Schema
+
+  typed_schema "detours" do
+    field :state, :map, null: true
+    field :state_value, :map, null: false
+    field :state_children, :map, null: true
+    field :undo_stack, {:array, :map}, default: [], null: false
+    field :route_patterns, {:array, :map}, null: false
+    field :route, :map, null: false
+    field :edited_directions, :string, null: true
+    field :detour_shape, :map, null: true
+    field :route_segments, :map, null: true
+    field :connection_points, :map, null: true
+    field :missed_stops, {:array, :map}, null: true
+  end
+end
+
+defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
+  # https://fly.io/phoenix-files/backfilling-data/
+
+  import Ecto.Query
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+  @batch_size 100
+  @throttle_ms 100
+
+  def up do
+    throttle_change_in_batches(&page_query/1, &do_change/1)
+  end
+
+  def down, do: :ok
+
+  defp page_query(last_id) do
+    from(
+      r in Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema,
+      select: r.id,
+      where: r.id > ^last_id,
+      order_by: [asc: r.id],
+      limit: @batch_size
+    )
+  end
+
+  defp do_change(batch_of_ids) do
+    from(
+      r in Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema,
+      select: [:id, :state],
+      where: r.id in ^batch_of_ids
+    )
+    |> repo().all(log: :info)
+    |> Enum.map(fn %Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema{
+                     id: id,
+                     state: state
+                   } = detour ->
+      detour
+      |> Ecto.Changeset.change(map_fields(state))
+      |> repo().update()
+      |> case do
+        {:error, _changeset} -> raise "#{id} was not updated"
+        {:ok, %{id: changed_id}} -> changed_id
+      end
+    end)
+    |> (fn changed -> {:ok, changed} end).()
+  end
+
+  # func (field, func) -> Ecto.Changeset.put_change(field, func(changeset))
+
+  defp map_fields(state) do
+    %{
+      state_value: get_in(state, ["value"]),
+      state_children: get_in(state, ["children"]),
+      undo_stack: get_in(state, ["context", "undoStack"]),
+      route_patterns: get_in(state, ["context", "routePatterns"]),
+      route: get_in(state, ["context", "route"]),
+      edited_directions: get_in(state, ["context", "editedDirections"]),
+      detour_shape: get_in(state, ["context", "detourShape"]),
+      route_segments: get_in(state, ["context", "finishedDetour", "routeSegments"]),
+      connection_points: get_in(state, ["context", "finishedDetour", "connectionPoints"]),
+      missed_stops: get_in(state, ["context", "finishedDetour", "missedStops"])
+    }
+    |> Enum.reject(fn {_field, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp throttle_change_in_batches(query_fun, change_fun, last_pos \\ 0)
+  defp throttle_change_in_batches(_query_fun, _change_fun, nil), do: :ok
+
+  defp throttle_change_in_batches(query_fun, change_fun, last_pos) do
+    case repo().all(query_fun.(last_pos), log: :info, timeout: :infinity) do
+      [] ->
+        :ok
+
+      ids ->
+        case change_fun.(List.flatten(ids)) do
+          {:ok, results} ->
+            next_page = results |> Enum.reverse() |> List.first()
+            Process.sleep(@throttle_ms)
+            throttle_change_in_batches(query_fun, change_fun, next_page)
+
+          error ->
+            raise error
+        end
+    end
+  end
+end

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -8,10 +8,11 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema do
   typed_schema "detours" do
     field :state, :map, null: true
     field :state_value, :map, null: false
-    field :state_children, :map, null: true
+    field :snapshot_children, :map, null: true
     field :undo_stack, {:array, :map}, default: [], null: false
     field :route_patterns, {:array, :map}, null: false
-    field :route, :map, null: false
+    field :garages, {:array, :string}
+    field :direction_names, :map
     field :edited_directions, :string, null: true
     field :detour_shape, :map, null: true
     field :route_segments, :map, null: true
@@ -74,10 +75,11 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
   defp map_fields(state) do
     %{
       state_value: get_in(state, ["value"]),
-      state_children: get_in(state, ["children"]),
+      snapshot_children: get_in(state, ["children"]),
       undo_stack: get_in(state, ["context", "undoStack"]),
       route_patterns: get_in(state, ["context", "routePatterns"]),
-      route: get_in(state, ["context", "route"]),
+      garages: get_in(state, ["context", "route", "garages"]),
+      direction_names: get_in(state, ["context", "route", "directionNames"]),
       edited_directions: get_in(state, ["context", "editedDirections"]),
       detour_shape: get_in(state, ["context", "detourShape"]),
       route_segments: get_in(state, ["context", "finishedDetour", "routeSegments"]),

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -71,6 +71,8 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
           Logger.warning(
             "backfill_migration: Row was not updated detour_id=#{id} reason=#{inspect(reason)}"
           )
+
+          id
       end
     end)
     |> (fn changed -> {:ok, changed} end).()

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -26,6 +26,7 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
   # https://fly.io/phoenix-files/backfilling-data/
 
   import Ecto.Query
+  require Logger
   use Ecto.Migration
 
   @disable_ddl_transaction true
@@ -60,12 +61,16 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
                      id: id,
                      state: state
                    } = detour ->
-      detour
-      |> Ecto.Changeset.change(map_fields(state))
-      |> repo().update()
-      |> case do
-        {:error, _changeset} -> raise "#{id} was not updated"
-        {:ok, %{id: changed_id}} -> changed_id
+      with changeset <- Ecto.Changeset.change(detour, map_fields(state)),
+           {:ok, valid_changeset} <- validate_changeset(changeset),
+           {:ok, %{id: changed_id}} <-
+             repo().update(valid_changeset) do
+        changed_id
+      else
+        {:error, reason} ->
+          Logger.warning(
+            "backfill_migration: Row was not updated detour_id=#{id} reason=#{inspect(reason)}"
+          )
       end
     end)
     |> (fn changed -> {:ok, changed} end).()
@@ -92,6 +97,14 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
     |> Map.new()
   end
 
+  defp validate_changeset(
+         %Ecto.Changeset{changes: %{state_value: _, route_patterns: _}} = changeset
+       ) do
+    {:ok, changeset}
+  end
+
+  defp validate_changeset(_), do: {:error, :missing_required_fields}
+
   defp throttle_change_in_batches(query_fun, change_fun, last_pos \\ 0)
   defp throttle_change_in_batches(_query_fun, _change_fun, nil), do: :ok
 
@@ -107,8 +120,8 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
             Process.sleep(@throttle_ms)
             throttle_change_in_batches(query_fun, change_fun, next_page)
 
-          error ->
-            raise error
+          {:error, reason} ->
+            Logger.warning("backfill_migration: Batch update failed reason=#{inspect(reason)}")
         end
     end
   end

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -13,6 +13,7 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot.MigratingSchema do
     field :route_patterns, {:array, :map}, null: false
     field :garages, {:array, :string}
     field :direction_names, :map
+    field :direction_id, :integer
     field :edited_directions, :string, null: true
     field :detour_shape, :map, null: true
     field :route_segments, :map, null: true
@@ -80,6 +81,7 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
       route_patterns: get_in(state, ["context", "routePatterns"]),
       garages: get_in(state, ["context", "route", "garages"]),
       direction_names: get_in(state, ["context", "route", "directionNames"]),
+      direction_id: get_in(state, ["context", "routePattern", "directionId"]),
       edited_directions: get_in(state, ["context", "editedDirections"]),
       detour_shape: get_in(state, ["context", "detourShape"]),
       route_segments: get_in(state, ["context", "finishedDetour", "routeSegments"]),

--- a/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
+++ b/priv/repo/async_migrations/20260817204135_backfill_serializing_snapshot.exs
@@ -83,7 +83,7 @@ defmodule Skate.Repo.Migrations.BackfillSerializingSnapshot do
       edited_directions: get_in(state, ["context", "editedDirections"]),
       detour_shape: get_in(state, ["context", "detourShape"]),
       route_segments: get_in(state, ["context", "finishedDetour", "routeSegments"]),
-      connection_points: get_in(state, ["context", "finishedDetour", "connectionPoints"]),
+      connection_points: get_in(state, ["context", "finishedDetour", "connectionPoint"]),
       missed_stops: get_in(state, ["context", "finishedDetour", "missedStops"])
     }
     |> Enum.reject(fn {_field, value} -> is_nil(value) end)

--- a/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
+++ b/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
@@ -12,6 +12,7 @@ defmodule Skate.Repo.Migrations.FinishSerializingSnapshotsFromDb do
       add :route_patterns, {:array, :map}
       add :garages, {:array, :string}
       add :direction_names, :map
+      add :direction_id, :integer
 
       # missing detour information
       add :edited_directions, :text, null: true

--- a/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
+++ b/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
@@ -5,15 +5,13 @@ defmodule Skate.Repo.Migrations.FinishSerializingSnapshotsFromDb do
     alter table(:detours) do
       # missing snapshot values
       add :state_value, :map
-      add :state_children, :map, null: true
+      add :snapshot_children, :map, null: true
       add :undo_stack, {:array, :map}, default: [], null: false
 
       # missing route information
       add :route_patterns, {:array, :map}
-      # store route object rather than two parts
-      add :route, :map
-      remove :route_id, :string, null: true
-      remove :route_name, :string, null: true
+      add :garages, {:array, :string}
+      add :direction_names, :map
 
       # missing detour information
       add :edited_directions, :text, null: true

--- a/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
+++ b/priv/repo/migrations/20260817190955_finish_serializing_snapshots_from_db.exs
@@ -1,0 +1,26 @@
+defmodule Skate.Repo.Migrations.FinishSerializingSnapshotsFromDb do
+  use Ecto.Migration
+
+  def change do
+    alter table(:detours) do
+      # missing snapshot values
+      add :state_value, :map
+      add :state_children, :map, null: true
+      add :undo_stack, {:array, :map}, default: [], null: false
+
+      # missing route information
+      add :route_patterns, {:array, :map}
+      # store route object rather than two parts
+      add :route, :map
+      remove :route_id, :string, null: true
+      remove :route_name, :string, null: true
+
+      # missing detour information
+      add :edited_directions, :text, null: true
+      add :detour_shape, :map, null: true
+      add :route_segments, :map, null: true
+      add :connection_points, :map, null: true
+      add :missed_stops, {:array, :map}, null: true
+    end
+  end
+end

--- a/test/skate/detours/s3_exporter_test.exs
+++ b/test/skate/detours/s3_exporter_test.exs
@@ -111,7 +111,7 @@ defmodule Skate.Detours.S3ExporterTest do
         detour =
           :detour
           |> build()
-          |> activated()
+          |> activated(~U[2026-01-05 15:00:00.000000Z])
           |> insert()
 
         # workaround because there's no `with_saved_context(...)` factory method
@@ -119,9 +119,6 @@ defmodule Skate.Detours.S3ExporterTest do
           detour
           | state: put_in(detour.state, ["context", "endPoint"], %{"id" => "start"})
         }
-
-        # `updated_at` is truncated to seconds, so ensure the save occurs in a later second.
-        Process.sleep(1_100)
 
         Skate.Detours.Detours.upsert_from_snapshot(author_id, with_id(snapshot, id))
       end

--- a/test/skate/detours/s3_exporter_test.exs
+++ b/test/skate/detours/s3_exporter_test.exs
@@ -117,12 +117,11 @@ defmodule Skate.Detours.S3ExporterTest do
         # workaround because there's no `with_saved_context(...)` factory method
         %{author_id: author_id, id: id, state: snapshot} = %{
           detour
-          | # the only way to tell when a user has finished editing a detour is by the
-            # existence of the "savedContext" attribute; this attribute is automatically
-            # included by the application after the user selects the final confirmation
-            # dialog when editing an active detour.
-            state: put_in(detour.state, ["context", "savedContext"], detour.state)
+          | state: put_in(detour.state, ["context", "endPoint"], %{"id" => "start"})
         }
+
+        # `updated_at` is truncated to seconds, so ensure the save occurs in a later second.
+        Process.sleep(1_100)
 
         Skate.Detours.Detours.upsert_from_snapshot(author_id, with_id(snapshot, id))
       end

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -155,16 +155,11 @@ defmodule Skate.DetourFactory do
             %Skate.Detours.Db.Detour{} = detour,
             %{name: route_name, id: route_id} = route
           ) do
-        detour
-        |> Map.put(:route_name, route_name)
-        |> Map.put(:route_id, route_id)
-        |> Map.put(:state, with_route(detour.state, route))
+        detour |> with_route_id(route_id) |> with_route_name(route_name)
       end
 
       def with_route(%{"context" => %{"route" => _}} = state, %{name: route_name, id: route_id}) do
-        state
-        |> put_in(["context", "route", "id"], route_id)
-        |> put_in(["context", "route", "name"], route_name)
+        state |> with_route_id(route_id) |> with_route_name(route_name)
       end
 
       def with_route_name(%Skate.Detours.Db.Detour{} = detour, name) do

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -45,6 +45,9 @@ defmodule Skate.DetourFactory do
           route_pattern_id: state["context"]["routePattern"]["id"],
           route_pattern_name: state["context"]["routePattern"]["name"],
           headsign: state["context"]["routePattern"]["headsign"],
+          direction_id: state["context"]["routePattern"]["directionId"],
+          undo_stack: state["context"]["undoStack"],
+          is_text_only: state["context"]["isTextOnly"],
           direction:
             Map.get(
               state["context"]["route"]["directionNames"],
@@ -74,7 +77,9 @@ defmodule Skate.DetourFactory do
               "id" =>
                 sequence("detour_route_pattern_id:") <> "-_-" <> Integer.to_string(direction_id)
             },
-            "nearestIntersection" => sequence("detour_nearest_intersection:")
+            "nearestIntersection" => sequence("detour_nearest_intersection:"),
+            "isTextOnly" => false,
+            "undoStack" => []
           },
           "value" => %{},
           "children" => %{},
@@ -83,11 +88,11 @@ defmodule Skate.DetourFactory do
       end
 
       def with_id(%Skate.Detours.Db.Detour{} = detour, id) do
-        %{
-          detour
-          | id: id,
-            state: with_id(detour.state, id)
-        }
+        state = put_in(detour.state, ["context", "uuid"], id)
+
+        detour
+        |> Map.put(:id, id)
+        |> Map.put(:state, state)
       end
 
       def with_id(%{"context" => %{"uuid" => _}} = snapshot, id) do
@@ -150,162 +155,142 @@ defmodule Skate.DetourFactory do
             %Skate.Detours.Db.Detour{} = detour,
             %{name: route_name, id: route_id} = route
           ) do
-        %{
-          detour
-          | state: with_route(detour.state, route),
-            route_name: route_name,
-            route_id: route_id
-        }
+        detour
+        |> Map.put(:route_name, route_name)
+        |> Map.put(:route_id, route_id)
+        |> Map.put(:state, with_route(detour.state, route))
       end
 
-      def with_route(
-            %{"context" => %{"route" => %{}}} = state,
-            %{name: route_name, id: route_id}
-          ) do
+      def with_route(%{"context" => %{"route" => _}} = state, %{name: route_name, id: route_id}) do
         state
-        |> with_route_id(route_id)
-        |> with_route_name(route_name)
+        |> put_in(["context", "route", "id"], route_id)
+        |> put_in(["context", "route", "name"], route_name)
       end
 
       def with_route_name(%Skate.Detours.Db.Detour{} = detour, name) do
-        %{detour | state: with_route_name(detour.state, name), route_name: name}
+        detour
+        |> Map.put(:route_name, name)
+        |> Map.put(:state, with_route_name(detour.state, name))
       end
 
-      def with_route_name(
-            %{"context" => %{"route" => %{"name" => _}}} = state,
-            name
-          ) do
-        put_in(state["context"]["route"]["name"], name)
+      def with_route_name(%{"context" => %{"route" => _}} = state, name) do
+        put_in(state, ["context", "route", "name"], name)
       end
 
       def with_route_id(%Skate.Detours.Db.Detour{} = detour, id) do
-        %{detour | state: with_route_id(detour.state, id)}
+        detour
+        |> Map.put(:route_id, id)
+        |> Map.put(:state, with_route_id(detour.state, id))
       end
 
-      def with_route_id(
-            %{"context" => %{"route" => %{"id" => _}}} = state,
-            id
-          ) do
-        put_in(state["context"]["route"]["id"], id)
+      def with_route_id(%{"context" => %{"route" => _}} = state, id) do
+        put_in(state, ["context", "route", "id"], id)
       end
 
       def with_direction(%Skate.Detours.Db.Detour{} = detour, direction) do
-        direction_str =
+        {direction_str, direction_id} =
           case direction do
-            :inbound -> "Inbound"
-            :outbound -> "Outbound"
+            :inbound -> {"Inbound", 1}
+            :outbound -> {"Outbound", 0}
           end
 
-        %{
-          detour
-          | state: with_direction(detour.state, direction),
-            direction: direction_str
-        }
+        detour
+        |> Map.put(:direction, direction_str)
+        |> Map.put(:direction_id, direction_id)
+        |> Map.put(:state, with_direction(detour.state, direction))
       end
 
-      def with_direction(
-            %{"context" => %{"routePattern" => %{"directionId" => _}}} = state,
-            :inbound
-          ) do
-        put_in(state["context"]["routePattern"]["directionId"], 1)
-      end
+      def with_direction(%{"context" => %{"routePattern" => _}} = state, direction) do
+        direction_id =
+          case direction do
+            :inbound -> 1
+            :outbound -> 0
+          end
 
-      def with_direction(
-            %{"context" => %{"routePattern" => %{"directionId" => _}}} = state,
-            :outbound
-          ) do
-        put_in(state["context"]["routePattern"]["directionId"], 0)
+        put_in(state, ["context", "routePattern", "directionId"], direction_id)
       end
 
       def with_route_pattern_id(%Skate.Detours.Db.Detour{} = detour, id) do
-        %{detour | state: with_route_pattern_id(detour.state, id)}
+        detour
+        |> Map.put(:route_pattern_id, id)
+        |> Map.put(:state, with_route_pattern_id(detour.state, id))
       end
 
-      def with_route_pattern_id(
-            %{"context" => %{"routePattern" => %{"id" => _}}} = state,
-            id
-          ) do
-        put_in(state["context"]["routePattern"]["id"], id)
+      def with_route_pattern_id(%{"context" => %{"routePattern" => _}} = state, id) do
+        put_in(state, ["context", "routePattern", "id"], id)
       end
 
       def with_headsign(%Skate.Detours.Db.Detour{} = detour, headsign) do
-        %{detour | state: with_headsign(detour.state, headsign), headsign: headsign}
+        detour
+        |> Map.put(:headsign, headsign)
+        |> Map.put(:state, with_headsign(detour.state, headsign))
       end
 
-      def with_headsign(
-            %{"context" => %{"routePattern" => %{"headsign" => _}}} = state,
-            id
-          ) do
-        put_in(state["context"]["routePattern"]["headsign"], id)
+      def with_headsign(%{"context" => %{"routePattern" => _}} = state, headsign) do
+        put_in(state, ["context", "routePattern", "headsign"], headsign)
       end
 
       def with_nearest_intersection(%Skate.Detours.Db.Detour{} = detour, value) do
-        %{
-          detour
-          | state: with_nearest_intersection(detour.state, value),
-            nearest_intersection: value
-        }
+        detour
+        |> Map.put(:nearest_intersection, value)
+        |> Map.put(:state, with_nearest_intersection(detour.state, value))
       end
 
-      def with_nearest_intersection(
-            %{"context" => %{"nearestIntersection" => _}} = state,
-            headsign
-          ) do
-        put_in(state["context"]["nearestIntersection"], headsign)
+      def with_nearest_intersection(%{"context" => %{"nearestIntersection" => _}} = state, value) do
+        put_in(state, ["context", "nearestIntersection"], value)
       end
 
       def with_coordinates(
-            detour,
+            update_arg,
             coordinates \\ [
-              %{
-                lat: 42.337949,
-                lon: -71.074936
-              },
-              %{
-                lat: 42.338488,
-                lon: -71.066487
-              },
-              %{
-                lat: 42.339672,
-                lon: -71.067018
-              },
-              %{
-                lat: 42.339848,
-                lon: -71.067554
-              },
-              %{
-                lat: 42.340134,
-                lon: -71.068427
-              },
-              %{
-                lat: 42.340216,
-                lon: -71.068579
-              }
+              %{lat: 42.337949, lon: -71.074936},
+              %{lat: 42.338488, lon: -71.066487},
+              %{lat: 42.339672, lon: -71.067018},
+              %{lat: 42.339848, lon: -71.067554},
+              %{lat: 42.340134, lon: -71.068427},
+              %{lat: 42.340216, lon: -71.068579}
             ]
           )
 
-      def with_coordinates(
-            %Skate.Detours.Db.Detour{} = detour,
-            coordinates
-          ) do
-        %{detour | state: with_coordinates(detour.state, coordinates)}
+      def with_coordinates(%Skate.Detours.Db.Detour{} = detour, coordinates) do
+        detour_shape = %{"ok" => %{"coordinates" => coordinates}}
+
+        detour
+        |> Map.put(:coordinates, coordinates)
+        |> Map.put(:detour_shape, detour_shape)
+        |> Map.put(:state, with_coordinates(detour.state, coordinates))
       end
 
-      def with_coordinates(state, coordinates) do
-        put_in(state["context"]["detourShape"], %{"ok" => %{"coordinates" => coordinates}})
+      def with_coordinates(%{"context" => %{}} = state, coordinates) do
+        put_in(state, ["context", "detourShape"], %{
+          "ok" => %{"coordinates" => coordinates}
+        })
       end
 
       def with_missed_stops(%Skate.Detours.Db.Detour{} = detour, stops) do
-        %{detour | state: with_missed_stops(detour.state, stops)}
+        missed_stops = Enum.map(stops, fn stop_id -> %{"id" => stop_id} end)
+
+        route_segments =
+          detour.route_segments || %{"beforeDetour" => [], "afterDetour" => [], "detour" => []}
+
+        detour_shape = detour.detour_shape || %{"ok" => %{"coordinates" => []}}
+
+        detour
+        |> Map.put(:missed_stops, missed_stops)
+        |> Map.put(:route_segments, route_segments)
+        |> Map.put(:detour_shape, detour_shape)
+        |> Map.put(:state, with_missed_stops(detour.state, stops))
       end
 
-      def with_missed_stops(state, stops) do
-        missed_stops = Enum.map(stops, fn stop_id -> %{"id" => stop_id} end)
-        put_in(state["context"]["finishedDetour"], %{"missedStops" => missed_stops})
+      def with_missed_stops(%{"context" => _} = state, stops) do
+        missed_stops = Enum.map(stops, &%{"id" => &1})
+        finished_detour = %{"finishedDetour" => %{"missedStops" => missed_stops}}
+
+        put_in(state, ["context", "finishedDetour"], finished_detour)
       end
 
       def with_author(%Skate.Detours.Db.Detour{} = detour, user) do
-        %{detour | author: user}
+        Map.put(detour, :author, user)
       end
     end
   end

--- a/test/support/factories/detour_factory.ex
+++ b/test/support/factories/detour_factory.ex
@@ -116,6 +116,7 @@ defmodule Skate.DetourFactory do
           detour
           | state: activated(detour.state, activated_at, estimated_duration),
             activated_at: activated_at,
+            updated_at: activated_at,
             status: :active,
             estimated_duration: estimated_duration
         }


### PR DESCRIPTION
Asana Ticket: [Prevent detour becoming stuck due to missing context values](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1217159544354832?focus=true)

### Summary of changes
* `priv/repo`: db migrations to add the fields necessary to populate the snapshot from flattened fields.
* `snapshot_serde`: serialize_snapshot delivers data to the front end as a snapshot. It use to derive those values from the stored snapshot. Now it primarily uses the database fields and uses the snapshot as a backup. If we no longer receive missing value warnings, we can retire the snapshot entirely from the db.
* `lib/skate/detours/db/detour.ex`: Add all the new fields to the db schema and define their changeset behavior.
    * A refactor: There are several fields that should actually be nullable, and others where they shouldn't be. Refactored to clearly store those lists.
    * copy to draft was also reworked to not depend on the state value so much.
* various other files were updated (swiftly, s3_export, notifications) to use the database columns instead of the state values.