### PR TITLE
chore: block vulnerability scanning requests

### DIFF
--- a/lib/skate_web/endpoint.ex
+++ b/lib/skate_web/endpoint.ex
@@ -38,6 +38,9 @@ defmodule SkateWeb.Endpoint do
 
   plug Plug.RequestId
 
+  # Reject common bot/scanner probes (LFI/RFI, WordPress paths, etc.)
+  plug SkateWeb.Plugs.BlockScannerRequests
+
   plug Logster.Plugs.Logger
 
   plug Plug.Parsers,

--- a/lib/skate_web/plugs/block_scanner_requests.ex
+++ b/lib/skate_web/plugs/block_scanner_requests.ex
@@ -1,0 +1,32 @@
+defmodule SkateWeb.Plugs.BlockScannerRequests do
+  @moduledoc """
+  Short-circuits requests matching common vulnerability-scanner probes, e.g.
+  `/index.php` path-traversal attempts hunting for PHP/CGI misconfigurations
+  that don't exist in this Phoenix app. Skips the router/logger noise by
+  responding 404 immediately and demoting the request's log level.
+  """
+
+  import Plug.Conn
+
+  # Requests for PHP/CGI/ASP files, `wp-*` WordPress paths, or `..` traversal
+  # sequences (raw or percent-encoded) in the path or query string.
+  @scanner_regex ~r{(\.(php\d?|phtml|asp|aspx|cgi)$|/wp-|\.\.(/|\\|%2f|%5c))}i
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    if scanner_request?(conn) do
+      conn
+      |> put_private(:logster_log_level, :debug)
+      |> send_resp(404, "")
+      |> halt()
+    else
+      conn
+    end
+  end
+
+  defp scanner_request?(conn) do
+    String.match?(conn.request_path, @scanner_regex) or
+      String.match?(conn.query_string, @scanner_regex)
+  end
+end

--- a/lib/skate_web/plugs/block_scanner_requests.ex
+++ b/lib/skate_web/plugs/block_scanner_requests.ex
@@ -30,14 +30,18 @@ defmodule SkateWeb.Plugs.BlockScannerRequests do
   end
 
   defp scanner_request?(conn) do
-    request = conn.request_path <> if(conn.query_string == "", do: "", else: "?#{conn.query_string}")
+    request =
+      conn.request_path <> if(conn.query_string == "", do: "", else: "?#{conn.query_string}")
 
-    Enum.any?([
-      @unsupported_stack_regex,
-      @traversal_regex,
-      @null_byte_regex,
-      @sensitive_file_regex,
-      @file_fetch_regex
-    ], &String.match?(request, &1))
+    Enum.any?(
+      [
+        @unsupported_stack_regex,
+        @traversal_regex,
+        @null_byte_regex,
+        @sensitive_file_regex,
+        @file_fetch_regex
+      ],
+      &String.match?(request, &1)
+    )
   end
 end

--- a/lib/skate_web/plugs/block_scanner_requests.ex
+++ b/lib/skate_web/plugs/block_scanner_requests.ex
@@ -8,9 +8,13 @@ defmodule SkateWeb.Plugs.BlockScannerRequests do
 
   import Plug.Conn
 
