### PR TITLE
chore: aggregate missing detour structure fields in logs

### DIFF
--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -8,6 +8,10 @@ defmodule Skate.Detours.SnapshotSerde do
 
   alias Skate.Detours.Db.Detour
 
+  # Process dictionary key used to batch `log_fallback/1` warnings emitted
+  # while serializing a single detour into one aggregated log line.
+  @fallback_fields_key :snapshot_serde_fallback_fields
+
   @doc """
   Converts a XState JSON Snapshot to Detours Database Changeset
   """
@@ -78,13 +82,21 @@ defmodule Skate.Detours.SnapshotSerde do
     MapDiff.diff(cleaned_state, cleaned_serialized_snapshot)
   end
 
-  defp serialize_snapshot(detour) do
-    %{
+  defp serialize_snapshot(%Detour{id: id, author_id: author_id} = detour) do
+    # Fallback warnings from `log_fallback/1` accumulate per-process during this
+    # call; flush them as a single aggregated warning instead of one per field.
+    Process.delete(@fallback_fields_key)
+
+    snapshot = %{
       "value" => state_from_detour(detour),
       "status" => "active",
       "context" => context_from_detour(detour),
       "children" => snapshot_children_from_detour(detour)
     }
+
+    log_fallback_summary(id, author_id)
+
+    snapshot
   end
 
   defp validate_serialized_snapshot(%Detour{id: id} = detour) do
@@ -151,7 +163,23 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defmacrop log_fallback(field) do
     quote do
-      Logger.warning("Unexpected detour structure. Using snapshot for field: #{unquote(field)}")
+      Process.put(
+        @fallback_fields_key,
+        [unquote(field) | Process.get(@fallback_fields_key, [])]
+      )
+    end
+  end
+
+  defp log_fallback_summary(detour_id, author_id) do
+    case Process.delete(@fallback_fields_key) do
+      fields when is_list(fields) and fields != [] ->
+        Logger.warning(
+          "Unexpected detour structure for detour_id=#{detour_id} author_id=#{author_id}. " <>
+            "Using snapshot for fields: #{fields |> Enum.reverse() |> Enum.join(", ")}"
+        )
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/skate/detours/snapshot_serde.ex
+++ b/lib/skate/detours/snapshot_serde.ex
@@ -367,14 +367,17 @@ defmodule Skate.Detours.SnapshotSerde do
 
   defp typeddetour_from_detour(_), do: nil
 
-  # defp selectedduration_from_detour(%Detour{snapshot_children: snapshot_children}), do: snapshot_children
+  # defp selectedduration_from_detour(%Detour{estimated_duration: estimated_duration}), do: estimated_duration
   defp selectedduration_from_detour(
          %Detour{
-           state: state
+           state: %{
+             "context" => %{
+               "selectedDuration" => selected_duration
+             }
+           }
          } = detour
        ) do
     log_fallback("selectedDuration")
-    selected_duration = state["context"]["selectedDuration"]
 
     if detour.status == :active and selected_duration == nil do
       Logger.warning(

--- a/test/skate/detours/snapshot_serde_test.exs
+++ b/test/skate/detours/snapshot_serde_test.exs
@@ -132,30 +132,29 @@ defmodule Skate.Detours.SnapshotSerdeTest do
     end
 
     @tag :capture_log
-    test "logs nothing when no fields fall back to the snapshot" do
-      %{id: id, state: snapshot} =
+    test "does not include optional fields that are absent from the snapshot" do
+      # `state`, `route`, `routePattern`, and `children` don't have dedicated db
+      # columns yet, so they always fall back to the snapshot. Optional fields
+      # like `routePatterns` and `selectedDuration` only fall back when present
+      # in the snapshot, so a bare build+insert (whose snapshot omits them)
+      # shouldn't mention them in the aggregated warning.
+      %{id: id, author_id: author_id} =
         detour =
         :detour
         |> build()
         |> insert()
-
-      snapshot =
-        snapshot
-        |> with_id(id)
-        |> put_in(["context", "route", "garages"], ["garage-a"])
-        |> put_in(["context", "routePatterns"], [])
-
-      detour =
-        detour
-        |> Skate.Detours.Detours.change_detour(%{state: snapshot})
-        |> Skate.Repo.update!()
 
       log =
         capture_log(fn ->
           SnapshotSerde.compare_snapshots(detour)
         end)
 
-      refute log =~ "Unexpected detour structure"
+      assert log =~
+               "Unexpected detour structure for detour_id=#{id} author_id=#{author_id}. " <>
+                 "Using snapshot for fields: state, route, routePattern, children"
+
+      refute log =~ "route_patterns"
+      refute log =~ "selectedDuration"
     end
   end
 end

--- a/test/skate/detours/snapshot_serde_test.exs
+++ b/test/skate/detours/snapshot_serde_test.exs
@@ -1,6 +1,7 @@
 defmodule Skate.Detours.SnapshotSerdeTest do
   use Skate.DataCase
   import Skate.Factory
+  import ExUnit.CaptureLog
 
   alias Skate.Detours.SnapshotSerde
 
@@ -103,6 +104,58 @@ defmodule Skate.Detours.SnapshotSerdeTest do
         |> Skate.Repo.update!()
 
       assert {true, _} = SnapshotSerde.compare_snapshots(detour)
+    end
+  end
+
+  describe "log_fallback_summary/2 (via serialize_snapshot fallback aggregation)" do
+    @tag :capture_log
+    test "logs a single aggregated warning listing every field that fell back to the snapshot" do
+      # A bare build+insert skips `Detour.changeset/2`'s `populate_fields_from_state/1`,
+      # so `state_value`, `route`-related, and `snapshot_children` columns are left
+      # unpopulated and their `*_from_detour/1` fallback clauses fire.
+      %{id: id, author_id: author_id} =
+        detour =
+        :detour
+        |> build()
+        |> insert()
+
+      log =
+        capture_log(fn ->
+          SnapshotSerde.compare_snapshots(detour)
+        end)
+
+      assert log =~
+               "Unexpected detour structure for detour_id=#{id} author_id=#{author_id}. " <>
+                 "Using snapshot for fields: state, route, routePattern, children"
+
+      assert length(String.split(log, "Unexpected detour structure")) == 2
+    end
+
+    @tag :capture_log
+    test "logs nothing when no fields fall back to the snapshot" do
+      %{id: id, state: snapshot} =
+        detour =
+        :detour
+        |> build()
+        |> insert()
+
+      snapshot =
+        snapshot
+        |> with_id(id)
+        |> put_in(["context", "route", "garages"], ["garage-a"])
+        |> put_in(["context", "routePatterns"], [])
+
+      detour =
+        detour
+        |> Skate.Detours.Detours.change_detour(%{state: snapshot})
+        |> Skate.Repo.update!()
+
+      log =
+        capture_log(fn ->
+          SnapshotSerde.compare_snapshots(detour)
+        end)
+
+      refute log =~ "Unexpected detour structure"
     end
   end
 end


### PR DESCRIPTION
Asana Ticket: [Unexpected Detour structure ~2k events/day](https://app.asana.com/1/15492006741476/project/1205385723132845/task/1217686645710922?focus=true) part of our overall Splunk investigation which includes decreasing the frequency of redundant warnings

This PR aggregates the "Unexpected detour structure" warnings so that instead of logging an warning in splunk for every field that's missing, it logs one warning per request and lists all the fields that are missing 

Example: we are currently getting 15 splunk events from one detour change request. With this PR we would get one event: `Unexpected detour structure for detour_id=123 author_id=456. Using snapshot for fields: children, isTextOnly, undoStack, selectedReason, selectedDuration, editedDirections, finishedDetour, state`

*Note*: the last commit involves a change to *selectedduration_from_detour* which previously matched unconditionally on %Detour{state: state} instead of requiring state["context"]["selectedDuration"] to be present (unlike its sibling selectedreason_from_detour/1). The change requires state["context"]["selectedDuration"] to be present in order for it to fall back on that.

If you need a rundown on the logic in snapshot_serde.ex:
- Line 87 — Process.delete(@fallback_fields_key) inside serialize_snapshot/1 (line 84).
Runs first, before anything else. It clears out any stale value under the :snapshot_serde_fallback_fields key in the current process's dictionary, so leftover state from a previous call in the same process (e.g. a previous detour serialized in the same request/test) can't bleed into this one.
- Lines 90-93 — building the snapshot map calls state_from_detour/1, context_from_detour/1 (line 138), and snapshot_children_from_detour/1. Each of these may internally call log_fallback(field) (the macro defined at line 156).
- Lines 158-161 (inside the log_fallback macro) — Process.put(@fallback_fields_key, [unquote(field) | Process.get(@fallback_fields_key, [])]).
This runs once per fallback field encountered, each time one of the *_from_detour/1 getters falls back to the raw snapshot instead of a proper DB column. Each call reads whatever list is currently stored (or [] if none yet) and prepends the new field name, then stores it back. So if 8 fields fall back, this line executes 8 times in a row, building up a list like ["state", "finishedDetour", "editedDirections", ...] (in reverse order since each new one is prepended).
- Line 95 — log_fallback_summary(id, author_id), called after the whole snapshot map has been fully built (after every *_from_detour call has had a chance to run log_fallback).


