### PR TITLE
hotfix: failing s3 exportjob

### DIFF
--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -524,7 +524,7 @@ defmodule Skate.Detours.Detours do
 
     if is_binary(reason) do
       case Application.fetch_env(:skate, :s3_bucket) do
-        {:ok, s3_bucket} ->
+        {:ok, s3_bucket} when is_binary(s3_bucket) ->
           %{
             reason: reason,
             filter: %{"status" => "active"},

--- a/lib/skate/detours/detours.ex
+++ b/lib/skate/detours/detours.ex
@@ -533,7 +533,7 @@ defmodule Skate.Detours.Detours do
           |> S3Exporter.new()
           |> Oban.insert()
 
-        :error ->
+        _ ->
           {:ok, nil}
       end
     else


### PR DESCRIPTION
@vgu-mbta identified new error logs in Splunk:

```
mfa=Skate.Detours.S3Exporter.Telemetry.handle_event/4 detour s3 export job: failed in 248943 ms with reason message 'Skate.Detours.S3Exporter failed with {:error, :invalid_job_args}'
```

while our production environment is not yet configured to export detour data to s3, these error logs should not appear (the job should not be queued at all)

the root cause is that the configuration value resolves to `nil` in production: https://github.com/mbta/skate/blob/ad4ffb86bcbafc7423da42dd035fa97e04f12a55/config/runtime.exs#L78

the fix is to match on the s3 bucket being a string and ignore all other cases