### PR TITLE
fix: CI tests failing due to hex not found in cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,6 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
-      - name: Ensure Hex is installed
-        run: mix local.hex --force
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       - if: steps.asdf-cache.outputs.cache-hit != 'true'
         # Git ref points to release tag 'v4'
         uses: asdf-vm/actions/install@156187456fbe441e7badfe93ec1fa4dda646b27e
+      - if: steps.asdf-cache.outputs.cache-hit != 'true'
+        uses: |
+          mix local.rebar --force
+          mix local.hex --force
       - name: Setup ASDF environment
         run: |
           ASDF_DIR=$HOME/.asdf
@@ -51,14 +55,9 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
-      - name: Ensure Hex is installed
-        run: mix local.hex --force
       - name: Install dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
+        run: mix deps.get
 
   build_elixir:
     permissions:
@@ -122,6 +121,8 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
+      - name: Ensure Hex is installed
+        run: mix local.hex --force
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       - if: steps.asdf-cache.outputs.cache-hit != 'true'
         # Git ref points to release tag 'v4'
         uses: asdf-vm/actions/install@156187456fbe441e7badfe93ec1fa4dda646b27e
-      - if: steps.asdf-cache.outputs.cache-hit != 'true'
-        uses: |
+      - run: |
           mix local.rebar --force
           mix local.hex --force
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
       - name: Setup ASDF environment
         run: |
           ASDF_DIR=$HOME/.asdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: Elixir and TypeScript CI
 on: [push, pull_request]
 
 # - https://docs.zizmor.sh/audits/#excessive-permissions
-permissions:
-  {} # Deliberately assign no default permissions
+permissions: {} # Deliberately assign no default permissions
 
 # Concurrency control is defined at the job level.
 # - https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
@@ -52,6 +51,8 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
+      - name: Ensure Hex is installed
+        run: mix local.hex --force
       - name: Install dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
@@ -179,7 +180,7 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
       - name: Install dependencies
-        run: npm --prefix=assets ci 
+        run: npm --prefix=assets ci
       - name: Check types / linting / formatting
         run: npm --prefix=assets run check
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - if: steps.asdf-cache.outputs.cache-hit != 'true'
         # Git ref points to release tag 'v4'
         uses: asdf-vm/actions/install@156187456fbe441e7badfe93ec1fa4dda646b27e
+      # hex and rebar are stored with the asdf cache
       - run: |
           mix local.rebar --force
           mix local.hex --force


### PR DESCRIPTION
Looks like hex/rebar are in the asdf cache. Other MBTA workflows fetch them if that cache is not found instead. Hopefully this resolves the issue we're having on our test runs.

https://github.com/mbta/api/blob/06e58f51c24a45a5d25b436dbe1ca0f1886ae68f/.github/workflows/elixir.yml#L61