### PR TITLE
chore: handle malformed keycloak request so process doesn't crash

### DIFF
--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -25,7 +25,9 @@ defmodule SkateWeb.AuthController do
     if suspicious_keycloak_request?(conn) do
       Logger.info("keycloak direct-ip probe blocked host=#{conn.host}")
     else
-      Logger.warning("keycloak request failure=#{Kernel.inspect(conn.assigns[:ueberauth_failure])}")
+      Logger.warning(
+        "keycloak request failure=#{Kernel.inspect(conn.assigns[:ueberauth_failure])}"
+      )
     end
 
     send_resp(conn, :bad_request, "invalid keycloak request")

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -9,6 +9,16 @@ defmodule SkateWeb.AuthController do
   alias SkateWeb.AuthManager
   alias SkateWeb.Plugs.CaptureAuthReturnPath
 
+  def request(%{assigns: %{ueberauth_failure: %{provider: :keycloak} = failure}} = conn, _params) do
+    Logger.warning("keycloak request failure=#{Kernel.inspect(failure)}")
+    send_resp(conn, :bad_request, "invalid keycloak request")
+  end
+
+  def request(conn, _params) do
+    Logger.warning("unhandled keycloak request")
+    send_resp(conn, :bad_request, "invalid keycloak request")
+  end
+
   def callback(%{assigns: %{ueberauth_auth: %{provider: :keycloak} = auth}} = conn, _params) do
     username = auth.uid
     email = auth.info.email

--- a/lib/skate_web/controllers/auth_controller.ex
+++ b/lib/skate_web/controllers/auth_controller.ex
@@ -10,13 +10,41 @@ defmodule SkateWeb.AuthController do
   alias SkateWeb.Plugs.CaptureAuthReturnPath
 
   def request(%{assigns: %{ueberauth_failure: %{provider: :keycloak} = failure}} = conn, _params) do
-    Logger.warning("keycloak request failure=#{Kernel.inspect(failure)}")
+    if suspicious_keycloak_request?(conn) do
+      Logger.info(
+        "keycloak direct-ip probe blocked host=#{conn.host} failure=#{Kernel.inspect(failure)}"
+      )
+    else
+      Logger.warning("keycloak request failure=#{Kernel.inspect(failure)}")
+    end
+
     send_resp(conn, :bad_request, "invalid keycloak request")
   end
 
   def request(conn, _params) do
-    Logger.warning("unhandled keycloak request")
+    if suspicious_keycloak_request?(conn) do
+      Logger.info("keycloak direct-ip probe blocked host=#{conn.host}")
+    else
+      Logger.warning("keycloak request failure=#{Kernel.inspect(conn.assigns[:ueberauth_failure])}")
+    end
+
     send_resp(conn, :bad_request, "invalid keycloak request")
+  end
+
+  defp suspicious_keycloak_request?(conn) do
+    case endpoint_host() do
+      nil ->
+        false
+
+      expected_host ->
+        conn.host != expected_host and conn.host not in ["localhost", "127.0.0.1", "0.0.0.0"]
+    end
+  end
+
+  defp endpoint_host do
+    SkateWeb.Endpoint
+    |> Application.get_env(:url, [])
+    |> Keyword.get(:host)
   end
 
   def callback(%{assigns: %{ueberauth_auth: %{provider: :keycloak} = auth}} = conn, _params) do

--- a/test/skate_web/controllers/auth_controller_test.exs
+++ b/test/skate_web/controllers/auth_controller_test.exs
@@ -11,6 +11,25 @@ defmodule SkateWeb.AuthControllerTest do
 
       assert redirected_to(conn) == ~p"/auth/keycloak/callback"
     end
+
+    test "returns bad request on a malformed keycloak authorization request", %{conn: conn} do
+      failure = %Ueberauth.Failure{
+        provider: :keycloak,
+        errors: [
+          %Ueberauth.Failure.Error{
+            message_key: "invalid_request",
+            message: "Invalid parameter: redirect_uri"
+          }
+        ]
+      }
+
+      conn =
+        conn
+        |> assign(:ueberauth_failure, failure)
+        |> SkateWeb.AuthController.request(%{})
+
+      assert response(conn, :bad_request) == "invalid keycloak request"
+    end
   end
 
   describe "GET /auth/keycloak/callback" do


### PR DESCRIPTION
Asana Ticket: [Investigate Skate.Endpoint stream terminated errors](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1218057073828437?focus=true)

This PR adds 
- a fallback request on keycloak ueberauth_failure  + a general failure clause in AuthController so a bad/malformed auth request returns a clean 4xx instead of crashing the process
- a suspicious_keycloak_request check in auth_controller.ex (checks if the host name matches), and it logs at info level to keep splunk logs cleaner, instead of warning

Why we get malformed requests: This request hit the app directly by IP address. Ueberauth.Strategy.Oidcc builds the redirect_uri for the OIDC authorize request from the incoming connection's host/scheme. Since 52.0.35.241 doesn't match the redirect URI(s) registered in the Keycloak client, oidcc rejects it client-side with invalid_request: Invalid parameter: redirect_uri before ever contacting Keycloak. This looks like automated internet scanning/bot traffic probing the raw ELB/EC2 IP rather than a legitimate user