### PR TITLE
fix: Prevent duplicate snapshot saves

### DIFF
--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -54,6 +54,8 @@ export const useDetour = (useDetourProps: UseDetourInput) => {
               .can({ type: "detour.save.set-uuid", uuid: uuid.ok })
           ) {
             actorRef.send({ type: "detour.save.set-uuid", uuid: uuid.ok })
+          } else if (!isOk(uuid)) {
+            actorRef.send({ type: "detour.save.save-failed" })
           }
         })
       }

--- a/assets/src/hooks/useDetour.ts
+++ b/assets/src/hooks/useDetour.ts
@@ -38,38 +38,26 @@ export const useDetour = (useDetourProps: UseDetourInput) => {
 
   // Record snapshots when changed
   useEffect(() => {
+    let wasSaving = false // prevent simultaneous saves
     const snapshotSubscription = actorRef.subscribe((snap) => {
       const persistedSnapshot = actorRef.getPersistedSnapshot()
       const serializedSnapshot = JSON.stringify(persistedSnapshot)
       localStorage.setItem("snapshot", serializedSnapshot)
-      // check for no-save tag before
-      if (snap.hasTag("no-save")) {
-        return
+
+      const isSaving = snap.matches({ SaveState: "Saving" })
+      if (!wasSaving && isSaving) {
+        putDetourUpdate(persistedSnapshot).then((uuid) => {
+          if (
+            isOk(uuid) &&
+            actorRef
+              .getSnapshot()
+              .can({ type: "detour.save.set-uuid", uuid: uuid.ok })
+          ) {
+            actorRef.send({ type: "detour.save.set-uuid", uuid: uuid.ok })
+          }
+        })
       }
-
-      // do not save if drawn detour has no start point
-      if (!snap.context.isTextOnly && !snap.context.nearestIntersection) {
-        return
-      }
-
-      // if detour already activated, do not save, unless overridden
-      if (snap.context.activatedAt && !snap.hasTag("save-activated")) {
-        return
-      }
-
-      if (actorRef.getSnapshot().can({ type: "detour.save.begin-save" }))
-        actorRef.send({ type: "detour.save.begin-save" })
-
-      putDetourUpdate(persistedSnapshot).then((uuid) => {
-        if (
-          isOk(uuid) &&
-          actorRef
-            .getSnapshot()
-            .can({ type: "detour.save.set-uuid", uuid: uuid.ok })
-        ) {
-          actorRef.send({ type: "detour.save.set-uuid", uuid: uuid.ok })
-        }
-      })
+      wasSaving = isSaving
     })
 
     return () => {

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -123,6 +123,7 @@ export const createDetourMachine = setup({
       | { type: "detour.save.begin-save-inactive" }
       | { type: "detour.save.begin-save" }
       | { type: "detour.save.set-uuid"; uuid: number }
+      | { type: "detour.save.save-failed" }
       | { type: "detour.delete.open-delete-modal" }
       | { type: "detour.delete.delete-modal.cancel" }
       | { type: "detour.delete.delete-modal.delete-draft" },
@@ -1295,6 +1296,9 @@ export const createDetourMachine = setup({
               actions: assign({
                 uuid: ({ event }) => event.uuid,
               }),
+            },
+            "detour.save.save-failed": {
+              target: "Unsaved",
             },
           },
         },

--- a/assets/src/models/createDetourMachine.ts
+++ b/assets/src/models/createDetourMachine.ts
@@ -1,4 +1,11 @@
-import { setup, assign, fromPromise, ActorLogicFrom, InputFrom } from "xstate"
+import {
+  setup,
+  assign,
+  fromPromise,
+  ActorLogicFrom,
+  InputFrom,
+  raise,
+} from "xstate"
 import { RoutePatternId, ShapePoint } from "../schedule"
 import { Route, RouteId, RoutePattern } from "../schedule"
 import { isOk, Ok, Result } from "../util/result"
@@ -113,22 +120,12 @@ export const createDetourMachine = setup({
       | { type: "detour.active.edit.resume" }
       | { type: "detour.active.edit.done" }
       | { type: "detour.active.edit.cancel" }
+      | { type: "detour.save.begin-save-inactive" }
       | { type: "detour.save.begin-save" }
       | { type: "detour.save.set-uuid"; uuid: number }
       | { type: "detour.delete.open-delete-modal" }
       | { type: "detour.delete.delete-modal.cancel" }
       | { type: "detour.delete.delete-modal.delete-draft" },
-
-    // We're making an assumption that we'll never want to save detour edits to the database when in particular stages
-    // of detour drafting:
-    // -- when starting a detour, before any user input
-    // -- when the route id / route pattern is getting selected
-    // -- right after the route pattern is finalized, before any waypoints are added
-    // That leads to the following interface: if the user begins drafting a detour, adds waypoints, and then changes the route,
-    // the database will reflect the old route and old waypoints up until the point where a new waypoint is added,
-    // unless they are editing an already activated detour, when it will only be saved upon re-activation
-    // If that UX assumption isn't the right one, we can iterate in the future!
-    tags: {} as "no-save" | "save-activated",
   },
   actors: {
     "fetch-route-patterns": fromPromise<
@@ -334,7 +331,6 @@ export const createDetourMachine = setup({
 
       states: {
         Begin: {
-          tags: "no-save",
           always: [
             {
               guard: ({ context }) =>
@@ -348,7 +344,6 @@ export const createDetourMachine = setup({
 
         "Pick Route Pattern": {
           initial: "Pick Route ID",
-          tags: "no-save",
           on: {
             "detour.route-pattern.select-route": {
               target: ".Pick Route ID",
@@ -545,7 +540,6 @@ export const createDetourMachine = setup({
           },
           states: {
             "Pick Start Point": {
-              tags: "no-save",
               on: {
                 "detour.edit.place-waypoint-on-route": {
                   target: "Place Waypoint",
@@ -572,6 +566,7 @@ export const createDetourMachine = setup({
               },
             },
             "Place Waypoint": {
+              entry: raise({ type: "detour.save.begin-save-inactive" }),
               invoke: [
                 {
                   src: "fetch-nearest-intersection",
@@ -720,6 +715,7 @@ export const createDetourMachine = setup({
               },
             },
             "Finished Drawing": {
+              entry: raise({ type: "detour.save.begin-save-inactive" }),
               invoke: {
                 src: "fetch-finished-detour",
                 input: ({
@@ -855,7 +851,6 @@ export const createDetourMachine = setup({
                   },
                 ],
                 "detour.delete.delete-modal.delete-draft": {
-                  tags: "no-save",
                   target: "#Deleted",
                 },
               },
@@ -922,20 +917,23 @@ export const createDetourMachine = setup({
               on: {
                 "detour.type.edit-typed-detour": {
                   target: "Typing",
-                  actions: assign({
-                    typedDetour: ({ context: { typedDetour }, event }) => {
-                      const current = typedDetour || {
-                        directions: "",
-                        missedStops: "",
-                        connectionPoints: "",
-                      }
+                  actions: [
+                    assign({
+                      typedDetour: ({ context: { typedDetour }, event }) => {
+                        const current = typedDetour || {
+                          directions: "",
+                          missedStops: "",
+                          connectionPoints: "",
+                        }
 
-                      return {
-                        ...current,
-                        ...event.typedDetour,
-                      }
-                    },
-                  }),
+                        return {
+                          ...current,
+                          ...event.typedDetour,
+                        }
+                      },
+                    }),
+                    raise({ type: "detour.save.begin-save-inactive" }),
+                  ],
                 },
                 "detour.delete.open-delete-modal": {
                   target: "Deleting",
@@ -951,7 +949,6 @@ export const createDetourMachine = setup({
                   target: "Typing",
                 },
                 "detour.delete.delete-modal.delete-draft": {
-                  tags: "no-save",
                   target: "#Deleted",
                 },
               },
@@ -991,6 +988,7 @@ export const createDetourMachine = setup({
 
         "Share Detour": {
           initial: "Reviewing",
+          entry: raise({ type: "detour.save.begin-save-inactive" }),
           on: {
             "detour.edit.resume": {
               target: "Editing.Finished Drawing",
@@ -1016,9 +1014,12 @@ export const createDetourMachine = setup({
                 },
                 "detour.share.edit-directions": {
                   target: "Reviewing",
-                  actions: assign({
-                    editedDirections: ({ event }) => event.detourText,
-                  }),
+                  actions: [
+                    assign({
+                      editedDirections: ({ event }) => event.detourText,
+                    }),
+                    raise({ type: "detour.save.begin-save-inactive" }),
+                  ],
                 },
                 "detour.delete.open-delete-modal": {
                   target: "Deleting",
@@ -1069,6 +1070,7 @@ export const createDetourMachine = setup({
                   },
                   onDone: {
                     target: "Selecting Reason",
+                    actions: raise({ type: "detour.save.begin-save-inactive" }),
                   },
                 },
                 "Selecting Reason": {
@@ -1109,6 +1111,7 @@ export const createDetourMachine = setup({
                   },
                   onDone: {
                     target: "Confirming",
+                    actions: raise({ type: "detour.save.begin-save-inactive" }),
                   },
                 },
                 Confirming: {
@@ -1125,7 +1128,6 @@ export const createDetourMachine = setup({
                   },
                 },
                 "Activating Server": {
-                  tags: "no-save",
                   invoke: {
                     id: "activate-detour",
                     src: "activate-detour",
@@ -1156,7 +1158,6 @@ export const createDetourMachine = setup({
                 },
                 Done: {
                   type: "final",
-                  tags: "no-save",
                 },
               },
               onDone: {
@@ -1170,7 +1171,6 @@ export const createDetourMachine = setup({
                   target: "Reviewing",
                 },
                 "detour.delete.delete-modal.delete-draft": {
-                  tags: "no-save",
                   target: "#Deleted",
                 },
               },
@@ -1184,6 +1184,7 @@ export const createDetourMachine = setup({
 
         Active: {
           initial: "Reviewing",
+          entry: raise({ type: "detour.save.begin-save" }),
           states: {
             Reviewing: {
               on: {
@@ -1220,11 +1221,14 @@ export const createDetourMachine = setup({
                 },
                 "detour.active.change-duration-modal.done": {
                   target: "Reviewing",
-                  actions: assign({
-                    selectedDuration: ({
-                      context: { editedSelectedDuration },
-                    }) => editedSelectedDuration,
-                  }),
+                  actions: [
+                    assign({
+                      selectedDuration: ({
+                        context: { editedSelectedDuration },
+                      }) => editedSelectedDuration,
+                    }),
+                    raise({ type: "detour.save.begin-save" }),
+                  ],
                   guard: ({ context: { editedSelectedDuration } }) =>
                     editedSelectedDuration !== undefined,
                 },
@@ -1249,33 +1253,42 @@ export const createDetourMachine = setup({
           onDone: {
             target: "Past",
           },
-          tags: "save-activated",
         },
 
         Past: {
-          tags: "save-activated",
+          entry: raise({ type: "detour.save.begin-save" }),
         },
 
         Deleted: {
           id: "Deleted",
-          tags: "no-save",
           type: "final",
         },
       },
     },
 
+    // We do not want to save detour edits when:
+    // -- when starting a detour, before any user input
+    // -- when the route id / route pattern is getting selected
+    // -- right after the route pattern is finalized, before any waypoints are added
+    // -- while editing an active detour
+    // That leads to the following interface: if the user begins drafting a detour, adds waypoints, and then changes the route,
+    // the database will reflect the old route and old waypoints up until the point where a new waypoint is added,
+    // unless they are editing an already activated detour, when it will only be saved upon re-activation
     SaveState: {
       initial: "Unsaved",
       states: {
         Unsaved: {
           on: {
+            "detour.save.begin-save-inactive": {
+              target: "Saving",
+              guard: ({ context }) => context.activatedAt === undefined,
+            },
             "detour.save.begin-save": {
               target: "Saving",
             },
           },
         },
         Saving: {
-          tags: "no-save",
           on: {
             "detour.save.set-uuid": {
               target: "Saved",
@@ -1285,7 +1298,17 @@ export const createDetourMachine = setup({
             },
           },
         },
-        Saved: {},
+        Saved: {
+          on: {
+            "detour.save.begin-save-inactive": {
+              target: "Saving",
+              guard: ({ context }) => context.activatedAt === undefined,
+            },
+            "detour.save.begin-save": {
+              target: "Saving",
+            },
+          },
+        },
       },
     },
   },

--- a/assets/tests/components/detours/diversionPage.saveDetour.test.tsx
+++ b/assets/tests/components/detours/diversionPage.saveDetour.test.tsx
@@ -86,7 +86,7 @@ describe("DiversionPage autosave flow", () => {
     })
 
     await waitFor(() => {
-      expect(putDetourUpdate).toHaveBeenCalledTimes(5)
+      expect(putDetourUpdate).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -12,7 +12,10 @@ defmodule Skate.Detours.SnapshotSerde do
   Converts a XState JSON Snapshot to Detours Database Changeset
   """
   def deserialize(user_id, %{} = snapshot) do
-    {activated_at, snapshot} = pop_in(snapshot, ["context", "activatedAt"])
+    {activated_at, snapshot} =
+      snapshot
+      |> put_in(["value", "SaveState"], "Saved")
+      |> pop_in(["context", "activatedAt"])
 
     id = id_from_snapshot(snapshot)
 

--- a/test/skate_web/controllers/detours_controller_test.exs
+++ b/test/skate_web/controllers/detours_controller_test.exs
@@ -42,9 +42,11 @@ defmodule SkateWeb.DetoursControllerTest do
   describe "update_snapshot/2" do
     @tag :authenticated
     test "adds new detour to database", %{conn: conn} do
+      snapshot = build(:detour_snapshot)
+
       conn =
         put(conn, "/api/detours/update_snapshot", %{
-          "snapshot" => %{"context" => %{}}
+          "snapshot" => snapshot
         })
 
       assert %{"data" => number} = json_response(conn, 200)
@@ -68,23 +70,14 @@ defmodule SkateWeb.DetoursControllerTest do
 
     @tag :authenticated
     test "updates detour in database if detour uuid provided", %{conn: conn} do
+      snapshot =
+        :detour_snapshot
+        |> build()
+        |> with_id(8)
+
       conn =
         put(conn, "/api/detours/update_snapshot", %{
-          "snapshot" => %{
-            "context" => %{
-              "nearestIntersection" => "Street A & Avenue B",
-              "route" => %{
-                "directionNames" => %{"0" => "Outbound", "1" => "Inbound"},
-                "name" => "23"
-              },
-              "routePattern" => %{
-                "directionId" => 0,
-                "headsign" => "Headsign",
-                "id" => "23-1-0"
-              },
-              "uuid" => 8
-            }
-          }
+          "snapshot" => snapshot
         })
 
       assert %{"data" => 8} = json_response(conn, 200)
@@ -336,6 +329,9 @@ defmodule SkateWeb.DetoursControllerTest do
         |> build()
         |> with_id(detour_id)
 
+      serialized_detour_snapshot =
+        put_in(detour_snapshot["value"]["SaveState"], "Saved")
+
       put(conn, "/api/detours/update_snapshot", %{"snapshot" => detour_snapshot})
 
       {conn, log} =
@@ -346,7 +342,7 @@ defmodule SkateWeb.DetoursControllerTest do
       refute log =~
                "Serialized detour doesn't match saved snapshot. Falling back to snapshot for detour_id=#{detour_id}"
 
-      assert detour_snapshot == json_response(conn, 200)["data"]["state"]
+      assert serialized_detour_snapshot == json_response(conn, 200)["data"]["state"]
     end
 
     @tag :authenticated


### PR DESCRIPTION
Asana Ticket: [Prevent detour becoming stuck due to missing context values](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1217159544354832?focus=true)

This refactor has been long wanted:
* If you open up your network requests while making a detour you'll see many snapshot updates per action, including when you first load the page.
* The source of the drift between the context and database values may have been a result of snapshot updates racing against each other.
* Even before we had these bugs, there was a feeling that the no-save tags and logic in useDetour was getting unwieldy and unpredictable.
* We also only used the Unsaved / Saving / Saved states for the first save. 

Instead, we only save when the action is raised, and move from unsaved / saved into saving. The useEffect will look for the Saving and begin a save which will also prevent duplicate ones. It will be marked as "Saved" in the backend as well so that when a snapshot is loaded from the db, it will not immediate save on load.