-  # Requests for PHP/CGI/ASP files, `wp-*` WordPress paths, or `..` traversal
-  # sequences (raw or percent-encoded) in the path or query string.
-  @scanner_regex ~r{(\.(php\d?|phtml|asp|aspx|cgi)$|/wp-|\.\.(/|\\|%2f|%5c))}i
+  # Requests for unsupported stacks, exposed metadata/credential files,
+  # traversal/null-byte probes, or fake file-fetch/proxy attempts.
+  @unsupported_stack_regex ~r{(\.(php\d?|phtml|phar|asp|aspx|cgi)(?:$|[/?#])|/(?:wp-admin|wp-login|wp-content|wp-includes)(?:$|[/?#]))}i
+  @traversal_regex ~r{(?:\.\.|%2e%2e)(?:/|\\|%2f|%5c)}i
+  @null_byte_regex ~r{(?:%00|\\u0000|\x00)}i
+  @sensitive_file_regex ~r{(?:^|/)(?:\.git/config|\.env(?:\.[a-z0-9_-]+)?|\.aws/credentials(?:\.[^/?#]+)?|\.azure/credentials(?:\.[^/?#]+)?|terraform\.tfstate(?:\.(?:orig|backup|bak|old))?|\.continue/config\.json|config/anthropic\.json|boot\.ini|win\.ini|etc/passwd)(?:$|[/?#])}i
+  @file_fetch_regex ~r{(?:^|[?&])(?:url|uri|path|endpoint)=.*(?:file:|file%3a|/root/|/etc/passwd|\.aws/credentials|\.azure/credentials)}i
 
   def init(opts), do: opts
 
@@ -26,7 +30,14 @@ defmodule SkateWeb.Plugs.BlockScannerRequests do
   end
 
   defp scanner_request?(conn) do
-    String.match?(conn.request_path, @scanner_regex) or
-      String.match?(conn.query_string, @scanner_regex)
+    request = conn.request_path <> if(conn.query_string == "", do: "", else: "?#{conn.query_string}")
+
+    Enum.any?([
+      @unsupported_stack_regex,
+      @traversal_regex,
+      @null_byte_regex,
+      @sensitive_file_regex,
+      @file_fetch_regex
+    ], &String.match?(request, &1))
   end
 end

--- a/test/skate_web/plugs/block_scanner_requests_test.exs
+++ b/test/skate_web/plugs/block_scanner_requests_test.exs
@@ -1,0 +1,45 @@
+defmodule SkateWeb.Plugs.BlockScannerRequestsTest do
+  use ExUnit.Case, async: true
+
+  alias SkateWeb.Plugs.BlockScannerRequests
+
+  test "halts and returns 404 for PHP file probes" do
+    conn = call_with_path("/index.php")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts and returns 404 for wordpress paths" do
+    conn = call_with_path("/wp-login.php")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts and returns 404 for path traversal in the path" do
+    conn = call_with_path("/../../../../etc/passwd")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts and returns 404 for path traversal in the query string" do
+    conn = call_with_path("/index.php", "page=../../../../boot.ini")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "passes through normal requests" do
+    conn = call_with_path("/")
+
+    refute conn.halted
+  end
+
+  defp call_with_path(path, query_string \\ "") do
+    :get
+    |> Plug.Test.conn(path <> if(query_string == "", do: "", else: "?#{query_string}"))
+    |> BlockScannerRequests.call(BlockScannerRequests.init([]))
+  end
+end

--- a/test/skate_web/plugs/block_scanner_requests_test.exs
+++ b/test/skate_web/plugs/block_scanner_requests_test.exs
@@ -31,6 +31,39 @@ defmodule SkateWeb.Plugs.BlockScannerRequestsTest do
     assert conn.status == 404
   end
 
+  test "halts and returns 404 for null-byte probes" do
+    conn = call_with_path("/index.php", "page=../../../../../../../../../../../etc/passwd\\u0000")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "halts and returns 404 for exposed metadata and credential file probes" do
+    for path <- [
+          "/.git/config",
+          "/login/.git/config",
+          "/.env",
+          "/.env.production",
+          "/.env.local",
+          "/.aws/credentials.backup",
+          "/terraform.tfstate.orig",
+          "/.continue/config.json",
+          "/config/anthropic.json"
+        ] do
+      conn = call_with_path(path)
+
+      assert conn.halted, "expected #{path} to halt"
+      assert conn.status == 404
+    end
+  end
+
+  test "halts and returns 404 for file fetch probes" do
+    conn = call_with_path("/fetch", "url=file:///root/.azure/credentials")
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
   test "passes through normal requests" do
     conn = call_with_path("/")
 


### PR DESCRIPTION
Asana Ticket: [Block Vulnerability Scanning Requests](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1218057073828438?focus=true)

Added block_scanner_requests.ex: a plug matching request path/query against a regex for .php/.asp/.cgi extensions, /wp-* WordPress paths, and ../ traversal sequences (raw or percent-encoded). Matches are short-circuited with an immediate 404 and demoted to :debug log level via Logster