### PR TITLE
fix: set updated_at when deactivating detours

### DIFF
--- a/lib/skate/detours/db/detour.ex
+++ b/lib/skate/detours/db/detour.ex
@@ -172,6 +172,14 @@ defmodule Skate.Detours.Db.Detour do
           NaiveDateTime.truncate(DateTime.to_naive(activated_at), :second)
         )
 
+      # set updated_at time for deactivated detours
+      {{:changes, :past}, _} ->
+        put_change(
+          changeset,
+          :updated_at,
+          NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+        )
+
       # Relies on snapshots being suppressed for changes to active detours
       {{:data, :active}, _} ->
         put_change(


### PR DESCRIPTION
Asana Ticket: [🐛 Prevent detour becoming stuck due to missing context values](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1217159544354832?focus=true)

Probably a regression from the save rework.